### PR TITLE
Fix cross-L2 state-root confusion in Optimism/Arbitrum consensus clients

### DIFF
--- a/modules/ismp/clients/ismp-arbitrum/src/lib.rs
+++ b/modules/ismp/clients/ismp-arbitrum/src/lib.rs
@@ -50,7 +50,6 @@ pub struct ConsensusState {
 
 #[derive(Encode, Decode)]
 pub struct ArbitrumUpdate {
-	pub state_machine_id: StateMachineId,
 	pub l1_height: u64,
 	pub proof: ArbitrumConsensusProof,
 }
@@ -105,12 +104,17 @@ impl<
 		trusted_consensus_state: Vec<u8>,
 		consensus_proof: Vec<u8>,
 	) -> Result<(Vec<u8>, VerifiedCommitments), Error> {
-		let ArbitrumUpdate { state_machine_id, l1_height, proof } =
+		let ArbitrumUpdate { l1_height, proof } =
 			ArbitrumUpdate::decode(&mut &consensus_proof[..])
 				.map_err(|_| Error::Custom("Cannot decode arbitrum update".to_string()))?;
 
 		let mut consensus_state = ConsensusState::decode(&mut &trusted_consensus_state[..])
 			.map_err(|_| Error::Custom("Cannot decode trusted consensus state".to_string()))?;
+
+		// The state machine being updated is fixed by the trusted consensus state, never
+		// supplied by the (untrusted) update. This binds verifier-config selection to the
+		// correct Arbitrum chain identity.
+		let state_machine_id = consensus_state.state_machine_id;
 
 		let l1_state_machine_height =
 			StateMachineHeight { id: consensus_state.l1_state_machine_id, height: l1_height };

--- a/modules/ismp/clients/ismp-optimism/src/lib.rs
+++ b/modules/ismp/clients/ismp-optimism/src/lib.rs
@@ -102,7 +102,6 @@ impl ConsensusState {
 
 #[derive(Encode, Decode)]
 pub struct OptimismUpdate {
-	pub state_machine_id: StateMachineId,
 	pub l1_height: u64,
 	pub proof: OptimismConsensusProof,
 }
@@ -157,12 +156,17 @@ impl<
 		trusted_consensus_state: Vec<u8>,
 		consensus_proof: Vec<u8>,
 	) -> Result<(Vec<u8>, VerifiedCommitments), Error> {
-		let OptimismUpdate { state_machine_id, l1_height, proof } =
+		let OptimismUpdate { l1_height, proof } =
 			OptimismUpdate::decode(&mut &consensus_proof[..])
 				.map_err(|_| Error::Custom("Cannot decode optimism update".to_string()))?;
 
 		let mut consensus_state = ConsensusState::decode_tolerant(&trusted_consensus_state)
 			.map_err(|_| Error::Custom("Cannot decode trusted consensus state".to_string()))?;
+
+		// The state machine being updated is fixed by the trusted consensus state, never
+		// supplied by the (untrusted) update. This binds verifier-config selection to the
+		// correct OP Stack chain identity.
+		let state_machine_id = consensus_state.state_machine_id;
 
 		let l1_state_machine_height =
 			StateMachineHeight { id: consensus_state.l1_state_machine_id, height: l1_height };

--- a/tesseract/consensus/arb-host/src/host.rs
+++ b/tesseract/consensus/arb-host/src/host.rs
@@ -72,10 +72,6 @@ impl IsmpHost for ArbHost {
 								match self.fetch_arbitrum_payload(current_height, event).await {
 									Ok(payload) => {
 										let update = ArbitrumUpdate {
-											state_machine_id: StateMachineId {
-												state_id: self.state_machine,
-												consensus_state_id: self.consensus_state_id,
-											},
 											l1_height: current_height,
 											proof: ArbitrumConsensusProof::ArbitrumOrbit(payload),
 										};
@@ -115,10 +111,6 @@ impl IsmpHost for ArbHost {
 								match self.fetch_arbitrum_bold_payload(current_height, event).await {
 									Ok(payload) => {
 										let update = ArbitrumUpdate {
-											state_machine_id: StateMachineId {
-												state_id: self.state_machine,
-												consensus_state_id: self.consensus_state_id,
-											},
 											l1_height: current_height,
 											proof: ArbitrumConsensusProof::ArbitrumBold(payload),
 										};

--- a/tesseract/consensus/op-host/src/host.rs
+++ b/tesseract/consensus/op-host/src/host.rs
@@ -645,10 +645,6 @@ async fn submit_consensus_update(
 							match client.fetch_op_payload(current_height, event).await {
 								Ok(payload) => {
 									let update = OptimismUpdate {
-										state_machine_id: StateMachineId {
-											state_id: client.state_machine,
-											consensus_state_id: client.consensus_state_id,
-										},
 										l1_height: current_height,
 										proof: OptimismConsensusProof::OpL2Oracle(payload),
 									};
@@ -704,10 +700,6 @@ async fn submit_consensus_update(
 								Ok(maybe_payload) => {
 									if let Some(payload) = maybe_payload {
 										let update = OptimismUpdate {
-											state_machine_id: StateMachineId {
-												state_id: client.state_machine,
-												consensus_state_id: client.consensus_state_id,
-											},
 											l1_height: current_height,
 											proof: OptimismConsensusProof::OpFaultProofGames(payload),
 										};


### PR DESCRIPTION
## Summary

The `OptimismUpdate`/`ArbitrumUpdate` consensus messages carried a caller-supplied
`state_machine_id` that selected which chain's verifier config (dispute-game factory /
L2 oracle / rollup core) the proof was checked against — while the resulting state
commitment was stored under the *trusted consensus state's* chain id.

Because OP Stack L2s share the same Ethereum L1 root, a valid proof for one L2 (e.g.
OP Mainnet) could be verified against that chain's config and then stored as the state
root of a different L2 (e.g. Base).

## Changes

- Remove `state_machine_id` from `OptimismUpdate` and `ArbitrumUpdate`.
- `verify_consensus` now derives the state machine id exclusively from the trusted
  consensus state, so verifier-config selection is bound to the correct chain identity.
- Update the op-host / arb-host relayers to match the new message format.

## Notes

This changes the SCALE encoding of the consensus-message payload — the consensus
client and relayer host binaries must be upgraded together. No storage migration is
needed (these messages are transient, never persisted).