### PR TITLE
[docs]: sync ISMP protocol spec with current code

### DIFF
--- a/docs/content/protocol/ismp/consensus.mdx
+++ b/docs/content/protocol/ismp/consensus.mdx
@@ -56,12 +56,15 @@ pub struct StateCommitment {
 }
 
 /// Identifies a state commitment at a given height
-pub struct IntermediateState {
-    /// The state machine identifier
+pub struct StateCommitmentHeight {
+    /// The state commitment
     pub commitment: StateCommitment,
     /// the corresponding block height
     pub height: u64,
 }
+
+/// A map of state machine identifier to verified state commitments
+pub type VerifiedCommitments = BTreeMap<StateMachineId, Vec<StateCommitmentHeight>>;
 
 /// We define the consensus client as a module that handles logic for consensus proof verification.
 pub trait ConsensusClient {
@@ -72,7 +75,7 @@ pub trait ConsensusClient {
         consensus_state_id: ConsensusStateId,
         trusted_consensus_state: Vec<u8>,
         proof: Vec<u8>,
-    ) -> Result<(Vec<u8>, BTreeMap<StateMachine, Vec<IntermediateState>>), Error>;
+    ) -> Result<(Vec<u8>, VerifiedCommitments), Error>;
 
     /// Given two distinct consensus proofs, verify that they're both valid and represent
     /// conflicting views of the network. returns Ok if they're both valid.
@@ -83,6 +86,9 @@ pub trait ConsensusClient {
         proof_1: Vec<u8>,
         proof_2: Vec<u8>,
     ) -> Result<(), Error>;
+
+    /// The consensus client Id provided by this client.
+    fn consensus_client_id(&self) -> ConsensusClientId;
 
     /// Return an implementation of a [`StateMachineClient`] for the given state machine.
     /// Return an error if the identifier is unknown.
@@ -117,10 +123,10 @@ pub struct CreateConsensusState {
     pub consensus_state_id: ConsensusStateId,
     /// Unbonding period for this consensus state.
     pub unbonding_period: u64,
-    /// Challenge period for this consensus state
-    pub challenge_period: u64,
+    /// Challenge period for the supported state machines
+    pub challenge_periods: BTreeMap<StateMachine, u64>,
     /// State machine commitments
-    pub state_machine_commitments: Vec<(StateMachineId, IntermediateState)>,
+    pub state_machine_commitments: Vec<(StateMachineId, StateCommitmentHeight)>,
 }
 
 /// Should handle the creation of consensus clients
@@ -145,6 +151,8 @@ pub struct ConsensusMessage {
     pub consensus_proof: Vec<u8>,
     /// The consensus state Id
     pub consensus_state_id: ConsensusStateId,
+    /// Public key of the sender
+    pub signer: Vec<u8>,
 }
 
 /// This function handles verification of consensus messages for consensus clients
@@ -173,6 +181,8 @@ pub struct FraudProofMessage {
     pub proof_2: Vec<u8>,
     /// The offending consensus state Id
     pub consensus_state_id: ConsensusStateId,
+    /// Public key of the sender
+    pub signer: Vec<u8>,
 }
 
 /// Freeze a consensus client by providing a valid consensus fault proof.
@@ -204,14 +214,20 @@ struct StateMachineUpdated {
 
 A `StateMachineUpdated` event is emitted to notify network participants (both relayers and fishermen) of some newly available `StateCommitment`s for a given state machine. Relayers will wait for the configured `challenge_period` before attempting to transmit new requests & responses. While fishermen will check if these pending `StateCommitment`s describe valid states on the counterparty network. If the `challenge_period` elapses without any fraud proofs being presented, we can safely conclude that the provided `StateCommitment`s are indeed canonical.
 
-### `ConsensusClientFrozen`
+### `StateCommitmentVetoed`
 
 ```rust showLineNumbers
-/// Indicates that a consensus client has been frozen
-struct ConsensusClientFrozen {
-    /// The offending client id
-    consensus_client_id: ConsensusClientId,
+/// Emitted when a `StateCommitment` has been successfully vetoed by a fisherman
+pub struct StateCommitmentVetoed {
+    /// The state commitment identifier
+    pub height: StateMachineHeight,
+    /// The account responsible
+    pub fisherman: Vec<u8>,
 }
 ```
 
-A `ConsensusClientFrozen` event is emitted after a consensus fault is successfully verified and the offending client frozen. This should instruct relayers to shut down any tasks for relaying requests from the byzantine network to the host network.
+A `StateCommitmentVetoed` event is emitted after a fisherman successfully vetoes a `StateCommitment` that is still within its challenge period. This instructs relayers to discard any pending requests/responses whose proofs rely on the vetoed commitment.
+
+### Frozen consensus clients
+
+A consensus client may also be frozen entirely after a successful `freeze_client` call with a valid fraud proof. The result is surfaced through the handler's `MessageResult::FrozenClient(consensus_state_id)` rather than a dedicated event, signalling that all relaying tasks for that client should be shut down.

--- a/docs/content/protocol/ismp/dispatcher.mdx
+++ b/docs/content/protocol/ismp/dispatcher.mdx
@@ -12,28 +12,30 @@ The dispatcher is the public interface which `IsmpModule`s use to _dispatch_ req
 pub struct DispatchPost {
     /// The destination state machine of this request.
     pub dest: StateMachine,
-    /// Module Id of the sending module
+    /// Module identifier of the sending module
     pub from: Vec<u8>,
-    /// Module ID of the receiving module
+    /// Module identifier of the receiving module
     pub to: Vec<u8>,
-    /// Timestamp which this request expires in seconds.
-    pub timeout_timestamp: u64,
-    /// Encoded Request.
-    pub data: Vec<u8>,
+    /// Relative from the current timestamp at which this request expires in seconds.
+    pub timeout: u64,
+    /// Encoded request body
+    pub body: Vec<u8>,
 }
 
 /// Simplified GET request, intended to be used for sending outgoing requests
 pub struct DispatchGet {
     /// The destination state machine of this request.
     pub dest: StateMachine,
-    /// Module Id of the sending module
+    /// Module identifier of the sending module
     pub from: Vec<u8>,
     /// Raw Storage keys that would be used to fetch the values from the counterparty
     pub keys: Vec<Vec<u8>>,
     /// Height at which to read the state machine.
     pub height: u64,
-    /// Host timestamp at which this request expires in seconds
-    pub timeout_timestamp: u64,
+    /// Some application-specific metadata relating to this request
+    pub context: Vec<u8>,
+    /// Relative from the current timestamp at which this request expires in seconds.
+    pub timeout: u64,
 }
 
 /// Simplified request, intended to be used for sending outgoing requests
@@ -44,21 +46,61 @@ pub enum DispatchRequest {
     Get(DispatchGet),
 }
 
-pub trait IsmpDispatcher {
-    /// This function should accept requests from modules and commit them to the state
-    /// It should emit the `Request` event after a successful dispatch
-    fn dispatch_request(&self, request: DispatchRequest) -> Result<(), Error>;
+/// Fee metadata for a dispatched request. Contains the account who paid for the request and
+/// how much was paid.
+pub struct FeeMetadata<A, B> {
+    /// The account which paid for this request
+    pub payer: A,
+    /// The fee that was paid for relayers.
+    pub fee: B,
+}
+
+/// The Ismp dispatcher provides an `IsmpModule` with the required interface for dispatching
+/// outgoing requests.
+///
+/// An `Event` should be emitted after successful dispatch.
+pub trait IsmpDispatcher: Default {
+    /// Sending account type
+    type Account;
+
+    /// The balance type
+    type Balance;
+
+    /// Dispatches an outgoing request, the dispatcher may commit the request to host's state
+    /// trie or an overlay tree. Returns the request commitment.
+    fn dispatch_request(
+        &self,
+        request: DispatchRequest,
+        fee: FeeMetadata<Self::Account, Self::Balance>,
+    ) -> Result<H256, anyhow::Error>;
 }
 ```
 
+The `timeout` field on `DispatchPost`/`DispatchGet` is a relative offset (in seconds) from the current host timestamp, not an absolute unix timestamp. The dispatcher resolves it to an absolute `timeout_timestamp` when constructing the underlying `PostRequest`/`GetRequest`.
+
 ## Events
 
-Events should be emitted when requests are dispatched. This notifies relayers of the new requests to be transmitted.
-The structure of ISMP dispatcher events is described below
+Events should be emitted when requests are dispatched. This notifies relayers of the new requests to be transmitted. The dispatcher emits one of the request-flavoured variants of the ISMP `Event` enum:
 
 ```rust showLineNumbers
 pub enum Event {
-    /// Emitted for an outgoing request
-    Request(Request),
+    /// Emitted when a state machine is successfully updated
+    StateMachineUpdated(StateMachineUpdated),
+    /// A `StateCommitment` has been vetoed by a fisherman
+    StateCommitmentVetoed(StateCommitmentVetoed),
+    /// Emitted when a post request is dispatched
+    PostRequest(PostRequest),
+    /// Emitted when a get response is dispatched
+    GetResponse(GetResponse),
+    /// Emitted when a get request is dispatched
+    GetRequest(GetRequest),
+    /// Emitted when a post request is handled
+    PostRequestHandled(RequestResponseHandled),
+    /// Emitted when a post request timeout is handled
+    PostRequestTimeoutHandled(TimeoutHandled),
+    /// Emitted when a get request is handled
+    GetRequestHandled(RequestResponseHandled),
+    /// Emitted when a get request timeout is handled
+    GetRequestTimeoutHandled(TimeoutHandled),
 }
 ```

--- a/docs/content/protocol/ismp/host.mdx
+++ b/docs/content/protocol/ismp/host.mdx
@@ -13,7 +13,7 @@ Notably, the handlers are agnostic to the underlying storage mechanism and allow
 ```rust showLineNumbers
 /// Defines the necessary interfaces that must be satisfied by a state machine for it be ISMP
 /// compatible.
-pub trait IsmpHost {
+pub trait IsmpHost: Keccak256 {
     /// Should return the state machine type for the host.
     fn host_state_machine(&self) -> StateMachine;
 
@@ -47,18 +47,15 @@ pub trait IsmpHost {
     /// Should return the encoded consensus state for a consensus state id provided
     fn consensus_state(&self, consensus_state_id: ConsensusStateId) -> Result<Vec<u8>, Error>;
 
-    /// Should return the current timestamp on the host state machine
+    /// Should return the current timestamp on the host
     fn timestamp(&self) -> Duration;
 
-    /// Checks if a consensus state is frozen
+    /// Checks if a consensus state is frozen, returns Ok(()) if it isn't.
     fn is_consensus_client_frozen(&self, consensus_state_id: ConsensusStateId)
         -> Result<(), Error>;
 
     /// Should return an error if request commitment does not exist in storage
     fn request_commitment(&self, req: H256) -> Result<(), Error>;
-
-    /// Should return an error if request commitment does not exist in storage
-    fn response_commitment(&self, req: H256) -> Result<(), Error>;
 
     /// Increment and return the next available nonce for an outgoing request.
     fn next_nonce(&self) -> u64;
@@ -68,7 +65,7 @@ pub trait IsmpHost {
 
     /// Should return Some(()) if a response has been received for the given request
     /// Implementors should store both the request and response objects
-    fn response_receipt(&self, res: &Response) -> Option<()>;
+    fn response_receipt(&self, res: &GetResponse) -> Option<()>;
 
     /// Store a map of consensus_state_id to the consensus_client_id
     /// Should return an error if the consensus_state_id already exists
@@ -113,6 +110,9 @@ pub trait IsmpHost {
         state: StateCommitment,
     ) -> Result<(), Error>;
 
+    /// Deletes a state commitment, ideally because it was invalid.
+    fn delete_state_commitment(&self, height: StateMachineHeight) -> Result<(), Error>;
+
     /// Freeze a consensus state with the given identifier
     fn freeze_consensus_client(&self, consensus_state_id: ConsensusStateId) -> Result<(), Error>;
 
@@ -121,24 +121,41 @@ pub trait IsmpHost {
 
     /// Delete a request commitment from storage, used when a request is timed out.
     /// Make sure to refund the user their relayer fee here.
-    fn delete_request_commitment(&self, req: &Request) -> Result<(), Error>;
+    /// Returns the scale encoded commitment metadata
+    fn delete_request_commitment(&self, req: &Request) -> Result<Vec<u8>, Error>;
+
+    /// Delete a request receipt from storage, used when a request is timed out.
+    /// Should only ever be called by a routing state machine. Returns the signer.
+    fn delete_request_receipt(&self, req: &Request) -> Result<Vec<u8>, Error>;
+
+    /// Delete a response receipt from storage, used when a response is timed out.
+    /// Should only ever be called by a routing state machine. Returns the signer.
+    fn delete_response_receipt(&self, res: &GetResponse) -> Result<Vec<u8>, Error>;
 
     /// Stores a receipt for an incoming request after it is successfully routed to a module.
-    /// Prevents duplicate incoming requests from being processed. Includes the relayer account
-    fn store_request_receipt(&self, req: &Request, signer: &Vec<u8>) -> Result<(), Error>;
+    /// Prevents duplicate incoming requests from being processed. Includes the relayer account.
+    fn store_request_receipt(&self, req: &Request, signer: &Vec<u8>) -> Result<Vec<u8>, Error>;
 
-    /// Stores a receipt that shows that the given request has received a response.
-    /// Includes the relayer account
+    /// Stores a receipt that shows that the given request has received a response. Includes the
+    /// relayer account.
     /// Implementors should map the request commitment to the response object commitment.
-    fn store_response_receipt(&self, req: &Response, signer: &Vec<u8>) -> Result<(), Error>;
+    fn store_response_receipt(&self, req: &GetResponse, signer: &Vec<u8>)
+        -> Result<Vec<u8>, Error>;
 
-    /// Should return a handle to the consensus client based on the id
+    /// Stores a commitment for an outgoing request alongside some scale encoded metadata
+    fn store_request_commitment(&self, req: &Request, meta: Vec<u8>) -> Result<(), Error>;
+
+    /// Should return a handle to the consensus client based on the id (default impl looks the
+    /// client up in `consensus_clients`).
     fn consensus_client(&self, id: ConsensusClientId) -> Result<Box<dyn ConsensusClient>, Error>;
 
-    /// Should return the configured delay period for a state machine
+    /// Should return the list of all configured consensus clients
+    fn consensus_clients(&self) -> Vec<Box<dyn ConsensusClient>>;
+
+    /// Should return the configured delay period for a consensus state
     fn challenge_period(&self, state_machine: StateMachineId) -> Option<Duration>;
 
-    /// Set the challenge period in seconds for a state machine.
+    /// Set the challenge period in seconds for a consensus state.
     fn store_challenge_period(
         &self,
         state_machine: StateMachineId,
@@ -180,5 +197,8 @@ pub trait IsmpHost {
             .map(|proxy| proxy == self.host_state_machine())
             .unwrap_or(false)
     }
+
+    /// Should return the previous height of the state machine
+    fn previous_commitment_height(&self, id: StateMachineId) -> Option<u64>;
 }
 ```

--- a/docs/content/protocol/ismp/requests.mdx
+++ b/docs/content/protocol/ismp/requests.mdx
@@ -23,7 +23,7 @@ ISMP requests can be either POST or GET, similar to HTTP. A POST request indicat
 
 ```rust showLineNumbers
 /// The ISMP POST request.
-pub struct Post {
+pub struct PostRequest {
     /// The source state machine of this request.
     pub source: StateMachine,
     /// The destination state machine of this request.
@@ -36,85 +36,62 @@ pub struct Post {
     pub to: Vec<u8>,
     /// Unix timestamp by which this request expires in seconds.
     pub timeout_timestamp: u64,
-    /// Encoded Request.
-    pub data: Vec<u8>,
+    /// Encoded request body
+    pub body: Vec<u8>,
 }
 
 /// The ISMP GET request.
-pub struct Get {
+pub struct GetRequest {
     /// The source state machine of this request.
     pub source: StateMachine,
     /// The destination state machine of this request.
     pub dest: StateMachine,
     /// The nonce of this request on the source chain
     pub nonce: u64,
-    /// Module Id of the sending module
+    /// Module identifier of the sending module
     pub from: Vec<u8>,
-    /// Raw Storage keys that would be used to fetch the values from the counterparty
-    /// For deriving storage keys for ink contract fields follow the guide in the link below
-    /// https://use.ink/datastructures/storage-in-metadata#a-full-example
-    /// The algorithms for calculating raw storage keys for different substrate pallet storage
-    /// types are described in the following links
-    /// https://github.com/paritytech/substrate/blob/master/frame/support/src/storage/types/map.rs#L34-L42
-    /// https://github.com/paritytech/substrate/blob/master/frame/support/src/storage/types/double_map.rs#L34-L44
-    /// https://github.com/paritytech/substrate/blob/master/frame/support/src/storage/types/nmap.rs#L39-L48
-    /// https://github.com/paritytech/substrate/blob/master/frame/support/src/storage/types/value.rs#L37
-    /// For fetching keys from EVM contracts each key should be 52 bytes
-    /// This should be a concatenation of contract address and slot hash
+    /// Raw Storage keys that would be used to fetch the values from the counterparty.
+    /// Substrate keys: see the storage-types guides in `paritytech/substrate`.
+    /// EVM keys: 52 bytes (contract address ++ slot hash) or 20 bytes (contract/account address).
     pub keys: Vec<Vec<u8>>,
     /// Height at which to read the state machine.
     pub height: u64,
-    /// Unix timestamp by which this request expires in seconds.
+    /// Some application-specific metadata relating to this request
+    pub context: Vec<u8>,
+    /// Host timestamp at which this request expires in seconds
     pub timeout_timestamp: u64,
+}
 
-}/// The ISMP request.
+/// The ISMP request.
 pub enum Request {
     /// A post request allows a module on a state machine to send arbitrary bytes to another module
     /// living in another state machine.
-    Post(Post),
+    Post(PostRequest),
     /// A get request allows a module on a state machine to read the storage of another module
     /// living in another state machine.
-    Get(Get),
+    Get(GetRequest),
 }
-
 ```
 
 ## Handlers
 
 The ISMP framework exposes a handler that allows relayers submit new requests, alongside the necessary state proofs required for verification so that they may be executed by `IsmpModules`s
 
-### `handle_post_request`
+### `handle`
 
 ```rust showLineNumbers
-/// The ISMP POST request.
-pub struct Post {
-    /// The source state machine of this request.
-    pub source: StateMachine,
-    /// The destination state machine of this request.
-    pub dest: StateMachine,
-    /// The nonce of this request on the source chain
-    pub nonce: u64,
-    /// Module Id of the sending module
-    pub from: Vec<u8>,
-    /// Module ID of the receiving module
-    pub to: Vec<u8>,
-    /// Unix timestamp which this request expires in seconds.
-    pub timeout_timestamp: u64,
-    /// Serialized request body.
-    pub data: Vec<u8>,
-
-}
-
 /// A request message holds a batch of incoming requests and their proofs.
 pub struct RequestMessage {
     /// POST requests from a source chain
-    pub requests: Vec<Post>,
+    pub requests: Vec<PostRequest>,
     /// Membership batch proof for these requests
     pub proof: Proof,
+    /// Signer information. Ideally should be their account identifier.
+    pub signer: Vec<u8>,
 }
 
 /// Handles incoming POST requests and dispatches them to the appropriate modules
-pub fn handle_post_requests<H>(host: &H, msg: RequestMessage) -> Result<(), Error>
+pub fn handle<H>(host: &H, msg: RequestMessage) -> Result<MessageResult, anyhow::Error>
 where
     H: IsmpHost,
 {
@@ -122,7 +99,7 @@ where
 }
 ```
 
-The `handle_post_requests` is used to notify onchain `IsmpModule`s of new requests to be processed. A relayer will construct the `RequestMessage` which holds a batch of new `Post` requests, as well as a _multi-proof_<sup>[1]</sup> of their existence on the source chain. The handler will perform the following operations
+The request `handle` is used to notify onchain `IsmpModule`s of new requests to be processed. A relayer will construct the `RequestMessage` which holds a batch of new `PostRequest`s, as well as a _multi-proof_<sup>[1]</sup> of their existence on the source chain. The handler will perform the following operations
 
 - Assert that the state machine's consensus client is not frozen
 - Assert that the configured `challenge_period` for the `StateCommitment` has elapsed

--- a/docs/content/protocol/ismp/responses.mdx
+++ b/docs/content/protocol/ismp/responses.mdx
@@ -5,45 +5,55 @@ description: The ISMP Response specification
 
 # Responses
 
-Responses in the ISMP framework are represented as `GetResponse`.
+In the current ISMP protocol, the only first-class response type is `GetResponse` — the verified storage values returned in reply to a `GetRequest`. POST requests do not produce protocol-level responses: applications that need a reply to a POST simply dispatch a follow-up POST in the opposite direction.
 
 ```rust showLineNumbers
 /// The response to a GET request
 pub struct GetResponse {
     /// The Get request that triggered this response.
-    pub get: Get,
-    /// Key-Values derived from the state proof
-    pub values: BTreeMap<Vec<u8>, Option<Vec<u8>>>,
+    pub get: GetRequest,
+    /// Values derived from the state proof
+    pub values: Vec<StorageValue>,
 }
 
-/// The ISMP response
-pub enum Response {
-    /// The response to a GET request
-    Get(GetResponse),
+/// The verified key-values for a GetResponse
+pub struct StorageValue {
+    /// The request storage key
+    pub key: Vec<u8>,
+    /// The verified value (None for non-membership)
+    pub value: Option<Vec<u8>>,
 }
 ```
 
 ## `GetResponse`
 
-A `GetResponse` provides the requested storage values of a `GetRequest`, it contains a map of the requested key-value pairs. These values may be null, in which case they are represented as `Option::None`. The key-value pairs are derived from the state proof verification of the values at the given `height`. This verification is performed using the `StateMachineClient` of the destination `StateMachine`.
+A `GetResponse` carries the requested storage values of a `GetRequest` as an ordered `Vec<StorageValue>`, one entry per key in the original request. A value of `Option::None` indicates that the key was absent from the verified state (a non-membership proof). The host produces the `GetResponse` itself by running the state machine client's `verify_state_proof` over the keys in `GetRequest`; relayers do not construct it.
 
 ## Handlers
 
-The ISMP framework exposes a handler that allows relayers submit new responses, alongside the necessary state proofs required for verification so that they may be executed by `IsmpModules`s
+The ISMP framework exposes a handler that allows relayers to submit a batch of `GetRequest`s together with the state proof needed to derive their responses.
 
-### `handle_response`
+### `handle`
 
 ```rust showLineNumbers
-/// A request message holds a batch of responses to be dispatched from a source state machine
+/// A response message holds a batch of GetRequests being responded to.
+///
+/// The protocol no longer carries `PostResponse`; the only responses processed by
+/// `handle` are `GetResponse`s constructed on-chain from the state proof. The
+/// relayer's job is to ferry the original `GetRequest`s plus the storage proof; the
+/// host produces the `GetResponse` itself.
 pub struct ResponseMessage {
-    /// A set of either POST requests or responses to be handled
-    pub datagram: RequestResponse,
-    /// Membership batch proof for these req/res
+    /// The batch of GetRequests being responded to.
+    pub requests: Vec<GetRequest>,
+    /// Membership batch proof for `requests`.
     pub proof: Proof,
+    /// Signer information. Ideally should be their account identifier.
+    pub signer: Vec<u8>,
 }
 
-/// Validate the state machine, verify the response message and dispatch the message to the router
-pub fn handle_response<H>(host: &H, msg: ResponseMessage) -> Result<(), Error>
+/// Validate the state machine, verify the response message and dispatch the message to the
+/// router.
+pub fn handle<H>(host: &H, msg: ResponseMessage) -> Result<MessageResult, anyhow::Error>
 where
     H: IsmpHost,
 {
@@ -51,14 +61,14 @@ where
 }
 ```
 
-The `handle_response` is used to notify onchain `IsmpModule`s of new responses to be processed. A relayer will construct the `ResponseMessage` which holds a batch of new responses, and their relevant proofs. The handler will perform the following operations
+The response `handle` is used to notify onchain `IsmpModule`s of new `GetResponse`s to be processed. A relayer constructs the `ResponseMessage` from the original `GetRequest`s and a state proof at `GetRequest::height` on the destination chain. The handler will perform the following operations:
 
-- Assert that the state machine's consensus client is not frozen
-- Assert that the configured `challenge_period` for the `StateCommitment` has elapsed
-- Assert that the responses have not been previously processed
-- Assert that the responses have not timed out
-- Assert that the proofs for the responses verify
-- Finally dispatch the responses to the relevant `IsmpModule::on_response` and store a receipt for each responses to prevent responses from being replayed.
+- Assert that the state machine's consensus client is not frozen.
+- Assert that the configured `challenge_period` for the `StateCommitment` has elapsed.
+- Assert that the responses have not been previously processed.
+- Assert that the `GetRequest`s have not timed out (`get.timeout_timestamp > host.timestamp()`).
+- Run `verify_state_proof` against `GetRequest::keys` at `GetRequest::height` to obtain the verified `Vec<StorageValue>` and construct each `GetResponse` on-chain.
+- Finally dispatch the responses to the relevant `IsmpModule::on_response` and store a receipt for each response to prevent responses from being replayed.
 
 <Callout title={'Danger'} type={"warn"}>
 It's important to note that if the `IsmpModule::on_response` does not return `Ok`, the receipt of this response will not be persisted, allowing the response to be **replayed**. Consequently, the `IsmpModule` is responsible for maintaining all invariants before modifying it's internal state to prevent partial state changes that could result in critical vulnerabilities in their response handler. This model ensures that if a response cannot be executed successfully on a destination state machine, it can time out gracefully on the source.

--- a/docs/content/protocol/ismp/router.mdx
+++ b/docs/content/protocol/ismp/router.mdx
@@ -11,7 +11,7 @@ The router lives in-between the ISMP message handlers and modules, the router pr
 pub trait IsmpRouter {
     /// Should decode the module id and return a handler to the appropriate `IsmpModule`
     /// implementation
-    fn module_for_id(&self, bytes: Vec<u8>) -> Result<Box<dyn IsmpModule>, Error>;
+    fn module_for_id(&self, bytes: Vec<u8>) -> Result<Box<dyn IsmpModule>, anyhow::Error>;
 }
 ```
 
@@ -23,16 +23,24 @@ Users cannot directly initiate requests or receive responses. Instead, they must
 /// Individual modules which live on a state machine must conform to this interface in order to send
 /// and receive ISMP requests and responses
 pub trait IsmpModule {
-    /// Called by the message handler on a module, to notify module of a new POST request
-    /// the module may choose to respond immediately, or in a later block
-    fn on_accept(&self, request: Post) -> Result<(), Error>;
+    /// Called by the message handler on a module, to notify module of a new POST request.
+    /// The module may choose to respond immediately, or in a later block.
+    fn on_accept(&self, _request: PostRequest) -> Result<Weight, anyhow::Error> {
+        Err(Error::CannotHandleMessage)?
+    }
 
     /// Called by the message handler on a module, to notify module of a response to a previously
-    /// sent out request
-    fn on_response(&self, response: Response) -> Result<(), Error>;
+    /// sent out GET request.
+    fn on_response(&self, _response: GetResponse) -> Result<Weight, anyhow::Error> {
+        Err(Error::CannotHandleMessage)?
+    }
 
-    /// Called by the message handler on a module, to notify module of requests that were previously
-    /// sent but have now timed-out
-    fn on_timeout(&self, request: Timeout) -> Result<(), Error>;
+    /// Called by the message handler on a module, to notify module of requests that were
+    /// previously sent but have now timed-out.
+    fn on_timeout(&self, _request: Request) -> Result<Weight, anyhow::Error> {
+        Err(Error::CannotHandleMessage)?
+    }
 }
 ```
+
+Every method has a default implementation that returns `Error::CannotHandleMessage`, so modules only need to implement the handlers they actually use. The returned `Weight` is the weight consumed by the module's handler, which the framework uses to bill the message.

--- a/docs/content/protocol/ismp/state-machine.mdx
+++ b/docs/content/protocol/ismp/state-machine.mdx
@@ -10,40 +10,50 @@ Now that we have a way to verify the consensus proofs of a blockchain in a fully
 The state machine client is an abstraction over the state proof scheme of a given state machine. By decoupling the `ConsensusClient` from the `StateMachineClient` which are typically combined to form a _light client_, the ISMP framework allows a consensus client to support multiple state machines, each potentially using different state proof schemes. This abstraction makes ISMP future-proof, enabling deployment on both monolithic and modular blockchain architectures, including Polkadot, Ethereum, and others.
 
 ```rust showLineNumbers
-/// Convenience enum
-pub enum RequestResponse {
-    /// A batch of requests
-    Request(Vec<Request>),
-    /// A batch of responses
-    Response(Vec<Response>),
-}
-
 /// Proof holds the relevant proof data for the context in which it's used.
 pub struct Proof {
-    /// The state machine identifier
-    pub id: StateMachineId,
-    /// the corresponding block height
-    pub height: u64,
-    /// Serialized proof
+    /// State machine height
+    pub height: StateMachineHeight,
+    /// Scale encoded proof
     pub proof: Vec<u8>,
 }
 
 /// A state machine client. An abstraction for the mechanism of state proof verification for state
-/// machines
+/// machines.
+///
+/// All trie-key derivation methods take `Vec<H256>` request commitment hashes rather than the
+/// full request/response objects. Callers compute the commitment via `hash_request` at the
+/// boundary so the trait stays agnostic to ISMP message types and just maps commitment hashes
+/// onto the per-chain storage layout.
 pub trait StateMachineClient {
-    /// Verify the overlay membership proof of a batch of requests/responses.
+    /// Verify the overlay membership proof of a batch of request commitments against `root`.
     fn verify_membership(
         &self,
         host: &dyn IsmpHost,
-        item: RequestResponse,
+        commitments: Vec<H256>,
         root: StateCommitment,
         proof: &Proof,
     ) -> Result<(), Error>;
 
-    /// Transform the requests/responses into their equivalent key in the state trie.
-    fn state_trie_key(&self, request: RequestResponse) -> Vec<Vec<u8>>;
+    /// Storage trie key for a request commitment (source-chain `RequestCommitments` slot).
+    fn commitment_state_trie_key(&self, commitments: Vec<H256>) -> Vec<Vec<u8>>;
 
-    /// Verify the state of proof of some arbitrary data. Should return the verified data
+    /// Storage trie key for a request delivery receipt (destination-chain `RequestReceipts` slot).
+    /// Used by the timeout handler to prove non-delivery.
+    fn receipts_state_trie_key(&self, commitments: Vec<H256>) -> Vec<Vec<u8>>;
+
+    /// Verify that none of the given request commitments appear as receipts in the chain's
+    /// ISMP-scoped storage at the given state commitment. Implementations must bind the proof
+    /// to the ISMP-scoped storage root for that chain.
+    fn verify_non_membership(
+        &self,
+        host: &dyn IsmpHost,
+        commitments: Vec<H256>,
+        root: StateCommitment,
+        proof: &Proof,
+    ) -> Result<(), Error>;
+
+    /// Verify the state of proof of some arbitrary data. Should return the verified data.
     fn verify_state_proof(
         &self,
         host: &dyn IsmpHost,
@@ -54,14 +64,20 @@ pub trait StateMachineClient {
 }
 ```
 
+The `StateMachineClient` operates on **request commitment hashes** (`H256`), not full request/response objects. Callers compute the commitment with `hash_request` at the boundary, keeping the trait agnostic to ISMP message types — it just maps commitment hashes onto each chain's storage layout.
+
 ## `verify_membership`
 
-Since the ISMP framework permits the the `IsmpHost` to persist the outgoing requests and responses in an _overlay tree_. The `StateMachineClient` must provide the verification algorithm for this overlay tree through the `verify_membership` method. If the host is unable to leverage an overlay trie, then this method will simply verify the state proofs of requests and responses.
+Since the ISMP framework permits the `IsmpHost` to persist outgoing request commitments in an _overlay tree_, the `StateMachineClient` must provide the verification algorithm for this overlay tree through the `verify_membership` method. If the host is unable to leverage an overlay trie, then this method will simply verify the state proofs of the request commitments against the global state root.
 
-## `state_trie_key`
+## `commitment_state_trie_key` & `receipts_state_trie_key`
 
-The ISMP framework does not enforce where requests & responses should be persisted in the state trie and allows state machines to store them wherever they like provided that they can describe a path to the request/response committed in storage given the full request/response.
+The ISMP framework does not enforce where request commitments and receipts must be persisted in the state trie; it only requires that the state machine client can describe the storage path for them given a commitment hash. `commitment_state_trie_key` returns the source-chain storage key for the `RequestCommitments` slot, while `receipts_state_trie_key` returns the destination-chain `RequestReceipts` slot — the latter is used by the timeout handler to construct non-membership proofs of non-delivery.
+
+## `verify_non_membership`
+
+Given a `StateCommitment`, a batch of commitment hashes and a non-membership proof, this method verifies that none of those commitments appear as receipts in the chain's ISMP-scoped storage. Implementations must bind the proof to the ISMP-scoped storage root for the chain. This is the primary mechanism by which the timeout handler establishes that a request was never delivered to its destination.
 
 ## `verify_state_proof`
 
-Given a `StateCommitment`, an arbitrary set of keys and a state proof, this method should perform state proof verification and return the verified values for provided storage keys. These keys may point to an empty leaf and as such should be represented with `Option::None`. This signals a non-membership proof for the provided keys which is used in request timeouts. State proof verification is also used in handling `Response::Get` in order to verify the storage values requested in the `Request::Get`
+Given a `StateCommitment`, an arbitrary set of keys and a state proof, this method performs state proof verification and returns the verified values for provided storage keys. These keys may point to an empty leaf and are represented with `Option::None`. State proof verification is also used in handling `Request::Get` in order to construct the `GetResponse` from the verified storage values.

--- a/docs/content/protocol/ismp/timeouts.mdx
+++ b/docs/content/protocol/ismp/timeouts.mdx
@@ -23,7 +23,7 @@ pub enum TimeoutMessage {
     /// A non membership proof for POST requests
     Post {
         /// Timed out requests
-        requests: Vec<Post>,
+        requests: Vec<PostRequest>,
         /// Non membership batch proof for these requests
         timeout_proof: Proof,
     },
@@ -36,7 +36,7 @@ pub enum TimeoutMessage {
 }
 
 /// Handle timed out messages
-pub fn handle_timeouts<H>(host: &H, msg: TimeoutMessage) -> Result<(), Error>
+pub fn handle<H>(host: &H, msg: TimeoutMessage) -> Result<MessageResult, anyhow::Error>
 where
     H: IsmpHost,
 {
@@ -44,7 +44,7 @@ where
 }
 ```
 
-The `handle_timeouts` is used to notify onchain `IsmpModule`s of outgoing requests that have now timed out. A relayer will construct the `TimeoutMessage` which holds a batch of these messages, and their relevant proofs. The handler will perform the following operations
+The timeout `handle` is used to notify onchain `IsmpModule`s of outgoing requests that have now timed out. A relayer will construct the `TimeoutMessage` which holds a batch of these messages, and their relevant proofs. The handler will perform the following operations
 
 - Assert that the state machine's consensus client is not frozen
 - Assert that the configured `challenge_period` for the `StateCommitment` has elapsed


### PR DESCRIPTION
## Summary

The ISMP protocol docs under `docs/content/protocol/ismp/` had drifted significantly from `modules/ismp/core/`. This PR realigns them with the current code.

### Highlights of drift fixed

- **responses.mdx (rewrite)**: removed the `Response` enum, `RequestResponse` datagram, and `PostResponse`-shaped framing (all gone post-#840). `ResponseMessage` is now `{ requests: Vec<GetRequest>, proof, signer }` and the doc reflects that the host constructs the `GetResponse` on-chain from the state proof — relayers only ferry the originating `GetRequest`s.
- **state-machine.mdx (rewrite)**: removed `RequestResponse`; `StateMachineClient` now operates on `Vec<H256>` commitment hashes; `state_trie_key` split into `commitment_state_trie_key`/`receipts_state_trie_key`; added the new `verify_non_membership` method.
- **host.mdx**: removed phantom `response_commitment`; receipt/response methods now take `&GetResponse`; return types corrected (`Result<Vec<u8>, Error>` where applicable); added `Keccak256` super-trait bound and the methods that were missing entirely (`delete_state_commitment`, `delete_request_receipt`, `delete_response_receipt`, `store_request_commitment`, `consensus_clients`, `previous_commitment_height`).
- **consensus.mdx**: `IntermediateState` → `StateCommitmentHeight`; `verify_consensus` returns `VerifiedCommitments`; `CreateConsensusState` uses `challenge_periods: BTreeMap<StateMachine, u64>`; added `signer` fields to `ConsensusMessage`/`FraudProofMessage`; replaced non-existent `ConsensusClientFrozen` event with the real `StateCommitmentVetoed`.
- **dispatcher.mdx**: `DispatchPost`/`DispatchGet` use `timeout`/`body` (not `timeout_timestamp`/`data`); added `context` to `DispatchGet`; `IsmpDispatcher` rewritten with `Default` bound, `Account`/`Balance` associated types, `FeeMetadata` parameter, and `Result<H256, anyhow::Error>` return; `Event` enum expanded to all 9 real variants.
- **requests.mdx**: `Post`/`Get` → `PostRequest`/`GetRequest`; `data` → `body`; added `context` to `GetRequest`; `RequestMessage` includes `signer`; handler renamed to `handle`.
- **router.mdx**: `module_for_id` returns `anyhow::Error`; `IsmpModule` uses `PostRequest`/`GetResponse`/`Request` with `Result<Weight, anyhow::Error>` returns and default impls.
- **timeouts.mdx**: `Post` → `PostRequest`; handler renamed to `handle`.

`introduction.mdx`, `proxies.mdx`, and `relayers.mdx` had no drift and are unchanged.

## Test plan

- [x] `pnpm types:check` in `docs/` — MDX generates cleanly (pre-existing TS errors in `src/app/**` are unrelated)
- [x] `pnpm dev` in `docs/` and spot-check each updated page renders
- [x] Review against `modules/ismp/core/src/{host,consensus,dispatcher,router,messaging,module,events}.rs`