### PR TITLE
[runtime]: Pallet-beefy-consensus-proofs fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28209,7 +28209,7 @@ dependencies = [
 
 [[package]]
 name = "tesseract-consensus"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "anyhow",
  "arb-host",

--- a/modules/ismp/clients/arbitrum/src/lib.rs
+++ b/modules/ismp/clients/arbitrum/src/lib.rs
@@ -337,13 +337,13 @@ pub fn verify_arbitrum_bold<H: Keccak256 + Send + Sync>(
 	// parent's `AssertionNode.secondChildBlock` (uint64 at struct offset 8) is non-zero iff a
 	// rival sibling exists. Read the parent's first storage word from the proof and check the
 	// secondChildBlock bytes.
-	let parent_key = derive_map_key::<H>(payload.previous_assertion_hash.0.to_vec(), ASSERTIONS_SLOT);
-	let parent_word_raw = get_value_from_proof::<H>(
-		parent_key.0.to_vec(),
-		storage_root,
-		payload.challenge_proof,
-	)?
-	.ok_or_else(|| anyhow!("Parent assertion not found in proof — cannot check challenge state"))?;
+	let parent_key =
+		derive_map_key::<H>(payload.previous_assertion_hash.0.to_vec(), ASSERTIONS_SLOT);
+	let parent_word_raw =
+		get_value_from_proof::<H>(parent_key.0.to_vec(), storage_root, payload.challenge_proof)?
+			.ok_or_else(|| {
+				anyhow!("Parent assertion not found in proof — cannot check challenge state")
+			})?;
 	let parent_word_bytes = <alloy_primitives::Bytes as Decodable>::decode(&mut &*parent_word_raw)
 		.map_err(|_| anyhow!("Error decoding parent assertion word {:?}", parent_word_raw))?
 		.0
@@ -357,9 +357,7 @@ pub fn verify_arbitrum_bold<H: Keccak256 + Send + Sync>(
 	// secondChildBlock occupies bytes word[16..24].
 	const ZERO_U64: [u8; 8] = [0u8; 8];
 	if &word[16..24] != ZERO_U64.as_slice() {
-		Err(anyhow!(
-			"Assertion has been challenged: parent.secondChildBlock != 0"
-		))?
+		Err(anyhow!("Assertion has been challenged: parent.secondChildBlock != 0"))?
 	}
 
 	Ok(IntermediateState {

--- a/modules/ismp/clients/ismp-optimism/src/migrations.rs
+++ b/modules/ismp/clients/ismp-optimism/src/migrations.rs
@@ -22,8 +22,8 @@
 //! handles on-chain storage-version gating and bumping automatically.
 
 use crate::{
-	pallet::{Config, StateMachinesDisputeGameFactoriesTypes},
 	Pallet,
+	pallet::{Config, StateMachinesDisputeGameFactoriesTypes},
 };
 use alloc::{vec, vec::Vec};
 use core::marker::PhantomData;
@@ -126,17 +126,17 @@ mod version_unchecked {
 			let mut dropped: u64 = 0;
 
 			StateMachinesDisputeGameFactoriesTypes::<T>::translate::<(H160, Vec<u32>), _>(
-				|state_machine_id, (factory, _old_game_types)| {
-					match configs_for(&state_machine_id.state_id) {
-						Some(configs) => {
-							translated = translated.saturating_add(1);
-							Some((factory, configs))
-						},
-						None => {
-							dropped = dropped.saturating_add(1);
-							None
-						},
-					}
+				|state_machine_id, (factory, _old_game_types)| match configs_for(
+					&state_machine_id.state_id,
+				) {
+					Some(configs) => {
+						translated = translated.saturating_add(1);
+						Some((factory, configs))
+					},
+					None => {
+						dropped = dropped.saturating_add(1);
+						None
+					},
 				},
 			);
 

--- a/modules/ismp/clients/ismp-optimism/src/pallet.rs
+++ b/modules/ismp/clients/ismp-optimism/src/pallet.rs
@@ -60,13 +60,8 @@ pub mod pallet {
 	// challenged" check during verification.
 	#[pallet::storage]
 	#[pallet::getter(fn state_machines_dispute_game_factories_types)]
-	pub type StateMachinesDisputeGameFactoriesTypes<T: Config> = StorageMap<
-		_,
-		Blake2_128Concat,
-		StateMachineId,
-		(H160, Vec<GameTypeConfig>),
-		OptionQuery,
-	>;
+	pub type StateMachinesDisputeGameFactoriesTypes<T: Config> =
+		StorageMap<_, Blake2_128Concat, StateMachineId, (H160, Vec<GameTypeConfig>), OptionQuery>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn supported_state_machines)]

--- a/modules/ismp/clients/optimism/src/lib.rs
+++ b/modules/ismp/clients/optimism/src/lib.rs
@@ -454,9 +454,8 @@ fn verify_not_challenged<H: Keccak256 + Send + Sync>(
 			// The MPT trie path for a storage slot is `keccak256(storage_key)`, so we hash
 			// once more here: the storage key for the array's first element is itself a
 			// keccak256 of the slot number.
-			let storage_key = H::keccak256(
-				&U256::from(FAULT_DISPUTE_CLAIM_DATA_SLOT).to_big_endian(),
-			);
+			let storage_key =
+				H::keccak256(&U256::from(FAULT_DISPUTE_CLAIM_DATA_SLOT).to_big_endian());
 			let trie_path = H::keccak256(&storage_key.0);
 			let value = get_value_from_proof::<H>(
 				trie_path.0.to_vec(),
@@ -475,9 +474,7 @@ fn verify_not_challenged<H: Keccak256 + Send + Sync>(
 				.0
 				.to_vec();
 			if raw.len() > 32 {
-				Err(Error::Custom(
-					"claimData[0] storage value longer than 32 bytes".to_string(),
-				))?
+				Err(Error::Custom("claimData[0] storage value longer than 32 bytes".to_string()))?
 			}
 			let mut word = vec![0u8; 32 - raw.len()];
 			word.extend_from_slice(&raw);
@@ -504,7 +501,8 @@ fn verify_not_challenged<H: Keccak256 + Send + Sync>(
 			// encoded as zero. `get_value_from_proof` returns `None` for absent keys.
 			//
 			// The MPT trie path for a direct storage slot is `keccak256(slot)`.
-			let storage_key = H256(U256::from(AGGREGATE_VERIFIER_COUNTERED_BY_SLOT).to_big_endian());
+			let storage_key =
+				H256(U256::from(AGGREGATE_VERIFIER_COUNTERED_BY_SLOT).to_big_endian());
 			let trie_path = H::keccak256(&storage_key.0);
 			let value = get_value_from_proof::<H>(
 				trie_path.0.to_vec(),

--- a/modules/ismp/core/src/consensus.rs
+++ b/modules/ismp/core/src/consensus.rs
@@ -47,6 +47,7 @@ pub type ConsensusClientId = [u8; 4];
 	PartialEq,
 	Hash,
 	Eq,
+	Default,
 	serde::Deserialize,
 	serde::Serialize,
 )]

--- a/modules/pallets/beefy-consensus-proofs/src/lib.rs
+++ b/modules/pallets/beefy-consensus-proofs/src/lib.rs
@@ -60,13 +60,14 @@ pub mod pallet {
 	};
 	use frame_system::pallet_prelude::*;
 	use ismp::{
-		consensus::{ConsensusClientId, ConsensusStateId},
+		consensus::{ConsensusClientId, ConsensusStateId, StateMachineHeight},
 		events::StateMachineUpdated,
 		handlers,
 		host::IsmpHost,
 		messaging::{ConsensusMessage as IsmpConsensusMessage, Message},
 	};
 	use ismp_solidity_abi::beefy::BeefyConsensusState as SolBeefyConsensusState;
+	use primitive_types::H256;
 	use sp_core::sr25519;
 	use sp_runtime::{
 		traits::AccountIdConversion,
@@ -130,8 +131,7 @@ pub mod pallet {
 	/// `ChildTrieRoot` snapshot at the last messaging reward — dirty-bit for "new dispatches
 	/// exist since we last paid".
 	#[pallet::storage]
-	pub type LastRewardedDispatchRoot<T: Config> =
-		StorageValue<_, <T as frame_system::Config>::Hash, OptionQuery>;
+	pub type LastRewardedDispatchRoot<T: Config> = StorageValue<_, H256, OptionQuery>;
 
 	/// Fixed reward amount per eligible proof.
 	#[pallet::storage]
@@ -186,6 +186,8 @@ pub mod pallet {
 		RewardTransferFailed,
 		/// `pallet-ismp` rejected the consensus message.
 		IsmpUpdateFailed,
+		/// The child trie root was not provided in the proof.
+		MissingChildTrieRoot,
 	}
 
 	#[pallet::event]
@@ -277,12 +279,11 @@ pub mod pallet {
 			let outcome = Self::verify_and_apply(&payload, &signature)?;
 
 			// Determine reward eligibility.
-			let child_trie_root = pallet_ismp::ChildTrieRoot::<T>::get();
-			let last_rewarded = LastRewardedDispatchRoot::<T>::get();
+			let last_rewarded = LastRewardedDispatchRoot::<T>::get().unwrap_or_default();
 			let prev_proven = LastProvenHeight::<T>::get();
 
 			let messaging_reward =
-				Some(child_trie_root) != last_rewarded && outcome.proven_height > prev_proven;
+				outcome.child_trie_root != last_rewarded && outcome.proven_height > prev_proven;
 			let should_reward = outcome.rotated || messaging_reward;
 
 			if !should_reward {
@@ -290,7 +291,7 @@ pub mod pallet {
 			}
 
 			if messaging_reward {
-				LastRewardedDispatchRoot::<T>::put(child_trie_root);
+				LastRewardedDispatchRoot::<T>::put(outcome.child_trie_root);
 			}
 			if outcome.proven_height > prev_proven {
 				LastProvenHeight::<T>::put(outcome.proven_height);
@@ -433,6 +434,8 @@ pub mod pallet {
 		pub current_set_id: u64,
 		/// True iff the proof rotated the current authority set.
 		pub rotated: bool,
+		/// Root of the child trie verified by this proof.
+		pub child_trie_root: H256,
 	}
 
 	impl<T: Config> Pallet<T>
@@ -518,17 +521,23 @@ pub mod pallet {
 				Err(Error::<T>::StaleProof)?
 			};
 			let coprocessor = T::Coprocessor::get().unwrap();
-			let proven_height = events
+			let (proven_height, state_commitment) = events
 				.into_iter()
 				.filter_map(|ev| match ev {
 					ismp::events::Event::StateMachineUpdated(StateMachineUpdated {
 						latest_height,
 						state_machine_id,
-					}) if state_machine_id.state_id == coprocessor => Some(latest_height),
+					}) if state_machine_id.state_id == coprocessor => host
+						.state_machine_commitment(StateMachineHeight {
+							height: latest_height,
+							id: state_machine_id,
+						})
+						.ok()
+						.map(|c| (latest_height, c)),
 					_ => None,
 				})
-				.max()
-				.unwrap_or(0);
+				.max_by_key(|c| c.0)
+				.unwrap_or((0, Default::default()));
 
 			// Read post-update consensus state to derive the new set id.
 			let new_state_bytes = host
@@ -552,6 +561,9 @@ pub mod pallet {
 				proven_height,
 				current_set_id: new_state.current_authorities.id,
 				rotated: new_state.current_authorities.id > prev_state.current_authorities.id,
+				child_trie_root: state_commitment
+					.overlay_root
+					.ok_or_else(|| Error::<T>::MissingChildTrieRoot)?,
 			})
 		}
 	}

--- a/parachain/runtimes/gargantua/src/lib.rs
+++ b/parachain/runtimes/gargantua/src/lib.rs
@@ -248,7 +248,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("gargantua"),
 	impl_name: Cow::Borrowed("gargantua"),
 	authoring_version: 1,
-	spec_version: 5_800,
+	spec_version: 5_900,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/tesseract/consensus/admin-relayer/bins/relayer.rs
+++ b/tesseract/consensus/admin-relayer/bins/relayer.rs
@@ -78,9 +78,7 @@ async fn main() -> anyhow::Result<()> {
 	for (label, chain_cfg) in &config.chains {
 		let state_machine = chain_cfg.evm.state_machine;
 		if !matches!(state_machine, StateMachine::Evm(_)) {
-			return Err(anyhow!(
-				"[{label}] expected EVM state machine, got {state_machine}"
-			));
+			return Err(anyhow!("[{label}] expected EVM state machine, got {state_machine}"));
 		}
 		let client = EvmClient::new(chain_cfg.evm.clone())
 			.await
@@ -108,9 +106,8 @@ async fn main() -> anyhow::Result<()> {
 	for (state_machine, client, mode) in &clients {
 		match mode {
 			SubmissionMode::Batched => ensure_delegated(client).await?,
-			SubmissionMode::Sequential => log::info!(
-				"[{state_machine}] sequential mode — skipping EIP-7702 delegation"
-			),
+			SubmissionMode::Sequential =>
+				log::info!("[{state_machine}] sequential mode — skipping EIP-7702 delegation"),
 		}
 	}
 

--- a/tesseract/consensus/admin-relayer/src/batch.rs
+++ b/tesseract/consensus/admin-relayer/src/batch.rs
@@ -5,12 +5,10 @@
 //!
 //! Two modes are supported via [`crate::config::SubmissionMode`]:
 //!
-//! * `Batched` — one ERC-7821 batch tx `[unfreeze, handleConsensus, freeze]`
-//!   dispatched from the relayer EOA that has been EIP-7702 delegated to a
-//!   per-chain Executor.
-//! * `Sequential` — three plain EOA txs (`setFrozenState(None)` →
-//!   `handleConsensus` → `setFrozenState(All)`) for chains that don't yet
-//!   accept EIP-7702 transactions.
+//! * `Batched` — one ERC-7821 batch tx `[unfreeze, handleConsensus, freeze]` dispatched from the
+//!   relayer EOA that has been EIP-7702 delegated to a per-chain Executor.
+//! * `Sequential` — three plain EOA txs (`setFrozenState(None)` → `handleConsensus` →
+//!   `setFrozenState(All)`) for chains that don't yet accept EIP-7702 transactions.
 //!
 //! In both modes every tx is awaited to full receipt before the next one is
 //! constructed — the caller observes the strict `submit → await receipt → next`
@@ -82,11 +80,9 @@ pub async fn submit_mandatory_batch(
 	let handler = resolve_handler(client).await?;
 
 	let unfreeze = EvmHost::setFrozenStateCall { newState: FROZEN_NONE }.abi_encode();
-	let consensus = Handler::handleConsensusCall {
-		host,
-		proof: Bytes::from(message.consensus_proof.clone()),
-	}
-	.abi_encode();
+	let consensus =
+		Handler::handleConsensusCall { host, proof: Bytes::from(message.consensus_proof.clone()) }
+			.abi_encode();
 	let freeze = EvmHost::setFrozenStateCall { newState: FROZEN_ALL }.abi_encode();
 
 	let calls = vec![
@@ -96,11 +92,9 @@ pub async fn submit_mandatory_batch(
 	];
 
 	let execution_data = <Vec<Erc7821Call> as SolValue>::abi_encode(&calls);
-	let calldata = executeCall {
-		mode: ERC7821_BATCH_MODE,
-		executionData: Bytes::from(execution_data),
-	}
-	.abi_encode();
+	let calldata =
+		executeCall { mode: ERC7821_BATCH_MODE, executionData: Bytes::from(execution_data) }
+			.abi_encode();
 
 	send_and_await_receipt(client, eoa, eoa, calldata, "consensus batch").await
 }
@@ -119,11 +113,9 @@ pub async fn submit_mandatory_sequential(
 	let chain = client.state_machine;
 
 	let _unfreeze_cd = EvmHost::setFrozenStateCall { newState: FROZEN_NONE }.abi_encode();
-	let consensus_cd = Handler::handleConsensusCall {
-		host,
-		proof: Bytes::from(message.consensus_proof.clone()),
-	}
-	.abi_encode();
+	let consensus_cd =
+		Handler::handleConsensusCall { host, proof: Bytes::from(message.consensus_proof.clone()) }
+			.abi_encode();
 	let _freeze_cd = EvmHost::setFrozenStateCall { newState: FROZEN_ALL }.abi_encode();
 
 	// log::info!("[{chain}] sequential step 1/3: unfreeze");
@@ -194,10 +186,7 @@ async fn send_and_await_receipt(
 	if !receipt.status() {
 		return Err(anyhow!("{label} reverted: {tx_hash:?}"));
 	}
-	log::info!(
-		"[{chain}] {label} confirmed in block {:?}: {tx_hash:?}",
-		receipt.block_number
-	);
+	log::info!("[{chain}] {label} confirmed in block {:?}: {tx_hash:?}", receipt.block_number);
 	Ok(tx_hash)
 }
 

--- a/tesseract/consensus/admin-relayer/src/delegation.rs
+++ b/tesseract/consensus/admin-relayer/src/delegation.rs
@@ -53,12 +53,12 @@ pub fn delegation_target(chain_id: u64) -> anyhow::Result<Address> {
 	} else if chain_id == 100 {
 		"0xd4d594C99f23b1Fb9d65fdd9062854B1A1C5780b"
 	} else {
-		return Err(anyhow!(
-			"no ERC-7821 delegation target is configured for chain id {chain_id}"
-		));
+		return Err(anyhow!("no ERC-7821 delegation target is configured for chain id {chain_id}"));
 	};
 
-	hex_addr.parse::<Address>().map_err(|e| anyhow!("invalid delegation address literal: {e}"))
+	hex_addr
+		.parse::<Address>()
+		.map_err(|e| anyhow!("invalid delegation address literal: {e}"))
 }
 
 /// Check whether `eoa` is already delegated to `target` via EIP-7702 on the chain
@@ -107,11 +107,8 @@ pub async fn ensure_delegated(client: &EvmClient) -> anyhow::Result<()> {
 		.checked_add(1)
 		.ok_or_else(|| anyhow!("nonce overflow while preparing authorization"))?;
 
-	let authorization = Authorization {
-		chain_id: U256::from(chain_id),
-		address: target,
-		nonce: auth_nonce,
-	};
+	let authorization =
+		Authorization { chain_id: U256::from(chain_id), address: target, nonce: auth_nonce };
 
 	let sig_hash: B256 = authorization.signature_hash();
 	let signature = client
@@ -127,8 +124,11 @@ pub async fn ensure_delegated(client: &EvmClient) -> anyhow::Result<()> {
 		.gas_limit(DELEGATION_TX_GAS_FLOOR);
 	tx.authorization_list = Some(vec![signed]);
 
-	let pending =
-		client.signer.send_transaction(tx).await.context("sending delegation tx failed")?;
+	let pending = client
+		.signer
+		.send_transaction(tx)
+		.await
+		.context("sending delegation tx failed")?;
 	let tx_hash = H256::from_slice(pending.tx_hash().as_slice());
 	log::info!("[{chain}] delegation tx submitted: {tx_hash:?}");
 

--- a/tesseract/consensus/admin-relayer/src/task.rs
+++ b/tesseract/consensus/admin-relayer/src/task.rs
@@ -107,9 +107,7 @@ pub async fn run_mandatory_task(
 			);
 
 			// Sanity-check against the counterparty's current view of consensus.
-			let encoded_state = match provider
-				.query_consensus_state(None, consensus_state_id)
-				.await
+			let encoded_state = match provider.query_consensus_state(None, consensus_state_id).await
 			{
 				Ok(s) => s,
 				Err(err) => {

--- a/tesseract/consensus/arb-host/src/lib.rs
+++ b/tesseract/consensus/arb-host/src/lib.rs
@@ -176,20 +176,16 @@ impl ArbHost {
 		// `eth_getStorageAt`.
 		let mut events = Vec::with_capacity(candidates.len());
 		for event in candidates {
-			let parent_key = derive_map_key(
-				event.parentAssertionHash.0.to_vec(),
-				ASSERTIONS_SLOT as u64,
-			);
+			let parent_key =
+				derive_map_key(event.parentAssertionHash.0.to_vec(), ASSERTIONS_SLOT as u64);
 			let word = self
 				.beacon_execution_client
-				.get_storage_at(
-					rollup_addr,
-					alloy::primitives::U256::from_be_slice(&parent_key.0),
-				)
+				.get_storage_at(rollup_addr, alloy::primitives::U256::from_be_slice(&parent_key.0))
 				.block_id(to.into())
 				.await?;
-			// AssertionNode slot 0 packs `[padding(16) || secondChildBlock(8) || firstChildBlock(8)]`
-			// (big-endian); secondChildBlock occupies bytes [16..24]. Non-zero = challenged.
+			// AssertionNode slot 0 packs `[padding(16) || secondChildBlock(8) ||
+			// firstChildBlock(8)]` (big-endian); secondChildBlock occupies bytes [16..24].
+			// Non-zero = challenged.
 			const ZERO_U64: [u8; 8] = [0u8; 8];
 			let bytes = word.to_be_bytes::<32>();
 			if &bytes[16..24] != ZERO_U64.as_slice() {
@@ -309,12 +305,7 @@ impl ArbHost {
 			previous_assertion_hash: event.parentAssertionHash.0.into(),
 			sequencer_batch_acc: event.afterInboxBatchAcc.0.into(),
 			storage_proof: storage_proof_entry(0, "assertion hash")?,
-			contract_proof: proof
-				.account_proof
-				.iter()
-				.cloned()
-				.map(|node| node.to_vec())
-				.collect(),
+			contract_proof: proof.account_proof.iter().cloned().map(|node| node.to_vec()).collect(),
 			challenge_proof: storage_proof_entry(1, "parent assertion")?,
 		};
 

--- a/tesseract/consensus/arb-host/src/tests.rs
+++ b/tesseract/consensus/arb-host/src/tests.rs
@@ -17,8 +17,7 @@ const ROLLUP_CORE: [u8; 20] = hex!("d80810638dbDF9081b72C1B33c65375e807281C8");
 /// Placeholder secp256k1 key for read-only tests. `EvmClient::new` requires a valid signer to
 /// construct, but none of the consensus-verification flow this file exercises actually signs
 /// or sends transactions.
-const DUMMY_SIGNING_KEY: &str =
-	"0000000000000000000000000000000000000000000000000000000000000001";
+const DUMMY_SIGNING_KEY: &str = "0000000000000000000000000000000000000000000000000000000000000001";
 
 #[derive(RlpDecodable, RlpEncodable, Debug, Clone)]
 pub struct Block {
@@ -178,13 +177,8 @@ async fn test_arbitrum_bold_assertion_verification() {
 		.await
 		.expect("fetch_arbitrum_bold_payload");
 
-	verify_arbitrum_bold::<Hasher>(
-		payload,
-		l1_state_root,
-		host.rollup_core,
-		Default::default(),
-	)
-	.expect("Arbitrum BoLD assertion proof must verify at latest L1 head");
+	verify_arbitrum_bold::<Hasher>(payload, l1_state_root, host.rollup_core, Default::default())
+		.expect("Arbitrum BoLD assertion proof must verify at latest L1 head");
 }
 
 #[test]

--- a/tesseract/consensus/beefy/src/backend/memory.rs
+++ b/tesseract/consensus/beefy/src/backend/memory.rs
@@ -60,28 +60,34 @@ impl ProofBackend for InMemoryProofBackend {
 
 	async fn send_mandatory_proof(
 		&self,
-		state_machine: &StateMachine,
+		state_machines: &[StateMachine],
 		proof: ConsensusProof,
 	) -> Result<(), anyhow::Error> {
 		let mut queues = self.mandatory_queues.write().await;
-		queues.entry(*state_machine).or_insert_with(VecDeque::new).push_back(proof);
-
-		// Notify consumers
-		let _ = self.notifier.send((*state_machine, StreamMessage::EpochChanged));
+		for state_machine in state_machines {
+			queues
+				.entry(*state_machine)
+				.or_insert_with(VecDeque::new)
+				.push_back(proof.clone());
+			let _ = self.notifier.send((*state_machine, StreamMessage::EpochChanged));
+		}
 
 		Ok(())
 	}
 
 	async fn send_messages_proof(
 		&self,
-		state_machine: &StateMachine,
+		state_machines: &[StateMachine],
 		proof: ConsensusProof,
 	) -> Result<(), anyhow::Error> {
 		let mut queues = self.messages_queues.write().await;
-		queues.entry(*state_machine).or_insert_with(VecDeque::new).push_back(proof);
-
-		// Notify consumers
-		let _ = self.notifier.send((*state_machine, StreamMessage::NewMessages));
+		for state_machine in state_machines {
+			queues
+				.entry(*state_machine)
+				.or_insert_with(VecDeque::new)
+				.push_back(proof.clone());
+			let _ = self.notifier.send((*state_machine, StreamMessage::NewMessages));
+		}
 
 		Ok(())
 	}

--- a/tesseract/consensus/beefy/src/backend/mod.rs
+++ b/tesseract/consensus/beefy/src/backend/mod.rs
@@ -68,17 +68,23 @@ pub trait ProofBackend: Send + Sync {
 	/// Initialize the queues for the given state machines
 	async fn init_queues(&self, state_machines: &[StateMachine]) -> Result<(), anyhow::Error>;
 
-	/// Send a mandatory consensus proof (authority set changes)
+	/// Send a mandatory consensus proof (authority set changes) targeted at the given
+	/// state machines. Backends are responsible for fanning the proof out to each
+	/// destination (queue-backed implementations) or submitting it once on behalf of
+	/// all destinations (on-chain implementations).
 	async fn send_mandatory_proof(
 		&self,
-		state_machine: &StateMachine,
+		state_machines: &[StateMachine],
 		proof: ConsensusProof,
 	) -> Result<(), anyhow::Error>;
 
-	/// Send a messages consensus proof (new messages finalized)
+	/// Send a messages consensus proof (new messages finalized) targeted at the given
+	/// state machines. Backends are responsible for fanning the proof out to each
+	/// destination (queue-backed implementations) or submitting it once on behalf of
+	/// all destinations (on-chain implementations).
 	async fn send_messages_proof(
 		&self,
-		state_machine: &StateMachine,
+		state_machines: &[StateMachine],
 		proof: ConsensusProof,
 	) -> Result<(), anyhow::Error>;
 

--- a/tesseract/consensus/beefy/src/backend/onchain.rs
+++ b/tesseract/consensus/beefy/src/backend/onchain.rs
@@ -100,7 +100,7 @@ where
 			vec![payload_value, signature_value],
 		);
 
-		send_unsigned_extrinsic(&self.client, tx, true).await?;
+		send_unsigned_extrinsic(&self.client, tx, false).await?;
 
 		tracing::info!(
 			"Successfully submitted proof to pallet-beefy-consensus-proofs (height: {})",
@@ -154,19 +154,19 @@ where
 
 	async fn send_mandatory_proof(
 		&self,
-		state_machine: &StateMachine,
+		state_machines: &[StateMachine],
 		proof: ConsensusProof,
 	) -> Result<(), anyhow::Error> {
-		tracing::info!("Submitting mandatory proof to pallet for {state_machine}");
+		tracing::info!("Submitting mandatory proof to pallet for {state_machines:?}");
 		self.submit_to_pallet(&proof).await
 	}
 
 	async fn send_messages_proof(
 		&self,
-		state_machine: &StateMachine,
+		state_machines: &[StateMachine],
 		proof: ConsensusProof,
 	) -> Result<(), anyhow::Error> {
-		tracing::info!("Submitting messages proof to pallet for {state_machine}");
+		tracing::info!("Submitting messages proof to pallet for {state_machines:?}");
 		self.submit_to_pallet(&proof).await
 	}
 

--- a/tesseract/consensus/beefy/src/backend/redis.rs
+++ b/tesseract/consensus/beefy/src/backend/redis.rs
@@ -212,21 +212,23 @@ impl ProofBackend for RedisProofBackend {
 
 	async fn send_mandatory_proof(
 		&self,
-		state_machine: &StateMachine,
+		state_machines: &[StateMachine],
 		proof: ConsensusProof,
 	) -> Result<(), anyhow::Error> {
-		let queue = self.config.mandatory_queue(state_machine);
-		let result = self
-			.rsmq
-			.lock()
-			.await
-			.send_message(queue.as_str(), proof, Some(Duration::ZERO))
-			.await;
+		for state_machine in state_machines {
+			let queue = self.config.mandatory_queue(state_machine);
+			let result = self
+				.rsmq
+				.lock()
+				.await
+				.send_message(queue.as_str(), proof.clone(), Some(Duration::ZERO))
+				.await;
 
-		if let Err(err) = result {
-			let anyhow_err = anyhow::Error::from(err);
-			self.handle_redis_error(&anyhow_err).await;
-			return Err(anyhow_err);
+			if let Err(err) = result {
+				let anyhow_err = anyhow::Error::from(err);
+				self.handle_redis_error(&anyhow_err).await;
+				return Err(anyhow_err);
+			}
 		}
 
 		Ok(())
@@ -234,21 +236,23 @@ impl ProofBackend for RedisProofBackend {
 
 	async fn send_messages_proof(
 		&self,
-		state_machine: &StateMachine,
+		state_machines: &[StateMachine],
 		proof: ConsensusProof,
 	) -> Result<(), anyhow::Error> {
-		let queue = self.config.messages_queue(state_machine);
-		let result = self
-			.rsmq
-			.lock()
-			.await
-			.send_message(queue.as_str(), proof, Some(Duration::ZERO))
-			.await;
+		for state_machine in state_machines {
+			let queue = self.config.messages_queue(state_machine);
+			let result = self
+				.rsmq
+				.lock()
+				.await
+				.send_message(queue.as_str(), proof.clone(), Some(Duration::ZERO))
+				.await;
 
-		if let Err(err) = result {
-			let anyhow_err = anyhow::Error::from(err);
-			self.handle_redis_error(&anyhow_err).await;
-			return Err(anyhow_err);
+			if let Err(err) = result {
+				let anyhow_err = anyhow::Error::from(err);
+				self.handle_redis_error(&anyhow_err).await;
+				return Err(anyhow_err);
+			}
 		}
 
 		Ok(())

--- a/tesseract/consensus/beefy/src/prover.rs
+++ b/tesseract/consensus/beefy/src/prover.rs
@@ -443,20 +443,9 @@ where
 							},
 						};
 
-						if self.config.state_machines.is_empty() {
-							let host = self.client.state_machine_id().state_id;
-							tracing::info!("Sending mandatory consensus proof for {host}");
-							self.backend.send_mandatory_proof(&host, message.clone()).await?;
-						} else {
-							for state_machine in self.config.state_machines.iter() {
-								tracing::info!(
-									"Sending mandatory consensus proof to {state_machine}"
-								);
-								self.backend
-									.send_mandatory_proof(state_machine, message.clone())
-									.await?;
-							}
-						}
+						let destinations: Vec<StateMachine> = self.config.state_machines.clone();
+						tracing::info!("Sending mandatory consensus proof");
+						self.backend.send_mandatory_proof(&destinations, message).await?;
 
 						// Advance the locally-computed view and persist it to the backend.
 						// Rotate authorities inline: new current = old next, new next =
@@ -575,12 +564,11 @@ where
 					},
 				};
 
-				for state_machine in state_machines {
-					tracing::info!(
-						"Sending consensus proof for new messages in range {lowest_message_height}..{latest_parachain_height} to {state_machine}"
-					);
-					self.backend.send_messages_proof(&state_machine, message.clone()).await?;
-				}
+				let destinations: Vec<StateMachine> = state_machines.into_iter().collect();
+				tracing::info!(
+					"Sending consensus proof for new messages in range {lowest_message_height}..{latest_parachain_height} to {destinations:?}"
+				);
+				self.backend.send_messages_proof(&destinations, message).await?;
 
 				consensus_state.inner.latest_beefy_height = *latest_beefy_header.number();
 				consensus_state.finalized_parachain_height = latest_parachain_height;

--- a/tesseract/consensus/op-host/src/host.rs
+++ b/tesseract/consensus/op-host/src/host.rs
@@ -15,9 +15,9 @@ use ismp_optimism::{
 	OPTIMISM_CONSENSUS_CLIENT_ID,
 };
 use op_verifier::{calculate_output_root, GameTypeConfig, CANNON};
-use subxt_utils::optimism_game_type_configs_storage_key;
 use reqwest::Url;
 use sp_core::{bytes::from_hex, Encode, H160, H256, U256};
+use subxt_utils::optimism_game_type_configs_storage_key;
 use sync_committee_primitives::consensus_types::{BeaconBlockHeader, Checkpoint};
 use sync_committee_prover::{
 	responses::{self, finality_checkpoint_response::FinalityCheckpoint},

--- a/tesseract/consensus/op-host/src/lib.rs
+++ b/tesseract/consensus/op-host/src/lib.rs
@@ -298,8 +298,7 @@ impl OpHost {
 		// `eth_getProof`, which `fetch_dispute_game_payload` does anyway for payloads we keep).
 		let mut events = Vec::with_capacity(candidates.len());
 		for event in candidates {
-			let Some(config) =
-				game_type_configs.iter().find(|c| c.game_type == event.gameType)
+			let Some(config) = game_type_configs.iter().find(|c| c.game_type == event.gameType)
 			else {
 				continue;
 			};
@@ -308,7 +307,10 @@ impl OpHost {
 				Some(slot) => {
 					let value = self
 						.beacon_execution_client
-						.get_storage_at(event.disputeProxy, alloy::primitives::U256::from_be_slice(slot.as_slice()))
+						.get_storage_at(
+							event.disputeProxy,
+							alloy::primitives::U256::from_be_slice(slot.as_slice()),
+						)
 						.block_id(to.into())
 						.await?;
 					game_is_challenged(&config.kind, value)
@@ -350,8 +352,9 @@ impl OpHost {
 				log::trace!(target: "tesseract", "Skipping dispute game with extraData shorter than 32 bytes ({} bytes)", extra_data.len());
 				continue;
 			}
-			let l2_block_num =
-				alloy::primitives::U256::from_be_slice(&extra_data[..32]).try_into().unwrap_or(u64::MAX);
+			let l2_block_num = alloy::primitives::U256::from_be_slice(&extra_data[..32])
+				.try_into()
+				.unwrap_or(u64::MAX);
 
 			// Since anyone can create dispute games including bots we need to be sure the block
 			// number exists
@@ -388,10 +391,7 @@ impl OpHost {
 				.beacon_execution_client
 				.get_proof(
 					factory_addr,
-					vec![
-						B256::from_slice(&dispute_game_key.0),
-						B256::from_slice(&game_impl_key.0),
-					],
+					vec![B256::from_slice(&dispute_game_key.0), B256::from_slice(&game_impl_key.0)],
 				)
 				.block_id(at.into())
 				.await?;

--- a/tesseract/consensus/op-host/src/tests.rs
+++ b/tesseract/consensus/op-host/src/tests.rs
@@ -10,9 +10,7 @@ use primitive_types::{H160, H256};
 // use op_verifier::{verify_optimism_dispute_game_proof, verify_optimism_payload};
 use crate::abi::DisputeGameFactory::DisputeGameCreated;
 use ismp::host::StateMachine;
-use op_verifier::{
-	verify_optimism_dispute_game_proof, DisputeGameImpl, GameTypeConfig,
-};
+use op_verifier::{verify_optimism_dispute_game_proof, DisputeGameImpl, GameTypeConfig};
 use tesseract_evm::EvmConfig;
 use tesseract_primitives::Hasher;
 
@@ -21,8 +19,7 @@ const MESSAGE_PARSER: [u8; 20] = hex!("4200000000000000000000000000000000000016"
 /// Placeholder secp256k1 key for read-only tests. `EvmClient::new` requires a valid signer to
 /// construct, but none of the consensus-verification flow this file exercises actually signs or
 /// sends transactions.
-const DUMMY_SIGNING_KEY: &str =
-	"0000000000000000000000000000000000000000000000000000000000000001";
+const DUMMY_SIGNING_KEY: &str = "0000000000000000000000000000000000000000000000000000000000000001";
 /// Verify a real `DisputeGameCreated` event against the factory on L1 at the latest block head
 /// by round-tripping through the host's own proof-construction path.
 ///
@@ -109,9 +106,7 @@ async fn test_aggregate_verifier_dispute_game_verification() {
 		.expect("BASE_SEPOLIA_RPC_URL must be set to a Base Sepolia RPC endpoint");
 
 	let event = DisputeGameCreated {
-		disputeProxy: Address::from_slice(&hex!(
-			"2c9ece6a5856ab7f5f2c49072e9f7a4f00d4c1e6"
-		)),
+		disputeProxy: Address::from_slice(&hex!("2c9ece6a5856ab7f5f2c49072e9f7a4f00d4c1e6")),
 		gameType: 621,
 		rootClaim: B256::from(hex!(
 			"a76fa38fcef8c7e910fb80064b2b98c275569a84c8db3c4e04141b9457867b95"
@@ -151,9 +146,7 @@ async fn test_cannon_dispute_game_verification() {
 		.expect("OP_MAINNET_RPC_URL must be set to an Optimism mainnet RPC endpoint");
 
 	let event = DisputeGameCreated {
-		disputeProxy: Address::from_slice(&hex!(
-			"e6512d19e2bac97a2ed17e2cc1c5df96e29d3ea8"
-		)),
+		disputeProxy: Address::from_slice(&hex!("e6512d19e2bac97a2ed17e2cc1c5df96e29d3ea8")),
 		gameType: 0,
 		rootClaim: B256::from(hex!(
 			"76b0808a7d3244f52677f7fec036a25faad2fb80ee4d9504c5458775a7024ffa"
@@ -168,6 +161,5 @@ async fn test_cannon_dispute_game_verification() {
 	}];
 
 	// Ethereum mainnet chain id = 1.
-	run_dispute_game_verification(l1_url, l2_url, 1, factory_addr, event, game_type_configs)
-		.await;
+	run_dispute_game_verification(l1_url, l2_url, 1, factory_addr, event, game_type_configs).await;
 }

--- a/tesseract/consensus/relayer/Cargo.toml
+++ b/tesseract/consensus/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tesseract-consensus"
-version = "1.8.1"
+version = "1.8.2"
 edition = "2021"
 
 [lib]

--- a/tesseract/messaging/primitives/src/lib.rs
+++ b/tesseract/messaging/primitives/src/lib.rs
@@ -272,10 +272,7 @@ pub trait IsmpProvider: ByzantineHandler + Send + Sync {
 	/// [`StorageKey::Substrate`] variant as a full pallet storage key; EVM backends consume
 	/// [`StorageKey::Evm`] as an `eth_getStorageAt(address, slot)` call. Providers return an
 	/// error when asked for a variant they don't support.
-	async fn query_storage(
-		&self,
-		_key: StorageKey,
-	) -> Result<Option<Vec<u8>>, anyhow::Error> {
+	async fn query_storage(&self, _key: StorageKey) -> Result<Option<Vec<u8>>, anyhow::Error> {
 		Err(anyhow!("query_storage is not supported on {}", self.name()))
 	}
 


### PR DESCRIPTION
We should record the last proven child trie root from the proof itself. Subtle bug, also prover shouldn't wait for finality when submitting proofs