### PR TITLE
chore: remove redundant words in comment

### DIFF
--- a/modules/ismp/state-machines/evm/src/lib.rs
+++ b/modules/ismp/state-machines/evm/src/lib.rs
@@ -86,7 +86,7 @@ pub fn verify_state_proof<H: Keccak256 + Send + Sync>(
 	for key in keys {
 		// For keys that are 52 bytes we expect the first 20 bytes to be the contract address and
 		// the last 32 bytes the slot hash.
-		// For keys that are 20 bytes we expect that to the the
+		// For keys that are 20 bytes we expect that to the
 		// contract or account address.
 		// For keys that are 32 bytes we expect that to be a slothash in
 		// the Ismp EVM host

--- a/modules/pallets/consensus-incentives/src/impls.rs
+++ b/modules/pallets/consensus-incentives/src/impls.rs
@@ -37,7 +37,7 @@ where
 	/// This is an internal function used to handle relayer rewards for each
 	/// processed message, this targets just ConsensusMessage for now.
 	///  It extracts relayer information, calculates the
-	/// appropriate reward, and and transfer the reward to the relayer.
+	/// appropriate reward, and transfer the reward to the relayer.
 	fn process_message(
 		state_machine_height: StateMachineHeight,
 		state_machine_id: StateMachineId,


### PR DESCRIPTION
remove redundant words in comment