### PR TITLE
[runtime]: Dedup commitments in accumulate_fees

### DIFF
--- a/modules/pallets/relayer/src/lib.rs
+++ b/modules/pallets/relayer/src/lib.rs
@@ -240,6 +240,8 @@ pub mod pallet {
 		ErrorCompletingCall,
 		/// Missing commitments
 		MissingCommitments,
+		/// The withdrawal proof's commitments batch contains a duplicate key.
+		DuplicateCommitment,
 		/// Fee accumulation proof contains no address
 		IncompleteProof,
 		/// Withdrawal batch contains commitments delivered by more than one
@@ -657,7 +659,16 @@ where
 	}
 
 	pub fn accumulate(mut withdrawal_proof: WithdrawalProof) -> DispatchResult {
-		// Filter out duplicate commitments
+		// Reject duplicate commitments within the batch. The wire format is a
+		// `Vec` and this extrinsic is unsigned, so this is the line of defence
+		// against an attacker padding the batch with identical commitments to
+		// double-claim fees.
+		let mut seen = alloc::collections::BTreeSet::new();
+		for key in withdrawal_proof.commitments.iter() {
+			ensure!(seen.insert(key.encode()), Error::<T>::DuplicateCommitment);
+		}
+
+		// Filter out already-claimed / missing commitments
 		withdrawal_proof.commitments = withdrawal_proof
 			.commitments
 			.into_iter()

--- a/modules/pallets/testsuite/src/tests/pallet_ismp_relayer.rs
+++ b/modules/pallets/testsuite/src/tests/pallet_ismp_relayer.rs
@@ -482,6 +482,50 @@ fn test_accumulate_fees_rejects_mixed_delivery_addresses() {
 	})
 }
 
+/// `accumulate_fees` is unsigned, so anyone can submit a `WithdrawalProof`.
+/// A batch padded with identical commitments must be rejected outright
+/// before any proof verification or fee credit, so an attacker cannot
+/// double-claim a single delivery.
+#[test]
+fn test_accumulate_fees_rejects_duplicate_commitments() {
+	let mut ext = new_test_ext();
+	ext.execute_with(|| {
+		let request = H256::repeat_byte(0xab);
+		let withdrawal_proof = WithdrawalProof {
+			commitments: vec![Key::Request(request), Key::Request(request)],
+			source_proof: Proof {
+				height: StateMachineHeight {
+					id: StateMachineId {
+						state_id: StateMachine::Kusama(2000),
+						consensus_state_id: MOCK_CONSENSUS_STATE_ID,
+					},
+					height: 1,
+				},
+				proof: vec![],
+			},
+			dest_proof: Proof {
+				height: StateMachineHeight {
+					id: StateMachineId {
+						state_id: StateMachine::Kusama(2001),
+						consensus_state_id: MOCK_CONSENSUS_STATE_ID,
+					},
+					height: 1,
+				},
+				proof: vec![],
+			},
+			beneficiary_details: None,
+		};
+
+		let err = pallet_ismp_relayer::Pallet::<Test>::accumulate_fees(
+			RuntimeOrigin::none(),
+			withdrawal_proof,
+		)
+		.expect_err("duplicate-commitment batch must be rejected");
+
+		assert_eq!(err, pallet_ismp_relayer::Error::<Test>::DuplicateCommitment.into());
+	})
+}
+
 #[test]
 fn test_accumulate_fees_evm_signatures() {
 	let mut ext = new_test_ext();


### PR DESCRIPTION
The unsigned accumulate_fees extrinsic processed WithdrawalProof.commitments without rejecting repeated keys; the existing filter only dropped already-claimed/missing commitments. A padded batch of identical unclaimed keys could flow into fee accumulation and double-claim a delivery. Reject duplicate commitments outright before any proof verification.