### PR TITLE
Removed the folder "target" from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-target
 .github
 .cargo
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 target
 !target/release/tesseract
 !target/release/telemetry-server
+!target/release/hyperbridge
 
 .github
 .cargo

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,8 @@
+# Exclude the executable files to be copied into the image
+target
+!target/release/tesseract
+!target/release/telemetry-server
+
 .github
 .cargo
 


### PR DESCRIPTION
local docker build for tesseract failing as we got the "target" folder in .dockerignore while the executable placed in there

Ref from tesseract.Dockerfile
`COPY ./target/release/tesseract ./`