### PR TITLE
[ci]: add SSH agent to EVM CI workflow

### DIFF
--- a/.github/workflows/evm.yml
+++ b/.github/workflows/evm.yml
@@ -14,7 +14,7 @@ on:
             - "evm/**/*.js"
             - ".github/workflows/evm.yml"
 
-    pull_request_target:
+    pull_request:
         types: [opened, synchronize, reopened, ready_for_review]
         paths:
             - "evm/**/*.sol"

--- a/.github/workflows/evm.yml
+++ b/.github/workflows/evm.yml
@@ -106,6 +106,10 @@ jobs:
             - name: Install Rust toolchain
               uses: dtolnay/rust-toolchain@stable
 
+            - uses: webfactory/ssh-agent@v0.7.0
+              with:
+                  ssh-private-key: ${{ secrets.SSH_KEY }}
+
             - name: Rust cache
               uses: Swatinem/rust-cache@v2
               with:

--- a/.github/workflows/evm.yml
+++ b/.github/workflows/evm.yml
@@ -14,7 +14,7 @@ on:
             - "evm/**/*.js"
             - ".github/workflows/evm.yml"
 
-    pull_request:
+    pull_request_target:
         types: [opened, synchronize, reopened, ready_for_review]
         paths:
             - "evm/**/*.sol"


### PR DESCRIPTION
## Summary
- The `integration-tests-rust` job in the EVM CI workflow was failing because it couldn't authenticate to clone the private `sp1-beefy` dependency over SSH
- Added the `webfactory/ssh-agent` step (using `secrets.SSH_KEY`) that all other workflows already have

## Context
Failed run: https://github.com/polytope-labs/hyperbridge/actions/runs/24952028933

