### PR TITLE
Update relayer.mdx - Removed "optional" directive for signer field on substrate

### DIFF
--- a/docs/pages/developers/network/relayer/messaging/relayer.mdx
+++ b/docs/pages/developers/network/relayer/messaging/relayer.mdx
@@ -351,7 +351,6 @@ consensus_state_id = "PARA"
 # max_rpc_payload_size = 150000000
 
 # Hex-encoded private key for the relayer account on this chain
-# Unneeded if the chain uses unsigned extrinsics for pallet-ismp
 signer = ""
 
 # (Optional) Frequency in seconds to poll the chain

--- a/docs/pages/developers/network/relayer/messaging/relayer.mdx
+++ b/docs/pages/developers/network/relayer/messaging/relayer.mdx
@@ -350,10 +350,9 @@ consensus_state_id = "PARA"
 # Configures the maximum size of an rpc request/response in bytes
 # max_rpc_payload_size = 150000000
 
-# (Optional)
 # Hex-encoded private key for the relayer account on this chain
 # Unneeded if the chain uses unsigned extrinsics for pallet-ismp
-# signer = ""
+signer = ""
 
 # (Optional) Frequency in seconds to poll the chain
 # for new state machine update events


### PR DESCRIPTION
Example config may confuse relayer operators as it mentions signer field is optional on substrate while it is required in order to accumulate fees to the correct account

As David informed on TG -> Please ensure you add signer to your hyperbridge config and also all substrate chain configs moving forward, so you don’t accumulate fees into an account you don’t control.