### PR TITLE
Update polygon fee token

### DIFF
--- a/docs/pages/developers/explore/configurations/mainnet.mdx
+++ b/docs/pages/developers/explore/configurations/mainnet.mdx
@@ -119,7 +119,7 @@ ISMP configurations is supported for the following networks:
 | `HandlerV1` | [`0x61f56ee7D15F4a11ba7ee9f233c136563cB5ad37`](https://polygonscan.com/address/0x61f56ee7D15F4a11ba7ee9f233c136563cB5ad37) |
 | `ConsensusClient` | [`0xb83AdB0eBAf5545C241862906f173d3cf7940E26`](https://polygonscan.com/address/0xb83AdB0eBAf5545C241862906f173d3cf7940E26) |
 | `HostManager` | [`0xe97EAf5Ea0Ba2B63963827Ff5CBBB7D50B431967`](https://polygonscan.com/address/0xe97EAf5Ea0Ba2B63963827Ff5CBBB7D50B431967) |
-| `FeeToken (DAI)` | [`0x8f3cf7ad23cd3cadbd9735aff958023239c6a063`](https://polygonscan.com/address/0x8f3cf7ad23cd3cadbd9735aff958023239c6a063) |
+| `FeeToken (USDC)` | [`0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359`](https://polygonscan.com/address/0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359) |
 | `UniswapV2` | [`0xedf6066a2b290C185783862C7F4776A2C8077AD1`](https://polygonscan.com/address/0xedf6066a2b290C185783862C7F4776A2C8077AD1) |
 | `TokenGateway` | [`0x8b536105b6Fae2aE9199f5146D3C57Dfe53b614E`](https://polygonscan.com/address/0x8b536105b6Fae2aE9199f5146D3C57Dfe53b614E) |
 | `IntentGateway` | [`0xd54165e45926720b062C192a5bacEC64d5bB08DA`](https://polygonscan.com/address/0xd54165e45926720b062C192a5bacEC64d5bB08DA) |


### PR DESCRIPTION
The fee token on Polygon has been changed to USDC due to liquidity issues with DAI.