### PR TITLE
Allow setting token balance through governance

### DIFF
--- a/modules/pallets/token-gateway-inspector/src/lib.rs
+++ b/modules/pallets/token-gateway-inspector/src/lib.rs
@@ -37,6 +37,9 @@ pub mod pallet {
 	use ismp::host::StateMachine;
 	use pallet_token_gateway::types::Body;
 	use pallet_token_governor::StandaloneChainAssets;
+	use polkadot_sdk::{
+		frame_support::dispatch::DispatchResult, frame_system::pallet_prelude::OriginFor,
+	};
 
 	#[pallet::pallet]
 	#[pallet::without_storage_info]
@@ -75,6 +78,25 @@ pub mod pallet {
 	impl<T> Default for Pallet<T> {
 		fn default() -> Self {
 			Self(PhantomData)
+		}
+	}
+
+	#[derive(Debug, Clone, Encode, Decode, scale_info::TypeInfo, PartialEq, Eq)]
+	pub struct NetInflow {
+		asset: H256,
+		chain: StateMachine,
+		balance: U256,
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		/// Set the balance of a chain through a governance action
+		#[pallet::call_index(0)]
+		#[pallet::weight(<T as frame_system::Config>::DbWeight::get().writes(1))]
+		pub fn set_chain_balance(origin: OriginFor<T>, inflow: NetInflow) -> DispatchResult {
+			T::AdminOrigin::ensure_origin(origin)?;
+			InflowBalances::<T>::insert(inflow.chain, inflow.asset, inflow.balance);
+			Ok(())
 		}
 	}
 

--- a/parachain/runtimes/nexus/src/lib.rs
+++ b/parachain/runtimes/nexus/src/lib.rs
@@ -221,7 +221,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("nexus"),
 	impl_name: create_runtime_str!("nexus"),
 	authoring_version: 1,
-	spec_version: 2_500,
+	spec_version: 2_600,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
Update token gateway inspector with a call to set the net inflow through a governance call.