### PR TITLE
fix(ci): build EVM artifacts in build-runtime workflow

### DIFF
--- a/.github/workflows/build-runtime.yml
+++ b/.github/workflows/build-runtime.yml
@@ -93,6 +93,30 @@ jobs:
           curl -L -o subwasm.deb https://github.com/chevdor/subwasm/releases/download/v0.21.3/subwasm_linux_amd64_v0.21.3.deb
           sudo dpkg -i subwasm.deb
 
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 22
+          cache-dependency-path: "evm/pnpm-lock.yaml"
+          cache: "pnpm"
+
+      - name: Install npm dependencies
+        working-directory: evm
+        run: pnpm install
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Build Foundry artifacts
+        working-directory: evm
+        run: forge build
+
       - name: Cache cargo
         uses: swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## Summary
- The `build-runtime` workflow was missing Node.js, pnpm, Foundry setup and `forge build` steps
- Without these, the EVM ABI artifacts (`evm/out/*.sol/*.json`) don't exist when cargo tries to compile `ismp-solidity-abi`, causing the build to fail
- Adds the same EVM build steps used in `ci.yml`

## Test plan
- [ ] Re-tag `gargantua-v5600` after merge and verify the build-runtime workflow passes