### PR TITLE
Fix truncated block hash in ismp_queryEvents*

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6803,7 +6803,7 @@ dependencies = [
 
 [[package]]
 name = "hyperclient"
-version = "0.3.23"
+version = "0.3.25"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -6825,6 +6825,7 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "serde",
+ "serde-utils",
  "serde-wasm-bindgen 0.6.5",
  "serde_json",
  "sp-core 28.0.0",

--- a/modules/hyperclient/Cargo.toml
+++ b/modules/hyperclient/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperclient"
-version = "0.3.23"
+version = "0.3.25"
 edition = "2021"
 description = "The hyperclient is a library for managing (in-flight) ISMP requests"
 repository = "https://github.com/polytope-labs/hyperbridge"
@@ -29,6 +29,7 @@ ethereum-triedb = { workspace = true }
 subxt-utils = { workspace = true }
 mmr-primitives = { workspace = true }
 sp-mmr-primitives = { workspace = true }
+serde-utils = { workspace = true }
 
 # crates.io
 getrandom = { version = "0.2", default-features = false, features = ["js"] }
@@ -60,6 +61,7 @@ std = [
     "subxt/jsonrpsee",
     "subxt-utils/std",
     "sp-core/std",
+    "serde-utils/std",
     "substrate-state-machine/std",
 ]
 testing = []

--- a/modules/hyperclient/build.sh
+++ b/modules/hyperclient/build.sh
@@ -6,12 +6,9 @@ pwd
 
 wasm-pack build -t bundler -d dist/bundler --release --no-default-features --features=wasm
 wasm-pack build -t nodejs -d dist/node --release --no-default-features --features=wasm
-wasm-pack build -t web -d dist/web --release --no-default-features --features=wasm
 
 rm dist/bundler/.gitignore dist/bundler/package.json dist/bundler/README.md dist/bundler/hyperclient.d.ts
 rm dist/node/.gitignore dist/node/package.json dist/node/README.md dist/node/hyperclient.d.ts
-rm dist/web/.gitignore dist/web/package.json dist/web/README.md dist/web/hyperclient.d.ts
 
 cp hyperclient.d.ts dist/bundler
 cp hyperclient.d.ts dist/node
-cp hyperclient.d.ts dist/web

--- a/modules/hyperclient/hyperclient.d.ts
+++ b/modules/hyperclient/hyperclient.d.ts
@@ -37,8 +37,6 @@ interface IChainConfig {
   state_machine: string;
   // contract address of the `IsmpHost` on this chain
   host_address: string;
-  // contract address of the `IHandler` on this chain
-  handler_address: string;
   // consensus state identifier of this chain on hyperbridge
   consensus_state_id: string;
 }
@@ -60,7 +58,7 @@ interface IPostRequest {
   // The nonce of this request on the source chain
   nonce: bigint;
   // Encoded request body.
-  data: string;
+  body: string;
   // Timestamp which this request expires in seconds.
   timeoutTimestamp: bigint;
   // Height at which this request was emitted on the source
@@ -71,7 +69,7 @@ interface IPostResponse {
   // The request that triggered this response.
   post: IPostRequest;
   // The response message.
-  response: Uint8Array;
+  response: string;
   // Timestamp at which this response expires in seconds.
   timeoutTimestamp: bigint;
 }
@@ -182,7 +180,7 @@ interface HyperbridgeFinalizedWithMetadata {
   // The block number where the event was emitted
   block_number: bigint;
   // The transaction calldata which can be used for self-relay
-  calldata: Uint8Array;
+  calldata: `0x{string}`;
 }
 
 // This event is emitted on hyperbridge
@@ -211,7 +209,7 @@ interface DestinationDeliveredWithMetadata {
 interface TimeoutMessage {
   kind: "TimeoutMessage";
   // encoded call for HandlerV1.handlePostRequestTimeouts
-  calldata: Uint8Array;
+  calldata: `0x{string}`;
 }
 
 // This event is emitted on hyperbridge

--- a/modules/hyperclient/package.json
+++ b/modules/hyperclient/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@polytope-labs/hyperclient",
   "description": "The hyperclient is a library for managing (in-flight) ISMP requests",
-  "version": "0.3.24",
+  "version": "0.3.33",
   "author": "Polytope Labs (hello@polytope.technology)",
   "license": "Apache-2.0",
   "bugs": {

--- a/modules/hyperclient/src/interfaces.rs
+++ b/modules/hyperclient/src/interfaces.rs
@@ -172,6 +172,7 @@ pub struct JsPostResponse {
 	/// The request that triggered this response.
 	pub post: JsPost,
 	/// The response message.
+	#[serde(with = "serde_utils::as_hex")]
 	pub response: Vec<u8>,
 	/// Timestamp at which this response expires in seconds.
 	#[serde(rename = "timeoutTimestamp")]

--- a/modules/hyperclient/src/internals.rs
+++ b/modules/hyperclient/src/internals.rs
@@ -228,14 +228,13 @@ pub async fn timeout_request_stream(
 											break;
 										}
 									},
-									Err(e) => {
+									Err(e) =>
 										return Ok(Some((
 											Err(anyhow!(
 												"Encountered error in time out stream {e:?}"
 											)),
 											state,
-										)))
-									},
+										))),
 								}
 							}
 							Ok(valid_proof_height.map(|ev| {
@@ -301,9 +300,7 @@ pub async fn timeout_request_stream(
 								.find_map(|event| match event.event {
 									Event::StateMachineUpdated(updated)
 										if updated.latest_height >= hyperbridge_height =>
-									{
-										Some(event.meta)
-									},
+										Some(event.meta),
 									_ => None,
 								});
 
@@ -339,19 +336,18 @@ pub async fn timeout_request_stream(
 									let commitment = source_client
 										.query_state_machine_commitment(state_machine_height)
 										.await?;
-									if commitment.timestamp > post.timeout_timestamp
-										&& ev.event.latest_height >= hyperbridge_height
+									if commitment.timestamp > post.timeout_timestamp &&
+										ev.event.latest_height >= hyperbridge_height
 									{
 										valid_proof_height = Some(ev);
 										break;
 									}
 								},
-								Err(e) => {
+								Err(e) =>
 									return Ok(Some((
 										Err(anyhow!("Encountered error in time out stream {e:?}")),
 										state,
-									)))
-								},
+									))),
 							}
 						}
 
