### PR TITLE
Update state commitments for ZkBeefy

### DIFF
--- a/evm/src/consensus/Header.sol
+++ b/evm/src/consensus/Header.sol
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.17;
 
+import {StateCommitment} from "ismp/IConsensusClient.sol";
+import "solidity-merkle-trees/trie/Bytes.sol";
+import "solidity-merkle-trees/trie/substrate/ScaleCodec.sol";
+
 struct DigestItem {
     bytes4 consensusId;
     bytes data;
@@ -24,4 +28,39 @@ struct Header {
     bytes32 stateRoot;
     bytes32 extrinsicRoot;
     Digest[] digests;
+}
+
+library HeaderImpl {
+    /// Digest Item ID
+    bytes4 public constant ISMP_CONSENSUS_ID = bytes4("ISMP");
+    /// ConsensusID for aura
+    bytes4 public constant AURA_CONSENSUS_ID = bytes4("aura");
+    /// Slot duration in milliseconds
+    uint256 public constant SLOT_DURATION = 12000;
+
+    // Extracts the `StateCommitment` from the provided header.
+    function stateCommitment(Header calldata self) public pure returns (StateCommitment memory) {
+        bytes32 mmrRoot;
+        bytes32 childTrieRoot;
+        uint256 timestamp;
+
+        for (uint256 j = 0; j < self.digests.length; j++) {
+            if (self.digests[j].isConsensus && self.digests[j].consensus.consensusId == ISMP_CONSENSUS_ID) {
+                mmrRoot = Bytes.toBytes32(self.digests[j].consensus.data[:32]);
+                childTrieRoot = Bytes.toBytes32(self.digests[j].consensus.data[32:]);
+            }
+
+            if (self.digests[j].isPreRuntime && self.digests[j].preruntime.consensusId == AURA_CONSENSUS_ID) {
+                uint256 slot = ScaleCodec.decodeUint256(self.digests[j].preruntime.data);
+                timestamp = slot * SLOT_DURATION;
+            }
+        }
+
+        // sanity check
+        require(timestamp != 0, "timestamp not found!");
+        require(childTrieRoot != bytes32(0), "Child trie commitment not found");
+        require(mmrRoot != bytes32(0), "Mmr root commitment not found");
+
+        return StateCommitment({timestamp: timestamp, overlayRoot: mmrRoot, stateRoot: childTrieRoot});
+    }
 }

--- a/evm/src/consensus/ZkBeefy.sol
+++ b/evm/src/consensus/ZkBeefy.sol
@@ -32,6 +32,7 @@ struct BeefyConsensusProof {
 contract ZkBeefyV1 is IConsensusClient {
     using HeaderImpl for Header;
     /// Slot duration in milliseconds
+
     uint256 public constant SLOT_DURATION = 12000;
     /// The PayloadId for the mmr root.
     bytes2 public constant MMR_ROOT_PAYLOAD_ID = bytes2("mh");

--- a/evm/src/consensus/ZkBeefy.sol
+++ b/evm/src/consensus/ZkBeefy.sol
@@ -30,6 +30,7 @@ struct BeefyConsensusProof {
 }
 
 contract ZkBeefyV1 is IConsensusClient {
+    using HeaderImpl for Header;
     /// Slot duration in milliseconds
     uint256 public constant SLOT_DURATION = 12000;
     /// The PayloadId for the mmr root.
@@ -171,28 +172,14 @@ contract ZkBeefyV1 is IConsensusClient {
 
         Header memory header = Codec.DecodeHeader(para.header);
         require(header.number != 0, "Genesis block should not be included");
-        // extract verified metadata from header
-        bytes32 commitment;
-        uint256 timestamp;
-        for (uint256 j = 0; j < header.digests.length; j++) {
-            if (header.digests[j].isConsensus && header.digests[j].consensus.consensusId == ISMP_CONSENSUS_ID) {
-                commitment = Bytes.toBytes32(header.digests[j].consensus.data);
-            }
-
-            if (header.digests[j].isPreRuntime && header.digests[j].preruntime.consensusId == AURA_CONSENSUS_ID) {
-                uint256 slot = ScaleCodec.decodeUint256(header.digests[j].preruntime.data);
-                timestamp = slot * SLOT_DURATION;
-            }
-        }
-        require(timestamp != 0, "timestamp not found!");
-
         leaves[0] = Node(
             para.index,
             keccak256(bytes.concat(ScaleCodec.encode32(uint32(para.id)), ScaleCodec.encodeBytes(para.header)))
         );
         require(MerkleMultiProof.VerifyProof(headsRoot, proof.proof, leaves), "Invalid parachains heads proof");
+        StateCommitment memory commitment = header.stateCommitment();
 
-        return IntermediateState(para.id, header.number, StateCommitment(timestamp, commitment, header.stateRoot));
+        return IntermediateState({stateMachineId: para.id, height: header.number, commitment: commitment});
     }
 
     /// Calculates the mmr leaf index for a block whose parent number is given.

--- a/modules/ismp/pallet/src/lib.rs
+++ b/modules/ismp/pallet/src/lib.rs
@@ -84,11 +84,11 @@ pub mod pallet {
     // Import various types used to declare pallet in scope.
     use super::*;
     use crate::{
+        child_trie::CHILD_TRIE_PREFIX,
         errors::HandlingError,
         mmr::primitives::{LeafIndex, NodeIndex},
         primitives::{ConsensusClientProvider, WeightUsed, ISMP_ID},
         weight_info::WeightProvider,
-        child_trie::CHILD_TRIE_PREFIX
     };
     use frame_support::{pallet_prelude::*, traits::UnixTime};
     use frame_system::pallet_prelude::*;
@@ -466,36 +466,36 @@ pub mod pallet {
             /// Commitment to the post
             commitment: H256,
             /// Relayer address who delivered the message
-            relayer: Vec<u8>
+            relayer: Vec<u8>,
         },
         /// Post Response Handled
         PostResponseHandled {
             /// Commitment to the response
             commitment: H256,
             /// Relayer address who delivered the message
-            relayer: Vec<u8>
+            relayer: Vec<u8>,
         },
         /// Get Response Handled
         GetResponseHandled {
             /// Commitment to the get request
             commitment: H256,
             /// Relayer address who delivered the message
-            relayer: Vec<u8>
+            relayer: Vec<u8>,
         },
         /// Post request timeout handled
         PostRequestTimeoutHandled {
             /// Commitment to the post request
-            commitment: H256
+            commitment: H256,
         },
         /// Post response timeout handled
         PostResponseTimeoutHandled {
             /// Commitment to the response
-            commitment: H256
+            commitment: H256,
         },
         /// Get request timeout handled
         GetRequestTimeoutHandled {
             /// Commitment to the get request
-            commitment: H256
+            commitment: H256,
         },
     }
 

--- a/parachain/chainspec/gargantua.json
+++ b/parachain/chainspec/gargantua.json
@@ -9,10 +9,6 @@
     [
       "/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F",
       0
-    ],
-    [
-      "/dns/telemetry.blockops.network/tcp/443/x-parity-wss/%2Fsubmit",
-      1
     ]
   ],
   "protocolId": "gargantua",

--- a/parachain/chainspec/gargantua.plain.json
+++ b/parachain/chainspec/gargantua.plain.json
@@ -10,10 +10,6 @@
     [
       "/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F",
       0
-    ],
-    [
-      "/dns/telemetry.blockops.network/tcp/443/x-parity-wss/%2Fsubmit",
-      1
     ]
   ],
   "protocolId": "gargantua",

--- a/parachain/chainspec/messier.json
+++ b/parachain/chainspec/messier.json
@@ -5,7 +5,12 @@
   "bootNodes": [
     "/ip4/35.240.101.10/tcp/30333/p2p/12D3KooWKqypQcAhfyRdwug3rqFJpfT69kygzdGrHWFYB2Vg7C5e"
   ],
-  "telemetryEndpoints": null,
+  "telemetryEndpoints": [
+    [
+      "/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F",
+      0
+    ]
+  ],
   "protocolId": "messier",
   "properties": {
     "ss58Format": 42,

--- a/parachain/chainspec/nexus.json
+++ b/parachain/chainspec/nexus.json
@@ -9,10 +9,6 @@
     [
       "/dns/telemetry.polkadot.io/tcp/443/x-parity-wss/%2Fsubmit%2F",
       0
-    ],
-    [
-      "/dns/telemetry.blockops.network/tcp/443/x-parity-wss/%2Fsubmit",
-      1
     ]
   ],
   "protocolId": "nexus",


### PR DESCRIPTION
Switch to using the child trie root as the state root for cheaper time out proofs