### PR TITLE
Try delivering failed messages at intervals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20402,7 +20402,7 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "tesseract"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/docs/pages/developers/network/relayer.mdx
+++ b/docs/pages/developers/network/relayer.mdx
@@ -171,6 +171,9 @@ module_filter = []
 withdrawal_frequency = 86400
 # Minimum amount to withdraw when auto-withdrawing, defaults to $100
 minimum_withdrawal_amount = 100
+# (Optional) How frequently to retry unprofitable or failed messages in seconds.
+# If this is value not supplied retries will not be enabled.
+unprofitable_retry_frequency = 600
 # (Optional) If not empty, tesseract will only deliver requests to the specified state-machines
 delivery_endpoints = [
     { Ethereum = "ExecutionLayer" },

--- a/tesseract/evm/src/provider.rs
+++ b/tesseract/evm/src/provider.rs
@@ -308,10 +308,16 @@ impl IsmpProvider for EvmClient {
 		Ok(events)
 	}
 
-	async fn query_request_receipt(&self, hash: H256) -> Result<H160, anyhow::Error> {
+	async fn query_request_receipt(&self, hash: H256) -> Result<Vec<u8>, anyhow::Error> {
 		let host_contract = EvmHost::new(self.config.ismp_host, self.signer.clone());
 		let address = host_contract.request_receipts(hash.into()).call().await?;
-		Ok(address)
+		Ok(address.0.to_vec())
+	}
+
+	async fn query_response_receipt(&self, hash: H256) -> Result<Vec<u8>, anyhow::Error> {
+		let host_contract = EvmHost::new(self.config.ismp_host, self.signer.clone());
+		let address = host_contract.response_receipts(hash.into()).call().await?.relayer;
+		Ok(address.0.to_vec())
 	}
 
 	fn name(&self) -> String {
@@ -777,9 +783,9 @@ pub fn check_trace_for_event(call_frame: CallFrame, event_in: CheckTraceForEvent
 				},
 			};
 		}
+	} else {
+		log::error!("Debug trace frame not found!");
 	}
-
-	log::error!("Debug trace frame not found!");
 
 	false
 }

--- a/tesseract/messaging/src/lib.rs
+++ b/tesseract/messaging/src/lib.rs
@@ -125,33 +125,35 @@ where
 		);
 	}
 
-	// Spawn retries for unprofitable messages
 	{
-		let hyperbridge = Arc::new(chain_a.clone());
-		let dest = chain_b.clone();
-		let client_map = client_map.clone();
-		let tx_payment = tx_payment.clone();
-		let config = config.clone();
-		let sender = sender.clone();
-		let name = format!("retries-{}-{}", dest.name(), hyperbridge.name());
-		task_manager.spawn_essential_handle().spawn_blocking(
-			Box::leak(Box::new(name.clone())),
-			"messaging",
-			async move {
-				let res = retry_unprofitable_messages(
-					dest,
-					hyperbridge,
-					client_map,
-					tx_payment,
-					config,
-					coprocessor,
-					sender,
-				)
-				.await;
-				tracing::error!("{name} terminated with result {res:?}");
-			}
-			.boxed(),
-		);
+		// Spawn retries for unprofitable messages
+		if config.unprofitable_retry_frequency.is_some() {
+			let hyperbridge = Arc::new(chain_a.clone());
+			let dest = chain_b.clone();
+			let client_map = client_map.clone();
+			let tx_payment = tx_payment.clone();
+			let config = config.clone();
+			let sender = sender.clone();
+			let name = format!("retries-{}-{}", dest.name(), hyperbridge.name());
+			task_manager.spawn_essential_handle().spawn_blocking(
+				Box::leak(Box::new(name.clone())),
+				"messaging",
+				async move {
+					let res = retry_unprofitable_messages(
+						dest,
+						hyperbridge,
+						client_map,
+						tx_payment,
+						config,
+						coprocessor,
+						sender,
+					)
+					.await;
+					tracing::error!("{name} terminated with result {res:?}");
+				}
+				.boxed(),
+			);
+		}
 	}
 
 	Ok(())

