### PR TITLE
chore: add graffiti parameter to placeOrder function

### DIFF
--- a/evm/src/modules/IntentGateway.sol
+++ b/evm/src/modules/IntentGateway.sol
@@ -353,7 +353,7 @@ contract IntentGateway is BaseIsmpModule {
      * @dev This function allows users to place an order by providing the order details.
      * @param order The order details to be placed.
      */
-    function placeOrder(Order memory order) public payable {
+    function placeOrder(Order memory order, bytes32 graffiti) public payable {
         address hostAddr = host();
         // fill out the order preludes
         order.nonce = _nonce;

--- a/evm/test/IntentGatewayTest.sol
+++ b/evm/test/IntentGatewayTest.sol
@@ -70,10 +70,10 @@ contract IntentGatewayTest is MainnetForkBaseTest {
         Order memory order = createTestOrder(bytes(""));
 
         // Place the order
-        intentGateway.placeOrder{value: 1 ether}(order);
+        intentGateway.placeOrder{value: 1 ether}(order, bytes32(""));
 
         vm.expectRevert(IntentGateway.InsufficientNativeToken.selector);
-        intentGateway.placeOrder{value: 0.9 ether}(order);
+        intentGateway.placeOrder{value: 0.9 ether}(order, bytes32(""));
 
         // Check the balances
         assertEq(address(this).balance, 99 ether);
@@ -85,7 +85,7 @@ contract IntentGatewayTest is MainnetForkBaseTest {
         Order memory order = createTestOrder(bytes(""));
 
         // Place the order
-        intentGateway.placeOrder{value: 1 ether}(order);
+        intentGateway.placeOrder{value: 1 ether}(order, bytes32(""));
 
         assertEq(filler.balance, 100 ether);
         assertEq(address(intentGateway).balance, 1 ether);
@@ -153,7 +153,7 @@ contract IntentGatewayTest is MainnetForkBaseTest {
         Order memory order = createTestOrder(bytes(""));
 
         // Place the order
-        intentGateway.placeOrder{value: 1 ether}(order);
+        intentGateway.placeOrder{value: 1 ether}(order, bytes32(""));
 
         assertEq(filler.balance, 100 ether);
         assertEq(address(intentGateway).balance, 1 ether);
@@ -207,7 +207,7 @@ contract IntentGatewayTest is MainnetForkBaseTest {
         // Place the order
         Order memory order = createTestOrder(bytes(""));
         order.deadline = block.number - 100;
-        intentGateway.placeOrder{value: 1 ether}(order);
+        intentGateway.placeOrder{value: 1 ether}(order, bytes32(""));
 
         assertEq(address(this).balance, 99 ether);
         assertEq(address(intentGateway).balance, 1 ether);
@@ -284,7 +284,7 @@ contract IntentGatewayTest is MainnetForkBaseTest {
 
         // ensure that intent gateway rejects the settlement request
         Order memory order = createTestOrder(bytes(""));
-        intentGateway.placeOrder{value: 1 ether}(order);
+        intentGateway.placeOrder{value: 1 ether}(order, bytes32(""));
         PostRequest memory redeemEscrowRequest = PostRequest({
             source: deployment.stateMachineId,
             dest: hostId,


### PR DESCRIPTION
Adds `graffiti` parameter to the `placeOrder` function in the `IntentGateway` contract.

### Changes:
- **Contract API**: Added `bytes32 graffiti` parameter to `IntentGateway.placeOrder()` function
- **Tests**: Updated all test calls to pass an empty `bytes32("")` value for the new graffiti parameter

### Purpose:
The graffiti parameter allows for attaching arbitrary metadata to orders

### Breaking Change:
⚠️ This is a breaking change to the contract API. All existing integrations will need to update their `placeOrder` calls to include the graffiti parameter.

### Migration:
For existing code, simply add `bytes32("")` as the second parameter to maintain current behavior:

```solidity
// Before
intentGateway.placeOrder{value: 1 ether}(order);

// After  
intentGateway.placeOrder{value: 1 ether}(order, bytes32(""));
```