### PR TITLE
[evm]: skip epoch for stale proofs

### DIFF
--- a/evm/src/core/HandlerV2.sol
+++ b/evm/src/core/HandlerV2.sol
@@ -89,9 +89,12 @@ contract HandlerV2 is HandlerV1, IHandlerV2 {
         uint256 delay = block.timestamp - host.consensusUpdateTime();
         if (delay >= host.unStakingPeriod()) revert ConsensusClientExpired();
 
+        bytes memory previousState = host.consensusState();
         (bytes memory verifiedState, IntermediateState[] memory intermediates, uint256 nextAuthoritySetId) =
-            IConsensusV2(host.consensusClient()).verify(host.consensusState(), proof);
+            IConsensusV2(host.consensusClient()).verify(previousState, proof);
         host.storeConsensusState(verifiedState);
+
+        if (keccak256(previousState) == keccak256(verifiedState)) return;
 
         uint256 intermediatesLen = intermediates.length;
         for (uint256 i = 0; i < intermediatesLen; i++) {

--- a/evm/test/HandlerV2Test.sol
+++ b/evm/test/HandlerV2Test.sol
@@ -132,8 +132,10 @@ contract HandlerV2Test is Test {
         vm.prank(tx.origin);
         handler.handleConsensus(host, proof);
 
+        // TestConsensusClientV2.verify returns `abi.encode(previousState, nextAuthoritySetId)`
+        // as the new state so handleConsensus can observe a state change.
         bytes memory stateAfter = host.consensusState();
-        assertEq(keccak256(stateAfter), keccak256(stateBefore));
+        assertEq(keccak256(stateAfter), keccak256(abi.encode(stateBefore, uint256(0))));
     }
 
     function testHandleConsensusV2RecordsRelayerOnEpochChange() public {

--- a/evm/test/TestConsensusClientV2.sol
+++ b/evm/test/TestConsensusClientV2.sol
@@ -43,6 +43,11 @@ contract TestConsensusClientV2 is IConsensus, IConsensusV2, ERC165 {
 
     /**
      * @dev IConsensusV2 implementation — used by HandlerV2.handleConsensus.
+     *
+     * The new consensus state is `abi.encode(previousState, nextAuthoritySetId)` so it
+     * always differs from `previousState`, mirroring a real client that advances state
+     * on a valid proof. Returning `previousState` unchanged would short-circuit the
+     * epoch-attribution path in HandlerV2.
      */
     function verify(bytes calldata previousState, bytes calldata proof)
         external
@@ -55,6 +60,7 @@ contract TestConsensusClientV2 is IConsensus, IConsensusV2, ERC165 {
         IntermediateState[] memory intermediates = new IntermediateState[](1);
         intermediates[0] = intermediate;
 
-        return (previousState, intermediates, nextAuthoritySetId);
+        bytes memory newState = abi.encode(previousState, nextAuthoritySetId);
+        return (newState, intermediates, nextAuthoritySetId);
     }
 }


### PR DESCRIPTION
## Summary

- Compare pre- and post-verify consensus state bytes in `HandlerV2.handleConsensus` and short-circuit when they match. Consensus verifiers that skip work on stale proofs (returning the previous state with no intermediates) previously still fell through to the epoch-attribution path — letting a relayer claim a reward by replaying a stale proof.
- Moved the skip above the intermediates loop so nothing gets written when the verify was a no-op.
- Updated `TestConsensusClientV2.verify` to emit a distinct output state (`abi.encode(previousState, nextAuthoritySetId)`) so tests exercise the real post-verify flow rather than the stale-state short-circuit, and adjusted the one assertion that depended on the old mock returning its input verbatim.

## Test plan

- [x] \`forge build\`
- [x] \`forge test --match-contract "HandlerV2Test|ConsensusRouterTest"\` — 28 passed
- [x] \`forge test\` — 217 passed, 0 failed