### PR TITLE
[evm]: scope HandlerV2 epoch tracking per host address

### DIFF
--- a/evm/src/core/HandlerV2.sol
+++ b/evm/src/core/HandlerV2.sol
@@ -114,15 +114,15 @@ contract HandlerV2 is IHandlerV2, ERC165, Context {
     event NewEpoch(uint256 indexed authoritySetId, address indexed relayer);
 
     /**
-     * @notice Maps an authority set ID (epoch) to the relayer that first submitted
+     * @notice Maps the host address an authority set ID (epoch) to the relayer that first submitted
      * the consensus proof for that epoch.
      */
-    mapping(uint256 => address) private _epochs;
+    mapping(address => mapping(uint256 => address)) private _epochs;
 
     /**
-     * @notice The most recent authority set ID for which a consensus proof has been submitted.
+     * @notice Maps the host to the recent authority set ID for which a consensus proof has been submitted.
      */
-    uint256 private _currentEpoch;
+    mapping(address => uint256) private _currentEpoch;
 
     /**
      * @dev Checks if the host permits incoming datagrams
@@ -143,18 +143,21 @@ contract HandlerV2 is IHandlerV2, ERC165, Context {
 
     /**
     * @dev Returns the relayer address for a given authority set ID.
+    * @param host - the host address
     * @param authoritySetId - the authority set / epoch ID
     * @return the relayer address, or address(0) if not set
     */
-    function relayerOf(uint256 authoritySetId) external view returns (address) {
-        return _epochs[authoritySetId];
+    function relayerOf(address host, uint256 authoritySetId) external view returns (address) {
+        return _epochs[host][authoritySetId];
     }
 
     /**
-    * @dev Returns the current authority set epoch.
+    * @dev Returns the current authority set epoch for the given host.
+    * @param host - the host address
+    * @return the current authority set epoch
     */
-    function currentEpoch() external view returns (uint256) {
-        return _currentEpoch;
+    function currentEpoch(address host) external view returns (uint256) {
+        return _currentEpoch[host];
     }
 
     /**
@@ -200,10 +203,12 @@ contract HandlerV2 is IHandlerV2, ERC165, Context {
             }
         }
 
-        if (nextAuthoritySetId > _currentEpoch) {
-            _currentEpoch = nextAuthoritySetId;
-            _epochs[nextAuthoritySetId] = msg.sender;
-            emit NewEpoch(nextAuthoritySetId, msg.sender);
+        uint256 currentEpoch = nextAuthoritySetId - 1;
+        address hostAddr = address(host);
+        if (currentEpoch > _currentEpoch[hostAddr]) {
+            _currentEpoch[hostAddr] = currentEpoch;
+            _epochs[hostAddr][currentEpoch] = msg.sender;
+            emit NewEpoch(currentEpoch, msg.sender);
         }
     }
 

--- a/evm/tests/foundry/HandlerV2Test.sol
+++ b/evm/tests/foundry/HandlerV2Test.sol
@@ -145,8 +145,8 @@ contract HandlerV2Test is Test {
         vm.prank(tx.origin);
         handler.handleConsensus(host, proof);
 
-        assertEq(handler.relayerOf(1), tx.origin);
-        assertEq(handler.currentEpoch(), 1);
+        assertEq(handler.relayerOf(address(host), 1), tx.origin);
+        assertEq(handler.currentEpoch(address(host)), 1);
     }
 
     function testHandleConsensusV2NoEpochChange() public {
@@ -156,11 +156,11 @@ contract HandlerV2Test is Test {
         vm.prank(tx.origin);
         handler.handleConsensus(host, proof);
 
-        assertEq(handler.relayerOf(0), address(0));
+        assertEq(handler.relayerOf(address(host), 0), address(0));
     }
 
     function testRelayerOfUnknownEpoch() public view {
-        assertEq(handler.relayerOf(999), address(0));
+        assertEq(handler.relayerOf(address(host), 999), address(0));
     }
 
     function testBatchCallRevertsAtomically() public {
@@ -176,7 +176,7 @@ contract HandlerV2Test is Test {
         handler.batchCall(calls);
 
         // relayer mapping should not have been set since batch reverted
-        assertEq(handler.relayerOf(1), address(0));
+        assertEq(handler.relayerOf(address(host), 1), address(0));
     }
 
     function testBatchCallPreservesMsgSender() public {
@@ -190,7 +190,7 @@ contract HandlerV2Test is Test {
         vm.prank(relayer);
         handler.batchCall(calls);
 
-        assertEq(handler.relayerOf(1), relayer);
+        assertEq(handler.relayerOf(address(host), 1), relayer);
     }
 
     function testSupportsInterfaceV2() public view {
@@ -203,7 +203,7 @@ contract HandlerV2Test is Test {
         vm.prank(tx.origin);
         handler.handleConsensus(host, proof);
 
-        assertEq(handler.relayerOf(1), tx.origin);
+        assertEq(handler.relayerOf(address(host), 1), tx.origin);
     }
 
     function testStaleEpochIgnored() public {
@@ -211,7 +211,7 @@ contract HandlerV2Test is Test {
         bytes memory proof1 = _makeConsensusProof(2000, 1, 1);
         vm.prank(tx.origin);
         handler.handleConsensus(host, proof1);
-        assertEq(handler.currentEpoch(), 1);
+        assertEq(handler.currentEpoch(address(host)), 1);
 
         // submit proof with same epoch (not increasing) — should not update relayer
         address otherRelayer = address(0xDEAD);
@@ -220,8 +220,8 @@ contract HandlerV2Test is Test {
         handler.handleConsensus(host, proof2);
 
         // epoch unchanged, relayer for epoch 1 still the original
-        assertEq(handler.currentEpoch(), 1);
-        assertEq(handler.relayerOf(1), tx.origin);
+        assertEq(handler.currentEpoch(address(host)), 1);
+        assertEq(handler.relayerOf(address(host), 1), tx.origin);
     }
 
     function testSequentialEpochs() public {
@@ -229,14 +229,14 @@ contract HandlerV2Test is Test {
         bytes memory proof1 = _makeConsensusProof(2000, 1, 1);
         vm.prank(tx.origin);
         handler.handleConsensus(host, proof1);
-        assertEq(handler.currentEpoch(), 1);
+        assertEq(handler.currentEpoch(address(host)), 1);
 
         // epoch 1 -> 2
         bytes memory proof2 = _makeConsensusProof(2000, 2, 2);
         vm.prank(tx.origin);
         handler.handleConsensus(host, proof2);
-        assertEq(handler.currentEpoch(), 2);
-        assertEq(handler.relayerOf(2), tx.origin);
+        assertEq(handler.currentEpoch(address(host)), 2);
+        assertEq(handler.relayerOf(address(host), 2), tx.origin);
     }
 
 

--- a/sdk/packages/sdk/src/abis/handlerV2.ts
+++ b/sdk/packages/sdk/src/abis/handlerV2.ts
@@ -13,7 +13,13 @@ const ABI = [
 		type: "function",
 	},
 	{
-		inputs: [],
+		inputs: [
+			{
+				internalType: "address",
+				name: "host",
+				type: "address",
+			},
+		],
 		name: "currentEpoch",
 		outputs: [
 			{
@@ -393,6 +399,11 @@ const ABI = [
 	},
 	{
 		inputs: [
+			{
+				internalType: "address",
+				name: "host",
+				type: "address",
+			},
 			{
 				internalType: "uint256",
 				name: "authoritySetId",

--- a/sdk/packages/sdk/src/chains/evm.ts
+++ b/sdk/packages/sdk/src/chains/evm.ts
@@ -248,6 +248,7 @@ export class EvmChain implements IChain {
 			address: hostParams.handler,
 			abi: HandlerV2.ABI,
 			functionName: "currentEpoch",
+			args: [this.params.host],
 		})
 		return BigInt(epoch)
 	}


### PR DESCRIPTION
## Summary
- Key `_currentEpoch` and `_epochs` mappings in HandlerV2 by `address(host)` to prevent a malicious host contract from advancing the epoch and front-running legitimate hosts
- Update `relayerOf()` and `currentEpoch()` signatures to accept a `host` parameter
- Update SDK ABI and callers to match new signatures

## Test plan
- [ ] HandlerV2Test passes with updated assertions
- [ ] SDK correctly passes host address to `currentEpoch` calls