### PR TITLE
Make the number of concurrent rpc queries configurable for substrate provider

### DIFF
--- a/tesseract/substrate/src/lib.rs
+++ b/tesseract/substrate/src/lib.rs
@@ -59,6 +59,8 @@ pub struct SubstrateConfig {
 	pub signer: Option<String>,
 	/// Latest state machine height
 	pub latest_height: Option<u64>,
+	/// Max concurrent rpc requests allowed
+	pub max_concurent_queries: Option<u64>,
 }
 
 /// Core substrate client.
@@ -77,6 +79,8 @@ pub struct SubstrateClient<C: subxt::Config> {
 	pub address: Vec<u8>,
 	/// Latest state machine height.
 	initial_height: u64,
+	/// Max concurrent rpc requests allowed
+	max_concurent_queries: Option<u64>,
 }
 
 impl<C> SubstrateClient<C>
@@ -122,6 +126,7 @@ where
 			signer,
 			address,
 			initial_height: latest_height,
+			max_concurent_queries: config.max_concurent_queries,
 		})
 	}
 
@@ -170,6 +175,7 @@ impl<C: subxt::Config> Clone for SubstrateClient<C> {
 			signer: self.signer.clone(),
 			address: self.address.clone(),
 			initial_height: self.initial_height,
+			max_concurent_queries: self.max_concurent_queries,
 		}
 	}
 }

--- a/tesseract/substrate/src/provider.rs
+++ b/tesseract/substrate/src/provider.rs
@@ -584,7 +584,7 @@ where
 	}
 
 	fn max_concurrent_queries(&self) -> usize {
-		50
+		self.max_concurent_queries.unwrap_or(10) as usize
 	}
 }
 


### PR DESCRIPTION
Previously we hardcoded a value for the number of maximum number of concurrent queries, this PR makes it configurable and uses a much smaller the default value