### PR TITLE
[indexer] Use `unsafeApi` to query evm state for tron networks

### DIFF
--- a/sdk/packages/indexer/scripts/generate-compose.ts
+++ b/sdk/packages/indexer/scripts/generate-compose.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url"
 import Handlebars from "handlebars"
 import { getEnv, getValidChains } from "../src/configs"
 
-const EVM_IMAGE = "polytopelabs/subql-node-ethereum:v6.3.1"
+const EVM_IMAGE = "polytopelabs/subql-node-ethereum:v6.3.4-0"
 const SUBSTRATE_IMAGE = "subquerynetwork/subql-node-substrate:v5.9.1"
 
 // Setup paths

--- a/sdk/packages/indexer/src/configs/config-mainnet.json
+++ b/sdk/packages/indexer/src/configs/config-mainnet.json
@@ -40,6 +40,7 @@
 		"chainId": "1",
 		"startBlock": 21099382,
 		"stateMachineId": "EVM-1",
+		"blockConfirmations": 2,
 		"contracts": {
 			"ethereumHost": "0x792A6236AF69787C40cF76b69B4c8c7B28c4cA20",
 			"erc6160ext20": "0x6B175474E89094C44Da98b954EedeAC495271d0F",

--- a/sdk/packages/indexer/src/configs/config-testnet.json
+++ b/sdk/packages/indexer/src/configs/config-testnet.json
@@ -28,6 +28,7 @@
 		"chainId": "11155111",
 		"startBlock": 6876874,
 		"stateMachineId": "EVM-11155111",
+		"blockConfirmations": 5,
 		"contracts": {
 			"ethereumHost": "0x2EdB74C269948b60ec1000040E104cef0eABaae8",
 			"handlerV1": "0xBf814fb3fD3eAaEB6a08C5A245c92da8b586f670",

--- a/sdk/packages/indexer/src/types/global.d.ts
+++ b/sdk/packages/indexer/src/types/global.d.ts
@@ -1,5 +1,5 @@
 import { Store } from "@subql/types-core"
-import { Provider, Signer } from "ethers"
+import { Provider, Signer, providers } from "ethers"
 import { Logger } from "@subql/types"
 import { ApiPromise } from "@polkadot/api"
 
@@ -8,6 +8,7 @@ import "@types/node-fetch"
 declare global {
 	const store: Store
 	const api: Provider | Signer | ApiPromise
+	const unsafeApi: providers.JsonRpcProvider | undefined
 	const logger: Logger
 	const chainId: string
 }

--- a/sdk/packages/indexer/src/utils/state-machine.helper.ts
+++ b/sdk/packages/indexer/src/utils/state-machine.helper.ts
@@ -5,7 +5,7 @@ import type { ApiPromise } from "@polkadot/api"
 import { Option as PolkadotOption } from "@polkadot/types"
 import { logger } from "ethers"
 import { TextEncoder } from "util"
-import { CHAINS_BY_ISMP_HOST } from "@/constants"
+import { CHAINS_BY_ISMP_HOST, TRON_CHAIN_IDS } from "@/constants"
 import { providers } from "ethers"
 import { Codec } from "@polkadot/types/types"
 
@@ -146,12 +146,26 @@ export async function fetchStateCommitmentsEVM(params: {
 	// Generate keys for timestamp, overlay, and state root
 	const [timestampKey, overlayKey, stateRootKey] = generateStateCommitmentKeys(paraId, height)
 
-	// For all other EVM chains, use SubQuery's api provider which correctly
-	// queries storage at the specific block height being indexed.
-	const provider = api as providers.Provider
-	const timestampValue = await provider.getStorageAt(hostContract, bytesToHex(timestampKey))
-	const overlayRootValue = await provider.getStorageAt(hostContract, bytesToHex(overlayKey))
-	const stateRootValue = await provider.getStorageAt(hostContract, bytesToHex(stateRootKey))
+	const isTron = TRON_CHAIN_IDS.has(chainId)
+	if (isTron && !unsafeApi) {
+		logger.warn("unsafeApi is not available for Tron chain, cannot fetch state commitments")
+		return null
+	}
+	const provider = (isTron ? unsafeApi! : api) as providers.Provider
+
+	let timestampValue: string | null
+	let overlayRootValue: string | null
+	let stateRootValue: string | null
+
+	if (isTron) {
+		timestampValue = await provider.getStorageAt(hostContract, bytesToHex(timestampKey), "latest")
+		overlayRootValue = await provider.getStorageAt(hostContract, bytesToHex(overlayKey), "latest")
+		stateRootValue = await provider.getStorageAt(hostContract, bytesToHex(stateRootKey), "latest")
+	} else {
+		timestampValue = await provider.getStorageAt(hostContract, bytesToHex(timestampKey))
+		overlayRootValue = await provider.getStorageAt(hostContract, bytesToHex(overlayKey))
+		stateRootValue = await provider.getStorageAt(hostContract, bytesToHex(stateRootKey))
+	}
 
 	if (!timestampValue) {
 		return null


### PR DESCRIPTION
- [x] use unsafeapi when querying state on tron
- [x] Use blockConfirmations for sepolia and ethereum, we've been noticing a lot of forks on sepolia indexer