### PR TITLE
Correct hyperbridge node version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7895,7 +7895,7 @@ dependencies = [
 
 [[package]]
 name = "hyperbridge"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "clap",
  "futures",

--- a/parachain/node/Cargo.toml
+++ b/parachain/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperbridge"
-version = "1.1.1"
+version = "1.2.0"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 description = "The Hyperbridge coprocessor node"
 repository = "https://github.com/polytope-labs/hyperbridge"


### PR DESCRIPTION
The new parachain inherent client would be incompatible with the previous version after the next runtime upgrade