### PR TITLE
[sdk/indexer] Enhance data migration and type handling

### DIFF
--- a/sdk/packages/indexer/scripts/migrate-entity-data.ts
+++ b/sdk/packages/indexer/scripts/migrate-entity-data.ts
@@ -159,7 +159,8 @@ async function copyTableData(
   logger: MigrationOptions['logger'],
   batchSize: number = 1000,
   limit?: number,
-  whereClause?: string
+  whereClause?: string,
+  columnTransforms?: Record<string, (value: any) => any>
 ): Promise<{ copiedRows: number; skippedColumns: string[] }> {
   const client = await pool.connect();
   
@@ -232,7 +233,10 @@ async function copyTableData(
       // Insert each row, using WHERE NOT EXISTS to skip duplicates (no unique constraint needed)
       for (const row of batchResult.rows) {
         const values = commonColumns.map(col => {
-          const v = row[col];
+          let v = row[col];
+          if (columnTransforms?.[col]) {
+            v = columnTransforms[col](v);
+          }
           // pg deserializes jsonb into JS objects/arrays, but re-serializes JS arrays
           // as PostgreSQL array literals instead of JSON. Stringify them so they're
           // sent as valid JSON for jsonb columns.
@@ -287,7 +291,8 @@ async function migrateEntity(
   versionedEntity: string,
   logger: MigrationOptions['logger'],
   limit?: number,
-  whereClause?: string
+  whereClause?: string,
+  columnTransforms?: Record<string, (value: any) => any>
 ): Promise<MigrationResult> {
   const suffix = extractVersionSuffix(versionedEntity);
   
@@ -345,7 +350,7 @@ async function migrateEntity(
   }
   
   try {
-    const result = await copyTableData(pool, schema, sourceTable, destTable, logger, 1000, limit, whereClause);
+    const result = await copyTableData(pool, schema, sourceTable, destTable, logger, 1000, limit, whereClause, columnTransforms);
     logger?.log(`  ✅ Migration completed for ${versionedEntity}`);
     logger?.log(`     Copied: ${result.copiedRows} rows`);
     if (result.skippedColumns.length > 0) {
@@ -407,10 +412,25 @@ export async function migrateEntities(options: MigrationOptions): Promise<Migrat
       'RelayerStatsPerChainV2': "chain LIKE 'EVM-%'",
     };
 
+    const stringToNumeric = (value: any): any => {
+      if (value === null || value === undefined) return null;
+      const str = String(value).trim();
+      if (str === '' || isNaN(Number(str))) return '0';
+      return String(Math.round(Number(str)));
+    };
+
+    // Column-level type transforms applied during migration
+    const entityColumnTransforms: Record<string, Record<string, (value: any) => any>> = {
+      'TokenGatewayAssetTeleportedV2': {
+        'usd_value': stringToNumeric,
+      },
+    };
+
     // Process each entity
     for (const entity of entities) {
       const whereClause = entityWhereClause[entity];
-      const result = await migrateEntity(pool, schema, entity, logger, limit, whereClause);
+      const columnTransforms = entityColumnTransforms[entity];
+      const result = await migrateEntity(pool, schema, entity, logger, limit, whereClause, columnTransforms);
       results.push(result);
     }
     

--- a/sdk/packages/indexer/src/configs/schema.graphql
+++ b/sdk/packages/indexer/src/configs/schema.graphql
@@ -1014,7 +1014,7 @@ type IOrderV2 @entity {
 	"""
 	Total input value in USD
 	"""
-	inputUSD: String!
+	inputUSD: BigInt!
 
 	"""
 	Status of the order
@@ -1390,7 +1390,7 @@ type TokenGatewayAssetTeleportedV2 @entity {
 	"""
 	Amount of value in USD being teleported
 	"""
-	usdValue: String!
+	usdValue: BigInt!
 
 	"""
 	Asset ID being teleported

--- a/sdk/packages/indexer/src/services/intentGatewayV2.service.ts
+++ b/sdk/packages/indexer/src/services/intentGatewayV2.service.ts
@@ -159,7 +159,7 @@ export class IntentGatewayV2Service {
 				nonce: order.nonce,
 				fees: order.fees,
 				session: order.session,
-				inputUSD: inputUSD,
+				inputUSD: BigInt(new Decimal(inputUSD).truncated().toString()),
 				predispatchCalldata: order.predispatch.call as string,
 				postDispatchCalldata: order.outputs.call as string,
 				status: OrderStatus.PLACED,
@@ -227,7 +227,7 @@ export class IntentGatewayV2Service {
 			orderPlaced.nonce = order.nonce
 			orderPlaced.fees = order.fees
 			orderPlaced.session = order.session
-			orderPlaced.inputUSD = inputUSD
+			orderPlaced.inputUSD = BigInt(new Decimal(inputUSD).truncated().toString())
 			orderPlaced.predispatchCalldata = order.predispatch.call as string
 			orderPlaced.postDispatchCalldata = order.outputs.call as string
 			orderPlaced.referrer = referrer
@@ -354,7 +354,7 @@ export class IntentGatewayV2Service {
 				nonce: BigInt(0),
 				fees: BigInt(0),
 				session: "0x0000000000000000000000000000000000000000" as Hex,
-				inputUSD: "0",
+				inputUSD: BigInt(0),
 				status: OrderStatus.FILLED,
 				referrer: DEFAULT_REFERRER,
 				predispatchCalldata: "",
@@ -394,7 +394,7 @@ export class IntentGatewayV2Service {
 
 					await VolumeService.updateVolume(`IntentGatewayV2.FILLER.${filler}`, outputUSD.total, timestamp)
 
-					const orderValue = new Decimal(orderPlaced.inputUSD)
+					const orderValue = new Decimal(orderPlaced.inputUSD.toString())
 					const pointsToAward = orderValue.floor().toNumber()
 
 					// Rewards
@@ -413,7 +413,7 @@ export class IntentGatewayV2Service {
 					const userAddress20 = bytes32ToBytes20(orderPlaced.user)
 					let user = await getOrCreateUser(userAddress20, orderPlaced.referrer)
 					user.totalOrderFilledVolumeUSD = new Decimal(user.totalOrderFilledVolumeUSD)
-						.plus(new Decimal(orderPlaced.inputUSD))
+						.plus(new Decimal(orderPlaced.inputUSD.toString()))
 						.toString()
 					user.totalFilledOrders = user.totalFilledOrders + BigInt(1)
 					await user.save()

--- a/sdk/packages/indexer/src/services/tokenGateway.service.ts
+++ b/sdk/packages/indexer/src/services/tokenGateway.service.ts
@@ -91,7 +91,7 @@ export class TokenGatewayService {
 				to: teleportParams.to,
 				redeem: teleportParams.redeem,
 				status: TeleportStatus.TELEPORTED,
-				usdValue: amountValueInUSD,
+				usdValue: BigInt(new Decimal(amountValueInUSD).truncated().toString()),
 				createdAt: timestampToDate(timestamp),
 				blockNumber: BigInt(blockNumber),
 				blockTimestamp: timestamp,


### PR DESCRIPTION
- Updated `migrate-entity-data.ts` to support column-level transformations during data migration.
- Modified GraphQL schema to change `inputUSD` and `usdValue` fields from `String` to `BigInt` for better numeric handling.
- Adjusted `intentGatewayV2.service.ts` and `tokenGateway.service.ts` to ensure proper conversion of `inputUSD` and `usdValue` to `BigInt` during order processing and teleportation.