### PR TITLE
Observe challenge period for source chain when accumulating fees

### DIFF
--- a/modules/hyperclient/hyperclient.d.ts
+++ b/modules/hyperclient/hyperclient.d.ts
@@ -185,10 +185,10 @@ export interface MessageDispatched {
   Dispatched: bigint
 }
 
-// The possible initial states of a timeout (Post request or response) stream
+// The possible initial states of a timeout (request or response) stream
 export type TimeoutStreamState = "Pending" | DestinationFinalizedState | HyperbridgeVerifiedState | HyperbridgeFinalizedState;
 
-// The possible initial states of a message status (Post request or response) stream
+// The possible initial states of a message status (request or response) stream
 export type MessageStatusStreamState = MessageDispatched | SourceFinalizedState | HyperbridgeVerifiedState | HyperbridgeFinalizedState;
 
 // The possible states of an inflight request
@@ -337,12 +337,15 @@ export class HyperClient {
   ): Promise<ReadableStream<MessageStatusWithMeta>>;
 
   /**
-   * Return the status of a get request as a `ReadableStream`
+   * Return the status of a get request as a `ReadableStream`. If the stream terminates abruptly,
+   * perhaps as a result of some error, it can be resumed given some initial state.
    * @param {IGetRequest} request
+   * @param {MessageStatusStreamState} state
    * @returns {Promise<ReadableStream<MessageStatusWithMeta>>}
    */
   get_request_status_stream(
     request: IGetRequest,
+    state: MessageStatusStreamState,
   ): Promise<ReadableStream<MessageStatusWithMeta>>;
 
   /**

--- a/modules/hyperclient/package.json
+++ b/modules/hyperclient/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@polytope-labs/hyperclient",
   "description": "The hyperclient is a library for managing (in-flight) ISMP requests",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "author": "Polytope Labs (hello@polytope.technology)",
   "license": "Apache-2.0",
   "bugs": {

--- a/modules/hyperclient/package.json
+++ b/modules/hyperclient/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@polytope-labs/hyperclient",
   "description": "The hyperclient is a library for managing (in-flight) ISMP requests",
-  "version": "0.6.2",
+  "version": "0.6.4",
   "author": "Polytope Labs (hello@polytope.technology)",
   "license": "Apache-2.0",
   "bugs": {

--- a/modules/ismp/pallets/rpc/src/lib.rs
+++ b/modules/ismp/pallets/rpc/src/lib.rs
@@ -314,7 +314,7 @@ where
 			.map_err(|_| runtime_error_into_rpc_error("Error accessing state backend"))?;
 		let child_root = state
 			.storage(child_info.prefixed_storage_key().as_slice())
-			.map_err(|_| runtime_error_into_rpc_error("Error reading child trie root"))?
+			.map_err(|err| runtime_error_into_rpc_error(format!("Storage Read Error: {err:?}")))?
 			.map(|r| {
 				let mut hash = <<Block::Header as Header>::Hashing as Hash>::Output::default();
 
@@ -323,7 +323,7 @@ where
 
 				hash
 			})
-			.ok_or_else(|| runtime_error_into_rpc_error("Error reading child trie root"))?;
+			.ok_or_else(|| runtime_error_into_rpc_error("Child trie root storage returned None"))?;
 
 		let db = storage_proof.into_memory_db::<<Block::Header as Header>::Hashing>();
 

--- a/tesseract/messaging/src/lib.rs
+++ b/tesseract/messaging/src/lib.rs
@@ -477,6 +477,7 @@ async fn fee_accumulation<A: IsmpProvider + Clone + Clone + HyperbridgeClaim + '
 							let proofs = tx_payment
 							.create_proof_from_receipts(source_height.into(), dest_height, source_chain.clone(), dest.clone(), receipts.clone())
 							.await?;
+							observe_challenge_period(source_chain.clone(), hyperbridge.clone(), source_height.into()).await?;
 							observe_challenge_period(dest.clone(), hyperbridge.clone(), dest_height).await?;
 							let mut commitments =  vec![];
 							for proof in proofs {


### PR DESCRIPTION
This PR adds a change to tesseract, we need to observe the challenge period of the source chain when accumulating fees since we are using the latest state machine height of the source chain to query proofs.