### PR TITLE
Support world state queries for EVM get requests

### DIFF
--- a/indexers/docker-compose.yml
+++ b/indexers/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - ${SUB_COMMAND:-} # set SUB_COMMAND env variable to "test" to run tests
       - -f=app/hyperbridge-gargantua.yaml
       - --db-schema=app
-      - --workers=3
+      - --workers=5
       - --batch-size=10
       - --disable-historical
       - --multi-chain
@@ -70,7 +70,7 @@ services:
       - ${SUB_COMMAND:-} # set SUB_COMMAND env variable to "test" to run tests
       - -f=app/ethereum-sepolia.yaml
       - --db-schema=app
-      - --workers=3
+      - --workers=5
       - --batch-size=10
       - --disable-historical
       - --multi-chain
@@ -105,7 +105,7 @@ services:
       - ${SUB_COMMAND:-} # set SUB_COMMAND env variable to "test" to run tests
       - -f=app/base-sepolia.yaml
       - --db-schema=app
-      - --workers=3
+      - --workers=5
       - --batch-size=10
       - --disable-historical
       - --multi-chain
@@ -135,7 +135,7 @@ services:
       - ${SUB_COMMAND:-} # set SUB_COMMAND env variable to "test" to run tests
       - -f=app/optimism-sepolia.yaml
       - --db-schema=app
-      - --workers=3
+      - --workers=5
       - --batch-size=10
       - --disable-historical
       - --multi-chain
@@ -170,7 +170,7 @@ services:
       - ${SUB_COMMAND:-} # set SUB_COMMAND env variable to "test" to run tests
       - -f=app/arbitrum-sepolia.yaml
       - --db-schema=app
-      - --workers=3
+      - --workers=5
       - --batch-size=10
       - --disable-historical
       - --multi-chain
@@ -205,7 +205,7 @@ services:
       - ${SUB_COMMAND:-} # set SUB_COMMAND env variable to "test" to run tests
       - -f=app/bsc-chapel.yaml
       - --db-schema=app
-      - --workers=3
+      - --workers=5
       - --batch-size=10
       - --disable-historical
       - --multi-chain

