### PR TITLE
proof of ownership for messages submitted to Hyperbridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14283,6 +14283,7 @@ version = "0.1.0"
 dependencies = [
  "ismp",
  "pallet-ismp",
+ "pallet-ismp-relayer",
  "parity-scale-codec",
  "polkadot-sdk",
  "scale-info",

--- a/modules/pallets/consensus-incentives/Cargo.toml
+++ b/modules/pallets/consensus-incentives/Cargo.toml
@@ -14,6 +14,7 @@ codec = { workspace = true }
 scale-info = { workspace = true }
 pallet-ismp = { workspace = true, default-features = false }
 ismp = { workspace = true, default-features = false }
+pallet-ismp-relayer = { workspace = true, default-features = false }
 
 [dependencies.polkadot-sdk]
 workspace = true
@@ -27,6 +28,7 @@ std = [
     "polkadot-sdk/std",
     "pallet-ismp/std",
     "ismp/std",
+    "pallet-ismp-relayer/std",
 ]
 runtime-benchmarks = ["polkadot-sdk/runtime-benchmarks"]
 try-runtime = ["polkadot-sdk/try-runtime"]

--- a/modules/pallets/consensus-incentives/src/impls.rs
+++ b/modules/pallets/consensus-incentives/src/impls.rs
@@ -25,12 +25,33 @@ use ismp::{
 	messaging::Message,
 };
 use pallet_ismp::fee_handler::FeeHandler;
-use polkadot_sdk::{frame_support::traits::fungible::Mutate, sp_runtime::traits::*};
+use pallet_ismp_relayer::withdrawal::Signature;
+use polkadot_sdk::{
+	frame_support::traits::fungible::Mutate, sp_core::sr25519, sp_runtime::traits::*,
+};
 
 impl<T: Config> Pallet<T>
 where
 	<T as frame_system::Config>::AccountId: From<[u8; 32]>,
 {
+	fn verify_and_get_relayer(signer: &Vec<u8>, signed_data: &[u8; 32]) -> Option<Vec<u8>> {
+		if let Ok(signature_enum) = Signature::decode(&mut &signer[..]) {
+			match signature_enum {
+				Signature::Sr25519 { public_key, signature } => {
+					if let (Ok(pub_key), Ok(sig)) = (
+						sr25519::Public::decode(&mut &public_key[..]),
+						sr25519::Signature::decode(&mut &signature[..]),
+					) {
+						if sp_io::crypto::sr25519_verify(&sig, signed_data, &pub_key) {
+							return Some(pub_key.0.into());
+						}
+					}
+				},
+				_ => return None,
+			}
+		}
+		None
+	}
 	/// Process a message and reward the relayer
 	///
 	/// This is an internal function used to handle relayer rewards for each
@@ -112,19 +133,25 @@ where
 
 		for message in messages {
 			if let Message::Consensus(consensus_msg) = message {
-				let maybe_match = state_machine_map.iter().find(|(_, (consensus_state_id, _))| {
-					*consensus_state_id == consensus_msg.consensus_state_id
-				});
+				let data = sp_io::hashing::keccak_256(&consensus_msg.consensus_proof.encode());
+				if let Some(relayer_account) =
+					Self::verify_and_get_relayer(&consensus_msg.signer, &data)
+				{
+					let maybe_match =
+						state_machine_map.iter().find(|(_, (consensus_state_id, _))| {
+							*consensus_state_id == consensus_msg.consensus_state_id
+						});
 
-				if let Some((state_machine_id, (_, height))) = maybe_match {
-					let state_machine_height =
-						StateMachineHeight { id: state_machine_id.clone(), height: height.clone() };
+					if let Some((state_machine_id, (_, height))) = maybe_match {
+						let state_machine_height =
+							StateMachineHeight { id: state_machine_id.clone(), height: *height };
 
-					Self::process_message(
-						state_machine_height,
-						state_machine_id.clone(),
-						consensus_msg.signer.clone(),
-					)?;
+						let _ = Self::process_message(
+							state_machine_height,
+							state_machine_id.clone(),
+							relayer_account,
+						);
+					}
 				}
 			}
 		}

--- a/modules/pallets/testsuite/src/tests/pallet_consensus_incentives.rs
+++ b/modules/pallets/testsuite/src/tests/pallet_consensus_incentives.rs
@@ -15,12 +15,13 @@
 
 #![cfg(test)]
 
+use codec::Encode;
 use frame_support::{
 	traits::fungible::{Inspect, Mutate},
 	PalletId,
 };
-use polkadot_sdk::*;
-use sp_core::{crypto::AccountId32, H256};
+use polkadot_sdk::{sp_runtime::RuntimeAppPublic, *};
+use sp_core::{crypto::AccountId32, keccak_256, sr25519, ByteArray, Pair, H256};
 use sp_runtime::traits::AccountIdConversion;
 
 use ismp::{
@@ -28,6 +29,7 @@ use ismp::{
 	host::{IsmpHost, StateMachine},
 	messaging::{ConsensusMessage, Message},
 };
+use pallet_ismp_relayer::withdrawal::Signature;
 
 use crate::runtime::{new_test_ext, Ismp, RuntimeOrigin, Test, *};
 
@@ -44,16 +46,33 @@ fn setup_balances(relayer_account: &AccountId32, treasury_account: &AccountId32)
 	Balances::mint_into(treasury_account, 20000 * UNIT).unwrap();
 }
 
-fn setup_host_and_message(relayer: H256, host: &Ismp) -> Message {
+fn setup_host_and_message(host: &Ismp) -> (Message, AccountId32) {
+	let relayer_pair = sr25519::Pair::from_seed(&H256::random().0);
+	let treasury_account = PalletId(*b"treasury").into_account_truncating();
+
+	let relayer_account: AccountId32 = relayer_pair.public().into();
+
+	setup_balances(&relayer_account.clone().into(), &treasury_account);
+
+	let consensus_proof: Vec<u8> = vec![0];
+	let signed_data = keccak_256(&consensus_proof.encode());
+	let signature = relayer_pair.sign(&signed_data);
+	let signature = Signature::Sr25519 {
+		public_key: relayer_pair.public().to_raw_vec(),
+		signature: signature.to_raw_vec(),
+	};
+
+	dbg!(relayer_pair.public());
+
 	let message = Message::Consensus(ConsensusMessage {
-		consensus_proof: vec![],
+		consensus_proof,
 		consensus_state_id: *b"mock",
-		signer: relayer.0.into(),
+		signer: signature.encode(),
 	});
 	setup_mock_client::<_, Test>(host);
 	host.unbonding_period(*b"mock").unwrap();
 	host.store_consensus_update_time(*b"mock", host.timestamp()).unwrap();
-	message
+	(message, relayer_account)
 }
 
 #[test]
@@ -63,12 +82,6 @@ fn test_incentivize_relayer() {
 		let host = Ismp::default();
 		let state_machine_id = setup_state_machine();
 
-		let relayer = H256::random().0;
-		let relayer_account: AccountId32 = relayer.into();
-		let treasury_account = PalletId(*b"treasury").into_account_truncating();
-
-		setup_balances(&relayer_account, &treasury_account);
-
 		pallet_consensus_incentives::Pallet::<Test>::update_cost_per_block(
 			RuntimeOrigin::root(),
 			state_machine_id,
@@ -76,7 +89,7 @@ fn test_incentivize_relayer() {
 		)
 		.unwrap();
 
-		let consensus_message = setup_host_and_message(relayer.into(), &host);
+		let (consensus_message, relayer_account) = setup_host_and_message(&host);
 
 		pallet_ismp::Pallet::<Test>::handle_unsigned(
 			RuntimeOrigin::none(),
@@ -93,14 +106,7 @@ fn skip_incentivizing_of_relayer_when_cost_per_block_is_not_set() {
 	let mut ext = new_test_ext();
 	ext.execute_with(|| {
 		let host = Ismp::default();
-
-		let relayer = H256::random().0;
-		let relayer_account: AccountId32 = relayer.into();
-		let treasury_account = PalletId(*b"treasury").into_account_truncating();
-
-		setup_balances(&relayer_account, &treasury_account);
-
-		let consensus_message = setup_host_and_message(relayer.into(), &host);
+		let (consensus_message, relayer_account) = setup_host_and_message(&host);
 
 		pallet_ismp::Pallet::<Test>::handle_unsigned(
 			RuntimeOrigin::none(),

--- a/modules/pallets/testsuite/src/tests/pallet_messaging_fees.rs
+++ b/modules/pallets/testsuite/src/tests/pallet_messaging_fees.rs
@@ -14,7 +14,7 @@ use polkadot_sdk::{
 };
 
 use scale_info::TypeInfo;
-use sp_core::{crypto::AccountId32, keccak_256, sr25519, Pair, H256, U256};
+use sp_core::{crypto::AccountId32, keccak_256, sr25519, ByteArray, Pair, H256, U256};
 
 use hyperbridge_client_machine::OnRequestProcessed;
 use ismp::{
@@ -25,6 +25,7 @@ use ismp::{
 };
 use pallet_ismp::fee_handler::FeeHandler;
 use pallet_ismp_host_executive::{EvmHostParam, HostParam, PerByteFee};
+use pallet_ismp_relayer::withdrawal::Signature;
 use pallet_messaging_fees::TotalBytesProcessed;
 
 use crate::runtime::{new_test_ext, Balances, RuntimeOrigin, Test, TreasuryAccount, UNIT};
@@ -71,7 +72,10 @@ fn create_request_message(
 	let requests = vec![post_request];
 	let signed_data = keccak_256(&requests.encode());
 	let signature = relayer_pair.sign(&signed_data);
-	let signer_tuple = (relayer_pair.public(), signature);
+	let signature = Signature::Sr25519 {
+		public_key: relayer_pair.public().to_raw_vec(),
+		signature: signature.to_raw_vec(),
+	};
 
 	let request_message = RequestMessage {
 		requests,
@@ -82,7 +86,7 @@ fn create_request_message(
 			},
 			proof: vec![],
 		},
-		signer: signer_tuple.encode(),
+		signer: signature.encode(),
 	};
 
 	Message::Request(request_message)

--- a/tesseract/messaging/substrate/src/provider.rs
+++ b/tesseract/messaging/substrate/src/provider.rs
@@ -21,11 +21,13 @@ use anyhow::{anyhow, Error};
 use codec::{Decode, Encode};
 use futures::{stream::FuturesOrdered, FutureExt};
 use hex_literal::hex;
-use polkadot_sdk::sp_core::{
-	storage::{ChildInfo, StorageData, StorageKey},
-	Pair, H160, U256,
+use polkadot_sdk::{
+	sp_core::{
+		storage::{ChildInfo, StorageData, StorageKey},
+		Pair, H160, U256,
+	},
+	sp_io::hashing::keccak_256,
 };
-use polkadot_sdk::sp_io::hashing::keccak_256;
 use subxt::{
 	config::{ExtrinsicParams, HashFor, Header},
 	ext::{
@@ -674,8 +676,7 @@ where
 						Message::Request(ref mut req) => req.signer = encoded_signer,
 						Message::Response(ref mut res) => res.signer = encoded_signer,
 						Message::Consensus(ref mut con) => con.signer = encoded_signer,
-						Message::FraudProof(ref mut fp) => fp.signer = encoded_signer,
-						_ => {}
+						_ => {},
 					}
 				}
 			}
@@ -920,21 +921,11 @@ pub fn system_events_key() -> StorageKey {
 
 fn encode_message(msg: &Message) -> Option<[u8; 32]> {
 	return match msg {
-		Message::Request(request_message) => {
-			Some(keccak_256(&request_message.requests.encode()))
-		}
-		Message::Response(response_message) => {
-			Some(keccak_256(&response_message.datagram.encode()))
-		}
-		Message::Consensus(consensus_message) => {
-			Some(keccak_256(&consensus_message.consensus_proof))
-		}
-		Message::FraudProof(fraud_proof) => {
-			Some(keccak_256(&(fraud_proof.proof_1.clone(), fraud_proof.proof_2.clone()).encode()))
-		}
-		Message::Timeout(_) => {
-			None
-		},
+		Message::Request(request_message) => Some(keccak_256(&request_message.requests.encode())),
+		Message::Response(response_message) =>
+			Some(keccak_256(&response_message.datagram.encode())),
+		Message::Consensus(consensus_message) =>
+			Some(keccak_256(&consensus_message.consensus_proof)),
+		Message::FraudProof(_) | Message::Timeout(_) => None,
 	}
 }
-


### PR DESCRIPTION
This pull request introduces is for  security enhancement to the relayer incentive mechanism. The previously trusted `signer` field in ISMP messages is now replaced with a cryptographic proof of ownership, ensuring that incentives are only distributed to the authenticated relayer who submitted the message.
