### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,20 +47,24 @@ Building the hyperbridge node requires some dependencies
 
 Debian/Ubuntu
 
-```bash 
+```bash
+sudo apt update
 sudo apt install --assume-yes git clang curl libssl-dev llvm libudev-dev make protobuf-compiler
 ```
+
 Arch
 
 ```bash
 pacman -Syu --needed --noconfirm curl git clang make protobuf
 ```
+
 Fedora
 
 ```bash
 sudo dnf update
 sudo dnf install clang curl git openssl-devel make protobuf-compiler
 ```
+
 Opensuse
 
 ```bash
@@ -75,23 +79,25 @@ If you don't have an already existing rust installation, you can install it usin
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-### Install WebAssembly target
-
-Hyperbridge's blockchain runtime compiles to wasm which allows it's code to be forklessly upgraded. In order to build hyperbridge we need the wasm toolchain installed.
-
-```bash
-rustup update nightly
-rustup target add wasm32-unknown-unknown --toolchain nightly
-```
-
 ### Clone the repo
 
 Download a local copy of the repo and checkout the latest release tag
 
 ```bash
 git clone https://github.com/polytope-labs/hyperbridge.git
-cd ./hyperbidge
+cd ./hyperbridge
 git checkout ${latest-tag}
+```
+
+### Install WebAssembly target
+
+Hyperbridge's blockchain runtime compiles to wasm which allows it's code to be forklessly upgraded. In order to build hyperbridge we need the wasm toolchain installed.
+
+```bash
+rustup update nightly
+rustup target add wasm32-unknown-unknown
+rustup target add wasm32-unknown-unknown --toolchain nightly
+rustup component add rust-src
 ```
 
 ### Build the node
@@ -103,10 +109,12 @@ cargo build --release -p hyperbridge
 ## Running the node
 
 ```bash
-hyperbridge --chain=messier --enable-offchain-indexing --base-path=$HOME/.hyperbridge --pruning-archive
+hyperbridge --chain=messier --base-path=$HOME/.hyperbridge --pruning-archive
 ```
 