@@ -553,8 +549,8 @@ pub async fn request_status_stream(
 						while let Some(item) = state_machine_updated_stream.next().await {
 							match item {
 								Ok(state_machine_update) => {
-									if state_machine_update.event.latest_height
-										>= post_request_height && state_machine_update
+									if state_machine_update.event.latest_height >=
+										post_request_height && state_machine_update
 										.event
 										.state_machine_id
 										.state_id == post.source
@@ -572,7 +568,7 @@ pub async fn request_status_stream(
 										)));
 									}
 								},
-								Err(e) => {
+								Err(e) =>
 									return Ok(Some((
 										Err(anyhow!(
 											"Encountered an error {:?}: in {:?}",
@@ -580,8 +576,7 @@ pub async fn request_status_stream(
 											e
 										)),
 										post_request_status,
-									)))
-								},
+									))),
 							};
 						}
 
@@ -642,11 +637,9 @@ pub async fn request_status_stream(
 								.into_iter()
 								.find_map(|event| match event.event {
 									Event::PostRequest(post_event)
-										if post.source == post_event.source
-											&& post.nonce == post_event.nonce =>
-									{
-										Some(event.meta)
-									},
+										if post.source == post_event.source &&
+											post.nonce == post_event.nonce =>
+										Some(event.meta),
 									_ => None,
 								});
 
@@ -746,9 +739,7 @@ pub async fn request_status_stream(
 								.find_map(|event| match event.event {
 									Event::StateMachineUpdated(updated)
 										if updated.latest_height >= height =>
-									{
-										Some((event.meta, updated))
-									},
+										Some((event.meta, updated)),
 									_ => None,
 								});
 
@@ -798,7 +789,7 @@ pub async fn request_status_stream(
 							.await?;
 						while let Some(update) = stream.next().await {
 							match update {
-								Ok(event) => {
+								Ok(event) =>
 									if event.event.latest_height >= height {
 										let calldata =
 											encode_request_message_and_wait_for_challenge_period(
@@ -821,9 +812,8 @@ pub async fn request_status_stream(
 										)));
 									} else {
 										continue;
-									}
-								},
-								Err(e) => {
+									},
+								Err(e) =>
 									return Ok(Some((
 										Err(anyhow!(
 											"Encountered an error {:?}: in {:?}",
@@ -831,8 +821,7 @@ pub async fn request_status_stream(
 											e
 										)),
 										post_request_status,
-									)))
-								},
+									))),
 							}
 						}
 						Ok(None)
