### PR TITLE
Ismp-grandpa: UX Improvement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8507,7 +8507,7 @@ version = "0.1.1"
 
 [[package]]
 name = "ismp-grandpa"
-version = "16.0.0"
+version = "16.0.1"
 dependencies = [
  "anyhow",
  "ckb-merkle-mountain-range",

--- a/docs/pages/developers/polkadot/solochains.mdx
+++ b/docs/pages/developers/polkadot/solochains.mdx
@@ -90,7 +90,10 @@ type = "grandpa"
 # Hyperbridge's relay chain websocket RPC
 rpc = ""
 # Hyperbridge's slot duration
-slot_duration = 6
+# on Polkadot
+# slot_duration = 12000
+# on Paseo
+slot_duration = 6000
 # How frequently to exchange consensus proofs
 consensus_update_frequency = 60
 # Hyperbridge's paraId on the provided relay chain
@@ -131,7 +134,7 @@ state_machine = "SUBSTRATE-myid"
 # Solochains's websocket RPC
 rpc = ""
 # Solochains's slot duration
-slot_duration = 6
+slot_duration = 6000
 # How frequently to exchange consensus proofs
 consensus_update_frequency = 60
 # Any para ids to prove if solochain is actually a relay chain

--- a/docs/pages/developers/polkadot/solochains.mdx
+++ b/docs/pages/developers/polkadot/solochains.mdx
@@ -16,7 +16,7 @@ Every other configuration detail remains unchanged as described in the previous 
 ```rust showLineNumbers [runtime.rs]
 
 pub RuntimeBlockLength: BlockLength =
-    BlockLength::max_with_normal_ratio(8 * 1024 * 1024, Perbill::from_percent(80));
+    BlockLength::max_with_normal_ratio(8 * 1024 * 1024, Perbill::from_percent(85));
 
 parameter_types! {
     // The hyperbridge parachain on Polkadot

--- a/docs/pages/developers/polkadot/solochains.mdx
+++ b/docs/pages/developers/polkadot/solochains.mdx
@@ -142,9 +142,9 @@ para_ids = []
 
 [relayer]
 maximum_update_intervals = [
-    # restart if the polkadot consensus client is not updated within 3 minutes
+    # restart if the polkadot consensus client on your solochain is not updated within 3 minutes
     [{state_id = "POLKADOT-3367", consensus_state_id = "DOT0"}, 180],
-    # restart if the your solochain consensus client is not updated within 3 minutes
+    # restart if your solochain consensus client on hyperbridge is not updated within 3 minutes
     [{state_id = "SUBSTRATE-myid", consensus_state_id = "MYID"}, 180],
 ]
 ```

--- a/docs/pages/developers/polkadot/solochains.mdx
+++ b/docs/pages/developers/polkadot/solochains.mdx
@@ -9,11 +9,15 @@ For solochains that want to integrate with hyperbridge, a GRANDPA consensus clie
 
 ## Runtime Integration
 
-In your runtime, you should configure Hyperbridge as the coprocessor and add a GRANDPA consensus client to the list of consensus clients. The host state machine should be assigned a unique value for each solochain connected to Hyperbridge.
+In your runtime, you should configure Hyperbridge as the coprocessor and add a GRANDPA consensus client to the list of consensus clients. The host state machine should be assigned a unique value for each solochain connected to Hyperbridge. You should also configure a larger block length limit to accommodate for large GRANDPA proofs. The new recommended limit is `8MB`, with a maximum extrinsic limit of 85%.
 
 Every other configuration detail remains unchanged as described in the previous sections
 
 ```rust showLineNumbers [runtime.rs]
+
+pub RuntimeBlockLength: BlockLength =
+    BlockLength::max_with_normal_ratio(8 * 1024 * 1024, Perbill::from_percent(80));
+
 parameter_types! {
     // The hyperbridge parachain on Polkadot
     pub const Coprocessor: Option<StateMachine> = Some(StateMachine::Polkadot(3367));
@@ -84,7 +88,7 @@ type = "grandpa"
 
 [hyperbridge.grandpa]
 # Hyperbridge's relay chain websocket RPC
-rpc = "" 
+rpc = ""
 # Hyperbridge's slot duration
 slot_duration = 6
 # How frequently to exchange consensus proofs
@@ -132,6 +136,14 @@ slot_duration = 6
 consensus_update_frequency = 60
 # Any para ids to prove if solochain is actually a relay chain
 para_ids = []
+
+[relayer]
+maximum_update_intervals = [
+    # restart if the polkadot consensus client is not updated within 3 minutes
+    [{state_id = "POLKADOT-3367", consensus_state_id = "DOT0"}, 180],
+    # restart if the your solochain consensus client is not updated within 3 minutes
+    [{state_id = "SUBSTRATE-myid", consensus_state_id = "MYID"}, 180],
+]
 ```
 
 ### Consensus State Initialization
@@ -178,11 +190,19 @@ log-consensus-state SUBSTRATE-myid
 Once all consensus states are set up, running the relayer is as easy as:
 
 ```bash
-docker run \
+docker run -d \
+--name=consensus \
+--restart=always \
 --network=host \
 -v /path/to/consensus.toml:/root/consensus.toml \
 polytopelabs/tesseract-consensus:latest \
 --config=/root/consensus.toml
+```
+
+Access it's logs via
+
+```bash
+docker logs -f consensus -n=${maximum_number_of_previous_log_lines}
 ```
 
 You will of course need to pair this with the [messaging relayer](/developers/network/relayer) which actually relays cross-chain messages.
@@ -197,5 +217,3 @@ The GRANDPA consensus client relies on digest items in the header to communicate
 
 - [ismp-grandpa](https://github.com/polytope-labs/hyperbridge/tree/main/modules/ismp/clients/grandpa)
 - [grandpa-verifier](https://github.com/polytope-labs/hyperbridge/tree/main/modules/consensus/grandpa/verifier)
-
-

--- a/modules/ismp/clients/grandpa/Cargo.toml
+++ b/modules/ismp/clients/grandpa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ismp-grandpa"
-version = "16.0.0"
+version = "16.0.1"
 edition = "2021"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 license = "Apache-2.0"

--- a/modules/ismp/clients/grandpa/src/consensus.rs
+++ b/modules/ismp/clients/grandpa/src/consensus.rs
@@ -177,10 +177,16 @@ where
 				.map_err(|err| {
 					Error::Custom(format!("Error verifying grandpa header: {err:#?}"))
 				})?;
-				let digest_result = fetch_overlay_root_and_timestamp(
-					header.digest(),
-					consensus_state.slot_duration,
-				)?;
+
+				let slot_duration = SupportedStateMachines::<T>::get(consensus_state.state_machine)
+					.ok_or_else(|| {
+						Error::Custom(format!(
+							"Error getting slot duration for state machine {}",
+							consensus_state.state_machine
+						))
+					})?;
+				let digest_result =
+					fetch_overlay_root_and_timestamp(header.digest(), slot_duration)?;
 
 				if digest_result.timestamp == 0 {
 					Err(Error::Custom("Timestamp or ismp root not found".into()))?

--- a/modules/pallets/token-governor/src/impls.rs
+++ b/modules/pallets/token-governor/src/impls.rs
@@ -372,9 +372,6 @@ where
 	/// Dispatches a request to create list an ERC20 asset on TokenGateway
 	pub fn create_erc20_asset_impl(asset: ERC20AssetRegistration) -> Result<(), Error<T>> {
 		let asset_id: H256 = sp_io::hashing::keccak_256(asset.symbol.as_ref()).into();
-		if AssetOwners::<T>::contains_key(&asset_id) {
-			Err(Error::<T>::AssetAlreadyExists)?
-		}
 
 		let metadata = AssetMetadata { name: asset.name.clone(), symbol: asset.symbol.clone() };
 

--- a/modules/pallets/token-governor/src/lib.rs
+++ b/modules/pallets/token-governor/src/lib.rs
@@ -209,10 +209,10 @@ pub mod pallet {
 		<T as frame_system::Config>::AccountId: From<[u8; 32]>,
 		<T as pallet_ismp::Config>::Balance: Default,
 	{
-		/// Registers a multi-chain ERC6160 asset. The asset should not already exist.
+		/// Creates a multi-chain ERC6160 asset.
 		///
-		/// This works by dispatching a request to the TokenGateway module on each requested chain
-		/// to create the asset.
+		/// This works by dispatching a governance request to the TokenGateway contract on each
+		/// requested chain to create the token contract for the asset
 		#[pallet::call_index(0)]
 		#[pallet::weight(weight())]
 		pub fn create_erc6160_asset(
@@ -320,10 +320,11 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Dispatches a request to update the Asset fees on the provided chain
+		/// Dispatches a governance request to the relevant TokenGateway contracts to map the
+		/// provided token contract to an asset id
 		#[pallet::call_index(6)]
 		#[pallet::weight(weight())]
-		pub fn create_erc20_asset(
+		pub fn create_asset_mapping(
 			origin: OriginFor<T>,
 			asset: ERC20AssetRegistration,
 		) -> DispatchResult {

--- a/parachain/runtimes/nexus/src/lib.rs
+++ b/parachain/runtimes/nexus/src/lib.rs
@@ -221,7 +221,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("nexus"),
 	impl_name: create_runtime_str!("nexus"),
 	authoring_version: 1,
-	spec_version: 2_600,
+	spec_version: 2_700,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
Prefer onchain slot duration over consensus state slot duration for state commitment timestamp derivation. Allowing solochains to evolve slot duration freely, without requiring a full consensus state reset.