### PR TITLE
Debug_trace transactions on Evm without `gas_price`

### DIFF
--- a/tesseract/evm/src/provider.rs
+++ b/tesseract/evm/src/provider.rs
@@ -357,7 +357,7 @@ impl IsmpProvider for EvmClient {
 			..GethDebugTracingCallOptions::default()
 		};
 
-		let calls = generate_contract_calls(self, messages).await?;
+		let calls = generate_contract_calls(self, messages, true).await?;
 		let gas_breakdown = get_current_gas_cost_in_usd(
 			self.chain_id,
 			self.state_machine,

--- a/tesseract/evm/src/tx.rs
+++ b/tesseract/evm/src/tx.rs
@@ -217,15 +217,19 @@ pub async fn generate_contract_calls(
 	let contract = IsmpHandler::new(client.config.handler, client.signer.clone());
 	let ismp_host = client.config.ismp_host;
 	let mut calls = Vec::new();
-	let gas_price = get_current_gas_cost_in_usd(
-		client.chain_id,
-		client.state_machine,
-		&client.config.etherscan_api_key.clone(),
-		client.client.clone(),
-		client.config.gas_price_buffer,
-	)
-	.await?
-	.gas_price;
+	let gas_price = if !debug_trace {
+		get_current_gas_cost_in_usd(
+			client.chain_id,
+			client.state_machine,
+			&client.config.etherscan_api_key.clone(),
+			client.client.clone(),
+			client.config.gas_price_buffer,
+		)
+		.await?
+		.gas_price
+	} else {
+		Default::default()
+	};
 
 	for message in messages {
 		match message {

--- a/tesseract/evm/src/tx.rs
+++ b/tesseract/evm/src/tx.rs
@@ -45,7 +45,7 @@ pub async fn submit_messages(
 	client: &EvmClient,
 	messages: Vec<Message>,
 ) -> anyhow::Result<BTreeSet<H256>> {
-	let calls = generate_contract_calls(client, messages.clone()).await?;
+	let calls = generate_contract_calls(client, messages.clone(), false).await?;
 	let mut events = BTreeSet::new();
 	for (index, call) in calls.into_iter().enumerate() {
 		let gas_price = call.tx.gas_price();
@@ -208,9 +208,11 @@ where
 }
 
 /// Function generates FunctionCall(s) from a batchs of messages
+/// If `debug_trace` is true then the gas_price will not be set on the generated call
 pub async fn generate_contract_calls(
 	client: &EvmClient,
 	messages: Vec<Message>,
+	debug_trace: bool,
 ) -> anyhow::Result<Vec<SolidityFunctionCall>> {
 	let contract = IsmpHandler::new(client.config.handler, client.signer.clone());
 	let ismp_host = client.config.ismp_host;
@@ -281,12 +283,15 @@ pub async fn generate_contract_calls(
 					requests: leaves,
 				};
 
-				let call = contract
-					.handle_post_requests(ismp_host, post_message)
-					.gas_price(gas_price)
-					.gas(gas_limit);
-
-				calls.push(call);
+				let call = if !debug_trace {
+					contract
+						.handle_post_requests(ismp_host, post_message)
+						.gas_price(gas_price)
+						.gas(gas_limit)
+				} else {
+					contract.handle_post_requests(ismp_host, post_message).gas(gas_limit)
+				};
+				calls.push(call)
 			},
 			Message::Response(ResponseMessage { datagram, proof, .. }) => {
 				let membership_proof = MmrProof::<H256>::decode(&mut proof.proof.as_slice())?;
@@ -342,10 +347,14 @@ pub async fn generate_contract_calls(
 								responses: leaves,
 							};
 
-						contract
-							.handle_post_responses(ismp_host, message)
-							.gas_price(gas_price)
-							.gas(gas_limit)
+						if !debug_trace {
+							contract
+								.handle_post_responses(ismp_host, message)
+								.gas_price(gas_price)
+								.gas(gas_limit)
+						} else {
+							contract.handle_post_responses(ismp_host, message).gas(gas_limit)
+						}
 					},
 					RequestResponse::Request(..) =>
 						Err(anyhow!("Get requests are not supported by relayer"))?,


### PR DESCRIPTION
This PR ensures the gas_price is not set on the evm transactions when debug tracing.