### PR TITLE
Add Helikon bootnodes.

### DIFF
--- a/parachain/chainspec/nexus.json
+++ b/parachain/chainspec/nexus.json
@@ -5,7 +5,9 @@
   "bootNodes": [
     "/ip4/34.34.161.178/tcp/30333/p2p/12D3KooWFhvrxiteNHigYA96J3zoD2Z2Gs3q6ihDp3N37Fyb4874",
     "/dns/nexus.boot.stake.plus/tcp/30332/wss/p2p/12D3KooWMVkkfZVVnZXXBwPjxrGqud6aoK1XMeBVGBjtyX5aobEU",
-    "/dns/nexus.boot.stake.plus/tcp/31332/wss/p2p/12D3KooWGXeeQ9VtdmeoTSX1uWKYWRMPKZ8mKvqMzAM6pXmbDFZ7"
+    "/dns/nexus.boot.stake.plus/tcp/31332/wss/p2p/12D3KooWGXeeQ9VtdmeoTSX1uWKYWRMPKZ8mKvqMzAM6pXmbDFZ7",
+    "/dns4/boot.helikon.io/tcp/8610/p2p/12D3KooWNvVYuuHtV9KSpUXy7puERNvoNyAcRGizp3s2QpHQuuhq",
+    "/dns4/boot.helikon.io/tcp/8612/wss/p2p/12D3KooWNvVYuuHtV9KSpUXy7puERNvoNyAcRGizp3s2QpHQuuhq"
   ],
   "telemetryEndpoints": [
     [


### PR DESCRIPTION
This PR adds Helikon bootnodes to the Nexus chain spec. Helikon nodes can be monitored on the [W3F Telemetry](https://telemetry.w3f.community/#list/0x61ea8a51fd4a058ee8c0e86df0a89cc85b8b67a0a66432893d09719050c9f540). You may test the bootnodes using the command:

```
./hyperbridge \
  --chain nexus \
  --relay-chain-rpc-urls=wss://rpc.helikon.io/polkadot \
  --tmp \
  --no-mdns \
  --no-telemetry \
  --no-hardware-benchmarks \
  --reserved-only \
  --reserved-nodes "/dns4/boot.helikon.io/tcp/8610/p2p/12D3KooWNvVYuuHtV9KSpUXy7puERNvoNyAcRGizp3s2QpHQuuhq"
```

and:

```
./hyperbridge \
  --chain nexus \
  --relay-chain-rpc-urls=wss://rpc.helikon.io/polkadot \
  --tmp \
  --no-mdns \
  --no-telemetry \
  --no-hardware-benchmarks \
  --reserved-only \
  --reserved-nodes "/dns4/boot.helikon.io/tcp/8612/wss/p2p/12D3KooWNvVYuuHtV9KSpUXy7puERNvoNyAcRGizp3s2QpHQuuhq"
```

Thanks.