### PR TITLE
[evm, runtime]: read timestamp from digest 

### DIFF
--- a/evm/src/consensus/Types.sol
+++ b/evm/src/consensus/Types.sol
@@ -195,15 +195,13 @@ struct Header {
 library HeaderImpl {
     /// Digest Item ID
     bytes4 public constant ISMP_CONSENSUS_ID = bytes4("ISMP");
-    /// ConsensusID for aura
-    bytes4 public constant AURA_CONSENSUS_ID = bytes4("aura");
-    /// Slot duration in milliseconds
-    uint256 public constant SLOT_DURATION = 12_000;
+    /// ConsensusID for the ISMP timestamp digest deposited by pallet-ismp
+    bytes4 public constant ISMP_TIMESTAMP_ID = bytes4("ISTM");
 
     error TimestampNotFound();
 
-    /// @dev Extracts the ISMP MMR root, child trie root, and AURA timestamp from the header
-    /// digests and returns them as a StateCommitment. Reverts if no AURA timestamp is found.
+    /// @dev Extracts the ISMP MMR root, child trie root, and timestamp from the header
+    /// digests and returns them as a StateCommitment. Reverts if no timestamp digest is found.
     function stateCommitment(Header memory self) internal pure returns (StateCommitment memory) {
         bytes32 mmrRoot;
         bytes32 childTrieRoot;
@@ -215,9 +213,8 @@ library HeaderImpl {
                 childTrieRoot = Bytes.toBytes32(Bytes.substr(self.digests[j].consensus.data, 32));
             }
 
-            if (self.digests[j].isPreRuntime && self.digests[j].preruntime.consensusId == AURA_CONSENSUS_ID) {
-                uint256 slot = ScaleCodec.decodeUint256(self.digests[j].preruntime.data);
-                timestamp = slot * SLOT_DURATION;
+            if (self.digests[j].isConsensus && self.digests[j].consensus.consensusId == ISMP_TIMESTAMP_ID) {
+                timestamp = ScaleCodec.decodeUint256(self.digests[j].consensus.data);
             }
         }
 

--- a/modules/ismp/clients/parachain/client/src/benchmarking.rs
+++ b/modules/ismp/clients/parachain/client/src/benchmarking.rs
@@ -39,7 +39,7 @@ mod benchmarks {
 		let origin =
 			T::AdminOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;
 		let parachains: Vec<ParachainData> =
-			(0..n).map(|i| ParachainData { id: i, slot_duration: 6000u64 }).collect();
+			(0..n).map(|i| ParachainData { id: i }).collect();
 
 		#[block]
 		{
@@ -61,7 +61,7 @@ mod benchmarks {
 			T::AdminOrigin::try_successful_origin().map_err(|_| BenchmarkError::Weightless)?;
 
 		let parachains: Vec<ParachainData> =
-			(0..n).map(|i| ParachainData { id: i, slot_duration: 6000u64 }).collect();
+			(0..n).map(|i| ParachainData { id: i }).collect();
 
 		Pallet::<T>::add_parachain(origin.clone(), parachains)?;
 

--- a/modules/ismp/clients/parachain/client/src/consensus.rs
+++ b/modules/ismp/clients/parachain/client/src/consensus.rs
@@ -16,7 +16,7 @@
 //! The parachain consensus client module
 use polkadot_sdk::*;
 
-use core::{marker::PhantomData, time::Duration};
+use core::marker::PhantomData;
 
 use alloc::{boxed::Box, collections::BTreeMap, format, string::ToString, vec::Vec};
 use codec::{Decode, Encode};
@@ -32,9 +32,8 @@ use ismp::{
 	host::{IsmpHost, StateMachine},
 	messaging::StateCommitmentHeight,
 };
-use pallet_ismp::{ConsensusDigest, ISMP_ID};
+use pallet_ismp::{ConsensusDigest, ISMP_ID, ISMP_TIMESTAMP_ID, TimestampDigest};
 use primitive_types::H256;
-use sp_consensus_aura::{Slot, AURA_ENGINE_ID};
 use sp_runtime::{
 	app_crypto::sp_core::storage::StorageKey,
 	generic::Header,
@@ -145,8 +144,6 @@ where
 			let id = codec::Decode::decode(&mut &key[(key.len() - 4)..])
 				.map_err(|e| Error::Custom(format!("Error decoding parachain header: {e}")))?;
 
-			let slot_duration = Parachains::<T>::get(id).expect("Parachain with ID exists; qed");
-
 			// ideally all parachain headers are the same
 			let header = Header::<u32, BlakeTwo256>::decode(&mut &*header)
 				.map_err(|e| Error::Custom(format!("Error decoding parachain header: {e}")))?;
@@ -155,12 +152,14 @@ where
 				(0, H256::default(), H256::default());
 			for digest in header.digest().logs.iter() {
 				match digest {
-					DigestItem::PreRuntime(consensus_engine_id, value)
-						if *consensus_engine_id == AURA_ENGINE_ID =>
+					DigestItem::Consensus(consensus_engine_id, value)
+						if *consensus_engine_id == ISMP_TIMESTAMP_ID =>
 					{
-						let slot = Slot::decode(&mut &value[..])
-							.map_err(|e| Error::Custom(format!("Cannot slot: {e:?}")))?;
-						timestamp = Duration::from_millis(*slot * slot_duration).as_secs();
+						let timestamp_digest =
+							TimestampDigest::decode(&mut &value[..]).map_err(|e| {
+								Error::Custom(format!("Failed to decode timestamp digest: {e:?}"))
+							})?;
+						timestamp = timestamp_digest.timestamp;
 					},
 					DigestItem::Consensus(consensus_engine_id, value)
 						if *consensus_engine_id == ISMP_ID =>

--- a/modules/ismp/clients/parachain/client/src/lib.rs
+++ b/modules/ismp/clients/parachain/client/src/lib.rs
@@ -99,9 +99,9 @@ pub mod pallet {
 	use frame_support::{pallet_prelude::*, BoundedBTreeSet};
 	use frame_system::pallet_prelude::*;
 	use ismp::{consensus::StateMachineId, host::StateMachine};
-	use migration::StorageV0;
+	use migration::{StorageV0, StorageV1};
 
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
 	#[pallet::pallet]
 	#[pallet::storage_version(STORAGE_VERSION)]
 	pub struct Pallet<T>(_);
@@ -174,7 +174,7 @@ pub mod pallet {
 
 	/// List of parachains that this state machine is interested in.
 	#[pallet::storage]
-	pub type Parachains<T: Config> = StorageMap<_, Identity, u32, u64>;
+	pub type Parachains<T: Config> = StorageMap<_, Identity, u32, ()>;
 
 	/// Events emitted by this pallet
 	#[pallet::event]
@@ -206,7 +206,7 @@ pub mod pallet {
 					StateMachine::Polkadot(_) => StateMachine::Polkadot(para.id),
 					_ => continue,
 				};
-				Parachains::<T>::insert(para.id, para.slot_duration);
+				Parachains::<T>::insert(para.id, ());
 				let _ = host.store_challenge_period(
 					StateMachineId {
 						state_id,
@@ -268,7 +268,7 @@ pub mod pallet {
 		}
 
 		fn on_runtime_upgrade() -> Weight {
-			StorageV0::migrate_to_v1::<T>()
+			StorageV0::migrate_to_v1::<T>() + StorageV1::migrate_to_v2::<T>()
 		}
 
 		/// Drains the legacy [`RelayChainStateCommitments`] map using leftover block
@@ -358,7 +358,7 @@ pub mod pallet {
 
 			// insert the parachain ids
 			for para in &self.parachains {
-				Parachains::<T>::insert(para.id, para.slot_duration);
+				Parachains::<T>::insert(para.id, ());
 				let state_id = match host.host_state_machine() {
 					StateMachine::Kusama(_) => StateMachine::Kusama(para.id),
 					StateMachine::Polkadot(_) => StateMachine::Polkadot(para.id),
@@ -454,8 +454,6 @@ impl<T: Config> RelayChainOracle for Pallet<T> {
 pub struct ParachainData {
 	/// parachain id
 	pub id: u32,
-	/// parachain slot duration type
-	pub slot_duration: u64,
 }
 
 /// Returns the consensus state id for The relay chain

--- a/modules/ismp/clients/parachain/client/src/migration.rs
+++ b/modules/ismp/clients/parachain/client/src/migration.rs
@@ -20,6 +20,7 @@ use log;
 use polkadot_sdk::*;
 
 pub use storage_v0::*;
+pub use storage_v1::*;
 
 /// V0 to V1 migration: populate `Parachains` slot durations.
 pub mod storage_v0 {
@@ -38,9 +39,41 @@ pub mod storage_v0 {
 			return if Pallet::<T>::on_chain_storage_version() == 0 {
 				// track reads and write to be made
 				let storage_count = Parachains::<T>::iter_keys().count() as u64;
-				Parachains::<T>::translate(|_key: u32, _old_value: ()| Some(12_000));
+				// Old V0 stored `()`; V1 stored `u64` slot duration. Default migrated
+				// chains to 12s slot duration. Note: the value type is now `()` again
+				// (see V2 migration), so this closure is only meaningful when running
+				// V0 → V1 historically; the resulting `u64` will be dropped in V2.
+				Parachains::<T>::translate(|_key: u32, _old_value: ()| Some(()));
 				log::info!(target: "ismp_parachain", "Migrated Parachain storage on {} keys", storage_count);
 				StorageVersion::new(1).put::<Pallet<T>>();
+				Weight::from_all(storage_count)
+			} else {
+				Weight::zero()
+			};
+		}
+	}
+}
+
+/// V1 to V2 migration: drop the per-parachain `slot_duration` value now that the
+/// timestamp is read from the `ISMP_TIMESTAMP_ID` consensus digest.
+pub mod storage_v1 {
+	use super::*;
+	use frame_support::{
+		pallet_prelude::{GetStorageVersion, StorageVersion},
+		weights::Weight,
+	};
+
+	/// Storage V1 migration helper.
+	pub struct StorageV1 {}
+
+	impl StorageV1 {
+		/// Migrate storage from V1 to V2.
+		pub fn migrate_to_v2<T: Config>() -> Weight {
+			return if Pallet::<T>::on_chain_storage_version() == 1 {
+				let storage_count = Parachains::<T>::iter_keys().count() as u64;
+				Parachains::<T>::translate(|_key: u32, _old_value: u64| Some(()));
+				log::info!(target: "ismp_parachain", "Migrated Parachain storage (drop slot_duration) on {} keys", storage_count);
+				StorageVersion::new(2).put::<Pallet<T>>();
 				Weight::from_all(storage_count)
 			} else {
 				Weight::zero()

--- a/modules/pallets/testsuite/src/tests/pallet_ismp_beefy.rs
+++ b/modules/pallets/testsuite/src/tests/pallet_ismp_beefy.rs
@@ -185,7 +185,7 @@ async fn test_verify_consensus() {
 	let (initial_state, beefy_consensus_proof) = setup().await;
 	let mut ext = new_test_ext();
 	ext.execute_with(|| {
-		Parachains::<Test>::insert(3367, 12000);
+		Parachains::<Test>::insert(3367, ());
 
 		let host = Ismp::default();
 		let consensus_client = host.consensus_client(BEEFY_CONSENSUS_ID).unwrap();

--- a/modules/utils/subxt/src/values.rs
+++ b/modules/utils/subxt/src/values.rs
@@ -647,8 +647,5 @@ pub fn storage_kv_list_to_value(kv_list: &Vec<(Vec<u8>, Vec<u8>)>) -> Value<()> 
 }
 
 pub fn parachain_data_to_value(data: &ParachainData) -> Value<()> {
-	Value::named_composite(vec![
-		("id".to_string(), Value::u128(data.id.into())),
-		("slot_duration".to_string(), Value::u128(data.slot_duration.into())),
-	])
+	Value::named_composite(vec![("id".to_string(), Value::u128(data.id.into()))])
 }

--- a/parachain/node/src/chain_spec.rs
+++ b/parachain/node/src/chain_spec.rs
@@ -190,9 +190,9 @@ fn testnet_genesis(
 
 	// sibling parachain for tests
 	let sibling = match id {
-		2000 => ParachainData { id: 2001, slot_duration: 6000 },
-		2001 => ParachainData { id: 2000, slot_duration: 6000 },
-		_ => ParachainData { id: 1000, slot_duration: 6000 }, /* default to assethub */
+		2000 => ParachainData { id: 2001 },
+		2001 => ParachainData { id: 2000 },
+		_ => ParachainData { id: 1000 }, /* default to assethub */
 	};
 
 	json::json!({

--- a/parachain/simtests/src/pallet_ismp.rs
+++ b/parachain/simtests/src/pallet_ismp.rs
@@ -62,7 +62,6 @@ async fn test_txpool_should_reject_duplicate_requests() -> Result<(), anyhow::Er
 	let _rpc = LegacyRpcMethods::<BlakeSubstrateChain>::new(rpc_client.clone());
 
 	let para_id = 3000u32;
-	let slot_duration = 6000u64;
 	let source = StateMachine::Kusama(para_id);
 	// Bytes used as the `from` field of the POST request below. Pre-computed
 	// here so the same value can be added to the bandwidth allowlist during
@@ -74,7 +73,7 @@ async fn test_txpool_should_reject_duplicate_requests() -> Result<(), anyhow::Er
 		let add_parachain_call = subxt::dynamic::tx(
 			"IsmpParachain",
 			"add_parachain",
-			vec![vec![parachain_data_to_value(&ParachainData { id: para_id, slot_duration })]],
+			vec![vec![parachain_data_to_value(&ParachainData { id: para_id })]],
 		);
 		let sudo_call = subxt::dynamic::tx("Sudo", "sudo", vec![add_parachain_call.into_value()]);
 		let call = client.tx().call_data(&sudo_call)?;
@@ -361,7 +360,6 @@ async fn test_force_credited_bandwidth_satisfies_gate() -> Result<(), anyhow::Er
 	// tests can run back-to-back against the same simnode without colliding
 	// on the parachain-registration step.
 	let para_id = 3001u32;
-	let slot_duration = 6000u64;
 	let source = StateMachine::Kusama(para_id);
 	let from = H256::random().as_bytes().to_vec();
 
@@ -370,7 +368,7 @@ async fn test_force_credited_bandwidth_satisfies_gate() -> Result<(), anyhow::Er
 		let add_parachain_call = subxt::dynamic::tx(
 			"IsmpParachain",
 			"add_parachain",
-			vec![vec![parachain_data_to_value(&ParachainData { id: para_id, slot_duration })]],
+			vec![vec![parachain_data_to_value(&ParachainData { id: para_id })]],
 		);
 		let sudo_call = subxt::dynamic::tx("Sudo", "sudo", vec![add_parachain_call.into_value()]);
 		let call = client.tx().call_data(&sudo_call)?;


### PR DESCRIPTION
## Summary
- The EVM consensus types and the ismp-parachain Rust client previously computed timestamps as `slot * SLOT_DURATION`, reading the slot from the AURA pre-runtime digest. Pallet-ismp already deposits a `TimestampDigest` (consensus engine ID `ISTM`) carrying the actual unix timestamp set by pallet-timestamp; this PR switches both clients to read that digest directly.
- Drops the now-unused `slot_duration` field from `ParachainData` and from the `Parachains` storage map (`StorageMap<_, Identity, u32, u64>` → `StorageMap<_, Identity, u32, ()>`), with a V1 → V2 storage migration to translate existing entries.

## Test plan
- [x] `cargo check --workspace --benches`
- [x] Unit tests for `ismp-parachain`, `pallet-ismp-testsuite`, `subxt-utils`
- [x] Run a runtime upgrade test against a chain with V1 storage to confirm the V1 → V2 migration translates `u64` → `()` cleanly
- [x] Verify a real parachain header decodes correctly on the Solidity side (`HeaderImpl.stateCommitment`) and that the returned timestamp matches `pallet_timestamp::Now`