### PR TITLE
Update Asset hub para id and chain id for testnet

### DIFF
--- a/modules/ismp/clients/parachain/client/src/consensus.rs
+++ b/modules/ismp/clients/parachain/client/src/consensus.rs
@@ -46,16 +46,13 @@ use substrate_state_machine::{read_proof_check_for_parachain, SubstrateStateMach
 
 use crate::{Parachains, RelayChainOracle};
 
-/// PassetHub testnet para ID
-pub const PASSET_HUB_TESTNET_PARA_ID: u32 = 1111;
-
 /// PassetHub testnet EVM chain ID
-pub const PASSET_HUB_TESTNET_CHAIN_ID: u32 = 420420422;
+pub const PASSET_HUB_TESTNET_CHAIN_ID: u32 = 420420417;
 
 /// AssetHub mainnet para ID
-pub const ASSET_HUB_MAINNET_PARA_ID: u32 = 1000;
+pub const ASSET_HUB_PARA_ID: u32 = 1000;
 
-/// AssetHub mainnet EVM chain ID (TBD)
+/// AssetHub mainnet EVM chain ID
 pub const ASSET_HUB_MAINNET_CHAIN_ID: u32 = 420420419;
 
 /// The state machine provider that resolves to a `StateMachineClient`
@@ -218,13 +215,16 @@ where
 			state_commitments_vec.push(intermediate);
 			// if the parachain is asset hub modify the evm state machine ID to be an EVM state
 			// machine
-			match id {
-				ASSET_HUB_MAINNET_PARA_ID =>
-					state_id = StateMachine::Evm(ASSET_HUB_MAINNET_CHAIN_ID),
-				PASSET_HUB_TESTNET_PARA_ID =>
-					state_id = StateMachine::Evm(PASSET_HUB_TESTNET_CHAIN_ID),
-				_ => {},
-			};
+			if id == ASSET_HUB_PARA_ID {
+				match host.host_state_machine() {
+					StateMachine::Kusama(_) =>
+						state_id = StateMachine::Evm(PASSET_HUB_TESTNET_CHAIN_ID),
+					StateMachine::Polkadot(_) =>
+						state_id = StateMachine::Evm(ASSET_HUB_MAINNET_CHAIN_ID),
+					_ => {},
+				}
+			}
+
 			intermediates
 				.insert(StateMachineId { state_id, consensus_state_id }, state_commitments_vec);
 		}
@@ -251,9 +251,9 @@ where
 		let para_id = match id {
 			StateMachine::Polkadot(id) | StateMachine::Kusama(id) => id,
 			StateMachine::Evm(chain_id) if chain_id == ASSET_HUB_MAINNET_CHAIN_ID =>
-				ASSET_HUB_MAINNET_PARA_ID,
+				ASSET_HUB_PARA_ID,
 			StateMachine::Evm(chain_id) if chain_id == PASSET_HUB_TESTNET_CHAIN_ID =>
-				PASSET_HUB_TESTNET_PARA_ID,
+				ASSET_HUB_PARA_ID,
 			_ => Err(Error::Custom(
 				"State Machine is not supported by this consensus client".to_string(),
 			))?,

--- a/parachain/runtimes/gargantua/src/lib.rs
+++ b/parachain/runtimes/gargantua/src/lib.rs
@@ -240,7 +240,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("gargantua"),
 	impl_name: Cow::Borrowed("gargantua"),
 	authoring_version: 1,
-	spec_version: 4_700,
+	spec_version: 4_800,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/parachain/runtimes/nexus/src/lib.rs
+++ b/parachain/runtimes/nexus/src/lib.rs
@@ -229,7 +229,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("nexus"),
 	impl_name: Cow::Borrowed("nexus"),
 	authoring_version: 1,
-	spec_version: 6_200,
+	spec_version: 6_300,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
Smart contract support has been deployed to the official paseo asset hub with para id 1000 and chainid 420420417
