### PR TITLE
Remove redundant u32 cast in signature filtering

### DIFF
--- a/modules/consensus/beefy/prover/src/fiat_shamir.rs
+++ b/modules/consensus/beefy/prover/src/fiat_shamir.rs
@@ -352,7 +352,7 @@ pub fn filter_signatures_for_challenge(
 		*last += 27;
 
 		filtered
-			.push(SignatureWithAuthorityIndex { index: authority_index as u32, signature: temp });
+			.push(SignatureWithAuthorityIndex { index: authority_index, signature: temp });
 	}
 
 	Ok(filtered)


### PR DESCRIPTION
Remove redundant cast since authority_index is already u32