### PR TITLE
[runtime]: charge BandwidthGate by abi-encoded request/response size

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ ISMP types (PostRequest, GetRequest, GetResponse) are hashed using `keccak256(ab
 ### Where the encoding lives
 
 - **Solidity**: `sdk/packages/core/contracts/libraries/Message.sol` — `encode()` and `hash()` functions
-- **Rust**: `modules/ismp/core/src/abi.rs` — `encode_post_request()`, `encode_get_request()`, `encode_get_response()`
+- **Rust**: `modules/ismp/core/src/abi.rs` — `encode_post_request()`, `encode_get_request()`, `encode_get_response()`, `encode_request()` (enum dispatch)
 - **Rust types**: `evm/rust/` (`ismp-abi` crate) — generated sol types from compiled ABI JSON artifacts
 - **Conversions**: `modules/ismp/core/src/abi.rs` — `From<router::PostRequest> for EvmHost::PostRequest`, etc.
 

--- a/modules/ismp/core/src/abi.rs
+++ b/modules/ismp/core/src/abi.rs
@@ -45,6 +45,14 @@ pub fn encode_get_request(req: &router::GetRequest) -> Vec<u8> {
 	sol.abi_encode()
 }
 
+/// Encode a [`router::Request`] as `abi.encode(req)`, dispatching on the variant.
+pub fn encode_request(req: &router::Request) -> Vec<u8> {
+	match req {
+		router::Request::Post(post) => encode_post_request(post),
+		router::Request::Get(get) => encode_get_request(get),
+	}
+}
+
 /// Encode a [`router::GetResponse`] as `abi.encode(res)`.
 pub fn encode_get_response(res: &router::GetResponse) -> Vec<u8> {
 	let sol: GetResponse = res.clone().into();

--- a/modules/ismp/core/src/router.rs
+++ b/modules/ismp/core/src/router.rs
@@ -263,10 +263,7 @@ impl Request {
 	/// Returns the ABI-encoded request, matching Solidity's `abi.encode(...)` semantics.
 	/// This prevents hash malleability vulnerabilities that exist with packed encoding.
 	pub fn encode(&self) -> Vec<u8> {
-		match self {
-			Request::Post(post) => abi::encode_post_request(post),
-			Request::Get(get) => abi::encode_get_request(get),
-		}
+		abi::encode_request(self)
 	}
 }
 

--- a/modules/pallets/state-coprocessor/src/impls.rs
+++ b/modules/pallets/state-coprocessor/src/impls.rs
@@ -124,11 +124,11 @@ where
 		let state_root = host.state_machine_commitment(response.height)?;
 
 		// Insert GetResponses into mmr
-		let mut get_responses = vec![];
+		let mut responses = vec![];
 		// Total payload bytes across this batch, used to mint reputation to
-		// the relayer named in `address`. Each request contributes the same
-		// `max(payload, 32)` quantity that the bandwidth gate charges so the
-		// mint stays proportional to the work paid for.
+		// the relayer named in `address`. Each response contributes its
+		// abi-encoded size — the same quantity the bandwidth gate charges —
+		// so the mint stays proportional to the work paid for.
 		let mut total_bytes: u32 = 0;
 		for req in requests {
 			let values: Vec<StorageValue> = dest_state_machine
@@ -137,22 +137,21 @@ where
 				.map(|(key, value)| StorageValue { key, value })
 				.collect();
 
-			// Meter the app's bandwidth: query payload (keys + context)
-			// plus the storage values being returned. 32-byte floor
-			// mirrors the on_accept precedent. Charged once per request
-			// after proof verification so the value size is final.
-			let value_bytes: usize =
-				values.iter().map(|sv| sv.value.as_ref().map(|v| v.len()).unwrap_or(0)).sum();
-			let payload_bytes: usize =
-				req.keys.iter().map(|k| k.len()).sum::<usize>() + req.context.len() + value_bytes;
-			let bytes = core::cmp::max(payload_bytes, 32) as u32;
-			<T as Config>::BandwidthGate::try_consume(&req.source, &req.from, bytes)
-				.map_err(|err| Error::Custom(alloc::format!("bandwidth gate: {err}")))?;
+			let response = GetResponse { get: req, values };
+
+			// Meter the app's bandwidth using the full size of the
+			// abi-encoded GetResponse. Charged after proof verification
+			// so the value sizes are final.
+			let bytes = ismp::abi::encode_get_response(&response).len() as u32;
+			<T as Config>::BandwidthGate::try_consume(
+				&response.get.source,
+				&response.get.from,
+				bytes,
+			)
+			.map_err(|err| Error::Custom(alloc::format!("bandwidth gate: {err}")))?;
 			total_bytes = total_bytes.saturating_add(bytes);
 
-			let get_response = GetResponse { get: req, values };
-
-			get_responses.push(get_response);
+			responses.push(response);
 		}
 
 		// Mint reputation tokens to the named relayer. The address is the
@@ -186,7 +185,7 @@ where
 			}
 		}
 
-		for get_response in get_responses {
+		for get_response in responses {
 			host.store_response_receipt(&get_response, &address)?;
 			Self::dispatch_get_response(get_response, address.clone())
 				.map_err(|_| Error::Custom("Failed to dispatch get response".to_string()))?;

--- a/parachain/runtimes/gargantua/src/ismp.rs
+++ b/parachain/runtimes/gargantua/src/ismp.rs
@@ -343,7 +343,7 @@ impl IsmpModule for ProxyModule {
 		// no-op and this block is compiled out entirely.
 		#[cfg(not(feature = "no-bandwidth"))]
 		if !pallet_bandwidth::Pallet::<Runtime>::is_purchase_message(&request) {
-			let bytes = core::cmp::max(request.body.len(), 32) as u32;
+			let bytes = ismp::abi::encode_post_request(&request).len() as u32;
 			<pallet_bandwidth::Pallet<Runtime> as pallet_bandwidth::BandwidthGate>::try_consume(
 				&request.source,
 				&request.from,

--- a/parachain/runtimes/nexus/src/ismp.rs
+++ b/parachain/runtimes/nexus/src/ismp.rs
@@ -315,7 +315,7 @@ impl IsmpModule for ProxyModule {
 		// Bandwidth gate. Always-enforce; skipped for purchase messages so the
 		// recharge flow itself doesn't need bandwidth.
 		if !pallet_bandwidth::Pallet::<Runtime>::is_purchase_message(&request) {
-			let bytes = core::cmp::max(request.body.len(), 32) as u32;
+			let bytes = ismp::abi::encode_post_request(&request).len() as u32;
 			<pallet_bandwidth::Pallet<Runtime> as pallet_bandwidth::BandwidthGate>::try_consume(
 				&request.source,
 				&request.from,


### PR DESCRIPTION
## Summary

- `BandwidthGate::try_consume` now charges the full abi-encoded size of the request being processed at all gate call sites, replacing ad-hoc `max(payload, 32)` heuristics.
- On_accept paths (`gargantua`, `nexus`): use `encode_post_request(&request).len()`.
- `pallet-state-coprocessor`: build the `GetResponse` first, then charge `encode_get_response(&response).len()` — this is the unit that actually carries values returned to the app.
- Added `ismp::abi::encode_request(&Request)` enum-dispatch helper; `Request::encode()` now delegates to it.

## Test plan

- [x] `cargo check -p pallet-state-coprocessor -p gargantua-runtime -p nexus-runtime` (passes locally)
- [x] Existing bandwidth pallet test suite passes
- [x] Cross-language abi-encoding parity tests still pass (no change to encoders)