### PR TITLE
[sdk]: simplex halts only on venue-priced overfill clamps

### DIFF
--- a/sdk/packages/simplex/src/bin/simplex.ts
+++ b/sdk/packages/simplex/src/bin/simplex.ts
@@ -175,7 +175,13 @@ interface FillerTomlConfig {
 			maxPriorityFeePerGasBumpPercent?: number
 			maxFeePerGasBumpPercent?: number
 		}
-		/** Overfill protection knobs. Defaults: maxOverfillBps=100, maxConsecutiveClamps=3. */
+		/**
+		 * Overfill protection knobs. Defaults: maxOverfillBps=100, maxConsecutiveClamps=3.
+		 * `maxOverfillBps` clamps the per-leg output ceiling on every strategy.
+		 * `maxConsecutiveClamps` only halts FXFiller, and only when the clamped legs
+		 * were priced by an on-chain venue (e.g. Uniswap V4). Offline-curve clamps warn
+		 * but never halt.
+		 */
 		overfillProtection?: {
 			maxOverfillBps?: number
 			maxConsecutiveClamps?: number

--- a/sdk/packages/simplex/src/strategies/basic.ts
+++ b/sdk/packages/simplex/src/strategies/basic.ts
@@ -27,14 +27,8 @@ export class BasicFiller implements FillerStrategy {
 	private bpsPolicy: FillerBpsPolicy
 	private signer: SigningAccount
 	private logger = getLogger("basic-simplex")
-	/** Consecutive orders where overfill clamp activated. Reset on a clean evaluation. */
-	private consecutiveClamps = 0
-	/** Once set, the filler refuses all orders until restart — likely systemic pricing error. */
-	private halted = false
 	/** Ceiling bps above user-requested output. Sourced from filler config. */
 	private readonly maxOverfillBps: bigint
-	/** Consecutive clamped evaluations before halting. Sourced from filler config. */
-	private readonly maxConsecutiveClamps: number
 	confirmationPolicy: { getConfirmationBlocks: (chainId: number, amountUsd: number) => number }
 
 	constructor(
@@ -55,7 +49,6 @@ export class BasicFiller implements FillerStrategy {
 		}
 		this.signer = signer
 		this.maxOverfillBps = configService.getMaxOverfillBps()
-		this.maxConsecutiveClamps = configService.getMaxConsecutiveClamps()
 	}
 
 	/**
@@ -65,10 +58,6 @@ export class BasicFiller implements FillerStrategy {
 	 * @returns True if the strategy can fill the order
 	 */
 	async canFill(order: Order): Promise<boolean> {
-		if (this.halted) {
-			this.logger.warn({ orderId: order.id }, "BasicFiller halted — rejecting order")
-			return false
-		}
 		try {
 			// Validate basic structure
 			if (order.inputs.length === 0 || order.inputs.length !== order.output.assets.length) {
@@ -141,10 +130,6 @@ export class BasicFiller implements FillerStrategy {
 	 * @returns The profit in USD (Number), or 0 if not profitable or output amounts don't meet minimum
 	 */
 	async calculateProfitability(order: Order): Promise<number> {
-		if (this.halted) {
-			this.logger.warn({ orderId: order.id }, "BasicFiller halted — rejecting order")
-			return 0
-		}
 		try {
 			const { decimals: destFeeTokenDecimals } = await this.contractService.getFeeTokenWithDecimals(
 				order.destination,
@@ -230,7 +215,6 @@ export class BasicFiller implements FillerStrategy {
 		const basisPoints = 10000n
 		let totalProfitNormalized = 0n
 		const fillerOutputs: TokenInfo[] = []
-		let anyLegClamped = false
 
 		for (let i = 0; i < order.inputs.length; i++) {
 			const input = order.inputs[i]
@@ -282,7 +266,6 @@ export class BasicFiller implements FillerStrategy {
 					"Overfill clamp activated",
 				)
 				fillerMaxOutput = overfillCeiling
-				anyLegClamped = true
 			}
 
 			// Store the filler's calculated output for this token
@@ -300,8 +283,6 @@ export class BasicFiller implements FillerStrategy {
 			totalProfitNormalized += profitNormalized
 		}
 
-		this.recordOrderOutcome(anyLegClamped, order.id)
-
 		// Cache filler outputs for use during order execution
 		this.contractService.cacheService.setFillerOutputs(order.id!, fillerOutputs)
 		this.logger.debug(
@@ -313,26 +294,6 @@ export class BasicFiller implements FillerStrategy {
 		)
 
 		return { isValid: true, profitFromSlippage: totalProfitNormalized }
-	}
-
-	/**
-	 * Update consecutive-clamp counter after a successful order evaluation.
-	 * Halts the filler if maxConsecutiveClamps is reached — a pattern that strongly
-	 * suggests a systemic pricing bug rather than benign one-off over-provision.
-	 */
-	private recordOrderOutcome(clamped: boolean, orderId: string | undefined) {
-		if (clamped) {
-			this.consecutiveClamps += 1
-			if (this.consecutiveClamps >= this.maxConsecutiveClamps) {
-				this.halted = true
-				this.logger.error(
-					{ orderId, consecutiveClamps: this.consecutiveClamps, maxConsecutiveClamps: this.maxConsecutiveClamps },
-					"BasicFiller HALTED — overfill clamp triggered consecutively; restart required after investigation",
-				)
-			}
-		} else {
-			this.consecutiveClamps = 0
-		}
 	}
 
 	/**

--- a/sdk/packages/simplex/src/strategies/fx.ts
+++ b/sdk/packages/simplex/src/strategies/fx.ts
@@ -342,6 +342,7 @@ export class FXFiller implements FillerStrategy {
 				const overfillCeiling = (output.amount * (10000n + this.maxOverfillBps)) / 10000n
 				let policyMaxOutput = rawPolicyMaxOutput
 				if (rawPolicyMaxOutput > overfillCeiling) {
+					const priceSource = venuePrice ? "venue" : "policy"
 					this.logger.warn(
 						{
 							orderId: order.id,
@@ -351,11 +352,18 @@ export class FXFiller implements FillerStrategy {
 							unclamped: rawPolicyMaxOutput.toString(),
 							clamped: overfillCeiling.toString(),
 							maxOverfillBps: this.maxOverfillBps.toString(),
+							priceSource,
 						},
 						"Overfill clamp activated",
 					)
 					policyMaxOutput = overfillCeiling
-					anyLegClamped = true
+					// Only count venue-sourced clamps toward the halt counter. Offline
+					// price-curve clamps still warn but never halt — the curve is
+					// operator-authored, so a mismatch is a config issue, not a live
+					// market signal worth tripping the kill switch over.
+					if (venuePrice) {
+						anyLegClamped = true
+					}
 				}
 
 				// Cap by wallet balance on the destination chain, optionally topped up via LP removal.
@@ -641,8 +649,10 @@ export class FXFiller implements FillerStrategy {
 
 	/**
 	 * Update consecutive-clamp counter after a successful order evaluation.
-	 * Halts the filler if maxConsecutiveClamps is reached — a pattern that strongly
-	 * suggests a systemic pricing bug rather than benign one-off over-provision.
+	 * Only venue-priced legs feed this counter (see clamp site) — a streak of those
+	 * is the signal that a live market source has gone off (stale pool, manipulated
+	 * venue) and the filler should stop until an operator investigates. Offline
+	 * price-curve clamps warn but never reach here.
 	 */
 	private recordOrderOutcome(clamped: boolean, orderId: string | undefined) {
 		if (clamped) {
@@ -651,7 +661,7 @@ export class FXFiller implements FillerStrategy {
 				this.halted = true
 				this.logger.error(
 					{ orderId, consecutiveClamps: this.consecutiveClamps, maxConsecutiveClamps: this.maxConsecutiveClamps },
-					"FXFiller HALTED — overfill clamp triggered consecutively; restart required after investigation",
+					"FXFiller HALTED — venue-priced overfill clamp triggered consecutively; restart required after investigation",
 				)
 			}
 		} else {


### PR DESCRIPTION
Offline price-curve mismatches are operator-authored config issues, not live market signals, so they no longer trip the kill switch, they still warn. BasicFiller, which is pure offline bps, drops the halt entirely; FXFiller only counts a clamp toward maxConsecutiveClamps when the leg was priced by a funding venue (Uniswap V4 etc.).