### PR TITLE
Corrected spelling mistake in Docs file for Relayers

### DIFF
--- a/docs/pages/network/relayer.mdx
+++ b/docs/pages/network/relayer.mdx
@@ -66,7 +66,7 @@ At the minimum, the hyperbridge relayer should be run on a machine with at least
 
 ## Running the relayer
 
-The tesseract relayer command line interface expects two arguments, which are the paths to it's configuration file and database file. Because it resides in a docker container, you will need to [map the directory](https://docs.docker.com/storage/bind-mounts/#start-a-container-with-a-bind-mount) where you've stored the configuration files on your host into the docker conatiner. Tesseract will write it's database to that directory once it's initialized.
+The tesseract relayer command line interface expects two arguments, which are the paths to it's configuration file and database file. Because it resides in a docker container, you will need to [map the directory](https://docs.docker.com/storage/bind-mounts/#start-a-container-with-a-bind-mount) where you've stored the configuration files on your host into the docker container. Tesseract will write it's database to that directory once it's initialized.
 
 
 ```bash


### PR DESCRIPTION
Fixed a minor spelling error in the README.md file. Changed "conatiner" to "container" for clarity and consistency.