### PR TITLE
[runtime]: ABI-decode proofs for on-chain verification

### DIFF
--- a/modules/pallets/beefy-consensus-proofs/src/lib.rs
+++ b/modules/pallets/beefy-consensus-proofs/src/lib.rs
@@ -472,13 +472,24 @@ pub mod pallet {
 				Err(Error::<T>::BadSignature)?
 			}
 
-			// expects (proof type byte || SCALE-encoded proof).
+			// expects (proof type byte || ABI-encoded SP1BeefyProof).
 			let proof_type = *payload.proof.first().ok_or(Error::<T>::UnknownProofType)?;
 			if proof_type != types::PROOF_TYPE_SP1 {
 				Err(Error::<T>::UnknownProofType)?
 			}
 
-			// Hand off to pallet-ismp.
+			// ABI-decode the proof, convert to SCALE for verification by ismp_beefy.
+			let abi_payload = &payload.proof[1..];
+			let abi_proof =
+				<ismp_solidity_abi::sp1_beefy::SP1Beefy::SP1BeefyProof as SolType>::abi_decode(
+					abi_payload,
+				)
+				.map_err(|_| Error::<T>::AbiDecodeFailed)?;
+			let scale_proof: beefy_verifier_primitives::Sp1BeefyProof = abi_proof.into();
+			let consensus_proof =
+				[&[types::PROOF_TYPE_SP1], scale_proof.encode().as_slice()].concat();
+
+			// Hand off to pallet-ismp with SCALE-encoded proof for verification.
 			let host = pallet_ismp::Pallet::<T>::default();
 			let prev_state_bytes = host
 				.consensus_state(BEEFY_CONSENSUS_ID)
@@ -489,7 +500,7 @@ pub mod pallet {
 			let result = handlers::handle_incoming_message(
 				&host,
 				Message::Consensus(IsmpConsensusMessage {
-					consensus_proof: payload.proof.clone(),
+					consensus_proof,
 					consensus_state_id: T::ConsensusStateId::get(),
 					signer: public.to_vec(),
 				}),

--- a/parachain/runtimes/gargantua/src/lib.rs
+++ b/parachain/runtimes/gargantua/src/lib.rs
@@ -247,7 +247,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("gargantua"),
 	impl_name: Cow::Borrowed("gargantua"),
 	authoring_version: 1,
-	spec_version: 5_600,
+	spec_version: 5_700,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
## Summary
- The beefy prover ABI-encodes ZK proofs (for EVM compatibility), but `ismp_beefy::BeefyConsensusClient` expects SCALE-encoded `Sp1BeefyProof`
- The pallet now ABI-decodes the incoming proof, converts to the SCALE `Sp1BeefyProof` type via the existing `From` impl, and passes the SCALE-encoded version to `handle_incoming_message` for verification
- The original ABI-encoded proof bytes are preserved as-is for storage (downstream EVM consumers need ABI encoding)
- Bumps gargantua spec_version to 5700

## Test plan
- [ ] Merge and build new gargantua runtime
- [ ] Enact runtime upgrade on gargantua
- [ ] Resume RunPod prover and verify proof submission succeeds