### PR TITLE
[runtime]: nexus migration — bump ismp child trie prefix 

### DIFF
--- a/evm/rust/src/host_params.rs
+++ b/evm/rust/src/host_params.rs
@@ -204,7 +204,7 @@ impl TryFrom<EvmHostParam> for EvmHostParamsAbi {
 	}
 }
 
-/// SCALE-encoded payload for the `withdraw_protocol_fees` extrinsic. Mirrors
+/// SCALE-encoded payload for the `withdraw` extrinsic. Mirrors
 /// the on-EVM `struct WithdrawParams { address beneficiary; uint256 amount;
 /// address token; }`.
 #[derive(

--- a/modules/pallets/host-executive/src/lib.rs
+++ b/modules/pallets/host-executive/src/lib.rs
@@ -275,7 +275,7 @@ pub mod pallet {
 		/// Issues a call to withdraw the protocol fees from an evm chain
 		#[pallet::weight(T::DbWeight::get().writes(1))]
 		#[pallet::call_index(4)]
-		pub fn withdraw_protocol_fees(
+		pub fn withdraw(
 			origin: OriginFor<T>,
 			state_machine: StateMachine,
 			withdrawal_params: WithdrawalParams,

--- a/modules/pallets/ismp/src/child_trie.rs
+++ b/modules/pallets/ismp/src/child_trie.rs
@@ -48,7 +48,7 @@ pub struct ResponseReceipts<T: Config>(PhantomData<T>);
 pub struct StateCommitments<T: Config>(PhantomData<T>);
 
 /// Child trie prefix for all substrate chains
-pub const CHILD_TRIE_PREFIX: &'static [u8] = b"ISMP";
+pub const CHILD_TRIE_PREFIX: &'static [u8] = b"ISMPv2";
 
 /// Key prefix for state commitments in the child trie.
 /// Used by the legacy drain migration.

--- a/parachain/runtimes/gargantua/src/lib.rs
+++ b/parachain/runtimes/gargantua/src/lib.rs
@@ -185,6 +185,7 @@ pub type Executive = frame_executive::Executive<
 pub type Migrations = (
 	pallet_mmr_tree::migrations::ResetMmrTree<Runtime>,
 	ismp_optimism::migrations::SeedDisputeGameConfigs<Runtime>,
+	pallet_ismp_host_executive::migrations::ClearLegacyHostParams<Runtime>,
 );
 
 /// Handles converting a weight scalar to a fee value, based on the scale and granularity of the

--- a/parachain/runtimes/gargantua/src/lib.rs
+++ b/parachain/runtimes/gargantua/src/lib.rs
@@ -1211,7 +1211,7 @@ impl_runtime_apis! {
 		}
 
 		fn execute_block(
-			block: Block,
+			block: <Block as sp_runtime::traits::Block>::LazyBlock,
 			state_root_check: bool,
 			signature_check: bool,
 			select: frame_try_runtime::TryStateSelect,

--- a/parachain/runtimes/nexus/src/lib.rs
+++ b/parachain/runtimes/nexus/src/lib.rs
@@ -1384,7 +1384,7 @@ impl_runtime_apis! {
 		}
 
 		fn execute_block(
-			block: Block,
+			block: <Block as sp_runtime::traits::Block>::LazyBlock,
 			state_root_check: bool,
 			signature_check: bool,
 			select: frame_try_runtime::TryStateSelect,

--- a/parachain/runtimes/nexus/src/lib.rs
+++ b/parachain/runtimes/nexus/src/lib.rs
@@ -172,6 +172,7 @@ pub type Executive = frame_executive::Executive<
 pub type Migrations = (
 	pallet_mmr_tree::migrations::ResetMmrTree<Runtime>,
 	ismp_optimism::migrations::SeedDisputeGameConfigs<Runtime>,
+	pallet_ismp_host_executive::migrations::ClearLegacyHostParams<Runtime>,
 );
 
 /// Handles converting a weight scalar to a fee value, based on the scale and granularity of the


### PR DESCRIPTION
## Summary
- Bumps `pallet-ismp` `CHILD_TRIE_PREFIX` from `b"ISMP"` → `b"ISMPv2"` so the new runtime writes/reads under a fresh child trie.
- Adds `pallet_ismp_host_executive::migrations::ClearLegacyHostParams<Runtime>` to the `Migrations` tuple in both `nexus` and `gargantua` runtimes. The `SubstrateHostParam` drop changed the SCALE encoding of `HostParams`; the migration clears the map and bumps storage version to v2. Governance repopulates post-upgrade.
- Renames `pallet-ismp-host-executive::withdraw_protocol_fees` → `withdraw` (call index 4 unchanged).
- Fixes the `--features try-runtime` build by updating both runtimes' `TryRuntime::execute_block` to take `<Block as sp_runtime::traits::Block>::LazyBlock` (matches the updated `frame-try-runtime` trait signature).

## try-runtime — on-runtime-upgrade (live state)

Run against `wss://nexus.rpc.polytope.technology` and `wss://gargantua.rpc.polytope.technology` with `--checks all`.

|                              | Nexus                | Gargantua            |
| ---------------------------- | -------------------- | -------------------- |
| `on_runtime_upgrade`         | succeeded            | succeeded            |
| Idempotent (2nd run)         | yes (same root)      | yes (same root)      |
| PoV size                     | 8.3 KiB              | 7.3 KiB              |
| Ref time                     | 0.71% of max (0.5s)  | 0.24% of max (2s)    |
| Weight safety check          | passed               | passed               |

The post-upgrade cumulus `unincluded segment` panic is a known try-runtime simulation quirk (empty-block production after the upgrade), unrelated to this PR.

## Pre-merge follow-up
- [ ] **Bump `gargantua` `spec_version`** — local is `6600`, on-chain is `6800`. Used `--disable-spec-version-check` for the dry-run; the actual upgrade will be rejected without a bump. Nexus is fine (`6900` > `6800`).
- [ ] Confirm whether the legacy `b"ISMP"` child trie should be drained in a follow-up migration.
- [ ] Governance batch to repopulate `HostParams` post-upgrade.

## Test plan
- [x] `cargo check -p nexus-runtime -p gargantua-runtime`
- [x] try-runtime `on-runtime-upgrade --checks all` against live nexus + gargantua
- [x] Verify EVM state proofs continue to verify post-upgrade against the new child trie root
