### PR TITLE
Add request commitment to pallet-asset-gateway events

### DIFF
--- a/evm/src/modules/TokenGateway.sol
+++ b/evm/src/modules/TokenGateway.sol
@@ -193,7 +193,7 @@ contract TokenGateway is BaseIsmpModule {
 
     // User has received some assets
     event AssetReceived(
-        bytes32 commitment, address indexed from, address indexed beneficiary, uint256 amount, bytes32 indexed assetId
+        bytes32 commitment, bytes32 indexed from, address indexed beneficiary, uint256 amount, bytes32 indexed assetId
     );
 
     // User has sent some assets
@@ -532,7 +532,7 @@ contract TokenGateway is BaseIsmpModule {
         emit AssetReceived({
             commitment: commitment,
             beneficiary: bytes32ToAddress(body.to),
-            from: bytes32ToAddress(body.from),
+            from: body.from,
             amount: body.amount,
             assetId: body.assetId
         });
@@ -563,7 +563,7 @@ contract TokenGateway is BaseIsmpModule {
         emit AssetReceived({
             commitment: commitment,
             beneficiary: bytes32ToAddress(body.to),
-            from: bytes32ToAddress(body.from),
+            from: body.from,
             amount: body.amount,
             assetId: body.assetId
         });

--- a/modules/ismp/pallets/asset-gateway/src/lib.rs
+++ b/modules/ismp/pallets/asset-gateway/src/lib.rs
@@ -118,6 +118,8 @@ pub mod pallet {
 			amount: <T::Assets as fungibles::Inspect<T::AccountId>>::Balance,
 			/// Destination chain
 			dest: StateMachine,
+			/// Request commitment
+			commitment: H256,
 		},
 
 		/// An asset has been received and transferred to the beneficiary's account on the
@@ -253,7 +255,7 @@ where
 
 		let metadata =
 			FeeMetadata { payer: multi_account.substrate_account.clone(), fee: Default::default() };
-		dispatcher
+		let commitment = dispatcher
 			.dispatch_request(DispatchRequest::Post(dispatch_post), metadata)
 			.map_err(|_| Error::<T>::DispatchPostError)?;
 
@@ -262,6 +264,7 @@ where
 			to: multi_account.evm_account,
 			dest: multi_account.dest_state_machine,
 			amount,
+			commitment,
 		});
 
 		Ok(())

--- a/parachain/runtimes/gargantua/src/lib.rs
+++ b/parachain/runtimes/gargantua/src/lib.rs
@@ -214,7 +214,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("gargantua"),
 	impl_name: create_runtime_str!("gargantua"),
 	authoring_version: 1,
-	spec_version: 300,
+	spec_version: 310,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
The `AssetTeleported` event was missing the request commitment to simplify ease of tracking.