### PR TITLE
Disable fraud proofs for ismp-parachain

### DIFF
--- a/modules/ismp/clients/parachain/client/src/consensus.rs
+++ b/modules/ismp/clients/parachain/client/src/consensus.rs
@@ -239,7 +239,7 @@ where
 		_proof_2: Vec<u8>,
 	) -> Result<(), Error> {
 		// There are no fraud proofs for the parachain client
-		Ok(())
+		Err(Error::CannotHandleMessage)
 	}
 
 	fn consensus_client_id(&self) -> [u8; 4] {


### PR DESCRIPTION
Fraud proof messages should not execute for parachain consensus client