@@ -871,9 +860,7 @@ pub async fn request_status_stream(
 								.find_map(|event| match event.event {
 									Event::PostRequestHandled(handled)
 										if handled.commitment == request_commitment =>
-									{
-										Some(event.meta)
-									},
+										Some(event.meta),
 									_ => None,
 								})
 								.unwrap_or_default();
@@ -902,9 +889,8 @@ pub async fn request_status_stream(
 						Ok(None)
 					},
 
-					PostStreamState::DestinationDelivered | PostStreamState::End => {
-						Ok::<Option<(Result<_, _>, PostStreamState)>, anyhow::Error>(None)
-					},
+					PostStreamState::DestinationDelivered | PostStreamState::End =>
+						Ok::<Option<(Result<_, _>, PostStreamState)>, anyhow::Error>(None),
 				}
 			};
 
@@ -942,9 +928,8 @@ pub async fn request_timeout_stream(
 		let value = match response {
 			Ok(true) => Some((Ok(Some(MessageStatusWithMetadata::Timeout)), client)),
 			Ok(false) => Some((Ok(None), client)),
-			Err(e) => {
-				Some((Err(anyhow!("Encountered an error in timeout stream: {:?}", e)), client))
-			},
+			Err(e) =>
+				Some((Err(anyhow!("Encountered an error in timeout stream: {:?}", e)), client)),
 		};
 
 		return value;

--- a/modules/hyperclient/src/internals.rs
+++ b/modules/hyperclient/src/internals.rs
@@ -45,10 +45,17 @@ pub async fn query_request_status_internal(
 	client: &HyperClient,
 	post: PostRequest,
 ) -> Result<MessageStatusWithMetadata, anyhow::Error> {
-	let destination_current_timestamp = client.dest.query_timestamp().await?;
+	let dest_client = if post.dest == client.dest.state_machine_id().state_id {
+		&client.dest
+	} else if post.dest == client.source.state_machine_id().state_id {
+		&client.source
+	} else {
+		Err(anyhow!("Unknown client for {}", post.source))?
+	};
+	let destination_current_timestamp = dest_client.query_timestamp().await?;
 	let req = Request::Post(post.clone());
 	let hash = hash_request::<Keccak256>(&req);
-	let relayer_address = client.dest.query_request_receipt(hash).await?;
+	let relayer_address = dest_client.query_request_receipt(hash).await?;
 	if let Some(ref status) = query_request_status_from_indexer(Request::Post(post.clone()), client)
 		.await
 		.ok()
@@ -87,10 +94,18 @@ pub async fn query_response_status_internal(
 	hyperclient: &HyperClient,
 	post_response: PostResponse,
 ) -> Result<MessageStatusWithMetadata, anyhow::Error> {
-	let response_destination_timeout = hyperclient.dest.query_timestamp().await?;
+	let dest_client = if post_response.dest_chain() == hyperclient.dest.state_machine_id().state_id
+	{
+		&hyperclient.dest
+	} else if post_response.dest_chain() == hyperclient.source.state_machine_id().state_id {
+		&hyperclient.source
+	} else {
+		Err(anyhow!("Unknown client for {}", post_response.dest_chain()))?
+	};
+	let response_destination_timeout = dest_client.query_timestamp().await?;
 	let res = Response::Post(post_response.clone());
 	let req_hash = hash_request::<Keccak256>(&res.request());
-	let response_receipt_relayer = hyperclient.dest.query_response_receipt(req_hash).await?;
+	let response_receipt_relayer = dest_client.query_response_receipt(req_hash).await?;
 	if let Some(ref status) =
 		query_response_status_from_indexer(Response::Post(post_response.clone()), hyperclient)
 			.await
@@ -144,9 +159,21 @@ pub async fn timeout_request_stream(
 	hyperclient: &HyperClient,
 	post: PostRequest,
 ) -> Result<BoxStream<TimeoutStatus>, anyhow::Error> {
-	let dest_client = hyperclient.dest.clone();
+	let source_client = if post.source == hyperclient.dest.state_machine_id().state_id {
+		hyperclient.dest.clone()
+	} else if post.source == hyperclient.source.state_machine_id().state_id {
+		hyperclient.source.clone()
+	} else {
+		Err(anyhow!("Unknown client for source: {}", post.source))?
+	};
+	let dest_client = if post.dest == hyperclient.dest.state_machine_id().state_id {
+		hyperclient.dest.clone()
+	} else if post.dest == hyperclient.source.state_machine_id().state_id {
+		hyperclient.source.clone()
+	} else {
+		Err(anyhow!("Unknown client for dest: {}", post.dest))?
+	};
 	let hyperbridge_client = hyperclient.hyperbridge.clone();
-	let source_client = hyperclient.source.clone();
 
 	let stream = stream::unfold(TimeoutStreamState::Pending, move |state| {
 		let dest_client = dest_client.clone();
@@ -201,13 +228,14 @@ pub async fn timeout_request_stream(
 											break;
 										}
 									},
-									Err(e) =>
+									Err(e) => {
 										return Ok(Some((
 											Err(anyhow!(
 												"Encountered error in time out stream {e:?}"
 											)),
 											state,
-										))),
+										)))
+									},
 								}
 							}
 							Ok(valid_proof_height.map(|ev| {
@@ -273,7 +301,9 @@ pub async fn timeout_request_stream(
 								.find_map(|event| match event.event {
 									Event::StateMachineUpdated(updated)
 										if updated.latest_height >= hyperbridge_height =>
-										Some(event.meta),
+									{
+										Some(event.meta)
+									},
 									_ => None,
 								});
 
@@ -309,18 +339,19 @@ pub async fn timeout_request_stream(
 									let commitment = source_client
 										.query_state_machine_commitment(state_machine_height)
 										.await?;
-									if commitment.timestamp > post.timeout_timestamp &&
-										ev.event.latest_height >= hyperbridge_height
+									if commitment.timestamp > post.timeout_timestamp
+										&& ev.event.latest_height >= hyperbridge_height
 									{
 										valid_proof_height = Some(ev);
 										break;
 									}
 								},
-								Err(e) =>
+								Err(e) => {
 									return Ok(Some((
 										Err(anyhow!("Encountered error in time out stream {e:?}")),
 										state,
-									))),
+									)))
+								},
 							}
 						}
 
