### PR TITLE
Fix bug where pruned relay chain block breaks ismp parachain inherent creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7539,7 +7539,7 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "ismp"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -7575,7 +7575,7 @@ version = "0.1.1"
 
 [[package]]
 name = "ismp-parachain"
-version = "1.6.2"
+version = "1.15.0"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
@@ -7599,7 +7599,7 @@ dependencies = [
 
 [[package]]
 name = "ismp-parachain-inherent"
-version = "1.6.3"
+version = "1.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7619,7 +7619,7 @@ dependencies = [
 
 [[package]]
 name = "ismp-parachain-runtime-api"
-version = "1.6.2"
+version = "1.15.0"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "sp-api 34.0.0",
@@ -10243,7 +10243,7 @@ dependencies = [
 
 [[package]]
 name = "mmr-primitives"
-version = "1.6.2"
+version = "1.15.0"
 dependencies = [
  "ckb-merkle-mountain-range",
  "frame-system",
@@ -12049,7 +12049,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-hyperbridge"
-version = "1.6.2"
+version = "1.15.0"
 dependencies = [
  "frame-support 37.0.0",
  "frame-system",
@@ -12117,7 +12117,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ismp"
-version = "1.6.2"
+version = "1.15.0"
 dependencies = [
  "env_logger 0.10.2",
  "fortuples",
@@ -12211,7 +12211,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ismp-rpc"
-version = "1.6.2"
+version = "1.15.0"
 dependencies = [
  "anyhow",
  "frame-system",
@@ -12239,7 +12239,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ismp-runtime-api"
-version = "1.6.2"
+version = "1.15.0"
 dependencies = [
  "ismp",
  "pallet-ismp",
@@ -22995,7 +22995,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-state-machine"
-version = "1.6.2"
+version = "1.15.0"
 dependencies = [
  "frame-support 37.0.0",
  "hash-db",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -239,7 +239,7 @@ jsonrpsee = { version = "0.23" }
 jsonrpsee-core = { version = "0.23" }
 
 # local crates
-ismp = { version = "0.1.2", path = "./modules/ismp/core", default-features = false }
+ismp = { version = "0.2.0", path = "./modules/ismp/core", default-features = false }
 ismp-testsuite = { path = "./modules/ismp/testsuite" }
 ismp-solidity-abi = { path = "./evm/abi", default-features = false }
 simnode-tests = { path = "parachain/simtests" }
@@ -259,23 +259,23 @@ sync-committee-verifier = { path = "./modules/consensus/sync-committee/verifier"
 
 # consensus clients
 ismp-bsc = { path = "./modules/ismp/clients/bsc", default-features = false }
-ismp-parachain = { version = "1.6.2", path = "./modules/ismp/clients/parachain/client", default-features = false }
-ismp-parachain-inherent = { version = "1.6.2", path = "./modules/ismp/clients/parachain/inherent" }
-ismp-parachain-runtime-api = { version = "1.6.2", path = "./modules/ismp/clients/parachain/runtime-api", default-features = false }
+ismp-parachain = { version = "1.15.0", path = "./modules/ismp/clients/parachain/client", default-features = false }
+ismp-parachain-inherent = { version = "1.15.0", path = "./modules/ismp/clients/parachain/inherent" }
+ismp-parachain-runtime-api = { version = "1.15.0", path = "./modules/ismp/clients/parachain/runtime-api", default-features = false }
 ismp-sync-committee = { path = "./modules/ismp/clients/sync-committee", default-features = false }
 evm-common = { path = "./modules/ismp/clients/sync-committee/evm-common", default-features = false }
 arbitrum-verifier = { path = "./modules/ismp/clients/arbitrum", default-features = false }
 op-verifier = { path = "./modules/ismp/clients/optimism", default-features = false }
 
 # state machine clients
-substrate-state-machine = { version = "1.6.2", path = "modules/ismp/state-machines/substrate", default-features = false }
+substrate-state-machine = { version = "1.15.0", path = "modules/ismp/state-machines/substrate", default-features = false }
 hyperbridge-client-machine = { path = "modules/ismp/state-machines/hyperbridge", default-features = false }
 
 # pallets
-pallet-ismp = { version = "1.6.2", path = "modules/ismp/pallets/pallet", default-features = false }
-pallet-ismp-rpc = { version = "1.6.2", path = "modules/ismp/pallets/rpc" }
-pallet-ismp-runtime-api = { version = "1.6.2", path = "modules/ismp/pallets/runtime-api", default-features = false }
-pallet-hyperbridge = { version = "1.6.2", path = "modules/ismp/pallets/hyperbridge", default-features = false }
+pallet-ismp = { version = "1.15.0", path = "modules/ismp/pallets/pallet", default-features = false }
+pallet-ismp-rpc = { version = "1.15.0", path = "modules/ismp/pallets/rpc" }
+pallet-ismp-runtime-api = { version = "1.15.0", path = "modules/ismp/pallets/runtime-api", default-features = false }
+pallet-hyperbridge = { version = "1.15.0", path = "modules/ismp/pallets/hyperbridge", default-features = false }
 pallet-fishermen = { path = "modules/ismp/pallets/fishermen", default-features = false }
 pallet-ismp-demo = { path = "modules/ismp/pallets/demo", default-features = false }
 pallet-ismp-relayer = { path = "modules/ismp/pallets/relayer", default-features = false }
@@ -290,7 +290,7 @@ pallet-mmr = { path = "modules/trees/mmr/pallet", default-features = false }
 pallet-mmr-runtime-api = { path = "modules/trees/mmr/pallet/runtime-api", default-features = false }
 mmr-gadget = { path = "modules/trees/mmr/gadget" }
 ethereum-triedb = { version = "0.1.1", path = "./modules/trees/ethereum", default-features = false }
-mmr-primitives = { version = "1.6.2", path = "modules/trees/mmr/primitives", default-features = false }
+mmr-primitives = { version = "1.15.0", path = "modules/trees/mmr/primitives", default-features = false }
 
 # runtimes
 gargantua-runtime = { path = "./parachain/runtimes/gargantua", default-features = false }

--- a/modules/ismp/clients/parachain/client/Cargo.toml
+++ b/modules/ismp/clients/parachain/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ismp-parachain"
-version = "1.6.2"
+version = "1.15.0"
 edition = "2021"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 license = "Apache-2.0"

--- a/modules/ismp/clients/parachain/client/src/lib.rs
+++ b/modules/ismp/clients/parachain/client/src/lib.rs
@@ -117,7 +117,7 @@ pub mod pallet {
 				"Only parachain consensus updates should be passed in the inherents!"
 			);
 
-			// Handling error will prevent this inherent from breaking block production is there's a
+			// Handling error will prevent this inherent from breaking block production if there's a
 			// reorg and it's no longer valid
 			if let Err(err) =
 				pallet_ismp::Pallet::<T>::handle_messages(vec![Message::Consensus(data)])

--- a/modules/ismp/clients/parachain/inherent/Cargo.toml
+++ b/modules/ismp/clients/parachain/inherent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ismp-parachain-inherent"
-version = "1.6.3"
+version = "1.15.0"
 edition = "2021"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 license = "Apache-2.0"

--- a/modules/ismp/clients/parachain/inherent/src/lib.rs
+++ b/modules/ismp/clients/parachain/inherent/src/lib.rs
@@ -67,10 +67,14 @@ impl ConsensusInherentProvider {
 			return Ok(ConsensusInherentProvider(None));
 		}
 
-		let relay_header = relay_chain_interface
-			.header(BlockId::Number(state.number))
-			.await?
-			.ok_or_else(|| anyhow!("Relay chain header for height {} not found", state.number))?;
+		let relay_header = if let Ok(Some(header)) =
+			relay_chain_interface.header(BlockId::Number(state.number)).await
+		{
+			header
+		} else {
+			log::trace!("Relay chain header not available for {}", state.number);
+			return Ok(ConsensusInherentProvider(None));
+		};
 
 		let mut para_ids_to_fetch = vec![];
 		for id in para_ids {

--- a/modules/ismp/clients/parachain/runtime-api/Cargo.toml
+++ b/modules/ismp/clients/parachain/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ismp-parachain-runtime-api"
-version = "1.6.2"
+version = "1.15.0"
 edition = "2021"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 license = "Apache-2.0"

--- a/modules/ismp/core/Cargo.toml
+++ b/modules/ismp/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ismp"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 description = "Rust implementation of the interoperable state machine protocol"
 authors = ["Polytope Labs <hello@polytope.technology>"]

--- a/modules/ismp/pallets/hyperbridge/Cargo.toml
+++ b/modules/ismp/pallets/hyperbridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-hyperbridge"
-version = "1.6.2"
+version = "1.15.0"
 edition = "2021"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 license = "Apache-2.0"

--- a/modules/ismp/pallets/pallet/Cargo.toml
+++ b/modules/ismp/pallets/pallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-ismp"
-version = "1.6.2"
+version = "1.15.0"
 edition = "2021"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 license = "Apache-2.0"

--- a/modules/ismp/pallets/rpc/Cargo.toml
+++ b/modules/ismp/pallets/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-ismp-rpc"
-version = "1.6.2"
+version = "1.15.0"
 edition = "2021"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 license = "Apache-2.0"

--- a/modules/ismp/pallets/runtime-api/Cargo.toml
+++ b/modules/ismp/pallets/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-ismp-runtime-api"
-version = "1.6.2"
+version = "1.15.0"
 edition = "2021"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 license = "Apache-2.0"

--- a/modules/ismp/state-machines/substrate/Cargo.toml
+++ b/modules/ismp/state-machines/substrate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-state-machine"
-version = "1.6.2"
+version = "1.15.0"
 edition = "2021"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 license = "Apache-2.0"

--- a/modules/trees/mmr/primitives/Cargo.toml
+++ b/modules/trees/mmr/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mmr-primitives"
-version = "1.6.2"
+version = "1.15.0"
 edition = "2021"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 license = "Apache-2.0"

--- a/tesseract/evm/src/provider.rs
+++ b/tesseract/evm/src/provider.rs
@@ -512,6 +512,10 @@ impl IsmpProvider for EvmClient {
 			let mut latest_height = from;
 			let state_machine = client.state_machine;
 			loop {
+				// If receiver has been dropped kill the task
+				if tx.is_closed() {
+					return
+				}
 				tokio::time::sleep(Duration::from_secs(poll_interval)).await;
 				// wait for an update with a greater height
 				let block_number = match client.client.get_block_number().await {

--- a/tesseract/substrate/src/provider.rs
+++ b/tesseract/substrate/src/provider.rs
@@ -420,6 +420,10 @@ where
 			let mut latest_height = from;
 			let state_machine = client.state_machine;
 			loop {
+				// Kill task when receiver is dropped
+				if tx.is_closed() {
+					return
+				}
 				tokio::time::sleep(Duration::from_secs(10)).await;
 				let header = match client.client.rpc().header(None).await {
 					Ok(Some(header)) => header,


### PR DESCRIPTION
Closes #296 

Skips inherent creation if relaychain block has been pruned.
Handles error in inherent execution, so block production is not broken if inherent becomes invalid during a reorg.

Update version number for ismp crates.

Kill orphaned background tasks in messaging relayer.