### PR TITLE
[runtime]: enforce epoch state proof on every verifier state update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15442,6 +15442,7 @@ dependencies = [
  "pharos-primitives",
  "pharos-prover",
  "pharos-state-machine",
+ "pharos-verifier",
  "polkadot-sdk",
  "primitive-types 0.13.1",
  "reqwest 0.11.27",

--- a/modules/consensus/pharos/primitives/src/types.rs
+++ b/modules/consensus/pharos/primitives/src/types.rs
@@ -200,6 +200,20 @@ pub struct ValidatorSetProof {
 	pub storage_values: Vec<Vec<u8>>,
 }
 
+/// State proof of `currentEpoch` (slot 5) on the staking contract.
+///
+/// Carries the proof path and the raw storage value at the update's block height,
+/// verified against the block's `state_root`. The proven `u64` epoch is what the
+/// verifier uses to decide whether the update crosses an epoch boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Encode, Decode)]
+#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+pub struct EpochProof {
+	/// Proof path for slot 5 of the staking contract, root-to-leaf.
+	pub proof: Vec<PharosProofNode>,
+	/// Raw big-endian storage value at slot 5 (decodes to `u64`).
+	pub value: Vec<u8>,
+}
+
 /// The trusted state maintained by the Pharos consensus client.
 ///
 /// This state is updated as new blocks are verified and represents