@@ -381,9 +412,21 @@ pub async fn request_status_stream(
 	hyperclient: &HyperClient,
 	post: PostRequest,
 	post_request_height: u64,
-) -> BoxStream<MessageStatusWithMetadata> {
-	let source_client = hyperclient.source.clone();
-	let dest_client = hyperclient.dest.clone();
+) -> Result<BoxStream<MessageStatusWithMetadata>, anyhow::Error> {
+	let source_client = if post.source == hyperclient.dest.state_machine_id().state_id {
+		hyperclient.dest.clone()
+	} else if post.source == hyperclient.source.state_machine_id().state_id {
+		hyperclient.source.clone()
+	} else {
+		Err(anyhow!("Unknown client for source: {}", post.source))?
+	};
+	let dest_client = if post.dest == hyperclient.dest.state_machine_id().state_id {
+		hyperclient.dest.clone()
+	} else if post.dest == hyperclient.source.state_machine_id().state_id {
+		hyperclient.source.clone()
+	} else {
+		Err(anyhow!("Unknown client for dest: {}", post.dest))?
+	};
 	let hyperbridge_client = hyperclient.hyperbridge.clone();
 	let hyperclient_clone = hyperclient.clone();
 
@@ -510,8 +553,8 @@ pub async fn request_status_stream(
 						while let Some(item) = state_machine_updated_stream.next().await {
 							match item {
 								Ok(state_machine_update) => {
-									if state_machine_update.event.latest_height >=
-										post_request_height && state_machine_update
+									if state_machine_update.event.latest_height
+										>= post_request_height && state_machine_update
 										.event
 										.state_machine_id
 										.state_id == post.source
@@ -529,7 +572,7 @@ pub async fn request_status_stream(
 										)));
 									}
 								},
-								Err(e) =>
+								Err(e) => {
 									return Ok(Some((
 										Err(anyhow!(
 											"Encountered an error {:?}: in {:?}",
@@ -537,7 +580,8 @@ pub async fn request_status_stream(
 											e
 										)),
 										post_request_status,
-									))),
+									)))
+								},
 							};
 						}
 
