### PR TITLE
Enable metadata hash when building the runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10009,6 +10009,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "merkleized-metadata"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f313fcff1d2a4bcaa2deeaa00bf7530d77d5f7bd0467a117dde2e29a75a7a17a"
+dependencies = [
+ "array-bytes 6.2.3",
+ "blake3",
+ "frame-metadata 16.0.0",
+ "parity-scale-codec",
+ "scale-decode 0.13.1",
+ "scale-info",
+]
+
+[[package]]
 name = "merlin"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19484,6 +19498,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "scale-bits"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57b1e7f6b65ed1f04e79a85a57d755ad56d76fdf1e9bddcc9ae14f71fcdcf54"
+dependencies = [
+ "parity-scale-codec",
+ "scale-type-resolver",
+]
+
+[[package]]
 name = "scale-decode"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19491,11 +19515,24 @@ checksum = "f0459d00b0dbd2e765009924a78ef36b2ff7ba116292d732f00eb0ed8e465d15"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
- "scale-bits",
+ "scale-bits 0.3.0",
  "scale-decode-derive",
  "scale-info",
  "smallvec",
  "thiserror",
+]
+
+[[package]]
+name = "scale-decode"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e98f3262c250d90e700bb802eb704e1f841e03331c2eb815e46516c4edbf5b27"
+dependencies = [
+ "derive_more",
+ "parity-scale-codec",
+ "scale-bits 0.6.0",
+ "scale-type-resolver",
+ "smallvec",
 ]
 
 [[package]]
@@ -19519,7 +19556,7 @@ checksum = "b0401b7cdae8b8aa33725f3611a051358d5b32887ecaa0fda5953a775b2d4d76"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
- "scale-bits",
+ "scale-bits 0.3.0",
  "scale-encode-derive",
  "scale-info",
  "smallvec",
@@ -19566,6 +19603,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scale-type-resolver"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0cded6518aa0bd6c1be2b88ac81bf7044992f0f154bfbabd5ad34f43512abcb"
+
+[[package]]
 name = "scale-value"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19576,8 +19619,8 @@ dependencies = [
  "either",
  "frame-metadata 15.1.0",
  "parity-scale-codec",
- "scale-bits",
- "scale-decode",
+ "scale-bits 0.3.0",
+ "scale-decode 0.7.0",
  "scale-encode",
  "scale-info",
  "serde",
@@ -23163,13 +23206,22 @@ version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0104598a022d22430f27e535b7aed148af9dcd0a3eb23697c02168071a325e33"
 dependencies = [
+ "array-bytes 6.2.3",
  "build-helper",
  "cargo_metadata 0.15.4",
  "console",
  "filetime",
+ "frame-metadata 16.0.0",
+ "merkleized-metadata",
+ "parity-scale-codec",
  "parity-wasm",
  "polkavm-linker",
+ "sc-executor 0.40.0",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
  "sp-maybe-compressed-blob",
+ "sp-tracing 17.0.0",
+ "sp-version 37.0.0",
  "strum 0.26.3",
  "tempfile",
  "toml 0.8.19",
@@ -23213,8 +23265,8 @@ dependencies = [
  "jsonrpsee 0.16.3",
  "parity-scale-codec",
  "primitive-types",
- "scale-bits",
- "scale-decode",
+ "scale-bits 0.3.0",
+ "scale-decode 0.7.0",
  "scale-encode",
  "scale-info",
  "scale-value",

--- a/parachain/runtimes/gargantua/Cargo.toml
+++ b/parachain/runtimes/gargantua/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [build-dependencies]
-substrate-wasm-builder = { workspace = true }
+substrate-wasm-builder = { workspace = true, features = ["metadata-hash"] }
 
 [dependencies]
 # crates.io

--- a/parachain/runtimes/gargantua/Cargo.toml
+++ b/parachain/runtimes/gargantua/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [build-dependencies]
-substrate-wasm-builder = { workspace = true, features = ["metadata-hash"] }
+substrate-wasm-builder = { workspace = true }
 
 [dependencies]
 # crates.io
@@ -245,3 +245,7 @@ try-runtime = [
 	"parachain-info/try-runtime",
 	"pallet-assets/runtime-benchmarks"
 ]
+
+
+# This must be used when buiding for a runtime upgrade so metadata hash verification is possible
+metadata-hash = ["substrate-wasm-builder/metadata-hash"]

--- a/parachain/runtimes/nexus/Cargo.toml
+++ b/parachain/runtimes/nexus/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
-substrate-wasm-builder = { workspace = true }
+substrate-wasm-builder = { workspace = true, features = ["metadata-hash"]}
 
 [dependencies]
 # crates.io

--- a/parachain/runtimes/nexus/Cargo.toml
+++ b/parachain/runtimes/nexus/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
-substrate-wasm-builder = { workspace = true, features = ["metadata-hash"]}
+substrate-wasm-builder = { workspace = true }
 
 [dependencies]
 # crates.io
@@ -255,3 +255,6 @@ try-runtime = [
 	"pallet-xcm/try-runtime",
 	"parachain-info/try-runtime",
 ]
+
+# This must be used when building for a runtime upgrade so metadata hash verification is possible
+metadata-hash = ["substrate-wasm-builder/metadata-hash"]

--- a/scripts/build_release_runtime.sh
+++ b/scripts/build_release_runtime.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cargo build -p $1 --features=metadata-hash --release


### PR DESCRIPTION
Build the runtimes with metadata hash so the `CheckMetadataSigned` Extension works