### PR TITLE
Fix check for minimum number of sync-committee participants in verifier

### DIFF
--- a/modules/consensus/sync-committee/verifier/src/lib.rs
+++ b/modules/consensus/sync-committee/verifier/src/lib.rs
@@ -44,7 +44,7 @@ pub fn verify_sync_committee_attestation<C: Config>(
     let sync_aggregate_participants: u64 =
         sync_committee_bits.iter().as_bitslice().count_ones() as u64;
 
-    if sync_aggregate_participants < ((2 * sync_committee_bits.len() as u64) / 3) {
+    if sync_aggregate_participants < ((2 * sync_committee_bits.len() as u64) / 3) + 1 {
         Err(Error::SyncCommitteeParticipantsTooLow)?
     }
 


### PR DESCRIPTION
According to the [code](https://github.com/polytope-labs/hyperbridge/blob/bdbc115bce984afae0800b6dda82d93680180822/modules/consensus/sync-committee/prover/src/lib.rs#L269) in the prover in prover, the number of sync-committee participants should be 2/3 + 1 (not just 2/3)