@@ -598,9 +642,11 @@ pub async fn request_status_stream(
 								.into_iter()
 								.find_map(|event| match event.event {
 									Event::PostRequest(post_event)
-										if post.source == post_event.source &&
-											post.nonce == post_event.nonce =>
-										Some(event.meta),
+										if post.source == post_event.source
+											&& post.nonce == post_event.nonce =>
+									{
+										Some(event.meta)
+									},
 									_ => None,
 								});
 
@@ -700,7 +746,9 @@ pub async fn request_status_stream(
 								.find_map(|event| match event.event {
 									Event::StateMachineUpdated(updated)
 										if updated.latest_height >= height =>
-										Some((event.meta, updated)),
+									{
+										Some((event.meta, updated))
+									},
 									_ => None,
 								});
 
@@ -750,7 +798,7 @@ pub async fn request_status_stream(
 							.await?;
 						while let Some(update) = stream.next().await {
 							match update {
-								Ok(event) =>
+								Ok(event) => {
 									if event.event.latest_height >= height {
 										let calldata =
 											encode_request_message_and_wait_for_challenge_period(
@@ -773,8 +821,9 @@ pub async fn request_status_stream(
 										)));
 									} else {
 										continue;
-									},
-								Err(e) =>
+									}
+								},
+								Err(e) => {
 									return Ok(Some((
 										Err(anyhow!(
 											"Encountered an error {:?}: in {:?}",
@@ -782,7 +831,8 @@ pub async fn request_status_stream(
 											e
 										)),
 										post_request_status,
-									))),
+									)))
+								},
 							}
 						}
 						Ok(None)
@@ -821,7 +871,9 @@ pub async fn request_status_stream(
 								.find_map(|event| match event.event {
 									Event::PostRequestHandled(handled)
 										if handled.commitment == request_commitment =>
-										Some(event.meta),
+									{
+										Some(event.meta)
+									},
 									_ => None,
 								})
 								.unwrap_or_default();
@@ -850,8 +902,9 @@ pub async fn request_status_stream(
 						Ok(None)
 					},
 
-					PostStreamState::DestinationDelivered | PostStreamState::End =>
-						Ok::<Option<(Result<_, _>, PostStreamState)>, anyhow::Error>(None),
+					PostStreamState::DestinationDelivered | PostStreamState::End => {
+						Ok::<Option<(Result<_, _>, PostStreamState)>, anyhow::Error>(None)
+					},
 				}
 			};
 
@@ -862,7 +915,7 @@ pub async fn request_status_stream(
 		}
 	});
 
-	Box::pin(stream)
+	Ok(Box::pin(stream))
 }
 
 /// This returns a stream that yields when the provided timeout value is reached on the chain for