-## Running a local tesnet with zombienet
+> Note: `--enable-offchain-indexing` is enabled by default
+
+## Running a local testnet with zombienet
 Download the zombienet binary for your operating system [here](https://github.com/paritytech/zombienet).
 
 ```bash
@@ -114,7 +122,7 @@ zombienet spawn --provider native ./scripts/zombienet/local-testnet.toml
 ```
 
 ## Running a local testnet with docker
-Build the and run the  hyperbridge docker image locally by running 
+Build and run the hyperbridge docker image locally by running
 
 ```bash
 docker build -t hyperbridge -f ./scripts/docker/Dockerfile .

--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 Download a local copy of the repo and checkout the latest release tag
 
 ```bash
-git clone https://github.com/polytope-labs/hyperbridge.git
+export LATEST_HYPERBRIDGE_RELEASE=v0.4.0
+git clone --branch ${LATEST_HYPERBRIDGE_RELEASE} https://github.com/polytope-labs/hyperbridge.git
 cd ./hyperbridge
-git checkout ${latest-tag}
 ```
 
 ### Install WebAssembly target

--- a/README.md
+++ b/README.md
@@ -84,9 +84,10 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 Download a local copy of the repo and checkout the latest release tag
 
 ```bash
-export LATEST_HYPERBRIDGE_RELEASE=v0.4.0
-git clone --branch ${LATEST_HYPERBRIDGE_RELEASE} https://github.com/polytope-labs/hyperbridge.git
+export LATEST_TAG=v0.4.0
+git clone https://github.com/polytope-labs/hyperbridge.git
 cd ./hyperbridge
+git checkout ${LATEST_TAG}
 ```
 
 ### Install WebAssembly target

--- a/docs/pages/network/node.mdx
+++ b/docs/pages/network/node.mdx
@@ -91,9 +91,10 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 Download a local copy of the repo and checkout the latest release tag
 
 ```bash
-export LATEST_HYPERBRIDGE_RELEASE=v0.4.0
-git clone --branch ${LATEST_HYPERBRIDGE_RELEASE} https://github.com/polytope-labs/hyperbridge.git
+export LATEST_TAG=v0.4.0
+git clone https://github.com/polytope-labs/hyperbridge.git
 cd ./hyperbridge
+git checkout ${LATEST_TAG}
 ```
 
 ### Install WebAssembly target

--- a/docs/pages/network/node.mdx
+++ b/docs/pages/network/node.mdx
@@ -59,6 +59,7 @@ Building the hyperbridge node requires some dependencies
 :::code-group
 
 ```bash [Debian]
+sudo apt update
 sudo apt install --assume-yes git clang curl libssl-dev llvm libudev-dev make protobuf-compiler
 ```
 
@@ -85,6 +86,16 @@ If you don't have an already existing rust installation, you can install it usin
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
+### Clone the repo
+
+Download a local copy of the repo and checkout the latest release tag
+
+```bash
+export LATEST_HYPERBRIDGE_RELEASE=v0.4.0
+git clone --branch ${LATEST_HYPERBRIDGE_RELEASE} https://github.com/polytope-labs/hyperbridge.git
+cd ./hyperbridge
+```
+
 ### Install WebAssembly target
 
 Hyperbridge's blockchain runtime compiles to wasm which allows it's code to be forklessly upgraded. In order to build hyperbridge we need the wasm toolchain installed.
@@ -93,16 +104,7 @@ Hyperbridge's blockchain runtime compiles to wasm which allows it's code to be f
 rustup update nightly
 rustup target add wasm32-unknown-unknown
 rustup target add wasm32-unknown-unknown --toolchain nightly
-```
-
-### Clone the repo
-
-Download a local copy of the repo and checkout the latest release tag
-
-```bash
-git clone https://github.com/polytope-labs/hyperbridge.git
-cd ./hyperbidge
-git checkout v0.3.5
+rustup component add rust-src
 ```
 
 ### Build the node
@@ -111,10 +113,21 @@ git checkout v0.3.5
 cargo build --release -p hyperbridge
 ```
 
-The hyperbidge node will now be available at `target/release/hyperbidge`, You can move the binary to your `$PATH` so you can run it directly.
+The hyperbridge node will now be available at `target/release/hyperbridge`, You can move the binary to your `$PATH` so you can run it directly.
+
+Update your path to include `${HOME}/.local/bin`. If you are using Bash, run the following.
+Alternatively, replace `${HOME}/.bashrc` with `${HOME}/.zshrc` if using Zsh.
+Replace `source` with `.` if necessary.
 
 ```bash
-mv target/release/hyperbidge $HOME/.local/bin/
+export RC_PATH=${HOME}/.bashrc
+echo 'export PATH="${HOME}/.local/bin:${PATH}"' >> ${RC_PATH}
+source ${RC_PATH}
+```
+
+```bash
+mkdir -p $HOME/.local/bin/
+mv target/release/hyperbridge $HOME/.local/bin/
 ```
 
 ::::
@@ -125,6 +138,7 @@ Hyperbridge is available on the rococo testnet, with a chainId of `gargantua` an
 This is fine because the rococo testnet has no economic value.
 
 ```bash
+export PUBLIC_IP_ADDRESS=<your-node-public-ip-address>
 hyperbridge \
     --base-path=$HOME/.hyperbridge \
     --pruning=archive \
@@ -137,10 +151,10 @@ hyperbridge \
     --no-mdns \
     --listen-addr=/ip4/0.0.0.0/tcp/30333 \
     --listen-addr=/ip6/::/tcp/30333 \
-    --public-addr=/ip4/your-node-ip-address/tcp/30333 \
+    --public-addr=/ip4/$PUBLIC_IP_ADDRESS/tcp/30333 \
     --out-peers=32 \
     -- \
-    -- sync=fast-unsafe
+    --sync=fast-unsafe
 ```
 
 ## Running the node (Kusama)
@@ -148,6 +162,7 @@ hyperbridge \
 Hyperbridge is live on Kusama with a chainId of `messier` and ParaId of `3340`
 
 ```bash
+export PUBLIC_IP_ADDRESS=<your-node-public-ip-address>
 hyperbridge \
     --base-path=$HOME/.hyperbridge \
     --pruning=archive \
@@ -160,7 +175,7 @@ hyperbridge \
     --no-mdns \
     --listen-addr=/ip4/0.0.0.0/tcp/30333 \
     --listen-addr=/ip6/::/tcp/30333 \
-    --public-addr=/ip4/your-node-ip-address/tcp/30333 \
+    --public-addr=/ip4/$PUBLIC_IP_ADDRESS/tcp/30333 \
     --out-peers=32
 ```
 
@@ -169,6 +184,7 @@ hyperbridge \
 Hyperbridge is also live on Polkadot with a chainId of `nexus` and ParaId of `3367`
 
 ```bash
+export PUBLIC_IP_ADDRESS=<your-node-public-ip-address>
 hyperbridge \
     --base-path=$HOME/.hyperbridge \
     --pruning=archive \
@@ -181,7 +197,7 @@ hyperbridge \
     --no-mdns \
     --listen-addr=/ip4/0.0.0.0/tcp/30333 \
     --listen-addr=/ip6/::/tcp/30333 \
-    --public-addr=/ip4/your-node-ip-address/tcp/30333 \
+    --public-addr=/ip4/$PUBLIC_IP_ADDRESS/tcp/30333 \
     --out-peers=32
 ```
 


### PR DESCRIPTION
note that i've suggested running `rustup target add wasm32-unknown-unknown` after cloning the repo since i did it in the previous order and it said i had to do `rustup target add wasm32-unknown-unknown` even though i'd already done it in the parent directory
