### PR TITLE
[evm]: Bind solver and session to a single transient-storage commitment

### DIFF
--- a/evm/src/apps/IntentGatewayV2.sol
+++ b/evm/src/apps/IntentGatewayV2.sol
@@ -414,16 +414,13 @@ contract IntentGatewayV2 is IntrinsicIntents, ExtrinsicIntents {
         if (_filled[commitment] != address(0)) revert Filled();
 
         if (_params.solverSelection) {
-            bytes32 solver;
-            bytes32 storedSessionKey;
-            bytes32 sessionSlot = bytes32(uint256(commitment) + 1);
+            bytes32 storedSelectionHash;
             assembly {
-                solver := tload(commitment)
-                storedSessionKey := tload(sessionSlot)
+                storedSelectionHash := tload(commitment)
             }
 
-            if (address(uint160(uint256(solver))) != msg.sender) revert Unauthorized();
-            if (address(uint160(uint256(storedSessionKey))) != order.session) revert Unauthorized();
+            bytes32 expectedSelectionHash = keccak256(abi.encode(msg.sender, order.session));
+            if (storedSelectionHash != expectedSelectionHash) revert Unauthorized();
         }
 
         uint256 outputsLen = order.output.assets.length;

--- a/evm/src/apps/intentsv2/IntentsBase.sol
+++ b/evm/src/apps/intentsv2/IntentsBase.sol
@@ -436,14 +436,14 @@ abstract contract IntentsBase is EIP712 {
     }
 
     /**
-     * @dev Verifies an EIP-712 solver selection signature and stores the selected solver
-     * and session key in transient storage. The solver and session key are stored using
-     * `tstore` so they are only available within the same transaction — this ensures
-     * atomicity between `select` and `fillOrder` calls.
+     * @dev Verifies an EIP-712 solver selection signature and stores a commitment to
+     * `keccak256(abi.encode(solver, sessionKey))` in transient storage. The hash is
+     * stored using `tstore` so it is only available within the same transaction —
+     * this ensures atomicity between `select` and `fillOrder` calls.
      *
      * The session key is recovered from the EIP-712 signature over the (commitment, solver)
-     * tuple. The recovered address is stored at `commitment + 1` in transient storage,
-     * while the solver address is stored at the commitment slot itself.
+     * tuple. At fill time, `fillOrder` re-derives the same hash from `msg.sender` and
+     * `order.session` and compares it against the value stored at the commitment slot.
      *
      * @param options The selection options containing the commitment, solver address, and signature.
      * @return The recovered session key address.
@@ -454,12 +454,9 @@ abstract contract IntentsBase is EIP712 {
         address sessionKey = ECDSA.recover(digest, options.signature);
 
         bytes32 commitment = options.commitment;
-        bytes32 solver = bytes32(uint256(uint160(options.solver)));
-        bytes32 sessionKeyBytes = bytes32(uint256(uint160(sessionKey)));
-        bytes32 sessionSlot = bytes32(uint256(commitment) + 1);
+        bytes32 selectionHash = keccak256(abi.encode(options.solver, sessionKey));
         assembly {
-            tstore(commitment, solver)
-            tstore(sessionSlot, sessionKeyBytes)
+            tstore(commitment, selectionHash)
         }
 
         return sessionKey;


### PR DESCRIPTION
## Summary

- `IntentGatewayV2.select` (via `_select` in `IntentsBase`) now stores `keccak256(abi.encode(solver, sessionKey))` in a single transient-storage slot at the commitment key, instead of writing the solver and session key into two separate slots (`commitment` and `commitment + 1`).
- `IntentGatewayV2.fillOrder` verifies the selection by re-deriving `keccak256(abi.encode(msg.sender, order.session))` and comparing it against the stored hash. A single mismatch reverts `Unauthorized`.
- Semantics are unchanged: still enforces `solver == msg.sender` AND `sessionKey == order.session`, just collapsed into one tload + one keccak256 + one comparison.

## Test plan

- [x] `forge test --match-test 'testFillOrderWithSolverSelection|testFillOrderWithWrongSolver'` passes
- [x] Full `IntentGatewayV2Test` + `IntentGatewayV2SameChainTest` suites pass (108 tests)
