### PR TITLE
Verification of Bsc headers when vote data is empty

### DIFF
--- a/parachain/modules/ismp/bnb-pos/src/lib.rs
+++ b/parachain/modules/ismp/bnb-pos/src/lib.rs
@@ -53,7 +53,7 @@ impl<H: IsmpHost + Send + Sync + Default + 'static> ConsensusClient for BnbClien
     fn verify_consensus(
         &self,
         _host: &dyn IsmpHost,
-        _consensus_state_id: ismp::consensus::ConsensusStateId,
+        _consensus_state_id: ConsensusStateId,
         trusted_consensus_state: Vec<u8>,
         proof: Vec<u8>,
     ) -> Result<(Vec<u8>, ismp::consensus::VerifiedCommitments), ismp::error::Error> {

--- a/parachain/modules/ismp/sync-committee/src/beacon_client.rs
+++ b/parachain/modules/ismp/sync-committee/src/beacon_client.rs
@@ -40,7 +40,7 @@ use crate::{
     arbitrum::verify_arbitrum_payload,
     optimism::verify_optimism_payload,
     prelude::*,
-    utils::{get_value_from_proof, get_values_from_proof},
+    utils::{get_value_from_proof, get_values_from_proof, req_res_receipt_keys},
 };
 
 pub const BEACON_CONSENSUS_ID: ConsensusClientId = *b"BEAC";
@@ -203,7 +203,9 @@ impl<H: IsmpHost + Send + Sync> StateMachineClient for EvmStateMachine<H> {
     }
 
     fn state_trie_key(&self, items: RequestResponse) -> Vec<Vec<u8>> {
-        req_res_to_key::<H>(items)
+        // State trie keys are used to process timeouts from EVM chains
+        // We return the trie keys for request or response receipts
+        req_res_receipt_keys::<H>(items)
     }
 
     fn verify_state_proof(

--- a/parachain/runtimes/gargantua/src/lib.rs
+++ b/parachain/runtimes/gargantua/src/lib.rs
@@ -211,7 +211,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("gargantua"),
     impl_name: create_runtime_str!("gargantua"),
     authoring_version: 1,
-    spec_version: 200,
+    spec_version: 201,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/parachain/runtimes/gargantua/src/lib.rs
+++ b/parachain/runtimes/gargantua/src/lib.rs
@@ -211,7 +211,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("gargantua"),
     impl_name: create_runtime_str!("gargantua"),
     authoring_version: 1,
-    spec_version: 201,
+    spec_version: 202,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
Allow attested header verification in BSC consensus client when the source header or target header are missing. 
This is needed because we have observed cases where the epoch change block might contain an empty vote data but it still needs to be verified to successfully rotate the validator set.