### PR TITLE
fix(sdk): auction-based bid collection & blockTime fix

### DIFF
--- a/sdk/packages/sdk/package.json
+++ b/sdk/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/sdk",
-	"version": "1.9.0",
+	"version": "1.9.1",
 	"description": "The hyperclient SDK provides utilities for querying proofs and statuses for cross-chain requests from HyperBridge.",
 	"type": "module",
 	"types": "./dist/node/index.d.ts",

--- a/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
+++ b/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
@@ -196,7 +196,7 @@ export class IntentGateway {
 	 * @param options - Optional tuning parameters:
 	 *   - `maxPriorityFeePerGasBumpPercent` — bump % for the priority fee estimate (default 8).
 	 *   - `maxFeePerGasBumpPercent` — bump % for the max fee estimate (default 10).
-	 *   - `minBids` — minimum bids to collect before selecting (default 1).
+	 *   - `auctionTimeMs` — duration in ms to collect bids before selecting the best one.
 	 *   - `pollIntervalMs` — interval between bid-polling attempts.
 	 * @yields {@link IntentOrderStatusUpdate} at each lifecycle stage.
 	 * @throws If the `placeOrder` generator behaves unexpectedly, or if gas
@@ -205,10 +205,10 @@ export class IntentGateway {
 	async *execute(
 		order: Order,
 		graffiti: HexString = DEFAULT_GRAFFITI,
-		options?: {
+		options: {
+			auctionTimeMs: number
 			maxPriorityFeePerGasBumpPercent?: number
 			maxFeePerGasBumpPercent?: number
-			minBids?: number
 			pollIntervalMs?: number
 			solver?: { address: HexString; timeoutMs: number }
 		},
@@ -254,9 +254,9 @@ export class IntentGateway {
 		for await (const status of this.orderExecutor.executeOrder({
 			order: finalizedOrder,
 			sessionPrivateKey,
-			minBids: options?.minBids,
-			pollIntervalMs: options?.pollIntervalMs,
-			solver: options?.solver,
+			auctionTimeMs: options.auctionTimeMs,
+			pollIntervalMs: options.pollIntervalMs,
+			solver: options.solver,
 		})) {
 			yield status
 		}
@@ -301,16 +301,16 @@ export class IntentGateway {
 	 */
 	async *resume(
 		order: Order,
-		options?: ResumeIntentOrderOptions,
+		options: ResumeIntentOrderOptions,
 	): AsyncGenerator<IntentOrderStatusUpdate, void> {
 		this.assertOrderCanResume(order)
 
 		for await (const status of this.orderExecutor.executeOrder({
 			order,
-			sessionPrivateKey: options?.sessionPrivateKey,
-			minBids: options?.minBids,
-			pollIntervalMs: options?.pollIntervalMs,
-			solver: options?.solver,
+			sessionPrivateKey: options.sessionPrivateKey,
+			auctionTimeMs: options.auctionTimeMs,
+			pollIntervalMs: options.pollIntervalMs,
+			solver: options.solver,
 		})) {
 			yield status
 		}

--- a/sdk/packages/sdk/src/protocols/intents/OrderExecutor.ts
+++ b/sdk/packages/sdk/src/protocols/intents/OrderExecutor.ts
@@ -41,14 +41,14 @@ export class OrderExecutor {
 		commitment: HexString,
 	): AsyncGenerator<IntentOrderStatusUpdate, void> {
 		const client = this.ctx.dest.client
-		const blockTimeSeconds = client.chain?.blockTime ?? 2
+		const blockTimeMs = client.chain?.blockTime ?? 2_000
 
 		while (true) {
 			const currentBlock = await client.getBlockNumber()
 			if (currentBlock >= deadline) break
 
 			const blocksRemaining = Number(deadline - currentBlock)
-			const sleepMs = blocksRemaining * blockTimeSeconds * 1_000
+			const sleepMs = blocksRemaining * blockTimeMs
 			await sleep(sleepMs)
 		}
 
@@ -243,7 +243,7 @@ export class OrderExecutor {
 	 *   (terminates — settlement is confirmed async via Hyperbridge)
 	 */
 	async *executeOrder(options: ExecuteIntentOrderOptions): AsyncGenerator<IntentOrderStatusUpdate, void> {
-		const { order, sessionPrivateKey, minBids = 1, pollIntervalMs = DEFAULT_POLL_INTERVAL, solver } = options
+		const { order, sessionPrivateKey, auctionTimeMs, pollIntervalMs = DEFAULT_POLL_INTERVAL, solver } = options
 
 		const commitment = order.id as HexString
 		const isSameChain = order.source === order.destination
@@ -269,7 +269,7 @@ export class OrderExecutor {
 			order,
 			sessionPrivateKey,
 			commitment,
-			minBids,
+			auctionTimeMs,
 			pollIntervalMs,
 			solver,
 			usedUserOps,
@@ -301,7 +301,7 @@ export class OrderExecutor {
 		order: Order
 		sessionPrivateKey?: HexString
 		commitment: HexString
-		minBids: number
+		auctionTimeMs: number
 		pollIntervalMs: number
 		solver?: { address: HexString; timeoutMs: number }
 		usedUserOps: Set<string>
@@ -314,7 +314,7 @@ export class OrderExecutor {
 			order,
 			sessionPrivateKey,
 			commitment,
-			minBids,
+			auctionTimeMs,
 			pollIntervalMs,
 			solver,
 			usedUserOps,
@@ -327,6 +327,12 @@ export class OrderExecutor {
 		yield { status: "AWAITING_BIDS", commitment, totalFilledAssets, remainingAssets }
 
 		try {
+			// Wait for auction time to collect bids
+			const auctionEnd = Date.now() + auctionTimeMs
+			while (Date.now() < auctionEnd) {
+				await sleep(Math.min(pollIntervalMs, auctionEnd - Date.now()))
+			}
+
 			while (true) {
 				let freshBids: FillerBid[]
 				try {
@@ -337,7 +343,7 @@ export class OrderExecutor {
 					continue
 				}
 
-				if (freshBids.length < minBids) {
+				if (freshBids.length === 0) {
 					await sleep(pollIntervalMs)
 					continue
 				}

--- a/sdk/packages/sdk/src/types/index.ts
+++ b/sdk/packages/sdk/src/types/index.ts
@@ -1391,7 +1391,8 @@ export interface SelectBidResult {
 export interface ExecuteIntentOrderOptions {
 	order: Order
 	sessionPrivateKey?: HexString
-	minBids?: number
+	/** Duration in ms to collect bids before selecting the best one. */
+	auctionTimeMs: number
 	pollIntervalMs?: number
 	/**
 	 * If set, bids are restricted to the given solver until `timeoutMs` elapses,
@@ -1408,7 +1409,8 @@ export interface ExecuteIntentOrderOptions {
 /** Options for resuming execution of a previously placed intent order */
 export interface ResumeIntentOrderOptions {
 	sessionPrivateKey?: HexString
-	minBids?: number
+	/** Duration in ms to collect bids before selecting the best one. */
+	auctionTimeMs: number
 	pollIntervalMs?: number
 	solver?: {
 		address: HexString


### PR DESCRIPTION
## Summary
- Replace `minBids` with required `auctionTimeMs` — waits for the auction duration to collect bids before selecting the best one, rather than proceeding as soon as a minimum count is reached
- Fix `blockTime` sleep calculation in `deadlineStream` — `chain.blockTime` from viem is already in milliseconds, so the `* 1_000` multiplier was making the sleep 1000x too long
- Patch bump SDK to 1.9.1

## Test plan
- [ ] Verify auction timer collects bids for the full duration before selecting
- [ ] Verify deadline stream sleeps for correct duration per block
- [ ] Confirm `execute` and `resume` require `auctionTimeMs`