### PR TITLE
Eliminate `pallet_ismp::host::Host`

### DIFF
--- a/modules/consensus/grandpa/src/lib.rs
+++ b/modules/consensus/grandpa/src/lib.rs
@@ -20,7 +20,6 @@ pub mod messages;
 
 use alloc::vec::Vec;
 pub use pallet::*;
-use pallet_ismp::host::Host;
 
 #[frame_support::pallet]
 pub mod pallet {

--- a/modules/ismp/clients/parachain/client/src/lib.rs
+++ b/modules/ismp/clients/parachain/client/src/lib.rs
@@ -54,7 +54,7 @@ pub mod pallet {
         type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
         /// The underlying [`IsmpHost`] implementation
-        type Host: IsmpHost + Default;
+        type IsmpHost: IsmpHost + Default;
     }
 
     /// Mapping of relay chain heights to it's state commitment. The state commitment of the parent
@@ -157,7 +157,7 @@ pub mod pallet {
         fn on_initialize(_n: BlockNumberFor<T>) -> Weight {
             // kill the storage, since this is the beginning of a new block.
             ConsensusUpdated::<T>::kill();
-            let host = T::Host::default();
+            let host = T::IsmpHost::default();
             if let Err(_) = host.consensus_state(PARACHAIN_CONSENSUS_ID) {
                 Pallet::<T>::initialize();
             }
@@ -227,7 +227,7 @@ impl<T: Config> Pallet<T> {
     /// `create_consensus_state` call, simply including this pallet in your runtime will create the
     /// ismp parachain client consensus state, either through `genesis_build` or `on_initialize`.
     pub fn initialize() {
-        let host = T::Host::default();
+        let host = T::IsmpHost::default();
         let message = CreateConsensusState {
             // insert empty bytes
             consensus_state: vec![],

--- a/modules/ismp/clients/polygon-pos/src/test.rs
+++ b/modules/ismp/clients/polygon-pos/src/test.rs
@@ -11,10 +11,7 @@ use geth_primitives::{CodecHeader, Header};
 use ismp::{
     consensus::ConsensusClient, host::StateMachine, module::IsmpModule, router::IsmpRouter,
 };
-use pallet_ismp::{
-    host::Host,
-    mocks::{mocks::MockModule, ExistentialDeposit},
-};
+use pallet_ismp::mocks::{mocks::MockModule, ExistentialDeposit};
 use sp_core::{Pair, H256};
 use sp_runtime::traits::{IdentityLookup, Keccak256};
 
@@ -182,7 +179,7 @@ fn verify_fraud_proof() {
     header_2.extra_data.extend_from_slice(&signature_2);
 
     let client = PolygonClient::<Test, Host<Test>>::default();
-    let host = Host::<Test>::default();
+    let host = Ismp::default();
 
     assert!(client
         .verify_fraud_proof(&host, consensus_state.encode(), header_1.encode(), header_2.encode())

--- a/modules/ismp/clients/sync-committee/src/pallet.rs
+++ b/modules/ismp/clients/sync-committee/src/pallet.rs
@@ -34,7 +34,7 @@ pub mod pallet {
         type AdminOrigin: EnsureOrigin<<Self as frame_system::Config>::RuntimeOrigin>;
 
         /// The underlying [`IsmpHost`] implementation
-        type Host: IsmpHost + Default;
+        type IsmpHost: IsmpHost + Default;
     }
 
     #[pallet::error]
@@ -64,7 +64,7 @@ pub mod pallet {
         ) -> DispatchResult {
             <T as Config>::AdminOrigin::ensure_origin(origin)?;
 
-            let host = <T as Config>::Host::default();
+            let host = <T as Config>::IsmpHost::default();
             let StateMachineId { consensus_state_id, state_id: state_machine } = state_machine_id;
             let encoded_consensus_state = host
                 .consensus_state(consensus_state_id)
@@ -94,7 +94,7 @@ pub mod pallet {
         ) -> DispatchResult {
             <T as Config>::AdminOrigin::ensure_origin(origin)?;
 
-            let host = <T as Config>::Host::default();
+            let host = <T as Config>::IsmpHost::default();
             let StateMachineId { consensus_state_id, state_id: state_machine } = state_machine_id;
 
             let encoded_consensus_state = host

--- a/modules/ismp/pallets/asset-gateway/src/lib.rs
+++ b/modules/ismp/pallets/asset-gateway/src/lib.rs
@@ -83,7 +83,7 @@ pub mod pallet {
         type Params: Get<TokenGatewayParams>;
 
         /// The [`IsmpDispatcher`] implementation to use for dispatching requests
-        type Host: IsmpHost + IsmpDispatcher<Account = Self::AccountId, Balance = Self::Balance>;
+        type IsmpHost: IsmpHost + IsmpDispatcher<Account = Self::AccountId, Balance = Self::Balance>;
 
         /// Fungible asset implementation
         type Assets: fungibles::Mutate<Self::AccountId> + fungibles::Inspect<Self::AccountId>;
@@ -229,7 +229,7 @@ where
         multi_account: MultiAccount<T::AccountId>,
         amount: <T::Assets as fungibles::Inspect<T::AccountId>>::Balance,
     ) -> Result<(), Error<T>> {
-        let dispatcher = <T as Config>::Host::default();
+        let dispatcher = <T as Config>::IsmpHost::default();
 
         let mut to = [0u8; 32];
         to[..20].copy_from_slice(&multi_account.evm_account.0);
@@ -449,7 +449,7 @@ where
         match request {
             Timeout::Request(Request::Post(post)) => {
                 let request = Request::Post(post.clone());
-                let commitment = hash_request::<<T as Config>::Host>(&request);
+                let commitment = hash_request::<<T as Config>::IsmpHost>(&request);
                 let fee_metadata = pallet_ismp::child_trie::RequestCommitments::<T>::get(
                     commitment,
                 )

--- a/modules/ismp/pallets/asset-gateway/src/lib.rs
+++ b/modules/ismp/pallets/asset-gateway/src/lib.rs
@@ -39,13 +39,12 @@ use staging_xcm::{
 use ismp::{
     dispatcher::{DispatchPost, DispatchRequest, FeeMetadata, IsmpDispatcher},
     events::Meta,
-    host::StateMachine,
+    host::{IsmpHost, StateMachine},
     messaging::hash_request,
     module::IsmpModule,
     router::{Request, Timeout},
 };
 pub use pallet::*;
-use pallet_ismp::host::Host;
 use xcm_utilities::MultiAccount;
 
 pub mod xcm_utilities;
@@ -84,8 +83,7 @@ pub mod pallet {
         type Params: Get<TokenGatewayParams>;
 
         /// The [`IsmpDispatcher`] implementation to use for dispatching requests
-        type Dispatcher: IsmpDispatcher<Account = Self::AccountId, Balance = Self::Balance>
-            + Default;
+        type Host: IsmpHost + IsmpDispatcher<Account = Self::AccountId, Balance = Self::Balance>;
 
         /// Fungible asset implementation
         type Assets: fungibles::Mutate<Self::AccountId> + fungibles::Inspect<Self::AccountId>;
@@ -231,7 +229,7 @@ where
         multi_account: MultiAccount<T::AccountId>,
         amount: <T::Assets as fungibles::Inspect<T::AccountId>>::Balance,
     ) -> Result<(), Error<T>> {
-        let dispatcher = T::Dispatcher::default();
+        let dispatcher = <T as Config>::Host::default();
 
         let mut to = [0u8; 32];
         to[..20].copy_from_slice(&multi_account.evm_account.0);
@@ -451,7 +449,7 @@ where
         match request {
             Timeout::Request(Request::Post(post)) => {
                 let request = Request::Post(post.clone());
-                let commitment = hash_request::<Host<T>>(&request);
+                let commitment = hash_request::<<T as Config>::Host>(&request);
                 let fee_metadata = pallet_ismp::child_trie::RequestCommitments::<T>::get(
                     commitment,
                 )

--- a/modules/ismp/pallets/demo/src/lib.rs
+++ b/modules/ismp/pallets/demo/src/lib.rs
@@ -147,7 +147,7 @@ pub mod pallet {
 
             // next, construct the request to be sent out
             let payload = Payload { to: params.to, from: origin.clone(), amount: params.amount };
-            let dest = match T::HostStateMachine::get() {
+            let dest = match <T as pallet_ismp::Config>::HostStateMachine::get() {
                 StateMachine::Kusama(_) => StateMachine::Kusama(params.para_id),
                 StateMachine::Polkadot(_) => StateMachine::Polkadot(params.para_id),
                 _ => Err(DispatchError::Other("Pallet only supports parachain hosts"))?,
@@ -186,7 +186,7 @@ pub mod pallet {
         #[pallet::call_index(1)]
         pub fn get_request(origin: OriginFor<T>, params: GetRequest) -> DispatchResult {
             let origin = ensure_signed(origin)?;
-            let dest = match T::HostStateMachine::get() {
+            let dest = match <T as pallet_ismp::Config>::HostStateMachine::get() {
                 StateMachine::Kusama(_) => StateMachine::Kusama(params.para_id),
                 StateMachine::Polkadot(_) => StateMachine::Polkadot(params.para_id),
                 _ => Err(DispatchError::Other("Pallet only supports parachain hosts"))?,

--- a/modules/ismp/pallets/fishermen/src/lib.rs
+++ b/modules/ismp/pallets/fishermen/src/lib.rs
@@ -43,7 +43,7 @@ pub mod pallet {
         type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
         /// The underlying [`IsmpHost`] implementation
-        type Host: IsmpHost + Default;
+        type IsmpHost: IsmpHost + Default;
     }
 
     /// Set of whitelisted fishermen accounts
@@ -118,7 +118,7 @@ pub mod pallet {
             let account = ensure_signed(origin.clone())?;
             ensure!(Fishermen::<T>::contains_key(&account), Error::<T>::UnauthorizedAction);
 
-            let ismp_host = <T as Config>::Host::default();
+            let ismp_host = <T as Config>::IsmpHost::default();
             let commitment =
                 ismp_host.state_machine_commitment(height).map_err(|_| Error::<T>::VetoFailed)?;
             ismp_host.delete_state_commitment(height).map_err(|_| Error::<T>::VetoFailed)?;

--- a/modules/ismp/pallets/fishermen/src/lib.rs
+++ b/modules/ismp/pallets/fishermen/src/lib.rs
@@ -31,7 +31,6 @@ pub mod pallet {
         events::StateCommitmentVetoed,
         host::IsmpHost,
     };
-    use pallet_ismp::host::Host;
 
     #[pallet::pallet]
     #[pallet::without_storage_info]
@@ -42,6 +41,9 @@ pub mod pallet {
     pub trait Config: frame_system::Config + pallet_ismp::Config {
         /// The overarching event type.
         type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+        /// The underlying [`IsmpHost`] implementation
+        type Host: IsmpHost + Default;
     }
 
     /// Set of whitelisted fishermen accounts
@@ -116,7 +118,7 @@ pub mod pallet {
             let account = ensure_signed(origin.clone())?;
             ensure!(Fishermen::<T>::contains_key(&account), Error::<T>::UnauthorizedAction);
 
-            let ismp_host = Host::<T>::default();
+            let ismp_host = <T as Config>::Host::default();
             let commitment =
                 ismp_host.state_machine_commitment(height).map_err(|_| Error::<T>::VetoFailed)?;
             ismp_host.delete_state_commitment(height).map_err(|_| Error::<T>::VetoFailed)?;

--- a/modules/ismp/pallets/host-executive/src/lib.rs
+++ b/modules/ismp/pallets/host-executive/src/lib.rs
@@ -55,7 +55,7 @@ pub mod pallet {
         type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
         /// The [`IsmpDispatcher`] implementation to use for dispatching requests
-        type Dispatcher: IsmpDispatcher<Account = Self::AccountId, Balance = Self::Balance>;
+        type Host: IsmpDispatcher<Account = Self::AccountId, Balance = Self::Balance>;
     }
 
     /// Host Manager Addresses on different chains
@@ -165,7 +165,7 @@ pub mod pallet {
                 _ => return Err(Error::<T>::MismatchedHostParams.into()),
             };
 
-            let dispatcher = T::Dispatcher::default();
+            let dispatcher = <T as Config>::Host::default();
             dispatcher
                 .dispatch_request(
                     DispatchRequest::Post(post),

--- a/modules/ismp/pallets/host-executive/src/lib.rs
+++ b/modules/ismp/pallets/host-executive/src/lib.rs
@@ -55,7 +55,7 @@ pub mod pallet {
         type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
         /// The [`IsmpDispatcher`] implementation to use for dispatching requests
-        type Host: IsmpDispatcher<Account = Self::AccountId, Balance = Self::Balance>;
+        type IsmpHost: IsmpDispatcher<Account = Self::AccountId, Balance = Self::Balance>;
     }
 
     /// Host Manager Addresses on different chains
@@ -165,7 +165,7 @@ pub mod pallet {
                 _ => return Err(Error::<T>::MismatchedHostParams.into()),
             };
 
-            let dispatcher = <T as Config>::Host::default();
+            let dispatcher = <T as Config>::IsmpHost::default();
             dispatcher
                 .dispatch_request(
                     DispatchRequest::Post(post),

--- a/modules/ismp/pallets/hyperbridge/src/lib.rs
+++ b/modules/ismp/pallets/hyperbridge/src/lib.rs
@@ -69,7 +69,7 @@ use ismp::{
     module::IsmpModule,
     router::{Post, PostResponse, Response, Timeout},
 };
-use pallet_ismp::{host::Host, RELAYER_FEE_ACCOUNT};
+use pallet_ismp::RELAYER_FEE_ACCOUNT;
 use primitive_types::H256;
 
 pub use pallet::*;
@@ -106,6 +106,9 @@ pub mod pallet {
     pub trait Config: frame_system::Config + pallet_ismp::Config {
         /// Because this pallet emits events, it depends on the runtime's definition of an event.
         type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+        /// The underlying [`IsmpHost`] implementation
+        type Host: IsmpDispatcher<Account = Self::AccountId, Balance = Self::Balance> + Default;
     }
 
     #[pallet::pallet]
@@ -198,7 +201,7 @@ where
             DispatchRequest::Get(_) => Default::default(),
         };
 
-        let host = Host::<T>::default();
+        let host = <T as Config>::Host::default();
         let commitment = host.dispatch_request(request, fee)?;
 
         // commit the fee collected to child-trie
@@ -228,7 +231,7 @@ where
             })?;
         }
 
-        let host = Host::<T>::default();
+        let host = <T as Config>::Host::default();
         let commitment = host.dispatch_response(response, fee)?;
 
         // commit the collected to child-trie

--- a/modules/ismp/pallets/hyperbridge/src/lib.rs
+++ b/modules/ismp/pallets/hyperbridge/src/lib.rs
@@ -108,7 +108,7 @@ pub mod pallet {
         type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
         /// The underlying [`IsmpHost`] implementation
-        type Host: IsmpDispatcher<Account = Self::AccountId, Balance = Self::Balance> + Default;
+        type IsmpHost: IsmpDispatcher<Account = Self::AccountId, Balance = Self::Balance> + Default;
     }
 
     #[pallet::pallet]
@@ -201,7 +201,7 @@ where
             DispatchRequest::Get(_) => Default::default(),
         };
 
-        let host = <T as Config>::Host::default();
+        let host = <T as Config>::IsmpHost::default();
         let commitment = host.dispatch_request(request, fee)?;
 
         // commit the fee collected to child-trie
@@ -231,7 +231,7 @@ where
             })?;
         }
 
-        let host = <T as Config>::Host::default();
+        let host = <T as Config>::IsmpHost::default();
         let commitment = host.dispatch_response(response, fee)?;
 
         // commit the collected to child-trie

--- a/modules/ismp/pallets/pallet/src/host.rs
+++ b/modules/ismp/pallets/pallet/src/host.rs
@@ -20,7 +20,7 @@ use crate::{
     dispatcher::{RefundingRouter, RequestMetadata},
     utils::{ConsensusClientProvider, ResponseReceipt},
     ChallengePeriod, Config, ConsensusClientUpdateTime, ConsensusStateClient, ConsensusStates,
-    FrozenConsensusClients, FrozenStateMachine, LatestStateMachineHeight, Nonce, Responded,
+    FrozenConsensusClients, FrozenStateMachine, LatestStateMachineHeight, Nonce, Pallet, Responded,
     StateCommitments, StateMachineUpdateTime, UnbondingPeriod,
 };
 use alloc::{format, string::ToString};
@@ -41,19 +41,9 @@ use sp_core::H256;
 use sp_runtime::SaturatedConversion;
 use sp_std::prelude::*;
 
-/// An implementation for the [`IsmpHost`]
-#[derive(Clone)]
-pub struct Host<T: Config>(core::marker::PhantomData<T>);
-
-impl<T: Config> Default for Host<T> {
-    fn default() -> Self {
-        Self(core::marker::PhantomData)
-    }
-}
-
-impl<T: Config> IsmpHost for Host<T> {
+impl<T: Config> IsmpHost for Pallet<T> {
     fn host_state_machine(&self) -> StateMachine {
-        T::HostStateMachine::get()
+        <T as Config>::HostStateMachine::get()
     }
 
     fn latest_commitment_height(&self, id: StateMachineId) -> Result<u64, Error> {
@@ -326,7 +316,7 @@ impl<T: Config> IsmpHost for Host<T> {
     }
 }
 
-impl<T: Config> ismp::messaging::Keccak256 for Host<T> {
+impl<T: Config> ismp::messaging::Keccak256 for Pallet<T> {
     fn keccak256(bytes: &[u8]) -> H256
     where
         Self: Sized,

--- a/modules/ismp/pallets/pallet/src/impls.rs
+++ b/modules/ismp/pallets/pallet/src/impls.rs
@@ -19,7 +19,6 @@ use crate::{
     child_trie::{RequestCommitments, ResponseCommitments},
     dispatcher::{FeeMetadata, RequestMetadata},
     events,
-    host::Host,
     mmr::{Leaf, LeafIndexAndPos, Proof, ProofKeys},
     weights::get_weight,
     Config, Error, Event, Pallet, Responded,
@@ -85,7 +84,7 @@ impl<T: Config> Pallet<T> {
     /// Provides a way to handle messages.
     pub fn handle_messages(messages: Vec<Message>) -> DispatchResultWithPostInfo {
         // Define a host
-        let host = Host::<T>::default();
+        let host = Pallet::<T>::default();
         let events = messages
             .iter()
             .map(|msg| handle_incoming_message(&host, msg.clone()))
@@ -127,7 +126,7 @@ impl<T: Config> Pallet<T> {
 
     /// Dispatch an outgoing request, returns the request commitment
     pub fn dispatch_request(request: Request, meta: FeeMetadata<T>) -> Result<H256, ismp::Error> {
-        let commitment = hash_request::<Host<T>>(&request);
+        let commitment = hash_request::<Pallet<T>>(&request);
 
         if RequestCommitments::<T>::contains_key(commitment) {
             Err(ismp::Error::Custom("Duplicate request".to_string()))?
@@ -164,13 +163,13 @@ impl<T: Config> Pallet<T> {
         response: Response,
         meta: FeeMetadata<T>,
     ) -> Result<H256, ismp::Error> {
-        let req_commitment = hash_request::<Host<T>>(&response.request());
+        let req_commitment = hash_request::<Pallet<T>>(&response.request());
 
         if Responded::<T>::contains_key(req_commitment) {
             Err(ismp::Error::Custom("Request has been responded to".to_string()))?
         }
 
-        let commitment = hash_response::<Host<T>>(&response);
+        let commitment = hash_response::<Pallet<T>>(&response);
 
         let (dest_chain, source_chain, nonce) =
             (response.dest_chain(), response.source_chain(), response.nonce());

--- a/modules/ismp/pallets/relayer/src/lib.rs
+++ b/modules/ismp/pallets/relayer/src/lib.rs
@@ -76,7 +76,7 @@ pub mod pallet {
         type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
         /// The underlying [`IsmpHost`] implementation
-        type Host: IsmpHost + IsmpDispatcher<Account = Self::AccountId, Balance = Self::Balance>;
+        type IsmpHost: IsmpHost + IsmpDispatcher<Account = Self::AccountId, Balance = Self::Balance>;
     }
 
     /// double map of address to source chain, which holds the amount of the relayer address
@@ -277,7 +277,7 @@ where
         if available_amount < withdrawal_data.amount {
             Err(Error::<T>::InvalidAmount)?
         }
-        let dispatcher = <T as Config>::Host::default();
+        let dispatcher = <T as Config>::IsmpHost::default();
         let relayer_manager_address = match withdrawal_data.dest_chain {
             StateMachine::Beefy(_) |
             StateMachine::Grandpa(_) |
@@ -453,7 +453,7 @@ where
         proof: &Proof,
         keys: Vec<Vec<u8>>,
     ) -> Result<BTreeMap<Vec<u8>, Option<Vec<u8>>>, DispatchError> {
-        let host = <T as Config>::Host::default();
+        let host = <T as Config>::IsmpHost::default();
         let state_machine = validate_state_machine(&host, proof.height)
             .map_err(|_| Error::<T>::ProofValidationError)?;
         let state = host
@@ -473,7 +473,7 @@ where
                 Key::Request(commitment) => match proof.source_proof.height.id.state_id {
                     StateMachine::Ethereum(_) | StateMachine::Polygon | StateMachine::Bsc => {
                         keys.push(
-                            derive_unhashed_map_key::<<T as Config>::Host>(
+                            derive_unhashed_map_key::<<T as Config>::IsmpHost>(
                                 commitment.0.to_vec(),
                                 REQUEST_COMMITMENTS_SLOT,
                             )
@@ -491,7 +491,7 @@ where
                     match proof.source_proof.height.id.state_id {
                         StateMachine::Ethereum(_) | StateMachine::Polygon | StateMachine::Bsc => {
                             keys.push(
-                                derive_unhashed_map_key::<<T as Config>::Host>(
+                                derive_unhashed_map_key::<<T as Config>::IsmpHost>(
                                     response_commitment.0.to_vec(),
                                     RESPONSE_COMMITMENTS_SLOT,
                                 )
@@ -519,7 +519,7 @@ where
                 Key::Request(commitment) => match proof.dest_proof.height.id.state_id {
                     StateMachine::Ethereum(_) | StateMachine::Polygon | StateMachine::Bsc => {
                         keys.push(
-                            derive_unhashed_map_key::<<T as Config>::Host>(
+                            derive_unhashed_map_key::<<T as Config>::IsmpHost>(
                                 commitment.0.to_vec(),
                                 REQUEST_RECEIPTS_SLOT,
                             )
@@ -538,7 +538,7 @@ where
                     match proof.dest_proof.height.id.state_id {
                         StateMachine::Ethereum(_) | StateMachine::Polygon | StateMachine::Bsc => {
                             keys.push(
-                                derive_unhashed_map_key::<<T as Config>::Host>(
+                                derive_unhashed_map_key::<<T as Config>::IsmpHost>(
                                     request_commitment.0.to_vec(),
                                     RESPONSE_RECEIPTS_SLOT,
                                 )

--- a/modules/ismp/pallets/testsuite/src/runtime.rs
+++ b/modules/ismp/pallets/testsuite/src/runtime.rs
@@ -38,7 +38,7 @@ use ismp::{
     Error,
 };
 use ismp_sync_committee::constants::sepolia::Sepolia;
-use pallet_ismp::{host::Host, mmr::Leaf, ModuleId};
+use pallet_ismp::{mmr::Leaf, ModuleId};
 use sp_core::{
     crypto::AccountId32,
     offchain::{testing::TestOffchainExt, OffchainDbExt, OffchainWorkerExt},
@@ -130,6 +130,7 @@ impl pallet_balances::Config for Test {
 
 impl pallet_fishermen::Config for Test {
     type RuntimeEvent = RuntimeEvent;
+    type Host = Ismp;
 }
 
 #[derive_impl(frame_system::config_preludes::ParaChainDefaultConfig as frame_system::DefaultConfig)]
@@ -182,8 +183,8 @@ impl pallet_ismp::Config for Test {
     type Currency = Balances;
     type ConsensusClients = (
         MockConsensusClient,
-        ismp_sync_committee::SyncCommitteeConsensusClient<Host<Test>, Sepolia>,
-        ismp_bsc::BscClient<Host<Test>>,
+        ismp_sync_committee::SyncCommitteeConsensusClient<Ismp, Sepolia>,
+        ismp_bsc::BscClient<Ismp>,
     );
     type Mmr = Mmr;
     type WeightProvider = ();
@@ -191,6 +192,7 @@ impl pallet_ismp::Config for Test {
 
 impl pallet_hyperbridge::Config for Test {
     type RuntimeEvent = RuntimeEvent;
+    type Host = Ismp;
 }
 
 impl pallet_mmr::Config for Test {
@@ -202,11 +204,12 @@ impl pallet_mmr::Config for Test {
 
 impl pallet_ismp_relayer::Config for Test {
     type RuntimeEvent = RuntimeEvent;
+    type Host = Ismp;
 }
 
 impl pallet_ismp_host_executive::Config for Test {
     type RuntimeEvent = RuntimeEvent;
-    type Dispatcher = Host<Test>;
+    type Host = Ismp;
 }
 
 impl pallet_call_decompressor::Config for Test {

--- a/modules/ismp/pallets/testsuite/src/runtime.rs
+++ b/modules/ismp/pallets/testsuite/src/runtime.rs
@@ -130,7 +130,7 @@ impl pallet_balances::Config for Test {
 
 impl pallet_fishermen::Config for Test {
     type RuntimeEvent = RuntimeEvent;
-    type Host = Ismp;
+    type IsmpHost = Ismp;
 }
 
 #[derive_impl(frame_system::config_preludes::ParaChainDefaultConfig as frame_system::DefaultConfig)]
@@ -192,7 +192,7 @@ impl pallet_ismp::Config for Test {
 
 impl pallet_hyperbridge::Config for Test {
     type RuntimeEvent = RuntimeEvent;
-    type Host = Ismp;
+    type IsmpHost = Ismp;
 }
 
 impl pallet_mmr::Config for Test {
@@ -204,12 +204,12 @@ impl pallet_mmr::Config for Test {
 
 impl pallet_ismp_relayer::Config for Test {
     type RuntimeEvent = RuntimeEvent;
-    type Host = Ismp;
+    type IsmpHost = Ismp;
 }
 
 impl pallet_ismp_host_executive::Config for Test {
     type RuntimeEvent = RuntimeEvent;
-    type Host = Ismp;
+    type IsmpHost = Ismp;
 }
 
 impl pallet_call_decompressor::Config for Test {

--- a/modules/ismp/pallets/testsuite/src/tests/pallet_fishermen.rs
+++ b/modules/ismp/pallets/testsuite/src/tests/pallet_fishermen.rs
@@ -15,13 +15,12 @@
 
 #![cfg(test)]
 
-use crate::runtime::{new_test_ext, RuntimeOrigin, Test};
+use crate::runtime::{new_test_ext, Ismp, RuntimeOrigin, Test};
 use ismp::{
     consensus::{StateCommitment, StateMachineHeight, StateMachineId},
     error::Error,
     host::{Ethereum, IsmpHost, StateMachine},
 };
-use pallet_ismp::host::Host;
 use sp_core::{crypto::AccountId32, H256};
 use sp_runtime::{DispatchError, ModuleError};
 
@@ -45,7 +44,7 @@ fn test_can_veto_state_commitments() {
             }))
         );
 
-        let host = Host::<Test>::default();
+        let host = Ismp::default();
         let height = StateMachineHeight {
             id: StateMachineId {
                 state_id: StateMachine::Ethereum(Ethereum::Optimism),

--- a/modules/ismp/pallets/testsuite/src/tests/pallet_ismp_relayer.rs
+++ b/modules/ismp/pallets/testsuite/src/tests/pallet_ismp_relayer.rs
@@ -29,7 +29,6 @@ use ismp::{
 use pallet_ismp::{
     child_trie::{RequestCommitments, RequestReceipts, ResponseCommitments, ResponseReceipts},
     dispatcher::FeeMetadata,
-    host::Host,
     ResponseReceipt,
 };
 use pallet_ismp_relayer::{
@@ -43,7 +42,7 @@ use substrate_state_machine::{HashAlgorithm, StateMachineProof, SubstrateStatePr
 use trie_db::{Recorder, Trie, TrieDBBuilder, TrieDBMutBuilder, TrieMut};
 
 use crate::runtime::{
-    new_test_ext, set_timestamp, RuntimeCall, RuntimeOrigin, Test, MOCK_CONSENSUS_CLIENT_ID,
+    new_test_ext, set_timestamp, Ismp, RuntimeCall, RuntimeOrigin, Test, MOCK_CONSENSUS_CLIENT_ID,
     MOCK_CONSENSUS_STATE_ID,
 };
 use ismp::host::Ethereum;
@@ -68,7 +67,7 @@ fn test_withdrawal_proof() {
                     timeout_timestamp: 0,
                     data: vec![],
                 };
-                hash_request::<Host<Test>>(&Request::Post(post))
+                hash_request::<Ismp>(&Request::Post(post))
             })
             .collect::<Vec<_>>();
 
@@ -89,10 +88,7 @@ fn test_withdrawal_proof() {
                     response: vec![0; 32],
                     timeout_timestamp: nonce,
                 };
-                (
-                    hash_request::<Host<Test>>(&Request::Post(post)),
-                    hash_post_response::<Host<Test>>(&response),
-                )
+                (hash_request::<Ismp>(&Request::Post(post)), hash_post_response::<Ismp>(&response))
             })
             .collect::<Vec<_>>();
 
@@ -189,7 +185,7 @@ fn test_withdrawal_proof() {
             storage_proof: dest_keys_proof,
         });
 
-        let host = Host::<Test>::default();
+        let host = Ismp::default();
         host.store_state_machine_commitment(
             StateMachineHeight {
                 id: StateMachineId {
@@ -414,7 +410,7 @@ fn test_evm_accumulate_fees() {
 
         dbg!(claim_proof.encode().len());
 
-        let host = Host::<Test>::default();
+        let host = Ismp::default();
         host.store_state_machine_commitment(
             claim_proof.source_proof.height,
             StateCommitment { timestamp: 100, overlay_root: None, state_root: bsc_root },
@@ -587,7 +583,7 @@ fn setup_host_for_accumulate_fees() -> WithdrawalProof {
         }
     }
 
-    let host = Host::<Test>::default();
+    let host = Ismp::default();
     host.store_state_machine_commitment(
         claim_proof.source_proof.height,
         StateCommitment { timestamp: 100, overlay_root: None, state_root: bsc_root },

--- a/modules/ismp/pallets/testsuite/src/xcm.rs
+++ b/modules/ismp/pallets/testsuite/src/xcm.rs
@@ -3,9 +3,9 @@
 use crate::{
     relay_chain,
     runtime::{
-        register_offchain_ext, Assets, Balance, Balances, MessageQueue, PalletXcm, ParachainInfo,
-        ParachainSystem, RuntimeCall, RuntimeEvent, RuntimeOrigin, System, Test, Timestamp,
-        XcmpQueue,
+        register_offchain_ext, Assets, Balance, Balances, Ismp, MessageQueue, PalletXcm,
+        ParachainInfo, ParachainSystem, RuntimeCall, RuntimeEvent, RuntimeOrigin, System, Test,
+        Timestamp, XcmpQueue,
     },
 };
 use codec::Decode;
@@ -59,7 +59,7 @@ impl EnsureOriginWithArg<RuntimeOrigin, MultiLocation> for ForeignCreators {
     ) -> sp_std::result::Result<Self::Success, RuntimeOrigin> {
         let origin_location = pallet_xcm::EnsureXcm::<Everything>::try_origin(o.clone())?;
         if !a.starts_with(&origin_location) {
-            return Err(o)
+            return Err(o);
         }
         SovereignAccountOf::convert_location(&origin_location).ok_or(o)
     }
@@ -259,7 +259,6 @@ impl cumulus_pallet_parachain_system::Config for Test {
 }
 
 use frame_support::traits::TransformOrigin;
-use pallet_ismp::host::Host;
 use parachains_common::message_queue::ParaIdToSibling;
 use polkadot_runtime_common::xcm_sender::NoPriceForMessageDelivery;
 
@@ -340,8 +339,8 @@ impl pallet_asset_gateway::Config for Test {
     type PalletId = AssetPalletId;
     type ProtocolAccount = ProtocolAccount;
     type Params = TransferParams;
-    type Dispatcher = Host<Test>;
     type Assets = Assets;
+    type Host = Ismp;
 }
 
 impl pallet_assets::Config for Test {

--- a/modules/ismp/pallets/testsuite/src/xcm.rs
+++ b/modules/ismp/pallets/testsuite/src/xcm.rs
@@ -340,7 +340,7 @@ impl pallet_asset_gateway::Config for Test {
     type ProtocolAccount = ProtocolAccount;
     type Params = TransferParams;
     type Assets = Assets;
-    type Host = Ismp;
+    type IsmpHost = Ismp;
 }
 
 impl pallet_assets::Config for Test {

--- a/modules/ismp/state-machines/substrate/src/lib.rs
+++ b/modules/ismp/state-machines/substrate/src/lib.rs
@@ -33,7 +33,6 @@ use ismp::{
 };
 use pallet_ismp::{
     child_trie::{RequestCommitments, RequestReceipts, ResponseCommitments, ResponseReceipts},
-    host::Host,
     ISMP_ID,
 };
 use primitive_types::H256;
@@ -132,14 +131,14 @@ where
             RequestResponse::Request(requests) => requests
                 .into_iter()
                 .map(|request| {
-                    let commitment = hash_request::<Host<T>>(&request);
+                    let commitment = hash_request::<pallet_ismp::Pallet<T>>(&request);
                     RequestCommitments::<T>::storage_key(commitment)
                 })
                 .collect::<Vec<Vec<u8>>>(),
             RequestResponse::Response(responses) => responses
                 .into_iter()
                 .map(|response| {
-                    let commitment = hash_response::<Host<T>>(&response);
+                    let commitment = hash_response::<pallet_ismp::Pallet<T>>(&response);
                     ResponseCommitments::<T>::storage_key(commitment)
                 })
                 .collect::<Vec<Vec<u8>>>(),
@@ -193,7 +192,7 @@ where
                     match req {
                         Request::Post(post) => {
                             let request = Request::Post(post);
-                            let commitment = hash_request::<Host<T>>(&request);
+                            let commitment = hash_request::<pallet_ismp::Pallet<T>>(&request);
                             keys.push(RequestReceipts::<T>::storage_key(commitment));
                         },
                         Request::Get(_) => continue,
@@ -203,7 +202,8 @@ where
                 for res in responses {
                     match res {
                         Response::Post(post_response) => {
-                            let commitment = hash_post_response::<Host<T>>(&post_response);
+                            let commitment =
+                                hash_post_response::<pallet_ismp::Pallet<T>>(&post_response);
                             keys.push(ResponseReceipts::<T>::storage_key(commitment));
                         },
                         Response::Get(_) => continue,

--- a/parachain/runtimes/gargantua/src/ismp.rs
+++ b/parachain/runtimes/gargantua/src/ismp.rs
@@ -57,7 +57,7 @@ impl Get<StateMachine> for HostStateMachine {
 
 impl ismp_sync_committee::pallet::Config for Runtime {
     type AdminOrigin = EnsureRoot<AccountId>;
-    type Host = Ismp;
+    type IsmpHost = Ismp;
 }
 
 pub struct Coprocessor;
@@ -98,12 +98,12 @@ impl pallet_ismp_demo::Config for Runtime {
 
 impl pallet_ismp_relayer::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
-    type Host = Ismp;
+    type IsmpHost = Ismp;
 }
 
 impl pallet_ismp_host_executive::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
-    type Host = Ismp;
+    type IsmpHost = Ismp;
 }
 
 impl pallet_call_decompressor::Config for Runtime {
@@ -112,7 +112,7 @@ impl pallet_call_decompressor::Config for Runtime {
 
 impl ismp_parachain::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
-    type Host = Ismp;
+    type IsmpHost = Ismp;
 }
 
 // todo: set corrrect parameters
@@ -128,7 +128,7 @@ impl pallet_asset_gateway::Config for Runtime {
     type ProtocolAccount = ProtocolAccount;
     type Params = TransferParams;
     type Assets = Assets;
-    type Host = Ismp;
+    type IsmpHost = Ismp;
 }
 
 #[cfg(feature = "runtime-benchmarks")]

--- a/parachain/runtimes/messier/src/ismp.rs
+++ b/parachain/runtimes/messier/src/ismp.rs
@@ -56,7 +56,7 @@ impl Get<StateMachine> for HostStateMachine {
 
 impl ismp_sync_committee::pallet::Config for Runtime {
     type AdminOrigin = EnsureRoot<AccountId>;
-    type Host = Ismp;
+    type IsmpHost = Ismp;
 }
 
 pub struct Coprocessor;
@@ -86,17 +86,17 @@ impl pallet_ismp::Config for Runtime {
 
 impl pallet_ismp_relayer::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
-    type Host = Ismp;
+    type IsmpHost = Ismp;
 }
 
 impl pallet_ismp_host_executive::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
-    type Host = Ismp;
+    type IsmpHost = Ismp;
 }
 
 impl ismp_parachain::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
-    type Host = Ismp;
+    type IsmpHost = Ismp;
 }
 
 impl pallet_call_decompressor::Config for Runtime {
@@ -115,7 +115,7 @@ impl pallet_asset_gateway::Config for Runtime {
     type PalletId = AssetPalletId;
     type ProtocolAccount = ProtocolAccount;
     type Params = TransferParams;
-    type Host = Ismp;
+    type IsmpHost = Ismp;
     type Assets = Assets;
 }
 

--- a/parachain/runtimes/messier/src/ismp.rs
+++ b/parachain/runtimes/messier/src/ismp.rs
@@ -39,7 +39,7 @@ use sp_runtime::Percent;
 
 use ismp::router::Timeout;
 use ismp_sync_committee::constants::mainnet::Mainnet;
-use pallet_ismp::{dispatcher::FeeMetadata, host::Host, ModuleId};
+use pallet_ismp::{dispatcher::FeeMetadata, ModuleId};
 use sp_std::prelude::*;
 use staging_xcm::latest::MultiLocation;
 
@@ -56,6 +56,7 @@ impl Get<StateMachine> for HostStateMachine {
 
 impl ismp_sync_committee::pallet::Config for Runtime {
     type AdminOrigin = EnsureRoot<AccountId>;
+    type Host = Ismp;
 }
 
 pub struct Coprocessor;
@@ -76,8 +77,8 @@ impl pallet_ismp::Config for Runtime {
     type Currency = Balances;
     type Coprocessor = Coprocessor;
     type ConsensusClients = (
-        ismp_bsc::BscClient<Host<Runtime>>,
-        ismp_sync_committee::SyncCommitteeConsensusClient<Host<Runtime>, Mainnet>,
+        ismp_bsc::BscClient<Ismp>,
+        ismp_sync_committee::SyncCommitteeConsensusClient<Ismp, Mainnet>,
     );
     type Mmr = Mmr;
     type WeightProvider = ();
@@ -85,15 +86,17 @@ impl pallet_ismp::Config for Runtime {
 
 impl pallet_ismp_relayer::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
+    type Host = Ismp;
 }
 
 impl pallet_ismp_host_executive::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
-    type Dispatcher = Host<Runtime>;
+    type Host = Ismp;
 }
 
 impl ismp_parachain::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
+    type Host = Ismp;
 }
 
 impl pallet_call_decompressor::Config for Runtime {
@@ -112,7 +115,7 @@ impl pallet_asset_gateway::Config for Runtime {
     type PalletId = AssetPalletId;
     type ProtocolAccount = ProtocolAccount;
     type Params = TransferParams;
-    type Dispatcher = Host<Runtime>;
+    type Host = Ismp;
     type Assets = Assets;
 }
 
@@ -162,7 +165,7 @@ impl IsmpModule for ProxyModule {
         if request.dest != HostStateMachine::get() {
             let meta = FeeMetadata::<Runtime> { payer: [0u8; 32].into(), fee: Default::default() };
             Ismp::dispatch_request(Request::Post(request), meta)?;
-            return Ok(())
+            return Ok(());
         }
 
         let pallet_id =
@@ -181,7 +184,7 @@ impl IsmpModule for ProxyModule {
         if response.dest_chain() != HostStateMachine::get() {
             let meta = FeeMetadata::<Runtime> { payer: [0u8; 32].into(), fee: Default::default() };
             Ismp::dispatch_response(response, meta)?;
-            return Ok(())
+            return Ok(());
         }
 
         let request = &response.request();

--- a/parachain/runtimes/nexus/src/ismp.rs
+++ b/parachain/runtimes/nexus/src/ismp.rs
@@ -56,7 +56,7 @@ impl Get<StateMachine> for HostStateMachine {
 
 impl ismp_sync_committee::pallet::Config for Runtime {
     type AdminOrigin = EnsureRoot<AccountId>;
-    type Host = Ismp;
+    type IsmpHost = Ismp;
 }
 
 pub struct Coprocessor;
@@ -87,12 +87,12 @@ impl pallet_ismp::Config for Runtime {
 
 impl pallet_ismp_relayer::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
-    type Host = Ismp;
+    type IsmpHost = Ismp;
 }
 
 impl pallet_ismp_host_executive::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
-    type Host = Ismp;
+    type IsmpHost = Ismp;
 }
 
 impl pallet_call_decompressor::Config for Runtime {
@@ -101,7 +101,7 @@ impl pallet_call_decompressor::Config for Runtime {
 
 impl ismp_parachain::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
-    type Host = Ismp;
+    type IsmpHost = Ismp;
 }
 
 // todo: set corrrect parameters
@@ -116,7 +116,7 @@ impl pallet_asset_gateway::Config for Runtime {
     type PalletId = AssetPalletId;
     type ProtocolAccount = ProtocolAccount;
     type Params = TransferParams;
-    type Host = Ismp;
+    type IsmpHost = Ismp;
     type Assets = Assets;
 }
 

--- a/parachain/runtimes/nexus/src/ismp.rs
+++ b/parachain/runtimes/nexus/src/ismp.rs
@@ -39,7 +39,7 @@ use sp_runtime::Percent;
 
 use ismp::router::Timeout;
 use ismp_sync_committee::constants::mainnet::Mainnet;
-use pallet_ismp::{dispatcher::FeeMetadata, host::Host, ModuleId};
+use pallet_ismp::{dispatcher::FeeMetadata, ModuleId};
 use sp_std::prelude::*;
 use staging_xcm::latest::MultiLocation;
 
@@ -56,6 +56,7 @@ impl Get<StateMachine> for HostStateMachine {
 
 impl ismp_sync_committee::pallet::Config for Runtime {
     type AdminOrigin = EnsureRoot<AccountId>;
+    type Host = Ismp;
 }
 
 pub struct Coprocessor;
@@ -76,8 +77,8 @@ impl pallet_ismp::Config for Runtime {
     type Currency = Balances;
     type Coprocessor = Coprocessor;
     type ConsensusClients = (
-        ismp_bsc::BscClient<Host<Runtime>>,
-        ismp_sync_committee::SyncCommitteeConsensusClient<Host<Runtime>, Mainnet>,
+        ismp_bsc::BscClient<Ismp>,
+        ismp_sync_committee::SyncCommitteeConsensusClient<Ismp, Mainnet>,
     );
 
     type Mmr = Mmr;
@@ -86,11 +87,12 @@ impl pallet_ismp::Config for Runtime {
 
 impl pallet_ismp_relayer::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
+    type Host = Ismp;
 }
 
 impl pallet_ismp_host_executive::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
-    type Dispatcher = Host<Runtime>;
+    type Host = Ismp;
 }
 
 impl pallet_call_decompressor::Config for Runtime {
@@ -99,6 +101,7 @@ impl pallet_call_decompressor::Config for Runtime {
 
 impl ismp_parachain::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
+    type Host = Ismp;
 }
 
 // todo: set corrrect parameters
@@ -113,7 +116,7 @@ impl pallet_asset_gateway::Config for Runtime {
     type PalletId = AssetPalletId;
     type ProtocolAccount = ProtocolAccount;
     type Params = TransferParams;
-    type Dispatcher = Host<Runtime>;
+    type Host = Ismp;
     type Assets = Assets;
 }
 
@@ -163,7 +166,7 @@ impl IsmpModule for ProxyModule {
         if request.dest != HostStateMachine::get() {
             let meta = FeeMetadata::<Runtime> { payer: [0u8; 32].into(), fee: Default::default() };
             Ismp::dispatch_request(Request::Post(request), meta)?;
-            return Ok(())
+            return Ok(());
         }
 
         let pallet_id =
@@ -182,7 +185,7 @@ impl IsmpModule for ProxyModule {
         if response.dest_chain() != HostStateMachine::get() {
             let meta = FeeMetadata::<Runtime> { payer: [0u8; 32].into(), fee: Default::default() };
             Ismp::dispatch_response(response, meta)?;
-            return Ok(())
+            return Ok(());
         }
 
         let request = &response.request();


### PR DESCRIPTION
Rather than needing a new type `IsmpHost` and `IsmpDispatcher` are now implemented directly on the `Pallet<T>` itself