### PR TITLE
[simplex]: fix phantom commitment from multi-placeOrder calldata mis-pairing

### DIFF
--- a/sdk/packages/sdk/src/chain.ts
+++ b/sdk/packages/sdk/src/chain.ts
@@ -231,7 +231,11 @@ export interface IEvmChain extends IChain {
 	getHostNonce(): Promise<bigint>
 	quoteNative(request: IPostRequest | IGetRequest, fee: bigint): Promise<bigint>
 	getFeeTokenWithDecimals(): Promise<{ address: HexString; decimals: number }>
-	getPlaceOrderCalldata(txHash: string, intentGatewayAddress: string): Promise<HexString>
+	getPlaceOrderCalldata(
+		txHash: string,
+		intentGatewayAddress: string,
+		occurrenceIndex?: number,
+	): Promise<HexString>
 	broadcastTransaction(signedTransaction: HexString): Promise<TransactionReceipt>
 	getTransactionReceipt(hash: HexString): Promise<TransactionReceipt>
 }

--- a/sdk/packages/sdk/src/chains/evm.ts
+++ b/sdk/packages/sdk/src/chains/evm.ts
@@ -53,7 +53,7 @@ import type {
 import {
 	ADDRESS_ZERO,
 	EvmStateProof,
-	getContractCallInput,
+	getContractCallInputs,
 	MmrProof,
 	SubstrateStateProof,
 	generateRootWithProof,
@@ -392,13 +392,28 @@ export class EvmChain implements IChain {
 
 	/**
 	 * Retrieves the placeOrder calldata from a transaction using debug_traceTransaction.
+	 * When the transaction contains multiple placeOrder calls, `occurrenceIndex`
+	 * selects which call's calldata to return (0-indexed in execution order).
 	 */
-	async getPlaceOrderCalldata(txHash: string, intentGatewayAddress: string): Promise<HexString> {
-		const callInput = await getContractCallInput(this.publicClient, txHash as HexString, intentGatewayAddress)
-		if (!callInput) {
+	async getPlaceOrderCalldata(
+		txHash: string,
+		intentGatewayAddress: string,
+		occurrenceIndex: number = 0,
+	): Promise<HexString> {
+		const callInputs = await getContractCallInputs(
+			this.publicClient,
+			txHash as HexString,
+			intentGatewayAddress,
+		)
+		if (callInputs.length === 0) {
 			throw new Error(`Failed to extract calldata from trace for tx ${txHash}`)
 		}
-		return callInput
+		if (occurrenceIndex >= callInputs.length) {
+			throw new Error(
+				`placeOrder occurrence ${occurrenceIndex} out of range for tx ${txHash} (found ${callInputs.length})`,
+			)
+		}
+		return callInputs[occurrenceIndex]
 	}
 
 	/**

--- a/sdk/packages/sdk/src/chains/evm.ts
+++ b/sdk/packages/sdk/src/chains/evm.ts
@@ -10,6 +10,7 @@ import {
 	keccak256,
 	pad,
 	toBytes,
+	toFunctionSelector,
 	toHex,
 	maxUint256,
 } from "viem"
@@ -39,6 +40,7 @@ import type { GetProofParameters, Hex, TransactionReceipt } from "viem"
 import EvmHost from "@/abis/evmHost"
 import evmHost from "@/abis/evmHost"
 import HandlerV2 from "@/abis/handlerV2"
+import { ABI as IntentGatewayV2ABI } from "@/abis/IntentGatewayV2"
 import type { IChain, IIsmpMessage } from "@/chain"
 import { ChainConfigService } from "@/configs/ChainConfigService"
 import type {
@@ -392,6 +394,8 @@ export class EvmChain implements IChain {
 
 	/**
 	 * Retrieves the placeOrder calldata from a transaction using debug_traceTransaction.
+	 * Filters to placeOrder calls by selector so unrelated calls to the gateway in
+	 * the same transaction (e.g. quote, fillOrder) do not skew indexing.
 	 * When the transaction contains multiple placeOrder calls, `occurrenceIndex`
 	 * selects which call's calldata to return (0-indexed in execution order).
 	 */
@@ -405,15 +409,21 @@ export class EvmChain implements IChain {
 			txHash as HexString,
 			intentGatewayAddress,
 		)
-		if (callInputs.length === 0) {
-			throw new Error(`Failed to extract calldata from trace for tx ${txHash}`)
+		const placeOrderSelector = toFunctionSelector(
+			IntentGatewayV2ABI.find((item: any) => item.type === "function" && item.name === "placeOrder") as any,
+		)
+		const placeOrderInputs = callInputs.filter(
+			(input) => input.slice(0, 10).toLowerCase() === placeOrderSelector.toLowerCase(),
+		)
+		if (placeOrderInputs.length === 0) {
+			throw new Error(`Failed to extract placeOrder calldata from trace for tx ${txHash}`)
 		}
-		if (occurrenceIndex >= callInputs.length) {
+		if (occurrenceIndex >= placeOrderInputs.length) {
 			throw new Error(
-				`placeOrder occurrence ${occurrenceIndex} out of range for tx ${txHash} (found ${callInputs.length})`,
+				`placeOrder occurrence ${occurrenceIndex} out of range for tx ${txHash} (found ${placeOrderInputs.length})`,
 			)
 		}
-		return callInputs[occurrenceIndex]
+		return placeOrderInputs[occurrenceIndex]
 	}
 
 	/**

--- a/sdk/packages/sdk/src/chains/pharos.ts
+++ b/sdk/packages/sdk/src/chains/pharos.ts
@@ -407,8 +407,12 @@ export class PharosChain implements IChain {
 		return this.evm.getFeeTokenWithDecimals()
 	}
 
-	getPlaceOrderCalldata(txHash: string, intentGatewayAddress: string): Promise<HexString> {
-		return this.evm.getPlaceOrderCalldata(txHash, intentGatewayAddress)
+	getPlaceOrderCalldata(
+		txHash: string,
+		intentGatewayAddress: string,
+		occurrenceIndex?: number,
+	): Promise<HexString> {
+		return this.evm.getPlaceOrderCalldata(txHash, intentGatewayAddress, occurrenceIndex)
 	}
 
 	estimateGas(request: IPostRequest): Promise<{ gas: bigint; postRequestCalldata: HexString }> {

--- a/sdk/packages/sdk/src/chains/polkadotHub.ts
+++ b/sdk/packages/sdk/src/chains/polkadotHub.ts
@@ -321,8 +321,12 @@ export class PolkadotHubChain implements IChain {
 		return this.evm.getFeeTokenWithDecimals()
 	}
 
-	getPlaceOrderCalldata(txHash: string, intentGatewayAddress: string): Promise<HexString> {
-		return this.evm.getPlaceOrderCalldata(txHash, intentGatewayAddress)
+	getPlaceOrderCalldata(
+		txHash: string,
+		intentGatewayAddress: string,
+		occurrenceIndex?: number,
+	): Promise<HexString> {
+		return this.evm.getPlaceOrderCalldata(txHash, intentGatewayAddress, occurrenceIndex)
 	}
 
 	estimateGas(request: IPostRequest): Promise<{ gas: bigint; postRequestCalldata: HexString }> {

--- a/sdk/packages/sdk/src/chains/tron.ts
+++ b/sdk/packages/sdk/src/chains/tron.ts
@@ -111,7 +111,11 @@ export class TronChain implements IChain {
 	 * Only works for direct calls to IntentGateway (not nested/multicall).
 	 * Tron does not support debug_traceTransaction.
 	 */
-	async getPlaceOrderCalldata(txHash: string, _intentGatewayAddress: string): Promise<HexString> {
+	async getPlaceOrderCalldata(
+		txHash: string,
+		_intentGatewayAddress: string,
+		_occurrenceIndex?: number,
+	): Promise<HexString> {
 		const tx = await retryPromise(() => this.tronWeb.trx.getTransaction(txHash), {
 			maxRetries: 3,
 			backoffMs: 250,

--- a/sdk/packages/sdk/src/index.ts
+++ b/sdk/packages/sdk/src/index.ts
@@ -32,6 +32,7 @@ export {
 	parseStateMachineId,
 	retryPromise,
 	getContractCallInput,
+	getContractCallInputs,
 	calculateBalanceMappingLocation,
 	calculateAllowanceMappingLocation,
 	MOCK_ADDRESS,

--- a/sdk/packages/sdk/src/tests/traceHelpers.test.ts
+++ b/sdk/packages/sdk/src/tests/traceHelpers.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from "vitest"
+import { encodeFunctionData, type PublicClient, type Hex } from "viem"
+import { getContractCallInputs, getContractCallInput, type HexString } from "@/utils"
+import { ABI as IntentGatewayV2ABI } from "@/abis/IntentGatewayV2"
+import { EvmChain } from "@/chains/evm"
+
+const GATEWAY = "0x000000000000000000000000000000000000ca11"
+const OTHER = "0x0000000000000000000000000000000000000bee"
+const TX_HASH = ("0x" + "ab".repeat(32)) as HexString
+
+const GRAFFITI = ("0x" + "00".repeat(32)) as Hex
+const USER = ("0x" + "11".repeat(32)) as Hex
+const TOKEN_IN = ("0x" + "aa".repeat(32)) as Hex
+const TOKEN_OUT = ("0x" + "bb".repeat(32)) as Hex
+const BENEFICIARY = ("0x" + "cc".repeat(32)) as Hex
+
+function makeOrderStruct(nonce: bigint) {
+	return {
+		user: USER,
+		source: "0x45564d2d31" as Hex, // "EVM-1"
+		destination: "0x45564d2d3130" as Hex, // "EVM-10"
+		deadline: 1700000000n,
+		nonce,
+		fees: 0n,
+		session: "0x0000000000000000000000000000000000000000" as Hex,
+		predispatch: { assets: [], call: "0x" as Hex },
+		inputs: [{ token: TOKEN_IN, amount: 100n }],
+		output: {
+			beneficiary: BENEFICIARY,
+			assets: [{ token: TOKEN_OUT, amount: 100n }],
+			call: "0x" as Hex,
+		},
+	}
+}
+
+function placeOrderCalldata(nonce: bigint): HexString {
+	return encodeFunctionData({
+		abi: IntentGatewayV2ABI,
+		functionName: "placeOrder",
+		args: [makeOrderStruct(nonce) as any, GRAFFITI],
+	}) as HexString
+}
+
+/**
+ * Builds a stub PublicClient.extend / debug_traceTransaction pipeline that
+ * surfaces a fixed CallTracerCall fixture to the code under test.
+ */
+function stubClient(trace: any): PublicClient {
+	const request = async ({ method }: { method: string }) => {
+		if (method === "debug_traceTransaction") return trace
+		throw new Error(`unexpected method: ${method}`)
+	}
+	const client: any = {
+		request,
+		extend(decorator: (c: any) => any) {
+			return { ...client, ...decorator(client) }
+		},
+	}
+	return client as PublicClient
+}
+
+describe("getContractCallInputs", () => {
+	it("returns every call to the target in execution order", async () => {
+		const trace = {
+			from: "0xabc",
+			to: GATEWAY,
+			input: "0xtop",
+			calls: [
+				{ from: GATEWAY, to: OTHER, input: "0x01", calls: [] },
+				{ from: "0xabc", to: GATEWAY, input: "0x02", calls: [] },
+				{
+					from: "0xabc",
+					to: OTHER,
+					input: "0x03",
+					calls: [{ from: OTHER, to: GATEWAY, input: "0x04", calls: [] }],
+				},
+			],
+		}
+
+		const inputs = await getContractCallInputs(stubClient(trace), TX_HASH, GATEWAY)
+
+		expect(inputs).toEqual(["0xtop", "0x02", "0x04"])
+	})
+
+	it("returns an empty list when the target is not called", async () => {
+		const trace = {
+			from: "0xabc",
+			to: OTHER,
+			input: "0x00",
+			calls: [{ from: "0xabc", to: OTHER, input: "0x01", calls: [] }],
+		}
+
+		const inputs = await getContractCallInputs(stubClient(trace), TX_HASH, GATEWAY)
+
+		expect(inputs).toEqual([])
+	})
+
+	it("getContractCallInput (legacy wrapper) returns the first match", async () => {
+		const trace = {
+			from: "0xabc",
+			to: OTHER,
+			input: "0x00",
+			calls: [
+				{ from: "0xabc", to: GATEWAY, input: "0xfirst", calls: [] },
+				{ from: "0xabc", to: GATEWAY, input: "0xsecond", calls: [] },
+			],
+		}
+
+		const result = await getContractCallInput(stubClient(trace), TX_HASH, GATEWAY)
+
+		expect(result).toBe("0xfirst")
+	})
+})
+
+describe("EvmChain.getPlaceOrderCalldata", () => {
+	function newChain(trace: any): EvmChain {
+		const chain = Object.create(EvmChain.prototype) as EvmChain
+		;(chain as any).publicClient = stubClient(trace)
+		return chain
+	}
+
+	it("returns the K-th placeOrder calldata in execution order", async () => {
+		const order0 = placeOrderCalldata(1n)
+		const order1 = placeOrderCalldata(2n)
+
+		const trace = {
+			from: "0xabc",
+			to: "0xabc",
+			input: "0x",
+			calls: [
+				{ from: "0xabc", to: GATEWAY, input: order0, calls: [] },
+				{ from: "0xabc", to: OTHER, input: "0xnoise", calls: [] },
+				{ from: "0xabc", to: GATEWAY, input: order1, calls: [] },
+			],
+		}
+
+		const chain = newChain(trace)
+		const first = await chain.getPlaceOrderCalldata(TX_HASH, GATEWAY, 0)
+		const second = await chain.getPlaceOrderCalldata(TX_HASH, GATEWAY, 1)
+
+		expect(first).toBe(order0)
+		expect(second).toBe(order1)
+	})
+
+	it("defaults occurrenceIndex to 0", async () => {
+		const order0 = placeOrderCalldata(7n)
+		const trace = {
+			from: "0xabc",
+			to: GATEWAY,
+			input: order0,
+			calls: [],
+		}
+
+		const chain = newChain(trace)
+		const result = await chain.getPlaceOrderCalldata(TX_HASH, GATEWAY)
+		expect(result).toBe(order0)
+	})
+
+	it("throws when occurrenceIndex is out of range", async () => {
+		const order0 = placeOrderCalldata(1n)
+		const trace = {
+			from: "0xabc",
+			to: GATEWAY,
+			input: order0,
+			calls: [],
+		}
+
+		const chain = newChain(trace)
+		await expect(chain.getPlaceOrderCalldata(TX_HASH, GATEWAY, 1)).rejects.toThrow(/out of range/)
+	})
+
+	it("throws when the gateway is not called at all", async () => {
+		const trace = {
+			from: "0xabc",
+			to: "0xabc",
+			input: "0x",
+			calls: [{ from: "0xabc", to: OTHER, input: "0xnoise", calls: [] }],
+		}
+
+		const chain = newChain(trace)
+		await expect(chain.getPlaceOrderCalldata(TX_HASH, GATEWAY, 0)).rejects.toThrow(/Failed to extract placeOrder/)
+	})
+})

--- a/sdk/packages/sdk/src/utils.ts
+++ b/sdk/packages/sdk/src/utils.ts
@@ -943,46 +943,44 @@ export const USE_ETHERSCAN_CHAINS = new Set(["EVM-137", "EVM-56", "EVM-1"])
 export const TESTNET_CHAINS = new Set(["EVM-10200", "EVM-97"])
 
 /**
- * Recursively searches through call tracer response to find a call matching the target contract address.
- * Searches only in nested calls; the top-level call should be handled by the caller.
+ * Recursively collects every call to the target contract from nested calls
+ * in execution order. The top-level call should be handled by the caller.
  * @param call The call object to search
  * @param targetContractAddress The target contract address to find
- * @returns The input (calldata) if found, null otherwise
+ * @param acc Accumulator for collected calldata inputs
  */
-function findCallInputByAddress(call: CallTracerCall, targetContractAddress: string): string | null {
+function collectCallInputsByAddress(call: CallTracerCall, targetContractAddress: string, acc: string[]): void {
 	const normalizedTarget = targetContractAddress.toLowerCase()
 
 	if (call.calls && Array.isArray(call.calls)) {
 		for (const nestedCall of call.calls) {
 			if (nestedCall.to.toLowerCase() === normalizedTarget) {
-				return nestedCall.input
+				acc.push(nestedCall.input)
 			}
-			const result = findCallInputByAddress(nestedCall, targetContractAddress)
-			if (result !== null) {
-				return result
-			}
+			collectCallInputsByAddress(nestedCall, targetContractAddress, acc)
 		}
 	}
-
-	return null
 }
 
 /**
- * Retrieves the calldata used to call a target contract within a transaction using debug_traceTransaction
- * with the callTracer. Unlike the indexer helper, this returns the calldata whether the target is called
- * directly by the transaction or via nested calls.
+ * Retrieves every call to `targetContractAddress` in `txHash`, in execution order,
+ * using debug_traceTransaction with the callTracer. Includes the top-level call when
+ * the transaction directly targets the contract, followed by every nested invocation.
+ *
+ * Callers with multiple logs from the same transaction should pair calldata entries
+ * to log positions by their order of appearance.
  *
  * @param client - viem PublicClient connected to an RPC node with debug API enabled
  * @param txHash - The transaction hash
- * @param targetContractAddress - The target contract address to find the call for
- * @returns The input (calldata) as a hex string, or null if the target is not found in the trace
+ * @param targetContractAddress - The target contract address to find calls for
+ * @returns An ordered list of calldata hex strings (empty if the target is not called)
  * @throws Error if the RPC call fails or returns an unexpected response
  */
-export async function getContractCallInput(
+export async function getContractCallInputs(
 	client: PublicClient,
 	txHash: HexString,
 	targetContractAddress: string,
-): Promise<HexString | null> {
+): Promise<HexString[]> {
 	const traceClient = client.extend((client) => ({
 		async traceTransaction(hash: HexString): Promise<CallTracerCall> {
 			// Cast to any to bypass viem's strict RPC method typing for debug_* methods
@@ -1009,16 +1007,35 @@ export async function getContractCallInput(
 	}
 
 	const normalizedTarget = targetContractAddress.toLowerCase()
+	const inputs: string[] = []
 
-	// If the top-level transaction directly calls the target contract, return its input
 	if (trace.to.toLowerCase() === normalizedTarget) {
-		return trace.input as HexString
+		inputs.push(trace.input)
 	}
 
-	// Otherwise search for the target contract in nested calls
-	const input = findCallInputByAddress(trace, targetContractAddress)
+	collectCallInputsByAddress(trace, targetContractAddress, inputs)
 
-	return input ? (input as HexString) : null
+	return inputs as HexString[]
+}
+
+/**
+ * Retrieves the calldata used to call a target contract within a transaction.
+ * Returns the first call by execution order; callers handling multiple logs
+ * from the same transaction should prefer {@link getContractCallInputs}.
+ *
+ * @param client - viem PublicClient connected to an RPC node with debug API enabled
+ * @param txHash - The transaction hash
+ * @param targetContractAddress - The target contract address to find the call for
+ * @returns The input (calldata) as a hex string, or null if the target is not found in the trace
+ * @throws Error if the RPC call fails or returns an unexpected response
+ */
+export async function getContractCallInput(
+	client: PublicClient,
+	txHash: HexString,
+	targetContractAddress: string,
+): Promise<HexString | null> {
+	const inputs = await getContractCallInputs(client, txHash, targetContractAddress)
+	return inputs.length > 0 ? inputs[0] : null
 }
 
 /**

--- a/sdk/packages/simplex/src/core/event-monitor.ts
+++ b/sdk/packages/simplex/src/core/event-monitor.ts
@@ -21,6 +21,90 @@ import { getLogger } from "@/services/Logger"
 import { QuorumPublicClient } from "@/services/QuorumPublicClient"
 import { Mutex } from "async-mutex"
 
+export interface ReconstructDeps {
+	getPlaceOrderCalldata: (txHash: string, occurrenceIndex: number) => Promise<HexString>
+	onError?: (err: unknown, log: DecodedOrderPlacedLog, occurrenceIndex: number) => void
+}
+
+/**
+ * Pure reconstruction of `OrderPlaced` logs into `Order` structs with commitments.
+ * Groups logs by transaction hash and pairs the K-th log in a tx with the K-th
+ * placeOrder calldata supplied by `deps.getPlaceOrderCalldata(txHash, K)`.
+ */
+export async function reconstructOrdersFromLogs(
+	logs: DecodedOrderPlacedLog[],
+	deps: ReconstructDeps,
+): Promise<{ order: Order; transactionHash: string }[]> {
+	const logsByTx = new Map<string, { log: DecodedOrderPlacedLog; occurrenceIndex: number }[]>()
+	for (const log of logs) {
+		const txHash = log.transactionHash as string
+		const bucket = logsByTx.get(txHash) ?? []
+		bucket.push({ log, occurrenceIndex: bucket.length })
+		logsByTx.set(txHash, bucket)
+	}
+
+	const out: { order: Order; transactionHash: string }[] = []
+
+	for (const [transactionHash, entries] of logsByTx) {
+		for (const { log: decodedLog, occurrenceIndex } of entries) {
+			try {
+				let order: Order = {
+					user: decodedLog.args.user,
+					source: hexToString(decodedLog.args.source) as HexString,
+					destination: hexToString(decodedLog.args.destination) as HexString,
+					deadline: decodedLog.args.deadline,
+					nonce: decodedLog.args.nonce,
+					fees: decodedLog.args.fees,
+					session: decodedLog.args.session,
+					predispatch: {
+						assets: decodedLog.args.predispatch.map(
+							(predispatch: { token: HexString; amount: bigint }) => ({
+								token: predispatch.token,
+								amount: predispatch.amount,
+							}),
+						),
+						call: "0x",
+					},
+					output: {
+						beneficiary: "0x0000000000000000000000000000000000000000",
+						assets: decodedLog.args.outputs.map(
+							(output: { token: HexString; amount: bigint }) => ({
+								token: output.token,
+								amount: output.amount,
+							}),
+						),
+						call: "0x",
+					},
+					inputs: decodedLog.args.inputs.map(
+						(input: { token: HexString; amount: bigint }) => ({
+							token: input.token,
+							amount: input.amount,
+						}),
+					),
+				}
+
+				const placeOrderCallInput = await deps.getPlaceOrderCalldata(transactionHash, occurrenceIndex)
+
+				const decodedCalldata = decodeFunctionData({
+					abi: INTENT_GATEWAY_V2_ABI,
+					data: placeOrderCallInput as HexString,
+				})?.args?.[0] as Order
+
+				order.output.beneficiary = decodedCalldata.output.beneficiary as `0x${string}`
+				order.output.call = decodedCalldata.output.call as HexString
+				order.predispatch.call = decodedCalldata.predispatch.call as HexString
+				order.id = orderCommitment(order)
+
+				out.push({ order, transactionHash })
+			} catch (error) {
+				if (deps.onError) deps.onError(error, decodedLog, occurrenceIndex)
+			}
+		}
+	}
+
+	return out
+}
+
 export class EventMonitor extends EventEmitter {
 	private chains: Map<number, IEvmChain> = new Map()
 	private quorumClients: Map<number, QuorumPublicClient> = new Map()
@@ -203,79 +287,25 @@ export class EventMonitor extends EventEmitter {
 	}
 
 	private async processOrderPlacedLogs(chainId: number, chain: IEvmChain, logs: any[]): Promise<void> {
-		const logsByTx = new Map<string, { log: DecodedOrderPlacedLog; occurrenceIndex: number }[]>()
-		for (const log of logs) {
-			const decodedLog = log as unknown as DecodedOrderPlacedLog
-			const txHash = decodedLog.transactionHash as string
-			const bucket = logsByTx.get(txHash) ?? []
-			bucket.push({ log: decodedLog, occurrenceIndex: bucket.length })
-			logsByTx.set(txHash, bucket)
-		}
+		const results = await reconstructOrdersFromLogs(logs as DecodedOrderPlacedLog[], {
+			getPlaceOrderCalldata: (txHash, occurrenceIndex) => {
+				const sourceFromTxHash = (logs as DecodedOrderPlacedLog[]).find(
+					(l) => l.transactionHash === txHash,
+				)
+				const source = sourceFromTxHash
+					? (hexToString(sourceFromTxHash.args.source) as HexString)
+					: undefined
+				const intentGatewayAddress = this.configService.getIntentGatewayV2Address(source!)
+				return chain.getPlaceOrderCalldata!(txHash, intentGatewayAddress, occurrenceIndex)
+			},
+			onError: (err, decodedLog, occurrenceIndex) => {
+				this.logger.error({ err, log: decodedLog, occurrenceIndex }, "Error parsing event log")
+			},
+		})
 
-		for (const [transactionHash, entries] of logsByTx) {
-			for (const { log: decodedLog, occurrenceIndex } of entries) {
-				try {
-					let order: Order = {
-						user: decodedLog.args.user,
-						source: hexToString(decodedLog.args.source) as HexString,
-						destination: hexToString(decodedLog.args.destination) as HexString,
-						deadline: decodedLog.args.deadline,
-						nonce: decodedLog.args.nonce,
-						fees: decodedLog.args.fees,
-						session: decodedLog.args.session,
-						predispatch: {
-							assets: decodedLog.args.predispatch.map(
-								(predispatch: { token: HexString; amount: bigint }) => ({
-									token: predispatch.token,
-									amount: predispatch.amount,
-								}),
-							),
-							call: "0x",
-						},
-						output: {
-							beneficiary: "0x0000000000000000000000000000000000000000",
-							assets: decodedLog.args.outputs.map(
-								(output: { token: HexString; amount: bigint }) => ({
-									token: output.token,
-									amount: output.amount,
-								}),
-							),
-							call: "0x",
-						},
-						inputs: decodedLog.args.inputs.map(
-							(input: { token: HexString; amount: bigint }) => ({
-								token: input.token,
-								amount: input.amount,
-							}),
-						),
-					}
-
-					const intentGatewayAddress = this.configService.getIntentGatewayV2Address(order.source)
-					const placeOrderCallInput = await chain.getPlaceOrderCalldata!(
-						transactionHash,
-						intentGatewayAddress,
-						occurrenceIndex,
-					)
-
-					const decodedCalldata = decodeFunctionData({
-						abi: INTENT_GATEWAY_V2_ABI,
-						data: placeOrderCallInput as HexString,
-					})?.args?.[0] as Order
-
-					order.output.beneficiary = decodedCalldata.output.beneficiary as `0x${string}`
-					order.output.call = decodedCalldata.output.call as HexString
-					order.predispatch.call = decodedCalldata.predispatch.call as HexString
-					order.id = orderCommitment(order)
-
-					this.logger.info({ orderId: order.id, txHash: transactionHash }, "New order detected")
-					this.emit("newOrder", { order, transactionHash })
-				} catch (error) {
-					this.logger.error(
-						{ err: error, log: decodedLog, occurrenceIndex },
-						"Error parsing event log",
-					)
-				}
-			}
+		for (const { order, transactionHash } of results) {
+			this.logger.info({ orderId: order.id, txHash: transactionHash }, "New order detected")
+			this.emit("newOrder", { order, transactionHash })
 		}
 	}
 

--- a/sdk/packages/simplex/src/core/event-monitor.ts
+++ b/sdk/packages/simplex/src/core/event-monitor.ts
@@ -203,59 +203,78 @@ export class EventMonitor extends EventEmitter {
 	}
 
 	private async processOrderPlacedLogs(chainId: number, chain: IEvmChain, logs: any[]): Promise<void> {
+		const logsByTx = new Map<string, { log: DecodedOrderPlacedLog; occurrenceIndex: number }[]>()
 		for (const log of logs) {
-			try {
-				const decodedLog = log as unknown as DecodedOrderPlacedLog
-				const transactionHash = decodedLog.transactionHash
-				let order: Order = {
-					user: decodedLog.args.user,
-					source: hexToString(decodedLog.args.source) as HexString,
-					destination: hexToString(decodedLog.args.destination) as HexString,
-					deadline: decodedLog.args.deadline,
-					nonce: decodedLog.args.nonce,
-					fees: decodedLog.args.fees,
-					session: decodedLog.args.session,
-					predispatch: {
-						assets: decodedLog.args.predispatch.map((predispatch) => ({
-							token: predispatch.token,
-							amount: predispatch.amount,
-						})),
-						call: "0x",
-					},
-					output: {
-						beneficiary: "0x0000000000000000000000000000000000000000",
-						assets: decodedLog.args.outputs.map((output) => ({
-							token: output.token,
-							amount: output.amount,
-						})),
-						call: "0x",
-					},
-					inputs: decodedLog.args.inputs.map((input) => ({
-						token: input.token,
-						amount: input.amount,
-					})),
+			const decodedLog = log as unknown as DecodedOrderPlacedLog
+			const txHash = decodedLog.transactionHash as string
+			const bucket = logsByTx.get(txHash) ?? []
+			bucket.push({ log: decodedLog, occurrenceIndex: bucket.length })
+			logsByTx.set(txHash, bucket)
+		}
+
+		for (const [transactionHash, entries] of logsByTx) {
+			for (const { log: decodedLog, occurrenceIndex } of entries) {
+				try {
+					let order: Order = {
+						user: decodedLog.args.user,
+						source: hexToString(decodedLog.args.source) as HexString,
+						destination: hexToString(decodedLog.args.destination) as HexString,
+						deadline: decodedLog.args.deadline,
+						nonce: decodedLog.args.nonce,
+						fees: decodedLog.args.fees,
+						session: decodedLog.args.session,
+						predispatch: {
+							assets: decodedLog.args.predispatch.map(
+								(predispatch: { token: HexString; amount: bigint }) => ({
+									token: predispatch.token,
+									amount: predispatch.amount,
+								}),
+							),
+							call: "0x",
+						},
+						output: {
+							beneficiary: "0x0000000000000000000000000000000000000000",
+							assets: decodedLog.args.outputs.map(
+								(output: { token: HexString; amount: bigint }) => ({
+									token: output.token,
+									amount: output.amount,
+								}),
+							),
+							call: "0x",
+						},
+						inputs: decodedLog.args.inputs.map(
+							(input: { token: HexString; amount: bigint }) => ({
+								token: input.token,
+								amount: input.amount,
+							}),
+						),
+					}
+
+					const intentGatewayAddress = this.configService.getIntentGatewayV2Address(order.source)
+					const placeOrderCallInput = await chain.getPlaceOrderCalldata!(
+						transactionHash,
+						intentGatewayAddress,
+						occurrenceIndex,
+					)
+
+					const decodedCalldata = decodeFunctionData({
+						abi: INTENT_GATEWAY_V2_ABI,
+						data: placeOrderCallInput as HexString,
+					})?.args?.[0] as Order
+
+					order.output.beneficiary = decodedCalldata.output.beneficiary as `0x${string}`
+					order.output.call = decodedCalldata.output.call as HexString
+					order.predispatch.call = decodedCalldata.predispatch.call as HexString
+					order.id = orderCommitment(order)
+
+					this.logger.info({ orderId: order.id, txHash: transactionHash }, "New order detected")
+					this.emit("newOrder", { order, transactionHash })
+				} catch (error) {
+					this.logger.error(
+						{ err: error, log: decodedLog, occurrenceIndex },
+						"Error parsing event log",
+					)
 				}
-
-				const intentGatewayAddress = this.configService.getIntentGatewayV2Address(order.source)
-				const placeOrderCallInput = await chain.getPlaceOrderCalldata!(
-					transactionHash as string,
-					intentGatewayAddress,
-				)
-
-				const decodedCalldata = decodeFunctionData({
-					abi: INTENT_GATEWAY_V2_ABI,
-					data: placeOrderCallInput as HexString,
-				})?.args?.[0] as Order
-
-				order.output.beneficiary = decodedCalldata.output.beneficiary as `0x${string}`
-				order.output.call = decodedCalldata.output.call as HexString
-				order.predispatch.call = decodedCalldata.predispatch.call as HexString
-				order.id = orderCommitment(order)
-
-				this.logger.info({ orderId: order.id, txHash: transactionHash }, "New order detected")
-				this.emit("newOrder", { order, transactionHash })
-			} catch (error) {
-				this.logger.error({ err: error, log }, "Error parsing event log")
 			}
 		}
 	}

--- a/sdk/packages/simplex/src/core/filler.ts
+++ b/sdk/packages/simplex/src/core/filler.ts
@@ -8,7 +8,11 @@ import {
 	retryPromise,
 	type HexString,
 	IntentsCoprocessor,
+	bytes32ToBytes20,
+	type TokenInfo,
 } from "@hyperbridge/sdk"
+import { INTENT_GATEWAY_V2_ABI } from "@/config/abis/IntentGatewayV2"
+import type { Address } from "viem"
 import pQueue from "p-queue"
 import {
 	BidStorageService,
@@ -287,6 +291,61 @@ export class IntentFiller {
 
 	// Operations
 
+	private async verifyOrderOnSource(order: Order): Promise<boolean> {
+		if (order.inputs.length === 0) {
+			this.logger.warn({ orderId: order.id }, "Order has no inputs, rejecting")
+			return false
+		}
+
+		const sourceClient = this.chainClientManager.getPublicClient(order.source)
+		const intentGatewayAddress = this.configService.getIntentGatewayV2Address(order.source)
+		const commitment = order.id as HexString
+
+		try {
+			const escrows = await Promise.all(
+				order.inputs.map((input: TokenInfo) =>
+					retryPromise(
+						() =>
+							sourceClient.readContract({
+								address: intentGatewayAddress,
+								abi: INTENT_GATEWAY_V2_ABI,
+								functionName: "_orders",
+								args: [commitment, bytes32ToBytes20(input.token) as Address],
+							}) as Promise<bigint>,
+						{
+							maxRetries: 3,
+							backoffMs: 250,
+							logMessage: "Failed to read _orders on source chain",
+						},
+					),
+				),
+			)
+
+			for (let i = 0; i < escrows.length; i++) {
+				if (escrows[i] === 0n) {
+					this.logger.warn(
+						{
+							orderId: order.id,
+							source: order.source,
+							inputIndex: i,
+							token: order.inputs[i].token,
+						},
+						"Phantom commitment: source escrow missing for input, skipping order",
+					)
+					return false
+				}
+			}
+
+			return true
+		} catch (err) {
+			this.logger.error(
+				{ orderId: order.id, source: order.source, err },
+				"Failed to verify source escrow, skipping order",
+			)
+			return false
+		}
+	}
+
 	private handleNewOrder(order: Order, transactionHash: string): void {
 		// Use the global queue for the initial analysis
 		// This can happen in parallel for PublicClient orders
@@ -304,6 +363,14 @@ export class IntentFiller {
 						{ orderId: order.id },
 						"Solver selection is active but Hyperbridge is not configured. Skipping order.",
 					)
+					return
+				}
+
+				// Guard against phantom commitments: the off-chain order reconstruction
+				// can mis-pair OrderPlaced logs with placeOrder calldata when a single tx
+				// contains multiple placeOrder calls, yielding a commitment that has no
+				// matching escrow on source. Reject those before bidding/filling.
+				if (!(await this.verifyOrderOnSource(order))) {
 					return
 				}
 

--- a/sdk/packages/simplex/src/tests/core/event-monitor-multi-order.test.ts
+++ b/sdk/packages/simplex/src/tests/core/event-monitor-multi-order.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect } from "vitest"
+import { encodeFunctionData, stringToHex, type Hex } from "viem"
+import { DecodedOrderPlacedLog, HexString, Order } from "@hyperbridge/sdk"
+import { INTENT_GATEWAY_V2_ABI } from "@/config/abis/IntentGatewayV2"
+import { reconstructOrdersFromLogs } from "@/core/event-monitor"
+
+const SOURCE = "EVM-1"
+const DESTINATION = "EVM-10"
+
+function pad32(addr: Hex): Hex {
+	return `0x${addr.slice(2).padStart(64, "0")}` as Hex
+}
+
+const USDC_INPUT = pad32("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48") // bytes32-encoded
+const USDC_OUTPUT = pad32("0x0b2c639c533813f4aa9d7837caf62653d097ff85")
+const USER = pad32("0x1111111111111111111111111111111111111111")
+const BENEFICIARY_1 = pad32("0xaaaa000000000000000000000000000000000001")
+const BENEFICIARY_2 = pad32("0xbbbb000000000000000000000000000000000002")
+const SESSION = "0x0000000000000000000000000000000000000000" as Hex
+
+const TX_HASH = "0xdeadbeef".padEnd(66, "0") as HexString
+
+function makeOrderStruct(args: {
+	nonce: bigint
+	beneficiary: Hex
+	outputAmount: bigint
+	predispatchCall: HexString
+	outputCall: HexString
+}) {
+	return {
+		user: USER,
+		source: stringToHex(SOURCE),
+		destination: stringToHex(DESTINATION),
+		deadline: 1700000000n,
+		nonce: args.nonce,
+		fees: 0n,
+		session: SESSION,
+		predispatch: {
+			assets: [],
+			call: args.predispatchCall,
+		},
+		inputs: [{ token: USDC_INPUT, amount: 100_000_000n }],
+		output: {
+			beneficiary: args.beneficiary,
+			assets: [{ token: USDC_OUTPUT, amount: args.outputAmount }],
+			call: args.outputCall,
+		},
+	}
+}
+
+const GRAFFITI = `0x${"00".repeat(32)}` as Hex
+
+function encodePlaceOrderCalldata(orderStruct: ReturnType<typeof makeOrderStruct>): HexString {
+	return encodeFunctionData({
+		abi: INTENT_GATEWAY_V2_ABI,
+		functionName: "placeOrder",
+		args: [orderStruct as any, GRAFFITI],
+	}) as HexString
+}
+
+function makeOrderPlacedLog(args: {
+	nonce: bigint
+	beneficiary: Hex
+	outputAmount: bigint
+}): DecodedOrderPlacedLog {
+	return {
+		eventName: "OrderPlaced",
+		transactionHash: TX_HASH,
+		args: {
+			user: USER as HexString,
+			source: stringToHex(SOURCE),
+			destination: stringToHex(DESTINATION),
+			deadline: 1700000000n,
+			nonce: args.nonce,
+			fees: 0n,
+			session: SESSION,
+			beneficiary: args.beneficiary as HexString,
+			predispatch: [],
+			inputs: [{ token: USDC_INPUT as HexString, amount: 100_000_000n }],
+			outputs: [{ token: USDC_OUTPUT as HexString, amount: args.outputAmount }],
+		},
+	} as unknown as DecodedOrderPlacedLog
+}
+
+describe("reconstructOrdersFromLogs", () => {
+	it("pairs the K-th log in a tx with the K-th placeOrder calldata", async () => {
+		const order1 = makeOrderStruct({
+			nonce: 1n,
+			beneficiary: BENEFICIARY_1,
+			outputAmount: 100_000_000n,
+			predispatchCall: "0x11",
+			outputCall: "0x21",
+		})
+		const order2 = makeOrderStruct({
+			nonce: 2n,
+			beneficiary: BENEFICIARY_2,
+			outputAmount: 200_000_000n,
+			predispatchCall: "0x12",
+			outputCall: "0x22",
+		})
+
+		const calldataByOccurrence: Record<number, HexString> = {
+			0: encodePlaceOrderCalldata(order1),
+			1: encodePlaceOrderCalldata(order2),
+		}
+
+		const log1 = makeOrderPlacedLog({
+			nonce: 1n,
+			beneficiary: BENEFICIARY_1,
+			outputAmount: 100_000_000n,
+		})
+		const log2 = makeOrderPlacedLog({
+			nonce: 2n,
+			beneficiary: BENEFICIARY_2,
+			outputAmount: 200_000_000n,
+		})
+
+		const reconstructed = await reconstructOrdersFromLogs([log1, log2], {
+			getPlaceOrderCalldata: async (txHash, occurrenceIndex) => {
+				expect(txHash).toBe(TX_HASH)
+				return calldataByOccurrence[occurrenceIndex]
+			},
+		})
+
+		expect(reconstructed).toHaveLength(2)
+		expect(reconstructed[0].order.output.beneficiary.toLowerCase()).toBe(BENEFICIARY_1.toLowerCase())
+		expect(reconstructed[0].order.predispatch.call).toBe("0x11")
+		expect(reconstructed[0].order.output.call).toBe("0x21")
+		expect(reconstructed[1].order.output.beneficiary.toLowerCase()).toBe(BENEFICIARY_2.toLowerCase())
+		expect(reconstructed[1].order.predispatch.call).toBe("0x12")
+		expect(reconstructed[1].order.output.call).toBe("0x22")
+		expect(reconstructed[0].order.id).not.toBe(reconstructed[1].order.id)
+	})
+
+	it("would have produced a phantom commitment if the calldata helper always returned order 1 (regression guard)", async () => {
+		const order1 = makeOrderStruct({
+			nonce: 1n,
+			beneficiary: BENEFICIARY_1,
+			outputAmount: 100_000_000n,
+			predispatchCall: "0x",
+			outputCall: "0x",
+		})
+
+		const log2 = makeOrderPlacedLog({
+			nonce: 2n,
+			beneficiary: BENEFICIARY_2,
+			outputAmount: 200_000_000n,
+		})
+
+		const reconstructed = await reconstructOrdersFromLogs([log2], {
+			getPlaceOrderCalldata: async () => encodePlaceOrderCalldata(order1),
+		})
+
+		expect(reconstructed).toHaveLength(1)
+		expect(reconstructed[0].order.output.beneficiary.toLowerCase()).toBe(BENEFICIARY_1.toLowerCase())
+		expect(reconstructed[0].order.output.beneficiary.toLowerCase()).not.toBe(BENEFICIARY_2.toLowerCase())
+	})
+
+	it("isolates logs across different transactions", async () => {
+		const tx1 = "0xaa".padEnd(66, "0") as HexString
+		const tx2 = "0xbb".padEnd(66, "0") as HexString
+
+		const order1 = makeOrderStruct({
+			nonce: 1n,
+			beneficiary: BENEFICIARY_1,
+			outputAmount: 100_000_000n,
+			predispatchCall: "0x",
+			outputCall: "0x",
+		})
+		const order2 = makeOrderStruct({
+			nonce: 2n,
+			beneficiary: BENEFICIARY_2,
+			outputAmount: 200_000_000n,
+			predispatchCall: "0x",
+			outputCall: "0x",
+		})
+
+		const log1 = {
+			...makeOrderPlacedLog({ nonce: 1n, beneficiary: BENEFICIARY_1, outputAmount: 100_000_000n }),
+			transactionHash: tx1,
+		}
+		const log2 = {
+			...makeOrderPlacedLog({ nonce: 2n, beneficiary: BENEFICIARY_2, outputAmount: 200_000_000n }),
+			transactionHash: tx2,
+		}
+
+		const reconstructed = await reconstructOrdersFromLogs(
+			[log1 as DecodedOrderPlacedLog, log2 as DecodedOrderPlacedLog],
+			{
+				getPlaceOrderCalldata: async (txHash, occurrenceIndex) => {
+					expect(occurrenceIndex).toBe(0)
+					if (txHash === tx1) return encodePlaceOrderCalldata(order1)
+					return encodePlaceOrderCalldata(order2)
+				},
+			},
+		)
+
+		expect(reconstructed).toHaveLength(2)
+		expect(reconstructed.find((r) => r.transactionHash === tx1)!.order.output.beneficiary.toLowerCase()).toBe(
+			BENEFICIARY_1.toLowerCase(),
+		)
+		expect(reconstructed.find((r) => r.transactionHash === tx2)!.order.output.beneficiary.toLowerCase()).toBe(
+			BENEFICIARY_2.toLowerCase(),
+		)
+	})
+
+	it("emits via onError and continues when one log's calldata fetch throws", async () => {
+		const order2 = makeOrderStruct({
+			nonce: 2n,
+			beneficiary: BENEFICIARY_2,
+			outputAmount: 200_000_000n,
+			predispatchCall: "0x",
+			outputCall: "0x",
+		})
+
+		const log1 = makeOrderPlacedLog({
+			nonce: 1n,
+			beneficiary: BENEFICIARY_1,
+			outputAmount: 100_000_000n,
+		})
+		const log2 = makeOrderPlacedLog({
+			nonce: 2n,
+			beneficiary: BENEFICIARY_2,
+			outputAmount: 200_000_000n,
+		})
+
+		const errors: { occurrenceIndex: number }[] = []
+		const reconstructed = await reconstructOrdersFromLogs([log1, log2], {
+			getPlaceOrderCalldata: async (_txHash, occurrenceIndex) => {
+				if (occurrenceIndex === 0) throw new Error("rpc failure")
+				return encodePlaceOrderCalldata(order2)
+			},
+			onError: (_err, _log, occurrenceIndex) => {
+				errors.push({ occurrenceIndex })
+			},
+		})
+
+		expect(errors).toEqual([{ occurrenceIndex: 0 }])
+		expect(reconstructed).toHaveLength(1)
+		expect((reconstructed[0].order as Order).nonce).toBe(2n)
+	})
+})


### PR DESCRIPTION
## Summary

**Problem:** when a single transaction contains multiple `placeOrder` calls into the gateway, the simplex filler reconstructed every `OrderPlaced` event against the first call's calldata. The K-th log past index 0 ended up paired with order 1's `output.beneficiary` / `output.call` / `predispatch.call`, producing a commitment that has no matching escrow on the source chain.

**Solution:** collect every call to the gateway in execution order, filter to `placeOrder` by selector, and pair the K-th `OrderPlaced` log in a tx with the K-th `placeOrder` calldata. As a guard, the filler now reads `_orders[commitment][token]` on the source chain for every input and skips the order if any escrow is zero.