### PR TITLE
[runtime] fix(polygon/tendermint): compare header hashes in fraud proof

### DIFF
--- a/modules/ismp/clients/polygon/src/error.rs
+++ b/modules/ismp/clients/polygon/src/error.rs
@@ -48,8 +48,9 @@ pub enum Error {
 	/// Fraud proofs were submitted for different block heights.
 	#[error("Fraud proofs must be for the same block height")]
 	FraudProofsDifferentHeight,
-	/// Fraud proofs were byte-identical.
-	#[error("Fraud proofs are identical")]
+	/// Both fraud proofs commit to the same Tendermint header, so they fail to
+	/// demonstrate equivocation.
+	#[error("Fraud proofs commit to the same block header")]
 	FraudProofsIdentical,
 	/// Asked to serve a state machine the client doesn't support.
 	#[error("Unsupported state machine or chain ID: {0:?}")]

--- a/modules/ismp/clients/polygon/src/lib.rs
+++ b/modules/ismp/clients/polygon/src/lib.rs
@@ -350,20 +350,6 @@ impl<H: IsmpHost + Send + Sync + Default + 'static, T: HostExecutiveConfig> Cons
 		let consensus_state: ConsensusState = Decode::decode(&mut &trusted_consensus_state[..])
 			.map_err(|e| PolygonError::DecodeConsensusState(e.to_string()))?;
 
-		let height_1 = update_1.tendermint_proof.signed_header.header.height;
-		let height_2 = update_2.tendermint_proof.signed_header.header.height;
-		if height_1 != height_2 {
-			return Err(PolygonError::FraudProofsDifferentHeight.into());
-		}
-
-		if proof_1 == proof_2 {
-			return Err(PolygonError::FraudProofsIdentical.into());
-		}
-
-		let trusted_state: TrustedState = consensus_state.clone().tendermint_state.into();
-
-		let time = host.timestamp().as_secs();
-
 		let consensus_proof_1 = update_1
 			.tendermint_proof
 			.to_consensus_proof()
@@ -373,6 +359,30 @@ impl<H: IsmpHost + Send + Sync + Default + 'static, T: HostExecutiveConfig> Cons
 			.tendermint_proof
 			.to_consensus_proof()
 			.map_err(|e| PolygonError::ConvertTendermintProof(e.to_string()))?;
+
+		let height_1 = consensus_proof_1.signed_header.header.height;
+		let height_2 = consensus_proof_2.signed_header.header.height;
+		if height_1 != height_2 {
+			return Err(PolygonError::FraudProofsDifferentHeight.into());
+		}
+
+		// A genuine fraud proof must demonstrate equivocation: two *distinct* blocks
+		// signed by the validator set at the same height. Comparing the raw proof
+		// bytes is insufficient — SCALE's `Decode` silently ignores trailing bytes
+		// and other non-canonical encodings, so an attacker could submit the *same*
+		// header twice with one copy malleated (e.g. an appended trailing byte or
+		// reordered commit signatures), pass this byte-inequality check, and freeze
+		// a live consensus client permissionlessly. Compare the canonical Tendermint
+		// header hashes instead — they uniquely identify the block being committed.
+		let header_hash_1 = consensus_proof_1.signed_header.header.hash();
+		let header_hash_2 = consensus_proof_2.signed_header.header.hash();
+		if header_hash_1 == header_hash_2 {
+			return Err(PolygonError::FraudProofsIdentical.into());
+		}
+
+		let trusted_state: TrustedState = consensus_state.clone().tendermint_state.into();
+
+		let time = host.timestamp().as_secs();
 
 		verify_header_update(trusted_state.clone(), consensus_proof_1, time)
 			.map_err(|e| PolygonError::VerifyHeaderUpdate(e.to_string()))?;

--- a/modules/ismp/clients/tendermint/src/lib.rs
+++ b/modules/ismp/clients/tendermint/src/lib.rs
@@ -146,20 +146,6 @@ impl<
 		let consensus_state: ConsensusState = Decode::decode(&mut &trusted_consensus_state[..])
 			.map_err(|e| Error::Custom(e.to_string()))?;
 
-		let height_1 = update_1.tendermint_proof.signed_header.header.height;
-		let height_2 = update_2.tendermint_proof.signed_header.header.height;
-		if height_1 != height_2 {
-			return Err(Error::Custom("Fraud proofs must be for the same block height".to_string()));
-		}
-
-		if proof_1 == proof_2 {
-			return Err(Error::Custom("Fraud proofs are identical".to_string()));
-		}
-
-		let trusted_state: TrustedState = consensus_state.clone().tendermint_state.into();
-
-		let time = host.timestamp().as_secs();
-
 		let consensus_proof_1 = update_1
 			.tendermint_proof
 			.to_consensus_proof()
@@ -169,6 +155,32 @@ impl<
 			.tendermint_proof
 			.to_consensus_proof()
 			.map_err(|e| Error::Custom(e.to_string()))?;
+
+		let height_1 = consensus_proof_1.signed_header.header.height;
+		let height_2 = consensus_proof_2.signed_header.header.height;
+		if height_1 != height_2 {
+			return Err(Error::Custom("Fraud proofs must be for the same block height".to_string()));
+		}
+
+		// A genuine fraud proof must demonstrate equivocation: two *distinct* blocks
+		// signed by the validator set at the same height. Comparing the raw proof
+		// bytes is insufficient — SCALE's `Decode` silently ignores trailing bytes
+		// and other non-canonical encodings, so an attacker could submit the *same*
+		// header twice with one copy malleated (e.g. an appended trailing byte or
+		// reordered commit signatures), pass this byte-inequality check, and freeze
+		// a live consensus client permissionlessly. Compare the canonical Tendermint
+		// header hashes instead — they uniquely identify the block being committed.
+		if consensus_proof_1.signed_header.header.hash() ==
+			consensus_proof_2.signed_header.header.hash()
+		{
+			return Err(Error::Custom(
+				"Fraud proofs commit to the same block header".to_string(),
+			));
+		}
+
+		let trusted_state: TrustedState = consensus_state.clone().tendermint_state.into();
+
+		let time = host.timestamp().as_secs();
 
 		verify_header_update(trusted_state.clone(), consensus_proof_1, time)
 			.map_err(|e| Error::Custom(e.to_string()))?;


### PR DESCRIPTION
The Polygon consensus client's `verify_fraud_proof` rejected fraud proofs only when the raw SCALE-encoded `proof_1` and `proof_2` were byte-identical. SCALE's `Decode` silently ignores trailing bytes and other non-canonical encodings, so an attacker could take a single valid consensus update, append a trailing byte (or otherwise malleate one copy), and submit the two as "conflicting" headers. Both decode to the same header and both verify, so the fraud proof was accepted — permissionlessly freezing a live POLY consensus client.

A genuine fraud proof must demonstrate equivocation: two distinct blocks signed at the same height. Compare the canonical Tendermint header hashes, which uniquely identify the committed block, instead of raw proof bytes.