### PR TITLE
Fix link path for pallet-mmr in hyperbridge

### DIFF
--- a/docs/content/protocol/cryptography/merkle-trees/mountain-range.mdx
+++ b/docs/content/protocol/cryptography/merkle-trees/mountain-range.mdx
@@ -208,7 +208,7 @@ Given this model, we can re-use the `CalculateMerkleRoot` function defined in th
 You can find the implementations of merkle mountain ranges in:
 
 - [polytope-labs/solidity-merkle-trees](https://github.com/polytope-labs/solidity-merkle-trees/blob/main/src/MerkleMountainRange.sol)
-- `pallet-mmr` in [polytope-labs/hyperbridge](https://github.com/polytope-labs/hyperbridge/tree/main/modules/trees/mmr/pallet)
+- `pallet-mmr` in [polytope-labs/hyperbridge](https://github.com/polytope-labs/hyperbridge/tree/main/modules/pallets/mmr)
 
 
 ## References


### PR DESCRIPTION
fix to : [ the break in doc link](https://github.com/polytope-labs/hyperbridge/issues/709)