### PR TITLE
Update relayer.mdx

### DIFF
--- a/docs/pages/network/relayer.mdx
+++ b/docs/pages/network/relayer.mdx
@@ -102,7 +102,7 @@ The configuration file is a toml file that at the moment, expects the following 
 [hyperbridge]
 # Hyperbridge chain spec, either one of Dev, Gargantua, Messier or Nexus
 chain = "Gargantua" # testnet
-# Hyperbidge node ws rpc endpoint.
+# Hyperbridge node ws rpc endpoint.
 rpc_ws = "ws://127.0.0.1:9944" # example endpoint
 
 [ethereum]


### PR DESCRIPTION
Also a typo here https://docs.hyperbridge.network/network/node#clone-the-repo,
should be `cd hyperbridge`, not `cd hyperbidge`