### PR TITLE
Fix deposit requests struct

### DIFF
--- a/modules/consensus/bsc/prover/src/test.rs
+++ b/modules/consensus/bsc/prover/src/test.rs
@@ -45,8 +45,8 @@ async fn setup_prover() -> BscPosProver<Testnet> {
 	dotenv::dotenv().ok();
 	let consensus_url = std::env::var("BSC_URL").unwrap();
 	let mut provider = Provider::<Http>::connect(&consensus_url).await;
-	// Bsc block time is 0.75s we don't want to deal with missing authority set changes while polling
-	// for blocks in our tests
+	// Bsc block time is 0.75s we don't want to deal with missing authority set changes while
+	// polling for blocks in our tests
 	provider.set_interval(Duration::from_millis(750));
 	BscPosProver::new(provider)
 }
@@ -92,9 +92,9 @@ async fn verify_bsc_pos_headers() {
 				update.epoch_header_ancestry = Default::default();
 			}
 
-			if next_validators.is_some()
-				&& update.attested_header.number.low_u64() % EPOCH_LENGTH
-					>= (validators.len() as u64 / 2)
+			if next_validators.is_some() &&
+				update.attested_header.number.low_u64() % EPOCH_LENGTH >=
+					(validators.len() as u64 / 2)
 			{
 				let result = verify_bsc_header::<Host, Testnet>(
 					&next_validators.clone().unwrap().validators,

--- a/modules/consensus/sync-committee/primitives/src/electra.rs
+++ b/modules/consensus/sync-committee/primitives/src/electra.rs
@@ -7,6 +7,7 @@ use ssz_rs::{prelude::*, Deserialize};
 #[derive(Default, Debug, SimpleSerialize, codec::Encode, codec::Decode, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct DepositRequest {
+	#[cfg_attr(feature = "std", serde(rename = "pubkey"))]
 	pub pub_key: BlsPublicKey,
 	pub withdrawal_credentials: Bytes32,
 	#[cfg_attr(feature = "std", serde(with = "serde_hex_utils::as_string"))]


### PR DESCRIPTION
Add a serde rename for `pubkey` field in `DepositRequests` struct for electra.
Fixes these errors in fetching blocks
```
2025-05-27 13:07:21 | 2025-05-27T12:07:21.447459Z ERROR tesseract_sync_committee::host: Failed to fetch consensus proof for Evm(1): Failed to fetch block with id 0x04992c7b6c16b0b4103dc35c2507996fd95c47e4c1d88cb6f0bf5a8624f338b2 due to error reqwest::Error { kind: Decode, source: Error("missing field `pub_key`", line: 1, column: 309042) }
2025-05-27 13:07:22 | 2025-05-27T12:07:22.417571Z ERROR tesseract_sync_committee::host: Failed to fetch consensus proof for Evm(1): Failed to fetch block with id 0x04992c7b6c16b0b4103dc35c2507996fd95c47e4c1d88cb6f0bf5a8624f338b2 due to error reqwest::Error { kind: Decode, source: Error("missing field `pub_key`", line: 1, column: 309042) }
2025-05-27 13:07:23 | 2025-05-27T12:07:23.458814Z ERROR tesseract_sync_committee::host: Failed to fetch consensus proof for Evm(1): Failed to fetch block with id 0x04992c7b6c16b0b4103dc35c2507996fd95c47e4c1d88cb6f0bf5a8624f338b2 due to error reqwest::Error { kind: Decode, source: Error("missing field `pub_key`", line: 1, column: 309042) }
2025-05-27 13:07:24 | 2025-05-27T12:07:24.421103Z ERROR tesseract_sync_committee::host: Failed to fetch consensus proof for Evm(1): Failed to fetch block with id 0x04992c7b6c16b0b4103dc35c2507996fd95c47e4c1d88cb6f0bf5a8624f338b2 due to error reqwest::Error { kind: Decode, source: Error("missing field `pub_key`", line: 1, column: 309042) }
```