@@ -235,19 +249,21 @@ impl VerifierState {
 
 /// Data required to update the verifier state.
 ///
-/// This is what the prover submits to advance the light client's state.
-/// Epoch transitions are determined by the presence of a `validator_set_proof`:
-/// if present, the epoch increments by 1. The relayer walks epoch-by-epoch,
-/// so each validator set proof corresponds to exactly one epoch transition.
+/// Every update carries an `EpochProof` of slot 5 (`currentEpoch`) on the staking
+/// contract. Rotation is driven by the proven epoch, not by the presence of a
+/// `validator_set_proof`: the proof is required whenever `observed_epoch` differs
+/// from the trusted epoch and disallowed otherwise.
 #[derive(Debug, Clone, Encode, Decode)]
 pub struct VerifierStateUpdate {
 	/// The header being attested to
 	pub header: CodecHeader,
 	/// Block proof from debug_getBlockProof containing the BLS signature
 	pub block_proof: BlockProof,
-	/// Optional validator set update proof (required at epoch transitions).
-	/// Presence of this proof signals an epoch boundary: new_epoch = current_epoch + 1.
+	/// Validator set update proof. Required when `current_epoch_proof` proves a
+	/// new epoch; must be absent when the update stays within the trusted epoch.
 	pub validator_set_proof: Option<ValidatorSetProof>,
+	/// Storage proof of `currentEpoch` (slot 5) against the header's `state_root`.
+	pub current_epoch_proof: EpochProof,
 }
 
 impl VerifierStateUpdate {

--- a/modules/consensus/pharos/prover/src/lib.rs
+++ b/modules/consensus/pharos/prover/src/lib.rs
@@ -21,8 +21,8 @@ pub mod rpc;
 pub use error::ProverError;
 
 use pharos_primitives::{
-	BlockProof, BlsPublicKey, Config, PharosProofNode, SiblingLeftmostLeafProof, ValidatorInfo,
-	ValidatorSet, ValidatorSetProof, VerifierStateUpdate, CURRENT_EPOCH_SLOT,
+	BlockProof, BlsPublicKey, Config, EpochProof, PharosProofNode, SiblingLeftmostLeafProof,
+	ValidatorInfo, ValidatorSet, ValidatorSetProof, VerifierStateUpdate, CURRENT_EPOCH_SLOT,
 	STAKING_CONTRACT_ADDRESS,
 };
 use pharos_verifier::state_proof::StakingContractLayout;
@@ -106,10 +106,8 @@ impl<C: Config> PharosProver<C> {
 
 	/// Fetch a block update for the given block number.
 	///
-	/// This will:
-	/// 1. Fetch the block header
-	/// 2. Fetch the block proof (BLS signature)
-	/// 3. If at epoch boundary, fetch validator set proof
+	/// Always attaches a storage proof of `currentEpoch` (slot 5). The validator
+	/// set proof is included only when the block crosses an epoch boundary.
 	pub async fn fetch_block_update(
 		&self,
 		block_number: u64,
@@ -118,6 +116,8 @@ impl<C: Config> PharosProver<C> {
 
 		let rpc_proof = self.rpc.get_block_proof(block_number).await?;
 		let block_proof = self.convert_rpc_block_proof(&rpc_proof)?;
+
+		let current_epoch_proof = self.fetch_current_epoch_proof(block_number).await?;
 
 		let is_boundary = self.is_epoch_boundary(block_number).await?;
 		let validator_set_proof = if is_boundary {
@@ -134,7 +134,24 @@ impl<C: Config> PharosProver<C> {
 			None
 		};
 
-		Ok(VerifierStateUpdate { header, block_proof, validator_set_proof })
+		Ok(VerifierStateUpdate { header, block_proof, validator_set_proof, current_epoch_proof })
+	}
+
+	/// Fetch a storage proof of `currentEpoch` (slot 5) at the given block height.
+	pub async fn fetch_current_epoch_proof(
+		&self,
+		block_number: u64,
+	) -> Result<EpochProof, ProverError> {
+		let address = H160::from_slice(STAKING_CONTRACT_ADDRESS.as_slice());
+		let slot_key = H256::from_low_u64_be(CURRENT_EPOCH_SLOT);
+
+		let proof = self.rpc.get_proof(address, vec![slot_key], block_number).await?;
+		let sp = proof
+			.storage_proof
+			.first()
+			.ok_or(ProverError::MissingStorageProof("currentEpoch"))?;
+
+		Ok(EpochProof { proof: rpc_to_proof_nodes(&sp.proof)?, value: hex_to_bytes(&sp.value)? })
 	}
 
 	/// Fetch only the block proof for a given block number.

--- a/modules/consensus/pharos/verifier/src/error.rs
+++ b/modules/consensus/pharos/verifier/src/error.rs
@@ -85,6 +85,24 @@ pub enum Error {
 		block_number: u64,
 	},
 
+	/// Proven epoch is lower than the trusted epoch
+	#[error("Epoch regressed: trusted {trusted}, observed {observed}")]
+	EpochRegressed {
+		/// The epoch the verifier currently trusts
+		trusted: u64,
+		/// The epoch proved by the update's slot-5 storage proof
+		observed: u64,
+	},
+
+	/// Proven epoch is more than one ahead of the trusted epoch
+	#[error("Epoch skip: trusted {trusted}, observed {observed}")]
+	EpochSkipped {
+		/// The epoch the verifier currently trusts
+		trusted: u64,
+		/// The epoch proved by the update's slot-5 storage proof
+		observed: u64,
+	},
+
 	/// Storage proof lookup failed
 	#[error("Storage proof lookup failed")]
 	StorageProofLookupFailed,

--- a/modules/consensus/pharos/verifier/src/lib.rs
+++ b/modules/consensus/pharos/verifier/src/lib.rs
@@ -22,6 +22,7 @@ extern crate alloc;
 pub mod error;
 pub mod state_proof;
 
+use core::cmp::Ordering;
 use error::Error;
 use geth_primitives::Header;
 use ismp::messaging::Keccak256;
@@ -35,9 +36,11 @@ pub const PHAROS_BLS_DST: &str = "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
 
 /// Verifies a Pharos block proof and updates the verifier state.
 ///
-/// Epoch transitions are determined by the presence of a `validator_set_proof`:
-/// if present, the epoch increments by 1. The relayer walks epoch-by-epoch,
-/// so each validator set proof corresponds to exactly one epoch transition.
+/// The proven epoch (from a storage proof of `currentEpoch` against the header's
+/// state root) drives rotation: same epoch keeps the trusted set, an increment of
+/// one rotates to the set proved in `validator_set_proof`, anything else is
+/// rejected. The BLS aggregate signature is verified against the post-rotation
+/// set because Pharos signs the boundary block with the new validators.
 pub fn verify_pharos_block<C: Config, H: Keccak256 + Send + Sync>(
 	trusted_state: VerifierState,
 	update: VerifierStateUpdate,
@@ -52,16 +55,6 @@ pub fn verify_pharos_block<C: Config, H: Keccak256 + Send + Sync>(
 		});
 	}
 
-	verify_validator_membership(
-		&trusted_state.current_validator_set,
-		&update.block_proof.participant_keys,
-	)?;
-
-	verify_stake_threshold(
-		&trusted_state.current_validator_set,
-		&update.block_proof.participant_keys,
-	)?;
-
 	let computed_hash = Header::from(&update.header).hash::<H>();
 
 	if computed_hash != update.block_proof.block_proof_hash {
@@ -71,37 +64,75 @@ pub fn verify_pharos_block<C: Config, H: Keccak256 + Send + Sync>(
 		});
 	}
 
-	verify_bls_signature(
-		&update.block_proof.participant_keys,
-		&update.block_proof,
-		update.block_proof.block_proof_hash,
+	let observed_epoch = state_proof::verify_current_epoch_proof(
+		update.header.state_root,
+		&update.current_epoch_proof,
 	)?;
 
-	// Epoch transition is determined by presence of validator_set_proof
-	let new_state = if let Some(validator_set_proof) = update.validator_set_proof {
-		let new_epoch = trusted_state.current_epoch + 1;
+	let trusted_epoch = trusted_state.current_epoch;
 
-		let new_validator_set = state_proof::verify_validator_set_proof::<H>(
-			update.header.state_root,
-			&validator_set_proof,
-			new_epoch,
-		)?;
+	match observed_epoch.cmp(&trusted_epoch) {
+		Ordering::Less =>
+			Err(Error::EpochRegressed { trusted: trusted_epoch, observed: observed_epoch }),
+		Ordering::Equal => {
+			if update.validator_set_proof.is_some() {
+				return Err(Error::UnexpectedValidatorSetProof {
+					block_number: update_block_number,
+				});
+			}
 
-		VerifierState {
-			current_validator_set: new_validator_set,
-			finalized_block_number: update_block_number,
-			finalized_hash: computed_hash,
-			current_epoch: new_epoch,
-		}
-	} else {
-		VerifierState {
-			finalized_block_number: update_block_number,
-			finalized_hash: computed_hash,
-			..trusted_state
-		}
-	};
+			verify_block_signature(
+				&trusted_state.current_validator_set,
+				&update.block_proof,
+				computed_hash,
+			)?;
 
-	Ok(new_state)
+			Ok(VerifierState {
+				finalized_block_number: update_block_number,
+				finalized_hash: computed_hash,
+				..trusted_state
+			})
+		},
+		Ordering::Greater => {
+			if observed_epoch != trusted_epoch + 1 {
+				return Err(Error::EpochSkipped {
+					trusted: trusted_epoch,
+					observed: observed_epoch,
+				});
+			}
+
+			let validator_set_proof = update
+				.validator_set_proof
+				.ok_or(Error::MissingValidatorSetProof { block_number: update_block_number })?;
+
+			let new_validator_set = state_proof::verify_validator_set_proof::<H>(
+				update.header.state_root,
+				&validator_set_proof,
+				observed_epoch,
+			)?;
+
+			verify_block_signature(&new_validator_set, &update.block_proof, computed_hash)?;
+
+			Ok(VerifierState {
+				current_validator_set: new_validator_set,
+				finalized_block_number: update_block_number,
+				finalized_hash: computed_hash,
+				current_epoch: observed_epoch,
+			})
+		},
+	}
+}
+
+/// Verify that the block proof's signers are a supermajority of `validator_set`
+/// and that the aggregate BLS signature is valid for `block_proof_hash`.
+fn verify_block_signature(
+	validator_set: &ValidatorSet,
+	block_proof: &BlockProof,
+	block_proof_hash: H256,
+) -> Result<(), Error> {
+	verify_validator_membership(validator_set, &block_proof.participant_keys)?;
+	verify_stake_threshold(validator_set, &block_proof.participant_keys)?;
+	verify_bls_signature(&block_proof.participant_keys, block_proof, block_proof_hash)
 }
 
 /// Verify that all participating validators are members of the trusted validator set.

--- a/modules/consensus/pharos/verifier/src/lib.rs
+++ b/modules/consensus/pharos/verifier/src/lib.rs
@@ -39,8 +39,9 @@ pub const PHAROS_BLS_DST: &str = "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
 /// The proven epoch (from a storage proof of `currentEpoch` against the header's
 /// state root) drives rotation: same epoch keeps the trusted set, an increment of
 /// one rotates to the set proved in `validator_set_proof`, anything else is
-/// rejected. The BLS aggregate signature is verified against the post-rotation
-/// set because Pharos signs the boundary block with the new validators.
+/// rejected. The BLS aggregate signature is always verified against the trusted
+/// validator set, so adopting a new set requires the existing set's blessing on
+/// the boundary header.
 pub fn verify_pharos_block<C: Config, H: Keccak256 + Send + Sync>(
 	trusted_state: VerifierState,
 	update: VerifierStateUpdate,
@@ -111,7 +112,11 @@ pub fn verify_pharos_block<C: Config, H: Keccak256 + Send + Sync>(
 				observed_epoch,
 			)?;
 
-			verify_block_signature(&new_validator_set, &update.block_proof, computed_hash)?;
+			verify_block_signature(
+				&trusted_state.current_validator_set,
+				&update.block_proof,
+				computed_hash,
+			)?;
 
 			Ok(VerifierState {
 				current_validator_set: new_validator_set,

--- a/modules/consensus/pharos/verifier/src/state_proof.rs
+++ b/modules/consensus/pharos/verifier/src/state_proof.rs
@@ -31,9 +31,34 @@ use crate::error::Error;
 use alloc::{collections::BTreeMap, vec::Vec};
 use ismp::messaging::Keccak256;
 use pharos_primitives::{
-	spv, PharosProofNode, ValidatorInfo, ValidatorSet, ValidatorSetProof, STAKING_CONTRACT_ADDRESS,
+	spv, EpochProof, PharosProofNode, ValidatorInfo, ValidatorSet, ValidatorSetProof,
+	CURRENT_EPOCH_SLOT, STAKING_CONTRACT_ADDRESS,
 };
 use primitive_types::{H256, U256};
+
+/// Verify a storage proof of `currentEpoch` (slot 5) against `state_root` and
+/// return the proven epoch number.
+pub fn verify_current_epoch_proof(state_root: H256, proof: &EpochProof) -> Result<u64, Error> {
+	let layout = StakingContractLayout::default();
+	let slot_key = layout.raw_slot_key(CURRENT_EPOCH_SLOT);
+	let address: [u8; 20] = STAKING_CONTRACT_ADDRESS.0 .0;
+
+	if proof.value.len() > 32 {
+		return Err(Error::StorageValueTooLarge);
+	}
+
+	let mut padded = [0u8; 32];
+	padded[32 - proof.value.len()..].copy_from_slice(&proof.value);
+
+	spv::verify_proof(
+		&proof.proof,
+		&spv::build_storage_key(&address, &slot_key.0),
+		&padded,
+		&state_root.0,
+	)?;
+
+	Ok(decode_u256_from_storage(&proof.value)?.low_u64())
+}
 
 /// This function verifies that the provided validator set is correctly stored
 /// in the staking contract at the given block.

--- a/modules/pallets/testsuite/Cargo.toml
+++ b/modules/pallets/testsuite/Cargo.toml
@@ -56,6 +56,7 @@ ismp-pharos = { workspace = true, default-features = true }
 pharos-primitives = { workspace = true, default-features = true }
 pharos-prover = { workspace = true, default-features = true }
 pharos-state-machine = { workspace = true, default-features = true }
+pharos-verifier = { workspace = true, default-features = true }
 geth-primitives = { workspace = true, default-features = true }
 bls = { workspace = true }
 crypto-utils = { workspace = true, default-features = true }

--- a/modules/pallets/testsuite/src/tests/ismp_pharos.rs
+++ b/modules/pallets/testsuite/src/tests/ismp_pharos.rs
@@ -22,8 +22,9 @@ use ismp::{
 	host::StateMachine,
 };
 use ismp_pharos::{ConsensusState, PharosClient, PHAROS_CONSENSUS_CLIENT_ID};
-use pharos_primitives::{Testnet, PHAROS_ATLANTIC_CHAIN_ID};
+use pharos_primitives::{Testnet, VerifierState, PHAROS_ATLANTIC_CHAIN_ID};
 use pharos_prover::PharosProver;
+use pharos_verifier::{error::Error as VerifierError, verify_pharos_block};
 use primitive_types::H256;
 
 #[tokio::test]
@@ -242,4 +243,178 @@ async fn test_ismp_pharos_epoch_boundary_consensus_verification() {
 			panic!("Epoch boundary verification failed: {:?}", e);
 		},
 	}
+}
+
+async fn fetch_latest_boundary(
+	prover: &PharosProver<Testnet>,
+) -> (u64, u64, pharos_primitives::VerifierStateUpdate) {
+	let latest = prover.get_latest_block().await.expect("latest block");
+	let current_epoch = prover.fetch_current_epoch(latest).await.expect("fetch epoch");
+	let previous_epoch = current_epoch - 1;
+	let boundary = prover
+		.find_epoch_boundary(latest.saturating_sub(5000), latest, previous_epoch)
+		.await
+		.expect("find epoch boundary");
+	let update = prover.fetch_block_update(boundary).await.expect("fetch boundary update");
+	(boundary, previous_epoch, update)
+}
+
+fn trusted_state_from_validators(
+	prover: &PharosProver<Testnet>,
+	validators: &[pharos_prover::rpc::RpcValidatorInfo],
+	epoch: u64,
+	finalized_height: u64,
+) -> VerifierState {
+	let validator_set = prover.build_validator_set(validators, epoch).expect("build validator set");
+	VerifierState {
+		current_validator_set: validator_set,
+		finalized_block_number: finalized_height,
+		finalized_hash: H256::zero(),
+		current_epoch: epoch,
+	}
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_in_epoch_update_with_unexpected_validator_set_proof_rejected() {
+	let rpc_url =
+		std::env::var("PHAROS_ATLANTIC_RPC").expect("PHAROS_ATLANTIC_RPC env variable must be set");
+	let prover = PharosProver::<Testnet>::new(&rpc_url).await.expect("create prover");
+
+	let (boundary, previous_epoch, boundary_update) = fetch_latest_boundary(&prover).await;
+
+	let mut target = boundary + 1;
+	while prover.is_epoch_boundary(target).await.expect("epoch boundary check") {
+		target += 1;
+	}
+
+	let validators_at_boundary =
+		prover.rpc.get_validator_info(Some(boundary)).await.expect("validator info");
+	let trusted = trusted_state_from_validators(
+		&prover,
+		&validators_at_boundary.validator_set,
+		previous_epoch + 1,
+		target - 1,
+	);
+
+	let mut update = prover.fetch_block_update(target).await.expect("fetch update");
+	update.validator_set_proof = boundary_update.validator_set_proof.clone();
+
+	let err = verify_pharos_block::<Testnet, Ismp>(trusted, update).expect_err("should reject");
+	assert!(matches!(err, VerifierError::UnexpectedValidatorSetProof { .. }), "got: {err:?}");
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_boundary_update_without_validator_set_proof_rejected() {
+	let rpc_url =
+		std::env::var("PHAROS_ATLANTIC_RPC").expect("PHAROS_ATLANTIC_RPC env variable must be set");
+	let prover = PharosProver::<Testnet>::new(&rpc_url).await.expect("create prover");
+
+	let (boundary, previous_epoch, mut update) = fetch_latest_boundary(&prover).await;
+	let validators_at_boundary =
+		prover.rpc.get_validator_info(Some(boundary)).await.expect("validator info");
+	let trusted = trusted_state_from_validators(
+		&prover,
+		&validators_at_boundary.validator_set,
+		previous_epoch,
+		boundary - 1,
+	);
+
+	update.validator_set_proof = None;
+
+	let err = verify_pharos_block::<Testnet, Ismp>(trusted, update).expect_err("should reject");
+	assert!(matches!(err, VerifierError::MissingValidatorSetProof { .. }), "got: {err:?}");
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_epoch_skip_rejected() {
+	let rpc_url =
+		std::env::var("PHAROS_ATLANTIC_RPC").expect("PHAROS_ATLANTIC_RPC env variable must be set");
+	let prover = PharosProver::<Testnet>::new(&rpc_url).await.expect("create prover");
+
+	let latest = prover.get_latest_block().await.expect("latest block");
+	let mut target = latest.saturating_sub(5);
+	while prover.is_epoch_boundary(target).await.expect("epoch boundary check") {
+		target = target.saturating_sub(1);
+	}
+	let observed_epoch = prover.fetch_current_epoch(target).await.expect("fetch epoch");
+
+	let validators = prover.rpc.get_validator_info(Some(target)).await.expect("validator info");
+	let trusted = trusted_state_from_validators(
+		&prover,
+		&validators.validator_set,
+		observed_epoch.saturating_sub(2),
+		target - 1,
+	);
+
+	let update = prover.fetch_block_update(target).await.expect("fetch update");
+
+	let err = verify_pharos_block::<Testnet, Ismp>(trusted, update).expect_err("should reject");
+	assert!(matches!(err, VerifierError::EpochSkipped { .. }), "got: {err:?}");
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_epoch_regression_rejected() {
+	let rpc_url =
+		std::env::var("PHAROS_ATLANTIC_RPC").expect("PHAROS_ATLANTIC_RPC env variable must be set");
+	let prover = PharosProver::<Testnet>::new(&rpc_url).await.expect("create prover");
+
+	let latest = prover.get_latest_block().await.expect("latest block");
+	let mut target = latest.saturating_sub(5);
+	while prover.is_epoch_boundary(target).await.expect("epoch boundary check") {
+		target = target.saturating_sub(1);
+	}
+	let observed_epoch = prover.fetch_current_epoch(target).await.expect("fetch epoch");
+
+	let validators = prover.rpc.get_validator_info(Some(target)).await.expect("validator info");
+	let trusted = trusted_state_from_validators(
+		&prover,
+		&validators.validator_set,
+		observed_epoch + 10,
+		target - 1,
+	);
+
+	let update = prover.fetch_block_update(target).await.expect("fetch update");
+
+	let err = verify_pharos_block::<Testnet, Ismp>(trusted, update).expect_err("should reject");
+	assert!(matches!(err, VerifierError::EpochRegressed { .. }), "got: {err:?}");
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_tampered_epoch_proof_rejected() {
+	let rpc_url =
+		std::env::var("PHAROS_ATLANTIC_RPC").expect("PHAROS_ATLANTIC_RPC env variable must be set");
+	let prover = PharosProver::<Testnet>::new(&rpc_url).await.expect("create prover");
+
+	let latest = prover.get_latest_block().await.expect("latest block");
+	let mut target = latest.saturating_sub(5);
+	while prover.is_epoch_boundary(target).await.expect("epoch boundary check") {
+		target = target.saturating_sub(1);
+	}
+	let observed_epoch = prover.fetch_current_epoch(target).await.expect("fetch epoch");
+
+	let validators = prover.rpc.get_validator_info(Some(target)).await.expect("validator info");
+	let trusted = trusted_state_from_validators(
+		&prover,
+		&validators.validator_set,
+		observed_epoch,
+		target - 1,
+	);
+
+	let mut update = prover.fetch_block_update(target).await.expect("fetch update");
+	let mut tampered = update.current_epoch_proof.value.clone();
+	if tampered.is_empty() {
+		tampered.push(0xff);
+	} else {
+		let last = tampered.len() - 1;
+		tampered[last] ^= 0xff;
+	}
+	update.current_epoch_proof.value = tampered;
+
+	let err = verify_pharos_block::<Testnet, Ismp>(trusted, update).expect_err("should reject");
+	assert!(matches!(err, VerifierError::StorageProofVerificationFailed(_)), "got: {err:?}");
 }


### PR DESCRIPTION
This PR ensures that every `VerifierStateUpdate` carries an `EpochProof` verified against the block's `state_root`, and the verifier decides whether to rotate based on the proven value.
