### PR TITLE
[prover]: Onchain proof backend 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28097,6 +28097,7 @@ dependencies = [
  "ismp",
  "ismp-solidity-abi",
  "log",
+ "pallet-beefy-consensus-proofs",
  "pallet-ismp",
  "pallet-ismp-rpc",
  "parity-scale-codec",

--- a/modules/consensus/beefy/verifier/src/test.rs
+++ b/modules/consensus/beefy/verifier/src/test.rs
@@ -255,10 +255,7 @@ fn dump_sp1_fixture_scale_bytes() {
 	let (commitment, leaf, headers, plonk_proof) =
 		<ProofTuple as SolType>::abi_decode_sequence(&proof_bytes).expect("decode proof tuple");
 	let sp1_proof = Sp1BeefyProof {
-		block_number: commitment
-			.blockNumber
-			.try_into()
-			.expect("block number out of bounds"),
+		block_number: commitment.blockNumber.try_into().expect("block number out of bounds"),
 		validator_set_id: commitment
 			.validatorSetId
 			.try_into()
@@ -312,10 +309,7 @@ fn test_sp1_verify_consensus_accepts_solidity_fixture() {
 	let (commitment, leaf, headers, plonk_proof) =
 		<ProofTuple as SolType>::abi_decode_sequence(&proof_bytes).expect("decode proof tuple");
 	let sp1_proof = Sp1BeefyProof {
-		block_number: commitment
-			.blockNumber
-			.try_into()
-			.expect("block number out of bounds"),
+		block_number: commitment.blockNumber.try_into().expect("block number out of bounds"),
 		validator_set_id: commitment
 			.validatorSetId
 			.try_into()

--- a/modules/pallets/beefy-consensus-proofs/src/lib.rs
+++ b/modules/pallets/beefy-consensus-proofs/src/lib.rs
@@ -44,8 +44,9 @@ pub use types::{Signature, SubmitProofPayload};
 pub use weights::WeightInfo;
 
 /// Offchain-storage key for the rotation proof that advanced the authority set to
-/// `set_id`. Relayers reconstruct this key off of a [`RotationProofs`](crate::pallet::RotationProofs)
-/// entry's key and read the raw ABI-encoded proof bytes from node-local offchain storage.
+/// `set_id`. Relayers reconstruct this key off of a
+/// [`RotationProofs`](crate::pallet::RotationProofs) entry's key and read the raw ABI-encoded proof
+/// bytes from node-local offchain storage.
 pub fn rotation_offchain_key(set_id: u64) -> alloc::vec::Vec<u8> {
 	let mut key = alloc::vec::Vec::with_capacity(
 		types::OFFCHAIN_PREFIX.len() + types::OFFCHAIN_ROT.len() + 8,
@@ -192,21 +193,15 @@ pub mod pallet {
 	/// reaches `T::MaxStoredProofs`). BEEFY set ids are monotone, so `pop_first` gives
 	/// FIFO eviction for free.
 	#[pallet::storage]
-	pub type RotationProofs<T: Config> = StorageValue<
-		_,
-		BoundedBTreeMap<u64, BlockNumberFor<T>, T::MaxStoredProofs>,
-		ValueQuery,
-	>;
+	pub type RotationProofs<T: Config> =
+		StorageValue<_, BoundedBTreeMap<u64, BlockNumberFor<T>, T::MaxStoredProofs>, ValueQuery>;
 
 	/// Bounded map of `proven_height → block number` for the most recent accepted
 	/// messaging proofs. See [`messaging_offchain_key`](crate::messaging_offchain_key)
 	/// for the matching offchain-storage lookup.
 	#[pallet::storage]
-	pub type MessagingProofs<T: Config> = StorageValue<
-		_,
-		BoundedBTreeMap<u64, BlockNumberFor<T>, T::MaxStoredProofs>,
-		ValueQuery,
-	>;
+	pub type MessagingProofs<T: Config> =
+		StorageValue<_, BoundedBTreeMap<u64, BlockNumberFor<T>, T::MaxStoredProofs>, ValueQuery>;
 
 	#[pallet::error]
 	pub enum Error<T> {
@@ -333,7 +328,7 @@ pub mod pallet {
 			let messaging_reward =
 				Some(child_trie_root) != last_rewarded && outcome.proven_height > prev_proven;
 			let should_reward = outcome.rotated || messaging_reward;
-			
+
 			if !should_reward {
 				return Ok(());
 			}
@@ -388,9 +383,9 @@ pub mod pallet {
 					if map.len() as u32 == T::MaxStoredProofs::get() {
 						if let Some(evicted_set_id) = map.iter().next().map(|(k, _)| *k) {
 							let _ = map.remove(&evicted_set_id);
-							sp_io::offchain_index::clear(
-								&crate::rotation_offchain_key(evicted_set_id),
-							);
+							sp_io::offchain_index::clear(&crate::rotation_offchain_key(
+								evicted_set_id,
+							));
 						}
 					}
 					let _ = map.try_insert(outcome.current_set_id, at);
@@ -403,9 +398,9 @@ pub mod pallet {
 					if map.len() as u32 == T::MaxStoredProofs::get() {
 						if let Some(evicted_height) = map.iter().next().map(|(k, _)| *k) {
 							let _ = map.remove(&evicted_height);
-							sp_io::offchain_index::clear(
-								&crate::messaging_offchain_key(evicted_height),
-							);
+							sp_io::offchain_index::clear(&crate::messaging_offchain_key(
+								evicted_height,
+							));
 						}
 					}
 					let _ = map.try_insert(outcome.proven_height, at);

--- a/tesseract/consensus/beefy/Cargo.toml
+++ b/tesseract/consensus/beefy/Cargo.toml
@@ -32,6 +32,7 @@ primitive-types = { workspace = true }
 # polytope-labs
 pallet-ismp = { workspace = true }
 pallet-ismp-rpc = { workspace = true }
+pallet-beefy-consensus-proofs = { workspace = true }
 ismp = { workspace = true }
 
 ismp-solidity-abi = { workspace = true }

--- a/tesseract/consensus/beefy/src/backend/mod.rs
+++ b/tesseract/consensus/beefy/src/backend/mod.rs
@@ -18,15 +18,37 @@
 //! allowing the prover and host to communicate without being tightly coupled to Redis.
 
 mod memory;
+mod onchain;
 mod redis;
 
 pub use memory::InMemoryProofBackend;
+pub use onchain::OnchainBackend;
 pub use redis::{RedisConfig, RedisProofBackend};
 
 use codec::{Decode, Encode};
 use futures::Stream;
 use ismp::{host::StateMachine, messaging::ConsensusMessage};
+use serde::{Deserialize, Serialize};
 use std::pin::Pin;
+
+/// Which proof backend the BEEFY prover/host should use.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ProofBackendConfig {
+	/// Persistent Redis-backed queue. The prover writes proofs into RSMQ queues
+	/// and a separate host process consumes them.
+	Redis {
+		#[serde(flatten)]
+		config: RedisConfig,
+	},
+	/// On-chain backend. The prover submits proofs directly to
+	/// `pallet-beefy-consensus-proofs` via unsigned extrinsics — no separate
+	/// host process is needed.
+	Onchain,
+	/// In-process queue shared between prover and host. Single-process only,
+	/// not persisted across restarts.
+	InMemory,
+}
 
 /// Consensus proof message exchanged between prover and host
 #[derive(Clone, Debug, Encode, Decode)]

--- a/tesseract/consensus/beefy/src/backend/onchain.rs
+++ b/tesseract/consensus/beefy/src/backend/onchain.rs
@@ -24,6 +24,7 @@ use beefy_verifier_primitives::ConsensusState;
 use codec::{Decode, Encode};
 use futures::Stream;
 use ismp::{consensus::ConsensusStateId, host::StateMachine};
+use pallet_beefy_consensus_proofs::types::SIGNATURE_DOMAIN;
 use sp_core::{sr25519, Pair};
 use std::{pin::Pin, sync::Arc};
 use subxt::{
@@ -32,9 +33,6 @@ use subxt::{
 };
 use tesseract_substrate::extrinsic::send_unsigned_extrinsic;
 use tokio::sync::RwLock;
-
-/// Domain separator matching `pallet_beefy_consensus_proofs::types::SIGNATURE_DOMAIN`.
-const SIGNATURE_DOMAIN: &[u8] = b"pallet_beefy_consensus_proofs";
 
 /// Proof backend that submits proofs directly to `pallet-beefy-consensus-proofs`
 /// on the hyperbridge parachain.

--- a/tesseract/consensus/beefy/src/backend/onchain.rs
+++ b/tesseract/consensus/beefy/src/backend/onchain.rs
@@ -1,0 +1,238 @@
+// Copyright (C) 2023 Polytope Labs.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Pallet-based implementation of the ProofBackend trait.
+//!
+//! Instead of queuing proofs for a separate host process, this backend submits proofs
+//! directly to the `pallet-beefy-consensus-proofs` on the hyperbridge parachain via
+//! unsigned extrinsics.
+
+use super::{ConsensusProof, ProofBackend, QueueMessage, StreamMessage};
+use anyhow::anyhow;
+use beefy_verifier_primitives::ConsensusState;
+use codec::{Decode, Encode};
+use futures::Stream;
+use ismp::{consensus::ConsensusStateId, host::StateMachine};
+use sp_core::{sr25519, Pair};
+use std::{pin::Pin, sync::Arc};
+use subxt::{
+	dynamic::Value, ext::subxt_rpcs::RpcClient, ext::subxt_rpcs::rpc_params,
+	utils::MultiSignature, OnlineClient,
+};
+use tesseract_substrate::extrinsic::send_unsigned_extrinsic;
+use tokio::sync::RwLock;
+
+/// Domain separator matching `pallet_beefy_consensus_proofs::types::SIGNATURE_DOMAIN`.
+const SIGNATURE_DOMAIN: &[u8] = b"pallet_beefy_consensus_proofs";
+
+/// Proof backend that submits proofs directly to `pallet-beefy-consensus-proofs`
+/// on the hyperbridge parachain.
+///
+/// When `send_mandatory_proof` or `send_messages_proof` is called, this backend
+/// constructs a `SubmitProofPayload`, signs it with SR25519, and submits the
+/// unsigned extrinsic directly to the chain. The pallet handles verification,
+/// consensus state updates, and reward distribution.
+///
+/// The host-side methods (`receive_*`, `queue_notifications`, `delete_message`)
+/// are no-ops since the pallet processes proofs inline — there is no intermediate
+/// queue for a separate host process to consume.
+pub struct OnchainBackend<P: subxt::Config> {
+	/// Subxt client for the hyperbridge parachain
+	client: OnlineClient<P>,
+	/// Raw RPC client for custom ISMP RPC calls
+	rpc_client: RpcClient,
+	/// SR25519 keypair used to sign proof payloads
+	signer: sr25519::Pair,
+	/// Consensus state id under which the BEEFY state is stored in `pallet-ismp`
+	consensus_state_id: ConsensusStateId,
+	/// In-memory cache of the last saved consensus state
+	state: Arc<RwLock<Option<crate::prover::ProverConsensusState>>>,
+}
+
+impl<P: subxt::Config> OnchainBackend<P> {
+	pub fn new(
+		client: OnlineClient<P>,
+		rpc_client: RpcClient,
+		signer: sr25519::Pair,
+		consensus_state_id: ConsensusStateId,
+	) -> Self {
+		Self {
+			client,
+			rpc_client,
+			signer,
+			consensus_state_id,
+			state: Arc::new(RwLock::new(None)),
+		}
+	}
+}
+
+impl<P> OnchainBackend<P>
+where
+	P: subxt::Config + Send + Sync,
+	P::Signature: From<MultiSignature> + Send + Sync,
+{
+	/// Submit a consensus proof to `pallet-beefy-consensus-proofs::submit_proof`.
+	async fn submit_to_pallet(&self, proof: &ConsensusProof) -> Result<(), anyhow::Error> {
+		let proof_bytes = proof.message.consensus_proof.clone();
+		let submitter_bytes: [u8; 32] = self.signer.public().0;
+
+		// Sign: keccak256((SIGNATURE_DOMAIN, submitter, keccak256(proof)).encode())
+		let proof_digest = sp_core::hashing::keccak_256(&proof_bytes);
+		let msg_preimage = (SIGNATURE_DOMAIN, submitter_bytes, proof_digest).encode();
+		let signed_msg = sp_core::hashing::keccak_256(&msg_preimage);
+		let signature = self.signer.sign(&signed_msg);
+
+		// Construct the dynamic extrinsic
+		let payload_value = Value::named_composite([
+			("submitter", Value::from_bytes(submitter_bytes)),
+			("proof", Value::from_bytes(proof_bytes)),
+		]);
+		let signature_value = Value::from_bytes(signature.0);
+
+		let tx = subxt::dynamic::tx(
+			"BeefyConsensusProofs",
+			"submit_proof",
+			vec![payload_value, signature_value],
+		);
+
+		send_unsigned_extrinsic(&self.client, tx, true).await?;
+
+		tracing::info!(
+			"Successfully submitted proof to pallet-beefy-consensus-proofs (height: {})",
+			proof.finalized_height
+		);
+
+		Ok(())
+	}
+
+	/// Fetch the BEEFY consensus state from `pallet-ismp` via the `ismp_queryConsensusState` RPC.
+	async fn fetch_onchain_consensus_state(&self) -> Result<ConsensusState, anyhow::Error> {
+		let params = rpc_params![None::<u32>, self.consensus_state_id];
+		let encoded: Vec<u8> = self
+			.rpc_client
+			.request("ismp_queryConsensusState", params)
+			.await
+			.map_err(|e| anyhow!("ismp_queryConsensusState failed: {e}"))?;
+		let state = ConsensusState::decode(&mut &encoded[..])
+			.map_err(|e| anyhow!("Failed to decode on-chain BEEFY consensus state: {e}"))?;
+		Ok(state)
+	}
+
+	/// Fetch `pallet-beefy-consensus-proofs::LastProvenHeight` via subxt storage query.
+	async fn fetch_last_proven_height(&self) -> Result<u64, anyhow::Error> {
+		let query = subxt::dynamic::storage(
+			"BeefyConsensusProofs",
+			"LastProvenHeight",
+			Vec::<Value>::new(),
+		);
+		let storage = self.client.storage().at_latest().await?;
+		let Some(raw) = storage.fetch(&query).await? else {
+			return Ok(0);
+		};
+		let bytes = raw.encoded();
+		let height = u64::decode(&mut &bytes[..])
+			.map_err(|e| anyhow!("Failed to decode LastProvenHeight: {e}"))?;
+		Ok(height)
+	}
+}
+
+#[async_trait::async_trait]
+impl<P> ProofBackend for OnchainBackend<P>
+where
+	P: subxt::Config + Send + Sync,
+	P::Signature: From<MultiSignature> + Send + Sync,
+{
+	async fn init_queues(&self, _state_machines: &[StateMachine]) -> Result<(), anyhow::Error> {
+		// No queues needed — proofs are submitted directly to the pallet.
+		Ok(())
+	}
+
+	async fn send_mandatory_proof(
+		&self,
+		state_machine: &StateMachine,
+		proof: ConsensusProof,
+	) -> Result<(), anyhow::Error> {
+		tracing::info!("Submitting mandatory proof to pallet for {state_machine}");
+		self.submit_to_pallet(&proof).await
+	}
+
+	async fn send_messages_proof(
+		&self,
+		state_machine: &StateMachine,
+		proof: ConsensusProof,
+	) -> Result<(), anyhow::Error> {
+		tracing::info!("Submitting messages proof to pallet for {state_machine}");
+		self.submit_to_pallet(&proof).await
+	}
+
+	async fn save_state(
+		&self,
+		state: &crate::prover::ProverConsensusState,
+	) -> Result<(), anyhow::Error> {
+		*self.state.write().await = Some(state.clone());
+		Ok(())
+	}
+
+	/// Fetches the prover consensus state from on-chain. The `inner` BEEFY consensus state is
+	/// read from `pallet-ismp`'s `ConsensusStates` storage (the pallet is the source of truth
+	/// after every accepted proof). The `finalized_parachain_height` is read from
+	/// `pallet-beefy-consensus-proofs::LastProvenHeight` — the highest parachain height the
+	/// pallet has ever accepted a proof for.
+	async fn load_state(&self) -> Result<crate::prover::ProverConsensusState, anyhow::Error> {
+		let inner = self.fetch_onchain_consensus_state().await?;
+		let finalized_parachain_height = self.fetch_last_proven_height().await?;
+
+		let state = crate::prover::ProverConsensusState { inner, finalized_parachain_height };
+		*self.state.write().await = Some(state.clone());
+		Ok(state)
+	}
+
+	async fn queue_notifications(
+		&self,
+		_state_machine: StateMachine,
+	) -> Result<
+		Pin<Box<dyn Stream<Item = Result<StreamMessage, anyhow::Error>> + Send>>,
+		anyhow::Error,
+	> {
+		// The pallet backend submits proofs directly — no host needs to consume from a queue.
+		// Return a stream that never yields so the host's start_consensus idles.
+		Ok(Box::pin(futures::stream::pending()))
+	}
+
+	async fn receive_mandatory_proof(
+		&self,
+		_state_machine: &StateMachine,
+	) -> Result<Option<QueueMessage>, anyhow::Error> {
+		// No queue to receive from — proofs go directly to the pallet.
+		Ok(None)
+	}
+
+	async fn receive_messages_proof(
+		&self,
+		_state_machine: &StateMachine,
+	) -> Result<Option<QueueMessage>, anyhow::Error> {
+		// No queue to receive from — proofs go directly to the pallet.
+		Ok(None)
+	}
+
+	async fn delete_message(
+		&self,
+		_state_machine: &StateMachine,
+		_message_id: &str,
+		_message_type: StreamMessage,
+	) -> Result<(), anyhow::Error> {
+		// No queue messages to delete.
+		Ok(())
+	}
+}

--- a/tesseract/consensus/beefy/src/backend/onchain.rs
+++ b/tesseract/consensus/beefy/src/backend/onchain.rs
@@ -28,8 +28,10 @@ use pallet_beefy_consensus_proofs::types::SIGNATURE_DOMAIN;
 use sp_core::{sr25519, Pair};
 use std::{pin::Pin, sync::Arc};
 use subxt::{
-	dynamic::Value, ext::subxt_rpcs::RpcClient, ext::subxt_rpcs::rpc_params,
-	utils::MultiSignature, OnlineClient,
+	dynamic::Value,
+	ext::subxt_rpcs::{rpc_params, RpcClient},
+	utils::MultiSignature,
+	OnlineClient,
 };
 use tesseract_substrate::extrinsic::send_unsigned_extrinsic;
 use tokio::sync::RwLock;
@@ -65,13 +67,7 @@ impl<P: subxt::Config> OnchainBackend<P> {
 		signer: sr25519::Pair,
 		consensus_state_id: ConsensusStateId,
 	) -> Self {
-		Self {
-			client,
-			rpc_client,
-			signer,
-			consensus_state_id,
-			state: Arc::new(RwLock::new(None)),
-		}
+		Self { client, rpc_client, signer, consensus_state_id, state: Arc::new(RwLock::new(None)) }
 	}
 }
 

--- a/tesseract/consensus/beefy/src/host.rs
+++ b/tesseract/consensus/beefy/src/host.rs
@@ -44,13 +44,11 @@ use crate::{
 pub struct BeefyHostConfig {
 	/// Consensus state id for the host on the counterparty
 	pub consensus_state_id: ConsensusStateId,
-	/// Optional Redis configuration for proof backend (if None, uses InMemoryProofBackend)
-	pub redis: Option<crate::backend::RedisConfig>,
 }
 
 /// The beefy host is responsible for receiving BEEFY proofs from the queue and submitting
 /// them to the counterparty.
-pub struct BeefyHost<R, P, B, Q>
+pub struct BeefyHost<R, P, B, Q: ?Sized>
 where
 	R: subxt::Config,
 	P: subxt::Config,
@@ -71,7 +69,7 @@ where
 	R: subxt::Config,
 	P: subxt::Config,
 	B: Sp1BeefyProverTrait,
-	Q: ProofBackend,
+	Q: ProofBackend + ?Sized,
 	P: subxt::Config + Send + Sync + Clone,
 	<P::ExtrinsicParams as ExtrinsicParams<P>>::Params: Send + Sync + DefaultParams,
 	P::Signature: From<MultiSignature> + Send + Sync,
@@ -125,7 +123,7 @@ where
 	R: subxt::Config + Send + Sync + Clone,
 	P: subxt::Config + Send + Sync + Clone,
 	B: Sp1BeefyProverTrait,
-	Q: ProofBackend,
+	Q: ProofBackend + ?Sized,
 	<P::ExtrinsicParams as ExtrinsicParams<P>>::Params: Send + Sync + DefaultParams,
 	P::Signature: From<MultiSignature> + Send + Sync,
 	P::AccountId: From<AccountId32> + Into<P::Address> + Clone + 'static + Send + Sync,

--- a/tesseract/consensus/beefy/src/lib.rs
+++ b/tesseract/consensus/beefy/src/lib.rs
@@ -53,10 +53,7 @@ impl BeefyConfig {
 	/// [`BeefyProverConfig::backend`](prover::BeefyProverConfig::backend).
 	pub async fn into_client<R, P>(
 		self,
-	) -> Result<
-		BeefyHost<R, P, zk_beefy::LocalProver, dyn backend::ProofBackend>,
-		anyhow::Error,
-	>
+	) -> Result<BeefyHost<R, P, zk_beefy::LocalProver, dyn backend::ProofBackend>, anyhow::Error>
 	where
 		R: subxt::Config + Send + Sync + Clone,
 		P: subxt::Config + Send + Sync + Clone,
@@ -74,13 +71,12 @@ impl BeefyConfig {
 				cfg.realtime = true; // Enable real-time notifications
 				Arc::new(backend::RedisProofBackend::new(cfg).await?)
 			},
-			backend::ProofBackendConfig::Onchain =>
-				Arc::new(backend::OnchainBackend::<P>::new(
-					client.client.clone(),
-					client.rpc_client.clone(),
-					client.signer.clone(),
-					self.host.consensus_state_id,
-				)),
+			backend::ProofBackendConfig::Onchain => Arc::new(backend::OnchainBackend::<P>::new(
+				client.client.clone(),
+				client.rpc_client.clone(),
+				client.signer.clone(),
+				self.host.consensus_state_id,
+			)),
 			backend::ProofBackendConfig::InMemory => {
 				let initial_state = prover.query_initial_consensus_state(None).await?;
 				Arc::new(backend::InMemoryProofBackend::new(initial_state))

--- a/tesseract/consensus/beefy/src/lib.rs
+++ b/tesseract/consensus/beefy/src/lib.rs
@@ -52,10 +52,14 @@ pub struct BeefyConfig {
 }
 
 impl BeefyConfig {
-	/// Constructs an instance of the [`IsmpHost`] from the provided configs using Redis backend
+	/// Constructs an instance of the [`IsmpHost`], selecting the proof backend based on
+	/// [`BeefyProverConfig::backend`](prover::BeefyProverConfig::backend).
 	pub async fn into_client<R, P>(
 		self,
-	) -> Result<BeefyHost<R, P, zk_beefy::LocalProver, backend::RedisProofBackend>, anyhow::Error>
+	) -> Result<
+		BeefyHost<R, P, zk_beefy::LocalProver, dyn backend::ProofBackend>,
+		anyhow::Error,
+	>
 	where
 		R: subxt::Config + Send + Sync + Clone,
 		P: subxt::Config + Send + Sync + Clone,
@@ -67,20 +71,29 @@ impl BeefyConfig {
 		let client = SubstrateClient::<P>::new(self.substrate).await?;
 		let prover = Prover::<R, P, zk_beefy::LocalProver>::new(self.prover.clone()).await?;
 
-		// Create Redis-based unified backend (required for into_client)
-		let redis_config =
-			self.host.redis.as_ref().ok_or_else(|| {
-				anyhow::anyhow!("Redis configuration is required for into_client")
-			})?;
-		let mut config = redis_config.clone();
-		config.realtime = true; // Enable real-time notifications
-		let backend = Arc::new(backend::RedisProofBackend::new(config).await?);
+		let backend: Arc<dyn backend::ProofBackend> = match self.prover_config.backend.clone() {
+			backend::ProofBackendConfig::Redis { config } => {
+				let mut cfg = config;
+				cfg.realtime = true; // Enable real-time notifications
+				Arc::new(backend::RedisProofBackend::new(cfg).await?)
+			},
+			backend::ProofBackendConfig::Onchain =>
+				Arc::new(backend::OnchainBackend::<P>::new(
+					client.client.clone(),
+					client.rpc_client.clone(),
+					client.signer.clone(),
+					self.host.consensus_state_id,
+				)),
+			backend::ProofBackendConfig::InMemory => {
+				let initial_state = prover.query_initial_consensus_state(None).await?;
+				Arc::new(backend::InMemoryProofBackend::new(initial_state))
+			},
+		};
 
-		let host =
-			BeefyHost::<R, P, zk_beefy::LocalProver, _>::new(self.host, prover, client, backend)
-				.await?;
-
-		Ok(host)
+		BeefyHost::<R, P, zk_beefy::LocalProver, dyn backend::ProofBackend>::new(
+			self.host, prover, client, backend,
+		)
+		.await
 	}
 }
 

--- a/tesseract/consensus/beefy/src/lib.rs
+++ b/tesseract/consensus/beefy/src/lib.rs
@@ -32,9 +32,6 @@ pub mod backend;
 pub mod host;
 pub mod prover;
 
-const VALIDATOR_SET_ID_KEY: [u8; 32] =
-	hex_literal::hex!("08c41974a97dbf15cfbec28365bea2da8f05bccc2f70ec66a32999c5761156be");
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BeefyConfig {
 	// Configuration options for the BEEFY prover

--- a/tesseract/consensus/beefy/src/prover.rs
+++ b/tesseract/consensus/beefy/src/prover.rs
@@ -56,7 +56,7 @@ use zk_beefy::BeefyProver as Sp1BeefyProverTrait;
 
 use crate::{
 	backend::{ConsensusProof, ProofBackend},
-	extract_para_id, VALIDATOR_SET_ID_KEY,
+	extract_para_id,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -295,7 +295,7 @@ where
 		};
 
 		let changes = relay_rpc
-			.state_query_storage(vec![&VALIDATOR_SET_ID_KEY[..]], from, Some(header.hash().into()))
+			.state_query_storage(vec![&BEEFY_VALIDATOR_SET_ID[..]], from, Some(header.hash().into()))
 			.await?;
 
 		let changes_iter = changes.into_iter().filter_map(|change| {

--- a/tesseract/consensus/beefy/src/prover.rs
+++ b/tesseract/consensus/beefy/src/prover.rs
@@ -67,8 +67,8 @@ pub struct BeefyProverConfig {
 	pub minimum_finalization_height: u64,
 	/// State machines we are proving for
 	pub state_machines: Vec<StateMachine>,
-	/// Optional Redis configuration for proof backend (if None, uses InMemoryProofBackend)
-	pub redis: Option<crate::backend::RedisConfig>,
+	/// Which proof backend the prover (and the corresponding host) should use.
+	pub backend: crate::backend::ProofBackendConfig,
 }
 
 /// Selects which proof strategy the BEEFY prover uses.
@@ -105,15 +105,18 @@ pub struct ProverConfig {
 /// The BEEFY prover produces BEEFY consensus proofs using either the naive or zk variety. Consensus
 /// proofs are produced when new messages are observed on the hyperbridge chain or when the
 /// authority set changes.
-pub struct BeefyProver<R: subxt::Config, P: subxt::Config, B: Sp1BeefyProverTrait, Q: ProofBackend>
-{
-	/// The prover's consensus state
-	consensus_state: ProverConsensusState,
+pub struct BeefyProver<
+	R: subxt::Config,
+	P: subxt::Config,
+	B: Sp1BeefyProverTrait,
+	Q: ProofBackend + ?Sized,
+> {
 	/// The hyperbridge substrate client
 	client: SubstrateClient<P>,
 	/// The beefy prover instance
 	prover: Prover<R, P, B>,
-	/// Unified backend for queue and state storage
+	/// Unified backend for queue and state storage. Consensus state is always loaded
+	/// fresh from this backend at each point of use rather than cached locally.
 	backend: Arc<Q>,
 	/// Prover configuration options
 	config: BeefyProverConfig,
@@ -137,7 +140,7 @@ where
 	R: subxt::Config + Send + Sync + Clone,
 	P: subxt::Config + Send + Sync + Clone,
 	B: Sp1BeefyProverTrait,
-	Q: ProofBackend,
+	Q: ProofBackend + ?Sized,
 	P::Header: Send + Sync,
 	<P::ExtrinsicParams as ExtrinsicParams<P>>::Params: Send + Sync + DefaultParams,
 	P::AccountId: From<AccountId32> + Into<P::Address> + Clone + Send + Sync,
@@ -152,34 +155,14 @@ where
 		prover: Prover<R, P, B>,
 		backend: Arc<Q>,
 	) -> Result<Self, anyhow::Error> {
+		// Sanity-check that the backend has a consensus state we can load.
 		let consensus_state = backend.load_state().await?;
-
 		log::info!("Loaded consensus state: {consensus_state:#?}");
 
 		// Initialize queues for the configured state machines
 		backend.init_queues(&config.state_machines).await?;
 
-		Ok(BeefyProver { consensus_state, prover, client, config, backend })
-	}
-
-	/// Rotate the prover's known authority set, using the network view at the provided hash
-	async fn rotate_authorities(&mut self, hash: HashFor<R>) -> Result<(), anyhow::Error> {
-		self.consensus_state.inner.current_authorities =
-			self.consensus_state.inner.next_authorities.clone();
-		self.consensus_state.inner.next_authorities =
-			beefy_prover::relay::beefy_mmr_leaf_next_authorities(
-				&self.prover.inner().relay_rpc,
-				Some(hash),
-			)
-			.await?;
-
-		tracing::info!(
-			"Rotated authority set. Current {}, Next: {}",
-			self.consensus_state.inner.current_authorities.id,
-			self.consensus_state.inner.next_authorities.id,
-		);
-
-		Ok(())
+		Ok(BeefyProver { prover, client, config, backend })
 	}
 
 	/// Generate an encoded proof
@@ -225,9 +208,10 @@ where
 	/// parachain block that was queried.
 	pub async fn latest_ismp_message_events(
 		&self,
+		consensus_state: &ProverConsensusState,
 		finalized: HashFor<R>,
 	) -> Result<(u64, Vec<EventWithMetadata>), anyhow::Error> {
-		let latest_height = self.consensus_state.finalized_parachain_height;
+		let latest_height = consensus_state.finalized_parachain_height;
 		let para_id = extract_para_id(self.client.state_machine_id().state_id)?;
 		let header =
 			query_parachain_header(&self.prover.inner().relay_rpc, finalized, para_id).await?;
@@ -286,8 +270,9 @@ where
 	/// by beefy and the last known finalized block.
 	pub async fn query_next_finalized_epoch(
 		&self,
+		consensus_state: &ProverConsensusState,
 	) -> Result<(Option<(HashFor<R>, u64)>, generic::Header<u32, BlakeTwo256>), anyhow::Error> {
-		let initial_height = self.consensus_state.inner.latest_beefy_height;
+		let initial_height = consensus_state.inner.latest_beefy_height;
 		let relay_rpc = self.prover.inner().relay_rpc.clone();
 		let from = relay_rpc
 			.chain_get_block_hash(Some(initial_height.into()))
@@ -324,7 +309,7 @@ where
 		tracing::trace!("Latest set ID: {:#?}", changes_iter.clone().next_back());
 
 		let block_hash_and_set_id = changes_iter
-			.filter(|(_, set_id)| *set_id >= self.consensus_state.inner.next_authorities.id)
+			.filter(|(_, set_id)| *set_id >= consensus_state.inner.next_authorities.id)
 			.next();
 
 		tracing::trace!("Block hash and set id: {:#?}", block_hash_and_set_id);
@@ -381,7 +366,7 @@ where
 
 	/// Runs the proving task. Will internally notify the appropriate channels of new epoch
 	/// justifications as well as new proofs for ISMP messages.
-	pub async fn run(&mut self) {
+	pub async fn run(&self) {
 		let hyperbridge = self.client.state_machine_id().state_id;
 		let para_id = extract_para_id(hyperbridge)
 			.expect("StateMachine should be either one of Polkadot or Kusama");
@@ -391,14 +376,19 @@ where
 			tokio::time::sleep(Duration::from_secs(10)).await;
 
 			let result: Result<_, anyhow::Error> = async {
+				// Load fresh consensus state from the backend each iteration so we never act
+				// on stale state — for the on-chain backend this reflects the latest accepted
+				// proof on the pallet; for Redis / in-memory it's the last saved progress.
+				let mut consensus_state = self.backend.load_state().await?;
+
 				let (update, latest_beefy_header) =
-					self.query_next_finalized_epoch().await?;
+					self.query_next_finalized_epoch(&consensus_state).await?;
 
 				match update {
 					Some((epoch_change_block_hash, next_set_id)) => {
 						// invariant, update should always be for the next set
 						tracing::info!("Next authority set: {next_set_id}");
-						assert_eq!(next_set_id, self.consensus_state.inner.next_authorities.id);
+						assert_eq!(next_set_id, consensus_state.inner.next_authorities.id);
 
 						let epoch_change_header = relay_rpc
 							.chain_get_header(Some(epoch_change_block_hash))
@@ -419,7 +409,7 @@ where
 						);
 
 						let consensus_proof = self
-							.consensus_proof(commitment.clone(), self.consensus_state.inner.clone())
+							.consensus_proof(commitment.clone(), consensus_state.inner.clone())
 							.await?;
 
 						let finalized_hash = relay_rpc
@@ -454,24 +444,41 @@ where
 								.await?;
 						}
 
-						self.consensus_state.finalized_parachain_height =
-							finalized_parachain_height;
-						self.consensus_state.inner.latest_beefy_height =
+						// Advance the locally-computed view and persist it to the backend.
+						// Rotate authorities inline: new current = old next, new next =
+						// queried from the relay at the epoch-change hash.
+						consensus_state.finalized_parachain_height = finalized_parachain_height;
+						consensus_state.inner.latest_beefy_height =
 							commitment.commitment.block_number;
-						self.rotate_authorities(epoch_change_block_hash).await?;
-						self.backend.save_state(&self.consensus_state).await?;
+						consensus_state.inner.current_authorities =
+							consensus_state.inner.next_authorities.clone();
+						consensus_state.inner.next_authorities =
+							beefy_prover::relay::beefy_mmr_leaf_next_authorities(
+								&self.prover.inner().relay_rpc,
+								Some(epoch_change_block_hash),
+							)
+							.await?;
+						tracing::info!(
+							"Rotated authority set. Current {}, Next: {}",
+							consensus_state.inner.current_authorities.id,
+							consensus_state.inner.next_authorities.id,
+						);
+						self.backend.save_state(&consensus_state).await?;
 						return Ok(()); // check for next updates
 					},
 					None => {},
 				}
 
 				let (latest_parachain_height, messages) = self
-					.latest_ismp_message_events(latest_beefy_header.parent_hash.into())
+					.latest_ismp_message_events(
+						&consensus_state,
+						latest_beefy_header.parent_hash.into(),
+					)
 					.await?;
 
 				if messages.is_empty() {
-					self.consensus_state.finalized_parachain_height = latest_parachain_height;
-					self.backend.save_state(&self.consensus_state).await?;
+					consensus_state.finalized_parachain_height = latest_parachain_height;
+					self.backend.save_state(&consensus_state).await?;
 					return Ok(());
 				}
 
@@ -531,7 +538,7 @@ where
 				)
 				.await?;
 				let consensus_proof = self
-					.consensus_proof(commitment.clone(), self.consensus_state.inner.clone())
+					.consensus_proof(commitment.clone(), consensus_state.inner.clone())
 					.await?;
 
 				let set_id = relay_rpc
@@ -562,9 +569,9 @@ where
 					self.backend.send_messages_proof(&state_machine, message.clone()).await?;
 				}
 
-				self.consensus_state.inner.latest_beefy_height = *latest_beefy_header.number();
-				self.consensus_state.finalized_parachain_height = latest_parachain_height;
-				self.backend.save_state(&self.consensus_state).await?;
+				consensus_state.inner.latest_beefy_height = *latest_beefy_header.number();
+				consensus_state.finalized_parachain_height = latest_parachain_height;
+				self.backend.save_state(&consensus_state).await?;
 
 				Ok(())
 			}

--- a/tesseract/consensus/beefy/src/prover.rs
+++ b/tesseract/consensus/beefy/src/prover.rs
@@ -295,7 +295,11 @@ where
 		};
 
 		let changes = relay_rpc
-			.state_query_storage(vec![&BEEFY_VALIDATOR_SET_ID[..]], from, Some(header.hash().into()))
+			.state_query_storage(
+				vec![&BEEFY_VALIDATOR_SET_ID[..]],
+				from,
+				Some(header.hash().into()),
+			)
 			.await?;
 
 		let changes_iter = changes.into_iter().filter_map(|change| {

--- a/tesseract/consensus/relayer/bins/polyhedron.rs
+++ b/tesseract/consensus/relayer/bins/polyhedron.rs
@@ -105,13 +105,9 @@ impl PolyhedronConfig {
 			);
 		}
 
-		// Ensure redis is not configured (we use in-memory backend)
-		if self.beefy.redis.is_some() {
-			log::warn!("Redis configuration detected in beefy config but will be ignored - Polyhedron uses in-memory backend");
-		}
-
-		if self.host.redis.is_some() {
-			log::warn!("Redis configuration detected in host config but will be ignored - Polyhedron uses in-memory backend");
+		// Ensure backend is set to in-memory — Polyhedron builds its own in-memory backend.
+		if !matches!(self.beefy.backend, tesseract_beefy::backend::ProofBackendConfig::InMemory) {
+			log::warn!("Non-in-memory backend configured in beefy config but will be ignored - Polyhedron uses in-memory backend");
 		}
 
 		// Ensure state_machines contains exactly the Tron state machine
@@ -230,7 +226,7 @@ async fn main() -> anyhow::Result<()> {
 	// Initialize BeefyProver with in-memory backend
 	let prover = Prover::new(config.prover.clone()).await.context("Failed to create prover")?;
 
-	let mut beefy_prover =
+	let beefy_prover =
 		BeefyProver::<
 			Blake2SubstrateChain,
 			KeccakSubstrateChain,

--- a/tesseract/consensus/relayer/bins/prover.rs
+++ b/tesseract/consensus/relayer/bins/prover.rs
@@ -57,18 +57,20 @@ async fn main() -> Result<(), anyhow::Error> {
 		SubstrateClient::new(substrate_config.try_into()?).await?
 	};
 
-	let mut beefy_prover = {
+	let beefy_prover = {
 		let beefy_config: tesseract_beefy::prover::BeefyProverConfig = config
 			.remove("beefy")
 			.ok_or_else(|| anyhow!("Substrate config missing; qed"))?
 			.try_into()?;
 
-		// Create Redis backend for prover
-		let redis_config = beefy_config
-			.redis
-			.as_ref()
-			.ok_or_else(|| anyhow::anyhow!("Redis configuration is required for prover"))?;
-		let mut redis_cfg = redis_config.clone();
+		// The prover binary submits through a Redis queue consumed by the host process —
+		// other backend variants don't apply here.
+		let tesseract_beefy::backend::ProofBackendConfig::Redis { config: ref redis_cfg } =
+			beefy_config.backend
+		else {
+			return Err(anyhow!("Redis backend is required for the beefy-prover binary"));
+		};
+		let mut redis_cfg = redis_cfg.clone();
 		redis_cfg.realtime = true;
 		let backend = Arc::new(tesseract_beefy::backend::RedisProofBackend::new(redis_cfg).await?);
 

--- a/tesseract/consensus/relayer/src/any.rs
+++ b/tesseract/consensus/relayer/src/any.rs
@@ -138,6 +138,8 @@ pub enum ConsensusHost {
 		prover: ProverConfig,
 		// Host options for BEEFY
 		beefy: BeefyHostConfig,
+		// Redis config for the relayer's proof queue
+		redis: tesseract_beefy::backend::RedisConfig,
 	},
 	Grandpa(GrandpaConfig),
 }
@@ -169,18 +171,13 @@ impl HyperbridgeHostConfig {
 		R::AccountId: From<AccountId32> + Into<R::Address> + Clone + 'static + Send + Sync,
 	{
 		let host = match self.host {
-			ConsensusHost::Beefy { substrate, prover, beefy } => {
+			ConsensusHost::Beefy { substrate, prover, beefy, redis } => {
 				let client = SubstrateClient::<P>::new(substrate).await?;
 				let prover_instance =
 					Prover::<R, P, zk_beefy::LocalProver>::new(prover.clone()).await?;
 
-				// Create Redis backend (required for relayer)
-				let redis_config = beefy.redis.as_ref().ok_or_else(|| {
-					anyhow::anyhow!("Redis configuration is required for relayer")
-				})?;
-				let config = redis_config.clone();
 				let backend =
-					Arc::new(tesseract_beefy::backend::RedisProofBackend::new(config).await?);
+					Arc::new(tesseract_beefy::backend::RedisProofBackend::new(redis).await?);
 
 				AnyHost::Beefy(BeefyHost::new(beefy, prover_instance, client, backend).await?)
 			},


### PR DESCRIPTION
## Summary
- Adds `OnchainBackend` that submits BEEFY consensus proofs directly to `pallet-beefy-consensus-proofs` via unsigned extrinsics, bypassing the Redis queue / separate host process.
- Replaces the ad-hoc `redis: Option<RedisConfig>` field with a `ProofBackendConfig` enum (`redis`, `onchain`, `in_memory`); `BeefyConfig::into_client` dispatches on the variant.
- `BeefyProver` / `BeefyHost` now use `Arc<dyn ProofBackend>` (added `?Sized` bounds on `Q`) instead of a hand-rolled enum wrapper.
- `OnchainBackend::load_state` reads the authoritative BEEFY consensus state from `pallet-ismp` (via `ismp_queryConsensusState`) and the parachain height from `pallet-beefy-consensus-proofs::LastProvenHeight`.
- `BeefyProver` no longer caches consensus state in a field — it calls `load_state` at the start of every iteration so it always acts on the freshest view.

Related #711

## Test plan
- [x] `cargo check --workspace` passes locally.
- [x] Run the relayer against a hyperbridge testnet with `backend = { type = "onchain" }` and confirm proofs land in `pallet-beefy-consensus-proofs` and advance `LastProvenHeight`.
- [x] Run with `backend = { type = "redis", ... }` and confirm existing Redis-queue behaviour is unchanged.
- [x] Polyhedron binary still relays Fiat-Shamir proofs to Tron via the in-memory backend.