### PR TITLE
Make ismp agnostic to relayer's Signature decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10491,10 +10491,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "ismp"
-version = "2506.0.0"
+version = "2506.1.0"
 dependencies = [
  "anyhow",
- "crypto-utils",
  "derive_more 1.0.0",
  "displaydoc",
  "hex",

--- a/modules/ismp/core/Cargo.toml
+++ b/modules/ismp/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ismp"
-version = "2506.0.0"
+version = "2506.1.0"
 edition = "2021"
 description = "Rust implementation of the interoperable state machine protocol"
 authors = ["Polytope Labs <hello@polytope.technology>"]
@@ -32,7 +32,6 @@ anyhow = { workspace = true, default-features = false }
 thiserror = { workspace = true }
 serde-hex-utils = { workspace = true, default-features = false }
 sp-weights = { workspace = true, default-features = false }
-crypto-utils = { workspace = true, default-features = false }
 
 [features]
 default = ["std"]
@@ -49,5 +48,4 @@ std = [
     "displaydoc/std",
     "anyhow/std",
     "sp-weights/std",
-    "crypto-utils/std"
 ]

--- a/modules/ismp/core/src/handlers/request.rs
+++ b/modules/ismp/core/src/handlers/request.rs
@@ -24,8 +24,6 @@ use crate::{
 	router::{Request, RequestResponse},
 };
 use alloc::vec::Vec;
-use codec::Decode;
-use crypto_utils::verification::Signature;
 use sp_weights::Weight;
 
 /// Validate the state machine, verify the request message and dispatch the message to the modules
@@ -33,10 +31,7 @@ pub fn handle<H>(host: &H, msg: RequestMessage) -> Result<MessageResult, anyhow:
 where
 	H: IsmpHost,
 {
-	let signer: Vec<u8> = Signature::decode(&mut msg.signer.as_slice())
-		.map_err(|_| Error::SignatureDecodingFailed)?
-		.signer();
-
+	let signer = msg.signer.clone();
 	let state_machine = validate_state_machine(host, msg.proof.height)?;
 	let consensus_clients = host.consensus_clients();
 	let check_state_machine_client = |state_machine: StateMachine| {
@@ -96,14 +91,14 @@ where
 			let mut lambda = || {
 				let cb = router.module_for_id(request.to.clone())?;
 				// Store request receipt to prevent reentrancy attack
-				host.store_request_receipt(&wrapped_req, &signer)?;
+				let signer = host.store_request_receipt(&wrapped_req, &signer)?;
 				let res = cb.on_accept(request.clone()).map(|weight| {
 					total_weights.saturating_accrue(weight);
 
 					let commitment = hash_request::<H>(&wrapped_req);
 					Event::PostRequestHandled(RequestResponseHandled {
 						commitment,
-						relayer: signer.clone(),
+						relayer: signer,
 					})
 				});
 				// Delete receipt if module callback failed so it can be timed out

--- a/modules/ismp/core/src/handlers/request.rs
+++ b/modules/ismp/core/src/handlers/request.rs
@@ -31,7 +31,6 @@ pub fn handle<H>(host: &H, msg: RequestMessage) -> Result<MessageResult, anyhow:
 where
 	H: IsmpHost,
 {
-	let signer = msg.signer.clone();
 	let state_machine = validate_state_machine(host, msg.proof.height)?;
 	let consensus_clients = host.consensus_clients();
 	let check_state_machine_client = |state_machine: StateMachine| {
@@ -91,7 +90,7 @@ where
 			let mut lambda = || {
 				let cb = router.module_for_id(request.to.clone())?;
 				// Store request receipt to prevent reentrancy attack
-				let signer = host.store_request_receipt(&wrapped_req, &signer)?;
+				let signer = host.store_request_receipt(&wrapped_req, &msg.signer)?;
 				let res = cb.on_accept(request.clone()).map(|weight| {
 					total_weights.saturating_accrue(weight);
 

--- a/modules/ismp/core/src/handlers/response.rs
+++ b/modules/ismp/core/src/handlers/response.rs
@@ -24,8 +24,6 @@ use crate::{
 	router::{GetResponse, Request, RequestResponse, Response, StorageValue},
 };
 use alloc::{vec, vec::Vec};
-use codec::Decode;
-use crypto_utils::verification::Signature;
 use sp_weights::Weight;
 
 /// Validate the state machine, verify the response message and dispatch the message to the modules
@@ -33,9 +31,7 @@ pub fn handle<H>(host: &H, msg: ResponseMessage) -> Result<MessageResult, anyhow
 where
 	H: IsmpHost,
 {
-	let signer: Vec<u8> = Signature::decode(&mut msg.signer.as_slice())
-		.map_err(|_| Error::SignatureDecodingFailed)?
-		.signer();
+	let signer = msg.signer.clone();
 
 	let proof = msg.proof();
 	let state_machine = validate_state_machine(host, proof.height)?;
@@ -96,7 +92,7 @@ where
 				.map(|response| {
 					let cb = router.module_for_id(response.destination_module())?;
 					// Store response receipt to prevent reentrancy attack
-					host.store_response_receipt(&response, &signer)?;
+					host.store_response_receipt(&response, &msg.signer)?;
 					let res = cb.on_response(response.clone()).map(|weight| {
 						total_weights.saturating_accrue(weight);
 						let commitment = hash_response::<H>(&response);
@@ -168,7 +164,7 @@ where
 						get: request.clone(),
 						values: Default::default(),
 					});
-					host.store_response_receipt(&response, &signer)?;
+					let signer = host.store_response_receipt(&response, &signer)?;
 					let res = cb
 						.on_response(Response::Get(GetResponse { get: request.clone(), values }))
 						.map(|weight| {
@@ -176,7 +172,7 @@ where
 							let commitment = hash_request::<H>(&wrapped_req);
 							Event::GetRequestHandled(RequestResponseHandled {
 								commitment,
-								relayer: signer.clone(),
+								relayer: signer,
 							})
 						});
 					// Delete receipt if module callback failed so it can be timed out

--- a/modules/ismp/core/src/handlers/response.rs
+++ b/modules/ismp/core/src/handlers/response.rs
@@ -164,7 +164,7 @@ where
 						get: request.clone(),
 						values: Default::default(),
 					});
-					let signer = host.store_response_receipt(&response, &signer)?;
+					let signer = host.store_response_receipt(&response, &msg.signer)?;
 					let res = cb
 						.on_response(Response::Get(GetResponse { get: request.clone(), values }))
 						.map(|weight| {

--- a/modules/ismp/core/src/host.rs
+++ b/modules/ismp/core/src/host.rs
@@ -165,12 +165,12 @@ pub trait IsmpHost: Keccak256 {
 
 	/// Stores a receipt for an incoming request after it is successfully routed to a module.
 	/// Prevents duplicate incoming requests from being processed. Includes the relayer account
-	fn store_request_receipt(&self, req: &Request, signer: &Vec<u8>) -> Result<(), Error>;
+	fn store_request_receipt(&self, req: &Request, signer: &Vec<u8>) -> Result<Vec<u8>, Error>;
 
 	/// Stores a receipt that shows that the given request has received a response. Includes the
 	/// relayer account
 	/// Implementors should map the request commitment to the response object commitment.
-	fn store_response_receipt(&self, req: &Response, signer: &Vec<u8>) -> Result<(), Error>;
+	fn store_response_receipt(&self, req: &Response, signer: &Vec<u8>) -> Result<Vec<u8>, Error>;
 
 	/// Stores a commitment for an outgoing request alongside some scale encoded metadata
 	fn store_request_commitment(&self, req: &Request, meta: Vec<u8>) -> Result<(), Error>;

--- a/modules/ismp/testsuite/src/mocks.rs
+++ b/modules/ismp/testsuite/src/mocks.rs
@@ -345,16 +345,16 @@ impl IsmpHost for Host {
 		Ok(val.encode())
 	}
 
-	fn store_request_receipt(&self, req: &Request, _signer: &Vec<u8>) -> Result<(), Error> {
+	fn store_request_receipt(&self, req: &Request, _signer: &Vec<u8>) -> Result<Vec<u8>, Error> {
 		let hash = hash_request::<Self>(req);
 		self.receipts.borrow_mut().insert(hash, ());
-		Ok(())
+		Ok(vec![])
 	}
 
-	fn store_response_receipt(&self, res: &Response, _signer: &Vec<u8>) -> Result<(), Error> {
+	fn store_response_receipt(&self, res: &Response, _signer: &Vec<u8>) -> Result<Vec<u8>, Error> {
 		let hash = hash_response::<Self>(res);
 		self.receipts.borrow_mut().insert(hash, ());
-		Ok(())
+		Ok(vec![])
 	}
 
 	fn store_request_commitment(&self, req: &Request, _meta: Vec<u8>) -> Result<(), Error> {

--- a/modules/pallets/ismp/src/host.rs
+++ b/modules/pallets/ismp/src/host.rs
@@ -27,6 +27,7 @@ use crate::{
 use alloc::{format, string::ToString};
 use codec::{Decode, Encode};
 use core::time::Duration;
+use crypto_utils::verification::Signature;
 use frame_support::traits::{Get, UnixTime};
 use ismp::{
 	consensus::{
@@ -254,20 +255,24 @@ impl<T: Config> IsmpHost for Pallet<T> {
 		Ok(meta.relayer)
 	}
 
-	fn store_request_receipt(&self, req: &Request, signer: &Vec<u8>) -> Result<(), Error> {
+	fn store_request_receipt(&self, req: &Request, signer: &Vec<u8>) -> Result<Vec<u8>, Error> {
+		let signer = extract_signer(signer)?;
+
 		let hash = hash_request::<Self>(req);
-		child_trie::RequestReceipts::<T>::insert(hash, signer);
-		Ok(())
+		child_trie::RequestReceipts::<T>::insert(hash, &signer);
+		Ok(signer)
 	}
 
-	fn store_response_receipt(&self, res: &Response, signer: &Vec<u8>) -> Result<(), Error> {
+	fn store_response_receipt(&self, res: &Response, signer: &Vec<u8>) -> Result<Vec<u8>, Error> {
+		let signer = extract_signer(signer)?;
+
 		let hash = hash_request::<Self>(&res.request());
 		let response = hash_response::<Self>(&res);
 		child_trie::ResponseReceipts::<T>::insert(
 			hash,
 			ResponseReceipt { response, relayer: signer.clone() },
 		);
-		Ok(())
+		Ok(signer)
 	}
 
 	fn consensus_clients(&self) -> Vec<Box<dyn ConsensusClient>> {
@@ -328,5 +333,15 @@ impl<T: Config> ismp::messaging::Keccak256 for Pallet<T> {
 		Self: Sized,
 	{
 		sp_io::hashing::keccak_256(bytes).into()
+	}
+}
+
+pub fn extract_signer(signer: &[u8]) -> Result<Vec<u8>, Error> {
+	if signer.len() > 32 {
+		Signature::decode(&mut signer.as_ref())
+			.map(|sig| sig.signer())
+			.map_err(|_| Error::SignatureDecodingFailed)
+	} else {
+		Ok(signer.to_vec())
 	}
 }


### PR DESCRIPTION
Signature decoding is now being done in the ISMP host implementation.