### PR TITLE
Support optional EIP-7685 fields in Geth Header

### DIFF
--- a/modules/consensus/geth-primitives/src/lib.rs
+++ b/modules/consensus/geth-primitives/src/lib.rs
@@ -1,18 +1,3 @@
-// Copyright (C) 2022 Polytope Labs.
-// SPDX-License-Identifier: Apache-2.0
-
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// 	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 #![cfg_attr(not(feature = "std"), no_std)]
 extern crate alloc;
 
@@ -48,6 +33,7 @@ pub struct Header {
 	pub blob_gas_used: Option<u64>,
 	pub excess_blob_gas_used: Option<u64>,
 	pub parent_beacon_root: Option<B256>,
+	pub requests_hash: Option<B256>,
 }
 
 #[derive(codec::Encode, codec::Decode, Debug, Clone, scale_info::TypeInfo)]
@@ -72,6 +58,7 @@ pub struct CodecHeader {
 	pub blob_gas_used: Option<u64>,
 	pub excess_blob_gas_used: Option<u64>,
 	pub parent_beacon_root: Option<H256>,
+	pub requests_hash: Option<H256>,
 }
 
 impl AsRef<CodecHeader> for CodecHeader {
@@ -113,6 +100,10 @@ impl From<Block<H256>> for CodecHeader {
 				.other
 				.get_deserialized::<H256>("parentBeaconBlockRoot")
 				.and_then(|val| val.ok()),
+			requests_hash: block
+				.other
+				.get_deserialized::<H256>("requestsHash")
+				.and_then(|val| val.ok()),
 		}
 	}
 }
@@ -152,6 +143,7 @@ impl From<&CodecHeader> for Header {
 			blob_gas_used: value.blob_gas_used,
 			excess_blob_gas_used: value.excess_blob_gas_used,
 			parent_beacon_root: value.parent_beacon_root.map(|val| val.0.into()),
+			requests_hash: value.requests_hash.map(|val| val.0.into()),
 		}
 	}
 }

--- a/modules/consensus/geth-primitives/src/lib.rs
+++ b/modules/consensus/geth-primitives/src/lib.rs
@@ -1,3 +1,18 @@
+// Copyright (C) 2022 Polytope Labs.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #![cfg_attr(not(feature = "std"), no_std)]
 extern crate alloc;
 

--- a/parachain/runtimes/gargantua/src/lib.rs
+++ b/parachain/runtimes/gargantua/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("gargantua"),
 	impl_name: create_runtime_str!("gargantua"),
 	authoring_version: 1,
-	spec_version: 2_200,
+	spec_version: 2_300,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
closes #375  : This is not a breaking change for other onchain light clients using the geth header since the field is optional, it would only be rlp encoded if it's found in the block header.