--- a/tesseract/primitives/src/config.rs
+++ b/tesseract/primitives/src/config.rs
@@ -29,7 +29,8 @@ pub struct RelayerConfig {
 	pub withdrawal_frequency: Option<u64>,
 	/// Minimum amount to withdraw when auto-withdrawing
 	pub minimum_withdrawal_amount: Option<u64>,
-	/// How frequently to retry unprofitable messages in seconds.
+	/// How frequently to retry unprofitable or failed messages in seconds.
+	/// If this is value not supplied retries will not be enabled
 	pub unprofitable_retry_frequency: Option<u64>,
 	/// Delivery endpoints: chains you intend to deliver messages to
 	pub delivery_endpoints: Vec<StateMachine>,

--- a/tesseract/primitives/src/lib.rs
+++ b/tesseract/primitives/src/lib.rs
@@ -32,7 +32,7 @@ use pallet_ismp_host_executive::HostParam;
 use pallet_ismp_relayer::withdrawal::Key;
 pub use pallet_ismp_relayer::withdrawal::{Signature, WithdrawalProof};
 use parity_scale_codec::{Decode, Encode};
-use primitive_types::{H160, H256, U256};
+use primitive_types::{H256, U256};
 use sp_core::keccak_256;
 use std::{
 	fmt::{Debug, Display, Formatter},
@@ -254,7 +254,11 @@ pub trait IsmpProvider: Send + Sync {
 
 	/// Should return the relayer delivered this request
 	/// if it has been delivered
-	async fn query_request_receipt(&self, _hash: H256) -> Result<H160, anyhow::Error>;
+	async fn query_request_receipt(&self, _hash: H256) -> Result<Vec<u8>, anyhow::Error>;
+
+	/// Should return the relayer delivered this response
+	/// if it has been delivered
+	async fn query_response_receipt(&self, _hash: H256) -> Result<Vec<u8>, anyhow::Error>;
 
 	/// Should return fee relayer would be recieving to relay a responce mesage giving a hash
 	/// (message commiment)

--- a/tesseract/primitives/src/mocks.rs
+++ b/tesseract/primitives/src/mocks.rs
@@ -13,7 +13,6 @@ use pallet_ismp_host_executive::HostParam;
 use pallet_ismp_relayer::withdrawal::{Key, WithdrawalProof};
 use parity_scale_codec::Codec;
 use primitive_types::{H256, U256};
-use sp_core::H160;
 use std::{
 	sync::{Arc, Mutex},
 	time::Duration,
@@ -235,7 +234,11 @@ impl<C: Codec + Send + Sync> IsmpProvider for MockHost<C> {
 		todo!()
 	}
 
-	async fn query_request_receipt(&self, _hash: H256) -> Result<H160, anyhow::Error> {
+	async fn query_request_receipt(&self, _hash: H256) -> Result<Vec<u8>, anyhow::Error> {
+		todo!()
+	}
+
+	async fn query_response_receipt(&self, _hash: H256) -> Result<Vec<u8>, anyhow::Error> {
 		todo!()
 	}
 }

--- a/tesseract/relayer/Cargo.toml
+++ b/tesseract/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tesseract"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 description = "Chain agnostic relayer implementation for Hyperbridge"
 authors = ["Polytope Labs <hello@polytope.technology>"]

--- a/tesseract/relayer/src/fees.rs
+++ b/tesseract/relayer/src/fees.rs
@@ -590,7 +590,7 @@ mod tests {
 						.query_request_receipt(commitment)
 						.await?;
 
-					if relayer != H160::default() {
+					if relayer != H160::default().0.to_vec() {
 						tracing::info!(
 							"Skipping already delivered withdraw event: {:?}",
 							withdraw_event.event

--- a/tesseract/substrate/src/provider.rs
+++ b/tesseract/substrate/src/provider.rs
@@ -329,7 +329,7 @@ where
 		Ok(leaf_meta.meta.fee.into())
 	}
 
-	async fn query_request_receipt(&self, _hash: H256) -> Result<H160, anyhow::Error> {
+	async fn query_request_receipt(&self, _hash: H256) -> Result<Vec<u8>, anyhow::Error> {
 		let key = self.req_receipts_key(_hash);
 		let child_storage_key = ChildInfo::new_default(CHILD_TRIE_PREFIX).prefixed_storage_key();
 		let storage_key = StorageKey(key);
@@ -337,9 +337,28 @@ where
 
 		let response: Option<StorageData> =
 			self.client.rpc().request("childstate_getStorage", params).await?;
-		let data = response.ok_or_else(|| anyhow!("Request fee metadata query returned None"))?;
-		let relayer = Vec::<u8>::decode(&mut &*data.0)?;
-		Ok(H160::from_slice(&relayer[..20]))
+		if let Some(data) = response {
+			let relayer = Vec::<u8>::decode(&mut &*data.0)?;
+			Ok(relayer)
+		} else {
+			Ok(H160::zero().0.to_vec())
+		}
+	}
+
+	async fn query_response_receipt(&self, _hash: H256) -> Result<Vec<u8>, anyhow::Error> {
+		let key = self.res_receipt_key(_hash);
+		let child_storage_key = ChildInfo::new_default(CHILD_TRIE_PREFIX).prefixed_storage_key();
+		let storage_key = StorageKey(key);
+		let params = rpc_params![child_storage_key, storage_key, Option::<C::Hash>::None];
+
+		let response: Option<StorageData> =
+			self.client.rpc().request("childstate_getStorage", params).await?;
+		if let Some(data) = response {
+			let relayer = pallet_ismp::ResponseReceipt::decode(&mut &*data.0)?.relayer;
+			Ok(relayer)
+		} else {
+			Ok(H160::zero().0.to_vec())
+		}
 	}
 
 	async fn query_response_fee_metadata(&self, _hash: H256) -> Result<U256, anyhow::Error> {


### PR DESCRIPTION
This PR implements retries for messages that failed the debug trace call due to errors other than being duplicate messages.
This messages will be retried in the background until their time out elapses.