### PR TITLE
Store requests and responses offchain when `NoOpMmrTree` is used

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8941,7 +8941,7 @@ dependencies = [
 
 [[package]]
 name = "mmr-primitives"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "ckb-merkle-mountain-range",
  "frame-system",
@@ -10713,7 +10713,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ismp"
-version = "1.6.1"
+version = "1.6.2"
 dependencies = [
  "env_logger 0.10.2",
  "fortuples",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8945,10 +8945,12 @@ version = "1.6.1"
 dependencies = [
  "ckb-merkle-mountain-range",
  "frame-system",
+ "ismp",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "sp-core 28.0.0",
+ "sp-io 30.0.0",
  "sp-mmr-primitives",
  "sp-runtime 31.0.1",
  "sp-std 14.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -255,7 +255,7 @@ substrate-state-machine = { version = "1.6.1", path = "modules/ismp/state-machin
 hyperbridge-client-machine = { path = "modules/ismp/state-machines/hyperbridge", default-features = false }
 
 # pallets
-pallet-ismp = { version = "1.6.1", path = "modules/ismp/pallets/pallet", default-features = false }
+pallet-ismp = { version = "1.6.2", path = "modules/ismp/pallets/pallet", default-features = false }
 pallet-ismp-rpc = { version = "1.6.1", path = "modules/ismp/pallets/rpc" }
 pallet-ismp-runtime-api = { version = "1.6.1", path = "modules/ismp/pallets/runtime-api", default-features = false }
 pallet-hyperbridge = { path = "modules/ismp/pallets/hyperbridge", default-features = false }
@@ -271,7 +271,7 @@ pallet-mmr = { path = "modules/trees/mmr/pallet", default-features = false }
 pallet-mmr-runtime-api = { path = "modules/trees/mmr/pallet/runtime-api", default-features = false }
 mmr-gadget = { path = "modules/trees/mmr/gadget" }
 ethereum-trie = { path = "./modules/trees/ethereum", default-features = false }
-mmr-primitives = { version = "1.6.1", path = "modules/trees/mmr/primitives", default-features = false }
+mmr-primitives = { version = "1.6.2", path = "modules/trees/mmr/primitives", default-features = false }
 
 # runtimes
 gargantua-runtime = { path = "./parachain/runtimes/gargantua", default-features = false }

--- a/modules/ismp/pallets/pallet/Cargo.toml
+++ b/modules/ismp/pallets/pallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-ismp"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2021"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 license = "Apache-2.0"

--- a/modules/ismp/pallets/pallet/src/lib.rs
+++ b/modules/ismp/pallets/pallet/src/lib.rs
@@ -120,7 +120,7 @@
 //!     );
 //!     // Optional merkle mountain range overlay tree, for cheaper outgoing request proofs.
 //!     // You most likely don't need it, just use the `NoOpMmrTree`
-//!     type Mmr = NoOpMmrTree;
+//!     type Mmr = NoOpMmrTree<Runtime>;
 //!     // Weight provider for local modules
 //!     type WeightProvider = ();
 //! }
@@ -194,8 +194,10 @@ pub use pallet::*;
 /// implementation does not panic for any runtime called methods, eg `push` or `finalize`
 /// It will always return the default values for those methods.
 ///
+/// Additionally this implementation stores the requests and responses directly inside the offchain
+/// db using the commitment as the offchain key
 /// *NOTE* it will return an error if you try to generate proofs.
-pub type NoOpMmrTree = NoOpTree<Leaf>;
+pub type NoOpMmrTree<T> = NoOpTree<Leaf, Pallet<T>>;
 
 // Definition of the pallet logic, to be aggregated at runtime definition through
 // `construct_runtime`.

--- a/modules/trees/mmr/primitives/Cargo.toml
+++ b/modules/trees/mmr/primitives/Cargo.toml
@@ -22,6 +22,8 @@ sp-mmr-primitives = { workspace = true }
 serde = { version = "1.0.136", features = ["derive"], default-features = false }
 scale-info = { workspace = true }
 frame-system = { workspace = true }
+ismp = { workspace = true }
+sp-io = { workspace = true }
 
 [features]
 default = ["std"]
@@ -34,5 +36,7 @@ std = [
     "scale-info/std",
     "sp-mmr-primitives/std",
     "merkle-mountain-range/std",
-    "frame-system/std"
+    "frame-system/std",
+    "ismp/std",
+    "sp-io/std"
 ]

--- a/modules/trees/mmr/primitives/Cargo.toml
+++ b/modules/trees/mmr/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mmr-primitives"
-version = "1.6.1"
+version = "1.6.2"
 edition = "2021"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 license = "Apache-2.0"

--- a/tesseract/primitives/src/lib.rs
+++ b/tesseract/primitives/src/lib.rs
@@ -344,7 +344,7 @@ pub trait IsmpHost: ByzantineHandler + Send + Sync {
 	/// they like. This method should never return unless it encounters an unrecoverable error, in
 	/// which case the consensus relayer will be shut down.
 	async fn start_consensus(
-		&self,
+		&mut self,
 		counterparty: Arc<dyn IsmpProvider>,
 	) -> Result<(), anyhow::Error>;
 

--- a/tesseract/primitives/src/mocks.rs
+++ b/tesseract/primitives/src/mocks.rs
@@ -67,7 +67,7 @@ impl<C: Codec + Send + Sync> ByzantineHandler for MockHost<C> {
 
 #[async_trait::async_trait]
 impl<C: Codec + Send + Sync> IsmpHost for MockHost<C> {
-	async fn start_consensus(&self, _counterparty: Arc<dyn IsmpProvider>) -> Result<(), Error> {
+	async fn start_consensus(&mut self, _counterparty: Arc<dyn IsmpProvider>) -> Result<(), Error> {
 		Ok(())
 	}
 


### PR DESCRIPTION
Requests and responses are not stored offchain when `NoOpMmrTree` is used, this makes the request and response data inaccessible through the rpc.
This PR fixes that by storing requests and responses in the offchain DB when `NoOpMmrTree` is used in place of the mmr pallet.

NOTE: `offchain_indexing` must be enabled for the substrate node client so relayers can access the requests and responses from the rpc server.