### PR TITLE
Add an identifier to xcm gateway asset teleported event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16884,6 +16884,7 @@ dependencies = [
  "alloy-sol-types 0.7.7",
  "anyhow",
  "ismp",
+ "log",
  "pallet-ismp",
  "pallet-token-gateway",
  "pallet-token-governor",

--- a/modules/pallets/collator-manager/src/lib.rs
+++ b/modules/pallets/collator-manager/src/lib.rs
@@ -72,9 +72,6 @@ pub mod pallet {
 	{
 		/// The pallet-assets instance that manages the reputation token.
 		type ReputationAsset: fungible::Mutate<Self::AccountId, Balance = <Self as pallet::Config>::Balance>;
-		/// A constant that defines the target number of collators for the active set.
-		#[pallet::constant]
-		type DesiredCollators: Get<u32>;
 
 		/// The Native balance type
 		type Balance: Parameter
@@ -134,7 +131,10 @@ pub mod pallet {
 	{
 		fn new_session(_new_index: SessionIndex) -> Option<Vec<T::AccountId>> {
 			let active_collators = <pallet_session::Pallet<T>>::validators();
-			let desired_collators = T::DesiredCollators::get() as usize;
+			let desired_collators = core::cmp::max(
+				pallet_collator_selection::DesiredCandidates::<T>::get(),
+				<T as pallet_collator_selection::Config>::MinEligibleCollators::get(),
+			) as usize;
 
 			let mut new_set_validators: Vec<<T as pallet_session::Config>::ValidatorId> =
 				Vec::new();

--- a/modules/pallets/consensus-incentives/src/impls.rs
+++ b/modules/pallets/consensus-incentives/src/impls.rs
@@ -16,7 +16,6 @@
 //! Implementation blocks for pallet-consensus-incentives.
 
 use crate::*;
-use alloc::collections::BTreeMap;
 use crypto_utils::verification::Signature;
 use frame_support::traits::tokens::Preservation;
 use ismp::{

--- a/modules/pallets/testsuite/src/lib.rs
+++ b/modules/pallets/testsuite/src/lib.rs
@@ -1,5 +1,5 @@
 #![recursion_limit = "256"]
-
+#![cfg(test)]
 mod runtime;
 mod tests;
 

--- a/modules/pallets/testsuite/src/runtime.rs
+++ b/modules/pallets/testsuite/src/runtime.rs
@@ -356,7 +356,6 @@ impl pallet_collator_selection::Config for Test {
 }
 impl pallet_collator_manager::Config for Test {
 	type ReputationAsset = ReputationAsset;
-	type DesiredCollators = DesiredCollators;
 	type Balance = Balance;
 	type NativeCurrency = Balances;
 	type LockId = CollatorBondLockId;
@@ -562,8 +561,9 @@ impl ConsensusClient for MockConsensusClient {
 
 	fn state_machine(&self, _id: StateMachine) -> Result<Box<dyn StateMachineClient>, IsmpError> {
 		let state_machine: Box<dyn StateMachineClient> = match _id {
-			StateMachine::Kusama(2000) | StateMachine::Kusama(2001) =>
-				Box::new(SubstrateStateMachine::<Test>::default()),
+			StateMachine::Kusama(2000) | StateMachine::Kusama(2001) => {
+				Box::new(SubstrateStateMachine::<Test>::default())
+			},
 			_ => Box::new(MockStateMachine),
 		};
 		Ok(state_machine)

--- a/modules/pallets/testsuite/src/runtime.rs
+++ b/modules/pallets/testsuite/src/runtime.rs
@@ -561,9 +561,8 @@ impl ConsensusClient for MockConsensusClient {
 
 	fn state_machine(&self, _id: StateMachine) -> Result<Box<dyn StateMachineClient>, IsmpError> {
 		let state_machine: Box<dyn StateMachineClient> = match _id {
-			StateMachine::Kusama(2000) | StateMachine::Kusama(2001) => {
-				Box::new(SubstrateStateMachine::<Test>::default())
-			},
+			StateMachine::Kusama(2000) | StateMachine::Kusama(2001) =>
+				Box::new(SubstrateStateMachine::<Test>::default()),
 			_ => Box::new(MockStateMachine),
 		};
 		Ok(state_machine)

--- a/modules/pallets/testsuite/src/runtime.rs
+++ b/modules/pallets/testsuite/src/runtime.rs
@@ -59,7 +59,6 @@ use sp_runtime::{
 use crate::runtime::sp_runtime::DispatchError;
 use hyperbridge_client_machine::HyperbridgeClientMachine;
 use ismp::consensus::IntermediateState;
-use pallet_ismp::weights::IsmpModuleWeight;
 use pallet_messaging_fees::types::PriceOracle;
 use substrate_state_machine::SubstrateStateMachine;
 

--- a/modules/pallets/testsuite/src/tests/pallet_collator_manager.rs
+++ b/modules/pallets/testsuite/src/tests/pallet_collator_manager.rs
@@ -1,7 +1,7 @@
 use crate::runtime::{
 	new_test_ext, Assets, Balance, Balances, CollatorBondLockId, CollatorManager,
-	CollatorSelection, ReputationAssetId, RuntimeCall, RuntimeOrigin, Session, Sudo, Test, Vesting,
-	ALICE, BOB, CHARLIE, DAVE, INITIAL_BALANCE, UNIT,
+	CollatorSelection, ReputationAssetId, RuntimeOrigin, Session, Sudo, Test, Vesting, ALICE, BOB,
+	CHARLIE, DAVE, INITIAL_BALANCE, UNIT,
 };
 use frame_system::Pallet as System;
 use pallet_collator_manager::Error;
@@ -11,8 +11,7 @@ use polkadot_sdk::{
 	frame_support::{
 		assert_err, assert_ok,
 		traits::{
-			fungible::Mutate as BalanceMutate, fungibles::Mutate, Currency, LockableCurrency,
-			OnInitialize, ReservableCurrency,
+			fungible::Mutate as BalanceMutate, fungibles::Mutate, OnInitialize, ReservableCurrency,
 		},
 	},
 	pallet_balances::BalanceLock,

--- a/modules/pallets/testsuite/src/tests/pallet_hyperbridge.rs
+++ b/modules/pallets/testsuite/src/tests/pallet_hyperbridge.rs
@@ -26,9 +26,7 @@ use ismp::{
 	module::IsmpModule,
 	router::PostRequest,
 };
-use pallet_hyperbridge::{
-	Message, SubstrateHostParams, VersionedHostParams, WithdrawalRequest, PALLET_HYPERBRIDGE,
-};
+use pallet_hyperbridge::{Message, SubstrateHostParams, VersionedHostParams, WithdrawalRequest};
 use pallet_ismp::RELAYER_FEE_ACCOUNT;
 
 use crate::runtime::{new_test_ext, Balances, Coprocessor, Hyperbridge, UNIT};

--- a/modules/pallets/testsuite/src/tests/pallet_xcm_gateway.rs
+++ b/modules/pallets/testsuite/src/tests/pallet_xcm_gateway.rs
@@ -29,13 +29,14 @@ pub type RelayChainPalletXcm = pallet_xcm::Pallet<relay_chain::Runtime>;
 fn should_dispatch_ismp_request_when_assets_are_received_from_relay_chain() {
 	MockNet::reset();
 
-	let beneficiary: Location = Junctions::X3(Arc::new([
+	let beneficiary: Location = Junctions::X4(Arc::new([
 		Junction::AccountId32 { network: None, id: ALICE.into() },
 		Junction::AccountKey20 {
 			network: Some(NetworkId::Ethereum { chain_id: 97 }),
 			key: [1u8; 20],
 		},
 		Junction::GeneralIndex(60 * 60),
+		Junction::GeneralIndex(1),
 	]))
 	.into_location();
 	let weight_limit = WeightLimit::Unlimited;
@@ -86,13 +87,14 @@ fn should_dispatch_ismp_request_when_assets_are_received_from_relay_chain() {
 fn should_process_on_accept_module_callback_correctly() {
 	MockNet::reset();
 
-	let beneficiary: Location = Junctions::X3(Arc::new([
+	let beneficiary: Location = Junctions::X4(Arc::new([
 		Junction::AccountId32 { network: None, id: ALICE.into() },
 		Junction::AccountKey20 {
 			network: Some(NetworkId::Ethereum { chain_id: 97 }),
 			key: [1u8; 20],
 		},
 		Junction::GeneralIndex(60 * 60),
+		Junction::GeneralIndex(1),
 	]))
 	.into_location();
 	let weight_limit = WeightLimit::Unlimited;
@@ -192,13 +194,14 @@ fn should_process_on_accept_module_callback_correctly() {
 fn should_process_on_timeout_module_callback_correctly() {
 	MockNet::reset();
 
-	let beneficiary: Location = Junctions::X3(Arc::new([
+	let beneficiary: Location = Junctions::X4(Arc::new([
 		Junction::AccountId32 { network: None, id: ALICE.into() },
 		Junction::AccountKey20 {
 			network: Some(NetworkId::Ethereum { chain_id: 97 }),
 			key: [0u8; 20],
 		},
 		Junction::GeneralIndex(60 * 60),
+		Junction::GeneralIndex(1),
 	]))
 	.into_location();
 	let weight_limit = WeightLimit::Unlimited;

--- a/modules/pallets/testsuite/src/tests/xcm_integration_test.rs
+++ b/modules/pallets/testsuite/src/tests/xcm_integration_test.rs
@@ -2,7 +2,6 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use alloy_primitives::hex;
 use alloy_sol_types::SolType;
 use anyhow::anyhow;
 use futures::StreamExt;
@@ -33,36 +32,26 @@ use subxt_utils::{send_extrinsic, BlakeSubstrateChain, Hyperbridge, InMemorySign
 
 const SEND_AMOUNT: u128 = 2_000_000_000_000;
 
-#[test]
-fn message_id() {
-	let bytes = vec![
-		106, 206, 18, 24, 137, 48, 158, 220, 103, 108, 104, 89, 2, 100, 104, 162, 242, 2, 244, 168,
-		45, 238, 140, 80, 105, 57, 151, 253, 14, 88, 174, 249,
-	];
-	let hex_string = hex::encode(bytes);
-	println!("Message Id: 0x{hex_string:?}");
-}
-
 #[ignore]
 #[tokio::test]
 async fn should_dispatch_ismp_request_when_xcm_is_received() -> anyhow::Result<()> {
 	dotenv::dotenv().ok();
-	let private_key =
-		"0xe5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a".to_string();
+	let private_key = std::env::var("SUBSTRATE_SIGNING_KEY").ok().unwrap_or(
+		"0xe5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a".to_string(),
+	);
 	let seed = from_hex(&private_key)?;
 	let pair = sr25519::Pair::from_seed_slice(&seed)?;
 	let signer = InMemorySigner::<BlakeSubstrateChain>::new(pair.clone());
-	let url = "ws://127.0.0.1:9922".to_string();
-	// .ok()
-	// .unwrap_or();
+	let url = std::env::var("ROCOCO_LOCAL_URL")
+		.ok()
+		.unwrap_or("ws://127.0.0.1:9922".to_string());
 	let client = OnlineClient::<BlakeSubstrateChain>::from_url(&url).await?;
 	let rpc_client = RpcClient::from_url(&url).await?;
 	let _rpc = LegacyRpcMethods::<BlakeSubstrateChain>::new(rpc_client.clone());
 
-	let para_url = "ws://127.0.0.1:9990".to_string();
-	// std::env::var("PARA_LOCAL_URL")
-	// 	.ok()
-	// 	.unwrap_or("ws://127.0.0.1:9990".to_string());
+	let para_url = std::env::var("PARA_LOCAL_URL")
+		.ok()
+		.unwrap_or("ws://127.0.0.1:9990".to_string());
 	let _para_client = OnlineClient::<Hyperbridge>::from_url(&para_url).await?;
 	let para_rpc_client = RpcClient::from_url(&para_url).await?;
 	let para_rpc = LegacyRpcMethods::<BlakeSubstrateChain>::new(para_rpc_client.clone());
@@ -117,7 +106,6 @@ async fn should_dispatch_ismp_request_when_xcm_is_received() -> anyhow::Result<(
 		send_extrinsic(&client, &signer, &tx, None).await?;
 	}
 
-	println!("Submitting xcm call");
 	let ext = subxt::dynamic::tx(
 		"XcmPallet",
 		"limited_reserve_transfer_assets",
@@ -135,8 +123,6 @@ async fn should_dispatch_ismp_request_when_xcm_is_received() -> anyhow::Result<(
 		.await?
 		.ok_or_else(|| anyhow!("Failed to fetch latest header"))?
 		.number();
-
-	println!("Sending extrinsic");
 
 	send_extrinsic(&client, &signer, &ext, None).await?;
 

--- a/modules/pallets/xcm-gateway/Cargo.toml
+++ b/modules/pallets/xcm-gateway/Cargo.toml
@@ -21,6 +21,7 @@ alloy-primitives = { workspace = true }
 alloy-rlp-derive = { workspace = true }
 alloy-sol-macro = { workspace = true }
 alloy-sol-types = { workspace = true }
+log = { workspace = true }
 
 [dependencies.polkadot-sdk]
 workspace = true

--- a/modules/pallets/xcm-gateway/src/lib.rs
+++ b/modules/pallets/xcm-gateway/src/lib.rs
@@ -150,8 +150,6 @@ pub mod pallet {
 			amount: <T::Assets as fungibles::Inspect<T::AccountId>>::Balance,
 			/// Destination chain
 			source: StateMachine,
-			// /// Request commitment
-			// commitment: H256,
 		},
 
 		/// An asset has been refunded and transferred to the beneficiary's account on the
@@ -163,8 +161,6 @@ pub mod pallet {
 			amount: <T::Assets as fungibles::Inspect<T::AccountId>>::Balance,
 			/// Destination chain
 			source: StateMachine,
-			// /// Request commitment
-			// commitment: H256,
 		},
 	}
 

--- a/modules/pallets/xcm-gateway/src/lib.rs
+++ b/modules/pallets/xcm-gateway/src/lib.rs
@@ -137,6 +137,8 @@ pub mod pallet {
 			dest: StateMachine,
 			/// Request commitment
 			commitment: H256,
+			/// XCM message hash
+			message_id: H256,
 		},
 
 		/// An asset has been received and transferred to the beneficiary's account on the
@@ -148,6 +150,8 @@ pub mod pallet {
 			amount: <T::Assets as fungibles::Inspect<T::AccountId>>::Balance,
 			/// Destination chain
 			source: StateMachine,
+			// /// Request commitment
+			// commitment: H256,
 		},
 
 		/// An asset has been refunded and transferred to the beneficiary's account on the
@@ -159,6 +163,8 @@ pub mod pallet {
 			amount: <T::Assets as fungibles::Inspect<T::AccountId>>::Balance,
 			/// Destination chain
 			source: StateMachine,
+			// /// Request commitment
+			// commitment: H256,
 		},
 	}
 
@@ -253,6 +259,7 @@ where
 	/// Dispatch ismp request to token gateway on destination chain
 	pub fn dispatch_request(
 		multi_account: MultiAccount<T::AccountId>,
+		identifier: H256,
 		amount: <T::Assets as fungibles::Inspect<T::AccountId>>::Balance,
 	) -> Result<(), Error<T>> {
 		let dispatcher = <T as Config>::IsmpHost::default();
@@ -300,6 +307,7 @@ where
 			dest: multi_account.dest_state_machine,
 			amount,
 			commitment,
+			message_id: identifier,
 		});
 
 		Ok(())

--- a/modules/pallets/xcm-gateway/src/xcm_utilities.rs
+++ b/modules/pallets/xcm-gateway/src/xcm_utilities.rs
@@ -236,7 +236,7 @@ where
 				.map_err(|e| XcmError::FailedToTransactAsset(e.into()))?;
 			// We dispatch an ismp request to the destination chain
 			let identifier = {
-				let encoded = (who.clone(), amount).encode();
+				let encoded = who.encode();
 				sp_io::hashing::keccak_256(&encoded).into()
 			};
 			Pallet::<T>::dispatch_request(who, identifier, remainder)

--- a/modules/pallets/xcm-gateway/src/xcm_utilities.rs
+++ b/modules/pallets/xcm-gateway/src/xcm_utilities.rs
@@ -54,7 +54,7 @@ pub struct MultilocationToMultiAccount<A>(PhantomData<A>);
 
 #[derive(Encode, Decode, Clone)]
 pub struct MultiAccount<A> {
-	/// Origin substrate account
+	/// Origin substrate account on the relaychain
 	pub substrate_account: A,
 	/// Destination evm account
 	pub evm_account: H160,
@@ -62,14 +62,16 @@ pub struct MultiAccount<A> {
 	pub dest_state_machine: StateMachine,
 	/// Request time out in seconds
 	pub timeout: u64,
-	/// Nonce of the substrate account that sent the tx
+	/// Nonce of the substrate account that sent the tx on the relaychain
 	pub account_nonce: u64,
 }
 
 // Supports a Multilocation interior of Junctions::X3
-// Junctions::X3(AccountId32 { .. }, AccountKey20 { .. }, GeneralIndex(..))
-// The value specified in the GeneralIndex will be used as the timeout in seconds for the ismp
+// Junctions::X4(AccountId32 { .. }, AccountKey20 { .. }, GeneralIndex(..), GeneralIndex(..))
+// The value specified in the first GeneralIndex will be used as the timeout in seconds for the ismp
 // request that will be dispatched
+// The value in the second GeneralIndex should be the nonce of the substrate account on the
+// relaychain
 impl<A> ConvertLocation<MultiAccount<A>> for MultilocationToMultiAccount<A>
 where
 	A: From<[u8; 32]> + Into<[u8; 32]> + Clone,

--- a/modules/pallets/xcm-gateway/src/xcm_utilities.rs
+++ b/modules/pallets/xcm-gateway/src/xcm_utilities.rs
@@ -15,7 +15,7 @@
 
 use crate::{AssetIds, Config, Pallet};
 use alloc::vec::Vec;
-use codec::Encode;
+use codec::{Decode, Encode};
 use core::{cmp::min, marker::PhantomData};
 use frame_support::traits::{
 	fungibles::{self, Mutate},
@@ -52,6 +52,7 @@ impl TryFrom<WrappedNetworkId> for StateMachine {
 /// description matches a supported Ismp State machine
 pub struct MultilocationToMultiAccount<A>(PhantomData<A>);
 
+#[derive(Encode, Decode, Clone)]
 pub struct MultiAccount<A> {
 	/// Origin substrate account
 	pub substrate_account: A,
@@ -61,6 +62,8 @@ pub struct MultiAccount<A> {
 	pub dest_state_machine: StateMachine,
 	/// Request time out in seconds
 	pub timeout: u64,
+	/// Nonce of the substrate account that sent the tx
+	pub account_nonce: u64,
 }
 
 // Supports a Multilocation interior of Junctions::X3
@@ -73,10 +76,10 @@ where
 {
 	fn convert_location(location: &Location) -> Option<MultiAccount<A>> {
 		match location {
-			Location { parents: 0, interior: Junctions::X3(arc_junctions) } => {
+			Location { parents: 0, interior: Junctions::X4(arc_junctions) } => {
 				// Dereference the Arc to access the underlying array
 				match arc_junctions.as_ref() {
-					[Junction::AccountId32 { id, .. }, Junction::AccountKey20 { network: Some(network), key }, Junction::GeneralIndex(timeout)] =>
+					[Junction::AccountId32 { id, .. }, Junction::AccountKey20 { network: Some(network), key }, Junction::GeneralIndex(timeout), Junction::GeneralIndex(nonce)] =>
 					{
 						// Ensure that the network Id is one of the supported ethereum networks
 						// If it transforms correctly we return the ethereum account
@@ -87,6 +90,7 @@ where
 							evm_account: H160::from(*key),
 							dest_state_machine,
 							timeout: *timeout as u64,
+							account_nonce: *nonce as u64,
 						})
 					},
 					_ => None,
@@ -203,7 +207,6 @@ where
 	fn deposit_asset(what: &Asset, who: &Location, _context: Option<&XcmContext>) -> XcmResult {
 		// Check we handle this asset.
 		let (asset_id, amount) = Matcher::matches_fungibles(what)?;
-
 		// Ismp xcm transaction
 		if let Some(who) = MultilocationToMultiAccount::<T::AccountId>::convert_location(who) {
 			// We would remove the protocol fee at this point
@@ -230,7 +233,11 @@ where
 			T::Assets::mint_into(asset_id, &pallet_account, remainder)
 				.map_err(|e| XcmError::FailedToTransactAsset(e.into()))?;
 			// We dispatch an ismp request to the destination chain
-			Pallet::<T>::dispatch_request(who, remainder)
+			let identifier = {
+				let encoded = (who.clone(), amount).encode();
+				sp_io::hashing::keccak_256(&encoded).into()
+			};
+			Pallet::<T>::dispatch_request(who, identifier, remainder)
 				.map_err(|e| XcmError::FailedToTransactAsset(e.into()))?;
 		} else {
 			Err(MatchError::AccountIdConversionFailed)?

--- a/parachain/runtimes/nexus/src/lib.rs
+++ b/parachain/runtimes/nexus/src/lib.rs
@@ -348,8 +348,8 @@ impl Contains<RuntimeCall> for IsTreasurySpend {
 	fn contains(c: &RuntimeCall) -> bool {
 		matches!(
 			c,
-			RuntimeCall::Treasury(pallet_treasury::Call::spend { .. })
-				| RuntimeCall::Treasury(pallet_treasury::Call::spend_local { .. })
+			RuntimeCall::Treasury(pallet_treasury::Call::spend { .. }) |
+				RuntimeCall::Treasury(pallet_treasury::Call::spend_local { .. })
 		)
 	}
 }
@@ -818,20 +818,19 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 	fn filter(&self, c: &RuntimeCall) -> bool {
 		match self {
 			ProxyType::Any => true,
-			ProxyType::NonTransfer => {
-				!matches!(c, RuntimeCall::Balances { .. } | RuntimeCall::Assets { .. })
-			},
+			ProxyType::NonTransfer =>
+				!matches!(c, RuntimeCall::Balances { .. } | RuntimeCall::Assets { .. }),
 			ProxyType::CancelProxy => matches!(
 				c,
-				RuntimeCall::Proxy(pallet_proxy::Call::reject_announcement { .. })
-					| RuntimeCall::Utility { .. }
-					| RuntimeCall::Multisig { .. }
+				RuntimeCall::Proxy(pallet_proxy::Call::reject_announcement { .. }) |
+					RuntimeCall::Utility { .. } |
+					RuntimeCall::Multisig { .. }
 			),
 			ProxyType::Collator => matches!(
 				c,
-				RuntimeCall::CollatorSelection { .. }
-					| RuntimeCall::Utility { .. }
-					| RuntimeCall::Multisig { .. }
+				RuntimeCall::CollatorSelection { .. } |
+					RuntimeCall::Utility { .. } |
+					RuntimeCall::Multisig { .. }
 			),
 		}
 	}

--- a/parachain/runtimes/nexus/src/lib.rs
+++ b/parachain/runtimes/nexus/src/lib.rs
@@ -229,7 +229,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("nexus"),
 	impl_name: Cow::Borrowed("nexus"),
 	authoring_version: 1,
-	spec_version: 5_100,
+	spec_version: 5_200,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -348,8 +348,8 @@ impl Contains<RuntimeCall> for IsTreasurySpend {
 	fn contains(c: &RuntimeCall) -> bool {
 		matches!(
 			c,
-			RuntimeCall::Treasury(pallet_treasury::Call::spend { .. }) |
-				RuntimeCall::Treasury(pallet_treasury::Call::spend_local { .. })
+			RuntimeCall::Treasury(pallet_treasury::Call::spend { .. })
+				| RuntimeCall::Treasury(pallet_treasury::Call::spend_local { .. })
 		)
 	}
 }
@@ -818,19 +818,20 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 	fn filter(&self, c: &RuntimeCall) -> bool {
 		match self {
 			ProxyType::Any => true,
-			ProxyType::NonTransfer =>
-				!matches!(c, RuntimeCall::Balances { .. } | RuntimeCall::Assets { .. }),
+			ProxyType::NonTransfer => {
+				!matches!(c, RuntimeCall::Balances { .. } | RuntimeCall::Assets { .. })
+			},
 			ProxyType::CancelProxy => matches!(
 				c,
-				RuntimeCall::Proxy(pallet_proxy::Call::reject_announcement { .. }) |
-					RuntimeCall::Utility { .. } |
-					RuntimeCall::Multisig { .. }
+				RuntimeCall::Proxy(pallet_proxy::Call::reject_announcement { .. })
+					| RuntimeCall::Utility { .. }
+					| RuntimeCall::Multisig { .. }
 			),
 			ProxyType::Collator => matches!(
 				c,
-				RuntimeCall::CollatorSelection { .. } |
-					RuntimeCall::Utility { .. } |
-					RuntimeCall::Multisig { .. }
+				RuntimeCall::CollatorSelection { .. }
+					| RuntimeCall::Utility { .. }
+					| RuntimeCall::Multisig { .. }
 			),
 		}
 	}
@@ -887,7 +888,6 @@ parameter_types! {
 
 impl pallet_collator_manager::Config for Runtime {
 	type ReputationAsset = ReputationAsset;
-	type DesiredCollators = MinEligibleCollators;
 	type Balance = Balance;
 	type NativeCurrency = Balances;
 	type LockId = CollatorBondLockId;


### PR DESCRIPTION
Adds a unique message id to the xcm gateway asset teleported event.
Use the desired candidate value from pallet-collator-selection