### PR TITLE
[evm]: fix BEEFY commitment SCALE encoding

### DIFF
--- a/.github/workflows/evm.yml
+++ b/.github/workflows/evm.yml
@@ -141,5 +141,5 @@ jobs:
                       exit 0
                   fi
                   cargo test -p evm-integration-tests --release \
-                      tests::beefy_v1::test_beefy_consensus_client \
+                      tests::ecdsa_beefy::test_beefy_consensus_client \
                       -- --ignored --nocapture

--- a/evm/src/consensus/Codec.sol
+++ b/evm/src/consensus/Codec.sol
@@ -37,19 +37,21 @@ library Codec {
     // @dev SCALE-encodes the BEEFY finality commitment
     function Encode(Commitment memory commitment) internal pure returns (bytes memory) {
         uint256 payloadLen = commitment.payload.length;
-        bytes memory accumulator = bytes("");
+        bytes memory payload = bytes("");
         for (uint256 i = 0; i < payloadLen; i++) {
-            accumulator = bytes.concat(
-                abi.encodePacked(commitment.payload[i].id), ScaleCodec.encodeBytes(commitment.payload[i].data)
+            payload = bytes.concat(
+                payload,
+                abi.encodePacked(commitment.payload[i].id),
+                ScaleCodec.encodeBytes(commitment.payload[i].data)
             );
         }
 
-        bytes memory payload = bytes.concat(ScaleCodec.encodeUintCompact(payloadLen), accumulator);
-        bytes memory rest = bytes.concat(
-            ScaleCodec.encode32(uint32(commitment.blockNumber)), ScaleCodec.encode64(uint64(commitment.validatorSetId))
+        return bytes.concat(
+            ScaleCodec.encodeUintCompact(payloadLen),
+            payload,
+            ScaleCodec.encode32(uint32(commitment.blockNumber)),
+            ScaleCodec.encode64(uint64(commitment.validatorSetId))
         );
-
-        return bytes.concat(payload, rest);
     }
 
     // @dev SCALE-encodes the BEEFY Mmr leaf


### PR DESCRIPTION
## Summary
- Fix bug in `Codec.sol` `Encode(Commitment)` where the payload accumulator was not concatenated with prior loop iterations
- Rename variable from `accumulator` to `payload` for clarity and restructure the `bytes.concat` call

## Test plan
- [x] Verify BEEFY consensus proof verification still passes with the corrected encoding