### PR TITLE
add dwellir bootnode

### DIFF
--- a/parachain/chainspec/nexus.json
+++ b/parachain/chainspec/nexus.json
@@ -7,7 +7,9 @@
     "/dns/nexus.boot.stake.plus/tcp/30332/wss/p2p/12D3KooWMVkkfZVVnZXXBwPjxrGqud6aoK1XMeBVGBjtyX5aobEU",
     "/dns/nexus.boot.stake.plus/tcp/31332/wss/p2p/12D3KooWGXeeQ9VtdmeoTSX1uWKYWRMPKZ8mKvqMzAM6pXmbDFZ7",
     "/dns4/boot.helikon.io/tcp/8610/p2p/12D3KooWNvVYuuHtV9KSpUXy7puERNvoNyAcRGizp3s2QpHQuuhq",
-    "/dns4/boot.helikon.io/tcp/8612/wss/p2p/12D3KooWNvVYuuHtV9KSpUXy7puERNvoNyAcRGizp3s2QpHQuuhq"
+    "/dns4/boot.helikon.io/tcp/8612/wss/p2p/12D3KooWNvVYuuHtV9KSpUXy7puERNvoNyAcRGizp3s2QpHQuuhq",
+    "/dns/hyperbridge-nexus-boot-ng.dwellir.com/tcp/30367/p2p/12D3KooWSQsd5E7SyPX184B7vPBWAiF5Wjn4DvhSt8TrRB6FQeDk",
+    "/dns/hyperbridge-nexus-boot-ng.dwellir.com/tcp/443/wss/p2p/12D3KooWSQsd5E7SyPX184B7vPBWAiF5Wjn4DvhSt8TrRB6FQeDk"
   ],
   "telemetryEndpoints": [
     [


### PR DESCRIPTION
Add new dwellir bootnode, you can verify with:

```
./hyperbridge --chain=nexus --reserved-only --reserved-nodes=/dns/hyperbridge-nexus-boot-ng.dwellir.com/tcp/30367/p2p/12D3KooWSQsd5E7SyPX184B7vPBWAiF5Wjn4DvhSt8TrRB6FQeDk
```
```
./hyperbridge --chain=nexus --reserved-only --reserved-nodes=/dns/hyperbridge-nexus-boot-ng.dwellir.com/tcp/443/wss/p2p/12D3KooWSQsd5E7SyPX184B7vPBWAiF5Wjn4DvhSt8TrRB6FQeDk
```