### PR TITLE
docs(ismp): fix challenge_period keyed by StateMachineId

### DIFF
--- a/docs/pages/protocol/ismp/host.mdx
+++ b/docs/pages/protocol/ismp/host.mdx
@@ -140,13 +140,13 @@ pub trait IsmpHost {
     /// Should return a handle to the consensus client based on the id
     fn consensus_client(&self, id: ConsensusClientId) -> Result<Box<dyn ConsensusClient>, Error>;
 
-    /// Should return the configured delay period for a consensus state
-    fn challenge_period(&self, consensus_state_id: ConsensusStateId) -> Option<Duration>;
+    /// Should return the configured delay period for a state machine
+    fn challenge_period(&self, state_machine: StateMachineId) -> Option<Duration>;
 
-    /// Set the challenge period in seconds for a consensus state.
+    /// Set the challenge period in seconds for a state machine.
     fn store_challenge_period(
         &self,
-        consensus_state_id: ConsensusStateId,
+        state_machine: StateMachineId,
         period: u64,
     ) -> Result<(), Error>;
 

--- a/modules/pallets/ismp/runtime-api/README.md
+++ b/modules/pallets/ismp/runtime-api/README.md
@@ -14,8 +14,8 @@ sp_api::impl_runtime_apis! {
             <Runtime as pallet_ismp::Config>::HostStateMachine::get()
         }
 
-        fn challenge_period(consensus_state_id: [u8; 4]) -> Option<u64> {
-            pallet_ismp::Pallet::<Runtime>::challenge_period(consensus_state_id)
+        fn challenge_period(state_machine_id: [u8; 4]) -> Option<u64> {
+            pallet_ismp::Pallet::<Runtime>::challenge_period(state_machine_id)
         }
 
         /// Fetch all ISMP events and their extrinsic metadata, should only be called from runtime-api.


### PR DESCRIPTION
## Summary
Fix docs mismatch: `challenge_period` / `store_challenge_period` are keyed by `StateMachineId` (not `ConsensusStateId`).

## Why
The challenge period delays the acceptance/use of **state-machine** commitments/proofs (per-counterparty state machine). Consensus client lifecycle parameters (freeze/expiry/unbonding) are keyed by `ConsensusStateId`.

## Changes
- docs/pages/protocol/ismp/host.mdx
- modules/pallets/ismp/runtime-api/README.md

## References
- Core trait: modules/ismp/core/src/host.rs
- Handler usage: modules/ismp/core/src/handlers.rs
- Pallet storage keying: modules/pallets/ismp/src/lib.rs (ChallengePeriod)
- Pallet host impl: modules/pallets/ismp/src/host.rs
- Runtime API: modules/pallets/ismp/runtime-api/src/lib.rs
