### PR TITLE
[runtime]: use `abi_decode_params` for SP1BeefyProof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28175,7 +28175,7 @@ dependencies = [
 
 [[package]]
 name = "tesseract-consensus"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "arb-host",

--- a/modules/pallets/beefy-consensus-proofs/src/lib.rs
+++ b/modules/pallets/beefy-consensus-proofs/src/lib.rs
@@ -481,7 +481,7 @@ pub mod pallet {
 			// ABI-decode the proof, convert to SCALE for verification by ismp_beefy.
 			let abi_payload = &payload.proof[1..];
 			let abi_proof =
-				<ismp_solidity_abi::sp1_beefy::SP1Beefy::SP1BeefyProof as SolType>::abi_decode(
+				<ismp_solidity_abi::sp1_beefy::SP1Beefy::SP1BeefyProof as SolType>::abi_decode_params(
 					abi_payload,
 				)
 				.map_err(|_| Error::<T>::AbiDecodeFailed)?;

--- a/parachain/runtimes/gargantua/src/lib.rs
+++ b/parachain/runtimes/gargantua/src/lib.rs
@@ -247,7 +247,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("gargantua"),
 	impl_name: Cow::Borrowed("gargantua"),
 	authoring_version: 1,
-	spec_version: 5_700,
+	spec_version: 5_800,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/tesseract/consensus/beefy/src/prover.rs
+++ b/tesseract/consensus/beefy/src/prover.rs
@@ -65,7 +65,8 @@ pub struct BeefyProverConfig {
 	pub consensus_state_id: ConsensusStateId,
 	/// Minimum height that must be enacted before we prove finality for new messages
 	pub minimum_finalization_height: u64,
-	/// State machines we are proving for
+	/// State machines we are proving for. If empty or omitted, prove all.
+	#[serde(default)]
 	pub state_machines: Vec<StateMachine>,
 	/// Which proof backend the prover (and the corresponding host) should use.
 	pub backend: crate::backend::ProofBackendConfig,
@@ -237,6 +238,10 @@ where
 				};
 
 				// filter out destinations that the prover isn't configured for
+				// empty state_machines means prove all
+				if self.config.state_machines.is_empty() {
+					return Some(event);
+				}
 				self.config.state_machines.iter().find(|s| **s == dest).map(|_| event)
 			})
 			.collect::<Vec<_>>();
@@ -439,13 +444,19 @@ where
 							},
 						};
 
-						for state_machine in self.config.state_machines.iter() {
-							tracing::info!(
-								"Sending mandatory consensus proof to {state_machine}"
-							);
-							self.backend
-								.send_mandatory_proof(state_machine, message.clone())
-								.await?;
+						if self.config.state_machines.is_empty() {
+							let host = self.client.state_machine_id().state_id;
+							tracing::info!("Sending mandatory consensus proof for {host}");
+							self.backend.send_mandatory_proof(&host, message.clone()).await?;
+						} else {
+							for state_machine in self.config.state_machines.iter() {
+								tracing::info!(
+									"Sending mandatory consensus proof to {state_machine}"
+								);
+								self.backend
+									.send_mandatory_proof(state_machine, message.clone())
+									.await?;
+							}
 						}
 
 						// Advance the locally-computed view and persist it to the backend.

--- a/tesseract/consensus/relayer/Cargo.toml
+++ b/tesseract/consensus/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tesseract-consensus"
-version = "1.7.1"
+version = "1.8.0"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
## Summary
- Use `abi_decode_params` instead of `abi_decode` in `pallet-beefy-consensus-proofs` to match the prover's `abi_encode_params` encoding and Solidity's `abi.decode` behavior.
- `SolType::abi_decode` adds an extra 32-byte offset wrapper that `abi_encode_params` does not produce, causing `AbiDecodeFailed` on proof submission.

## Test plan
- [x] Deployed prover on RunPod (RTX 5090) generating SP1 Groth16 proofs from Paseo relay chain
- [x] Verified proofs are accepted by simnode running patched runtime (`LastProvenHeight` advancing)
- [x] Confirmed Solidity `abi.decode` compatibility via eth_abi test