### PR TITLE
Use ContractScan for multichain deployment links

### DIFF
--- a/docs/pages/evm/integration.mdx
+++ b/docs/pages/evm/integration.mdx
@@ -19,10 +19,10 @@
 |Base Sepolia        | [`0x0B26ba93424A7d00153abEb6388C55F960529E89`](https://sepolia.basescan.org/address/0x0B26ba93424A7d00153abEb6388C55F960529E89)  | [`0x1D14e30e440B8DBA9765108eC291B7b66F98Fd09`](https://sepolia.basescan.org/address/0x1D14e30e440B8DBA9765108eC291B7b66F98Fd09) |
 |Bsc Testnet         | [`0x3aBA86C71C86353e5a96E98e1E08411063B5e2DB`](https://testnet.bscscan.com/address/0x3aBA86C71C86353e5a96E98e1E08411063B5e2DB)  | [`0x4e5bbdd9fE89F54157DDb64b21eD4D1CA1CDf9a6`](https://testnet.bscscan.com/address/0x4e5bbdd9fE89F54157DDb64b21eD4D1CA1CDf9a6) |
 
-PingModule: [`0xd4812d6A3b9fB46feA314260Cbb61D57EBc71D7F`](https://blockscan.com/address/0xd4812d6A3b9fB46feA314260Cbb61D57EBc71D7F)
+PingModule: [`0xd4812d6A3b9fB46feA314260Cbb61D57EBc71D7F`](https://contractscan.xyz/contract/0xd4812d6A3b9fB46feA314260Cbb61D57EBc71D7F)
 
-TokenGateway: [`0x1e03401CD8698b8500F35840d07Bcddc98da7CE1`](https://blockscan.com/address/0x1e03401CD8698b8500F35840d07Bcddc98da7CE1)
+TokenGateway: [`0x1e03401CD8698b8500F35840d07Bcddc98da7CE1`](https://contractscan.xyz/contract/0x1e03401CD8698b8500F35840d07Bcddc98da7CE1)
 
-TokenFaucet: [`0xcf57F890f578f1d517aC15e715cdEB0AFAaEea04`](https://blockscan.com/address/0xcf57F890f578f1d517aC15e715cdEB0AFAaEea04)
+TokenFaucet: [`0xcf57F890f578f1d517aC15e715cdEB0AFAaEea04`](https://contractscan.xyz/contract/0xcf57F890f578f1d517aC15e715cdEB0AFAaEea04)
 
-HyperUSD (FeeToken): [`0x6df8dE86458D15a3Be3A6B907e6aE6B7af352452`](https://blockscan.com/address/0x6df8dE86458D15a3Be3A6B907e6aE6B7af352452)
+HyperUSD (FeeToken): [`0x6df8dE86458D15a3Be3A6B907e6aE6B7af352452`](https://contractscan.xyz/contract/0x6df8dE86458D15a3Be3A6B907e6aE6B7af352452)


### PR DESCRIPTION
Replaces Blockscan with ContractScan. The latter only highlights the networks where the code is actually deployed (vs those that have no code but some state e.g. balance), supports over 100 networks (vs 50ish), and is open-source.

> Disclaimer: author of ContractScan