@@ -889,8 +942,9 @@ pub async fn request_timeout_stream(
 		let value = match response {
 			Ok(true) => Some((Ok(Some(MessageStatusWithMetadata::Timeout)), client)),
 			Ok(false) => Some((Ok(None), client)),
-			Err(e) =>
-				Some((Err(anyhow!("Encountered an error in timeout stream: {:?}", e)), client)),
+			Err(e) => {
+				Some((Err(anyhow!("Encountered an error in timeout stream: {:?}", e)), client))
+			},
 		};
 
 		return value;

--- a/modules/hyperclient/src/lib.rs
+++ b/modules/hyperclient/src/lib.rs
@@ -379,7 +379,7 @@ impl HyperClient {
 				internals::request_timeout_stream(post.timeout_timestamp, self.source.clone())
 					.await;
 
-			let request_status = internals::request_status_stream(&self, post, height).await;
+			let request_status = internals::request_status_stream(&self, post, height).await?;
 
 			let stream = futures::stream::select(request_status, timed_out).map(|res| {
 				res.map(|status| serde_wasm_bindgen::to_value(&status).expect("Infallible"))

--- a/modules/hyperclient/src/testing.rs
+++ b/modules/hyperclient/src/testing.rs
@@ -139,7 +139,7 @@ pub async fn subscribe_to_request_status() -> Result<(), anyhow::Error> {
 	let block = receipt.block_number.unwrap();
 	tracing::info!("\n\nTx block: {block}\n\n");
 
-	let mut stream = request_status_stream(&hyperclient, post, block.low_u64()).await;
+	let mut stream = request_status_stream(&hyperclient, post, block.low_u64()).await?;
 
 	while let Some(res) = stream.next().await {
 		match res {
@@ -262,7 +262,7 @@ pub async fn test_timeout_request() -> Result<(), anyhow::Error> {
 	let block = receipt.block_number.unwrap();
 	tracing::info!("\n\nTx block: {block}\n\n");
 
-	let request_status = request_status_stream(&hyperclient, post.clone(), block.low_u64()).await;
+	let request_status = request_status_stream(&hyperclient, post.clone(), block.low_u64()).await?;
 
 	// Obtaining the request stream and the timeout stream
 	let timed_out =

--- a/modules/hyperclient/src/types.rs
+++ b/modules/hyperclient/src/types.rs
@@ -143,6 +143,7 @@ pub enum MessageStatusWithMetadata {
 		#[serde(flatten)]
 		meta: EventMetadata,
 		/// Calldata that encodes the proof for the message to be sent to the destination.
+		#[serde(with = "serde_utils::as_hex")]
 		calldata: Bytes,
 	},
 	/// Delivered to destination
@@ -162,6 +163,12 @@ pub enum MessageStatusWithMetadata {
 
 #[derive(PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct Bytes(pub Vec<u8>);
+
+impl AsRef<[u8]> for Bytes {
+	fn as_ref(&self) -> &[u8] {
+		&self.0
+	}
+}
 
 impl From<Vec<u8>> for Bytes {
 	fn from(value: Vec<u8>) -> Bytes {
@@ -228,6 +235,7 @@ pub enum TimeoutStatus {
 	/// Encoded call data to be submitted to source chain
 	TimeoutMessage {
 		/// Calldata that encodes the proof for the timeout message on the source.
+		#[serde(with = "serde_utils::as_hex")]
 		calldata: Bytes,
 	},
 }

--- a/modules/ismp/pallets/rpc/src/lib.rs
+++ b/modules/ismp/pallets/rpc/src/lib.rs
@@ -431,7 +431,7 @@ where
 				runtime_error_into_rpc_error(format!("failed to read block events {:?}", e))
 			})?;
 
-			events.insert(header.hash().to_string(), temp);
+			events.insert(format!("{:?}", header.hash()), temp);
 			header = self
 				.client
 				.header(*header.parent_hash())
@@ -535,7 +535,8 @@ where
 				});
 			}
 
-			events.insert(header.hash().to_string(), temp);
+			// Display is truncated for H256
+			events.insert(format!("{:?}", header.hash()), temp);
 			header = self
 				.client
 				.header(*header.parent_hash())


### PR DESCRIPTION
Before

```json
{
  "jsonrpc": "2.0",
  "result": {
    "0x265c…399d": [ // display
      {
        "meta": {
          "block_hash": "0x265c08d74ad68963d7b236cf7dab5ec3a1205b3c0195ad000e3786694470399d",
          "transaction_hash": "0x8a15927e7f9c53b653772e561fdba806ad6cb619959eac75587a6262d2e4f6c8",
          "block_number": 821396
        },
        "event": {
          "StateMachineUpdated": {
            "state_machine_id": {
              "state_id": "BSC",
              "consensus_state_id": "BSC0"
            },
            "latest_height": 42174000
          }
        }
      },
      {
        "meta": {
          "block_hash": "0x265c08d74ad68963d7b236cf7dab5ec3a1205b3c0195ad000e3786694470399d",
          "transaction_hash": "0x954229bd5e8e653999f26abc9c02ce7f171e4f9935c149b46c0201c6cb82cccd",
          "block_number": 821396
        },
        "event": {
          "PostRequest": {
            "source": "BSC",
            "dest": "ETHE",
            "nonce": 2501,
            "from": "0x8e4ca395cfaa033a71fc618792fce99106633b90",
            "to": "0x8e4ca395cfaa033a71fc618792fce99106633b90",
            "timeout_timestamp": 1721249124,
            "body": "0x68656c6c6f2066726f6d20425343"
          }
        }
      },
      {
        "meta": {
          "block_hash": "0x265c08d74ad68963d7b236cf7dab5ec3a1205b3c0195ad000e3786694470399d",
          "transaction_hash": "0x954229bd5e8e653999f26abc9c02ce7f171e4f9935c149b46c0201c6cb82cccd",
          "block_number": 821396
        },
        "event": {
          "PostRequestHandled": {
            "commitment": "0x61895cd35a71ca4552c6d995408ccab270e0da7c4c911aa2abba7771ee84871a",
            "relayer": "0x588177cf191e890d83b10e9653cfd663c8a382d5afce8518636dd9565c22a631"
          }
        }
      }
    ]
  },
  "id": 38
}
```

After

```json
{
  "jsonrpc": "2.0",
  "result": {
    "0x265c08d74ad68963d7b236cf7dab5ec3a1205b3c0195ad000e3786694470399d": [ // debug
      {
        "meta": {
          "block_hash": "0x265c08d74ad68963d7b236cf7dab5ec3a1205b3c0195ad000e3786694470399d",
          "transaction_hash": "0x8a15927e7f9c53b653772e561fdba806ad6cb619959eac75587a6262d2e4f6c8",
          "block_number": 821396
        },
        "event": {
          "StateMachineUpdated": {
            "state_machine_id": {
              "state_id": "BSC",
              "consensus_state_id": "BSC0"
            },
            "latest_height": 42174000
          }
        }
      },
      {
        "meta": {
          "block_hash": "0x265c08d74ad68963d7b236cf7dab5ec3a1205b3c0195ad000e3786694470399d",
          "transaction_hash": "0x954229bd5e8e653999f26abc9c02ce7f171e4f9935c149b46c0201c6cb82cccd",
          "block_number": 821396
        },
        "event": {
          "PostRequest": {
            "source": "BSC",
            "dest": "ETHE",
            "nonce": 2501,
            "from": "0x8e4ca395cfaa033a71fc618792fce99106633b90",
            "to": "0x8e4ca395cfaa033a71fc618792fce99106633b90",
            "timeout_timestamp": 1721249124,
            "body": "0x68656c6c6f2066726f6d20425343"
          }
        }
      },
      {
        "meta": {
          "block_hash": "0x265c08d74ad68963d7b236cf7dab5ec3a1205b3c0195ad000e3786694470399d",
          "transaction_hash": "0x954229bd5e8e653999f26abc9c02ce7f171e4f9935c149b46c0201c6cb82cccd",
          "block_number": 821396
        },
        "event": {
          "PostRequestHandled": {
            "commitment": "0x61895cd35a71ca4552c6d995408ccab270e0da7c4c911aa2abba7771ee84871a",
            "relayer": "0x588177cf191e890d83b10e9653cfd663c8a382d5afce8518636dd9565c22a631"
          }
        }
      }
    ]
  },
  "id": 38
}
```