--- a/indexers/src/utils/substrate.helpers.ts
+++ b/indexers/src/utils/substrate.helpers.ts
@@ -18,25 +18,8 @@ export const extractStateMachineIdFromSubstrateEventData = (
       });
 
       switch (main_key) {
-        case "ETHEREUM":
-          switch (value.toUpperCase()) {
-            case "EXECUTIONLAYER":
-              return "EVM-11155111";
-            case "OPTIMISM":
-              return "EVM-11155420";
-            case "ARBITRUM":
-              return "EVM-421614";
-            case "BASE":
-              return "EVM-84532";
-            default:
-              throw new Error(
-                `Unknown state machine ID ${value} encountered in extractStateMachineIdFromSubstrateEventData`
-              );
-          }
-        case "BSC":
-          return "BSC";
-        case "POLYGON":
-          return "POLY";
+        case "EVM":
+          return "EVM-".concat(value);
         case "POLKADOT":
           return "POLKADOT-".concat(value);
         case "KUSAMA":

--- a/modules/ismp/clients/arbitrum/src/lib.rs
+++ b/modules/ismp/clients/arbitrum/src/lib.rs
@@ -23,7 +23,7 @@ mod tests;
 use alloc::format;
 use alloy_rlp::Decodable;
 use ethabi::ethereum_types::{H160, H256, U256};
-use evm_common::{derive_map_key, get_contract_storage_root, get_value_from_proof, prelude::*};
+use evm_common::{derive_map_key, get_contract_account, get_value_from_proof, prelude::*};
 use geth_primitives::{CodecHeader, Header};
 use ismp::{
 	consensus::{
@@ -128,7 +128,10 @@ pub fn verify_arbitrum_payload<H: Keccak256 + Send + Sync>(
 	consensus_state_id: ConsensusStateId,
 ) -> Result<IntermediateState, Error> {
 	let storage_root =
-		get_contract_storage_root::<H>(payload.contract_proof, &rollup_core_address.0, root)?;
+		get_contract_account::<H>(payload.contract_proof, &rollup_core_address.0, root)?
+			.storage_root
+			.0
+			.into();
 
 	let header: Header = payload.arbitrum_header.as_ref().into();
 	if &payload.global_state.send_root[..] != &payload.arbitrum_header.extra_data {

--- a/modules/ismp/clients/optimism/src/lib.rs
+++ b/modules/ismp/clients/optimism/src/lib.rs
@@ -21,8 +21,7 @@ use alloc::format;
 use alloy_rlp::Decodable;
 use ethabi::ethereum_types::{H160, H256, U128, U256};
 use evm_common::{
-	derive_array_item_key, derive_map_key, get_contract_storage_root, get_value_from_proof,
-	prelude::*,
+	derive_array_item_key, derive_map_key, get_contract_account, get_value_from_proof, prelude::*,
 };
 use geth_primitives::{CodecHeader, Header};
 use ismp::{
@@ -72,7 +71,10 @@ pub fn verify_optimism_payload<H: Keccak256 + Send + Sync>(
 	consensus_state_id: ConsensusStateId,
 ) -> Result<IntermediateState, Error> {
 	let storage_root =
-		get_contract_storage_root::<H>(payload.l2_oracle_proof, &l2_oracle_address.0, root)?;
+		get_contract_account::<H>(payload.l2_oracle_proof, &l2_oracle_address.0, root)?
+			.storage_root
+			.0
+			.into();
 
 	let output_root = calculate_output_root::<H>(
 		payload.version,
@@ -220,11 +222,11 @@ pub fn verify_optimism_dispute_game_proof<H: Keccak256 + Send + Sync>(
 			"Game type must be the respected game type".to_string(),
 		))?;
 	}
-	let storage_root = get_contract_storage_root::<H>(
-		payload.dispute_factory_proof,
-		&dispute_factory_address.0,
-		root,
-	)?;
+	let storage_root =
+		get_contract_account::<H>(payload.dispute_factory_proof, &dispute_factory_address.0, root)?
+			.storage_root
+			.0
+			.into();
 	let l2_block_hash = Header::from(&payload.header).hash::<H>();
 
 	let root_claim = calculate_output_root::<H>(

--- a/modules/ismp/clients/sync-committee/evm-common/src/lib.rs
+++ b/modules/ismp/clients/sync-committee/evm-common/src/lib.rs
@@ -85,8 +85,10 @@ pub fn verify_state_proof<H: Keccak256 + Send + Sync>(
 	// Group keys by the contract address they belong to
 	for key in keys {
 		// For keys that are 52 bytes we expect the first 20 bytes to be the contract address and
-		// the last 32 bytes the slot hash For keys that are 20 bytes we expect that to the the
-		// contract or account address For keys that are 32 bytes we expect that to be a slothash in
+		// the last 32 bytes the slot hash.
+		// For keys that are 20 bytes we expect that to the the
+		// contract or account address.
+		// For keys that are 32 bytes we expect that to be a slothash in
 		// the Ismp EVM host
 		let contract_address = if key.len() == 52 {
 			H160::from_slice(&key[..20])
@@ -96,7 +98,10 @@ pub fn verify_state_proof<H: Keccak256 + Send + Sync>(
 			contract_account_queries.push(H160::from_slice(&key));
 			continue
 		} else {
-			Err(Error::Custom("Unsupported Key format".to_string()))?
+			Err(Error::Custom(
+				"Unsupported Key type, found a key whose length is not one of 20, 32 or 52"
+					.to_string(),
+			))?
 		};
 		let entry = contract_to_keys.entry(contract_address.0.to_vec()).or_insert(vec![]);
 

--- a/modules/ismp/clients/sync-committee/evm-common/src/lib.rs
+++ b/modules/ismp/clients/sync-committee/evm-common/src/lib.rs
@@ -55,11 +55,14 @@ pub fn verify_membership<H: Keccak256 + Send + Sync>(
 		.ok_or_else(|| Error::Custom("Ismp contract account trie proof is missing".to_string()))?;
 	let keys = req_res_commitment_key::<H>(item);
 	let root = H256::from_slice(&root.state_root[..]);
-	let contract_root = get_contract_storage_root::<H>(
+	let contract_root = get_contract_account::<H>(
 		evm_state_proof.contract_proof,
 		&contract_address.0,
 		root.clone(),
-	)?;
+	)?
+	.storage_root
+	.0
+	.into();
 	let values = get_values_from_proof::<H>(keys, contract_root, storage_proof)?;
 
 	if values.into_iter().any(|val| val.is_none()) {
@@ -78,12 +81,23 @@ pub fn verify_state_proof<H: Keccak256 + Send + Sync>(
 	let evm_state_proof = decode_evm_state_proof(proof)?;
 	let mut map = BTreeMap::new();
 	let mut contract_to_keys = BTreeMap::new();
+	let mut contract_account_queries = Vec::new();
 	// Group keys by the contract address they belong to
 	for key in keys {
-		// For keys less than 52 bytes we default to the ismp contract address as the contract
-		// key
-		let contract_address =
-			if key.len() == 52 { H160::from_slice(&key[..20]) } else { ismp_address };
+		// For keys that are 52 bytes we expect the first 20 bytes to be the contract address and
+		// the last 32 bytes the slot hash For keys that are 20 bytes we expect that to the the
+		// contract or account address For keys that are 32 bytes we expect that to be a slothash in
+		// the Ismp EVM host
+		let contract_address = if key.len() == 52 {
+			H160::from_slice(&key[..20])
+		} else if key.len() == 32 {
+			ismp_address
+		} else if key.len() == 20 {
+			contract_account_queries.push(H160::from_slice(&key));
+			continue
+		} else {
+			Err(Error::Custom("Unsupported Key format".to_string()))?
+		};
 		let entry = contract_to_keys.entry(contract_address.0.to_vec()).or_insert(vec![]);
 
 		let slot_hash = if key.len() == 52 {
@@ -96,11 +110,14 @@ pub fn verify_state_proof<H: Keccak256 + Send + Sync>(
 	}
 
 	for (contract_address, storage_proof) in evm_state_proof.storage_proof {
-		let contract_root = get_contract_storage_root::<H>(
+		let contract_root = get_contract_account::<H>(
 			evm_state_proof.contract_proof.clone(),
 			&contract_address,
 			root.state_root,
-		)?;
+		)?
+		.storage_root
+		.0
+		.into();
 
 		if let Some(keys) = contract_to_keys.remove(&contract_address) {
 			let slot_hashes = keys.iter().map(|(_, slot_hash)| slot_hash.clone()).collect();
@@ -109,6 +126,19 @@ pub fn verify_state_proof<H: Keccak256 + Send + Sync>(
 				map.insert(key, value);
 			});
 		}
+	}
+
+	for contract_address in contract_account_queries {
+		let account = get_contract_account::<H>(
+			evm_state_proof.contract_proof.clone(),
+			&contract_address[..],
+			root.state_root,
+		)?;
+
+		// Using rlp encoding for uniformity, storage values from state proofs are rlp encoded
+		let encoded = alloy_rlp::encode(account);
+
+		map.insert(contract_address.0.to_vec(), Some(encoded));
 	}
 
 	Ok(map)

--- a/modules/ismp/clients/sync-committee/evm-common/src/utils.rs
+++ b/modules/ismp/clients/sync-committee/evm-common/src/utils.rs
@@ -132,11 +132,11 @@ pub(super) fn to_bytes_32(bytes: &[u8]) -> Result<[u8; 32], Error> {
 	Ok(array)
 }
 
-pub fn get_contract_storage_root<H: Keccak256 + Send + Sync>(
+pub fn get_contract_account<H: Keccak256 + Send + Sync>(
 	contract_account_proof: Vec<Vec<u8>>,
 	contract_address: &[u8],
 	root: H256,
-) -> Result<H256, Error> {
+) -> Result<Account, Error> {
 	let db = StorageProof::new(contract_account_proof).into_memory_db::<KeccakHasher<H>>();
 	let trie = TrieDBBuilder::<EIP1186Layout<KeccakHasher<H>>>::new(&db, &root).build();
 	let key = H::keccak256(contract_address).0;
@@ -149,7 +149,7 @@ pub fn get_contract_storage_root<H: Keccak256 + Send + Sync>(
 		Error::Custom(format!("Error decoding contract account from value {:?}", &result))
 	})?;
 
-	Ok(contract_account.storage_root.0.into())
+	Ok(contract_account)
 }
 
 pub fn derive_map_key<H: Keccak256>(mut key: Vec<u8>, slot: u64) -> H256 {

--- a/modules/ismp/core/src/router.rs
+++ b/modules/ismp/core/src/router.rs
@@ -96,14 +96,17 @@ pub struct GetRequest {
 	/// Raw Storage keys that would be used to fetch the values from the counterparty
 	/// For deriving storage keys for ink contract fields follow the guide in the link below
 	/// `<https://use.ink/datastructures/storage-in-metadata#a-full-example>`
+	/// Substrate Keys
 	/// The algorithms for calculating raw storage keys for different substrate pallet storage
 	/// types are described in the following links
 	/// `<https://github.com/paritytech/substrate/blob/master/frame/support/src/storage/types/map.rs#L34-L42>`
 	/// `<https://github.com/paritytech/substrate/blob/master/frame/support/src/storage/types/double_map.rs#L34-L44>`
 	/// `<https://github.com/paritytech/substrate/blob/master/frame/support/src/storage/types/nmap.rs#L39-L48>`
 	/// `<https://github.com/paritytech/substrate/blob/master/frame/support/src/storage/types/value.rs#L37>`
-	/// For fetching keys from EVM contracts each key should be 52 bytes
-	/// This should be a concatenation of contract address and slot hash
+	/// EVM Keys
+	/// For fetching keys from EVM contracts each key should either be 52 bytes or 20 bytes
+	/// For 52 byte keys we expect it to be a concatenation of contract address and slot hash
+	/// For 20 bytes we expect it to be a contract or account address
 	#[serde(with = "serde_utils::seq_of_hex")]
 	pub keys: Vec<Vec<u8>>,
 	/// Height at which to read the state machine.

--- a/tesseract/evm/src/test.rs
+++ b/tesseract/evm/src/test.rs
@@ -2,7 +2,7 @@ use crate::{EvmClient, EvmConfig};
 use codec::Decode;
 use ethers::providers::Middleware;
 use evm_common::{
-	get_contract_storage_root, get_value_from_proof, types::EvmStateProof, verify_membership,
+	get_contract_account, get_value_from_proof, types::EvmStateProof, verify_membership,
 };
 use hex_literal::hex;
 use ismp::{
@@ -87,12 +87,15 @@ async fn test_ismp_state_proof() {
 		.await
 		.unwrap();
 	let evm_state_proof = EvmStateProof::decode(&mut &*proof).unwrap();
-	let contract_root = get_contract_storage_root::<Keccak256Hasher>(
+	let contract_root = get_contract_account::<Keccak256Hasher>(
 		evm_state_proof.contract_proof,
 		&ISMP_HOST.0,
 		state_root,
 	)
-	.unwrap();
+	.unwrap()
+	.storage_root
+	.0
+	.into();
 
 	let key = sp_core::keccak_256(&client.request_commitment_key(query.commitment).1 .0).to_vec();
 	let value = get_value_from_proof::<Keccak256Hasher>(


### PR DESCRIPTION
Allow querying world state from EVM chains in get requests.
Fixes how state machine Id is extracted from hyperbridge events.