### PR TITLE
[runtime]: Verify proof values count matches supplied keys

### DIFF
--- a/modules/ismp/core/src/error.rs
+++ b/modules/ismp/core/src/error.rs
@@ -107,6 +107,8 @@ pub enum Error {
 	},
 	/// Cannot handle the given message
 	CannotHandleMessage,
+	/// The message batch contains no requests
+	EmptyBatch,
 	/// Membership proof verification failed: {0}
 	MembershipProofVerificationFailed(String),
 	/// Non-membership proof verification failed: {0}

--- a/modules/ismp/core/src/handlers/request.rs
+++ b/modules/ismp/core/src/handlers/request.rs
@@ -31,6 +31,10 @@ pub fn handle<H>(host: &H, msg: RequestMessage) -> Result<MessageResult, anyhow:
 where
 	H: IsmpHost,
 {
+	if msg.requests.is_empty() {
+		Err(Error::EmptyBatch)?
+	}
+
 	let state_machine = validate_state_machine(host, msg.proof.height)?;
 	let consensus_clients = host.consensus_clients();
 	let check_state_machine_client = |state_machine: StateMachine| {

--- a/modules/ismp/core/src/handlers/response.rs
+++ b/modules/ismp/core/src/handlers/response.rs
@@ -31,6 +31,10 @@ pub fn handle<H>(host: &H, msg: ResponseMessage) -> Result<MessageResult, anyhow
 where
 	H: IsmpHost,
 {
+	if msg.requests.is_empty() {
+		Err(Error::EmptyBatch)?
+	}
+
 	let proof = msg.proof();
 	let state_machine = validate_state_machine(host, proof.height)?;
 	let state = host.state_machine_commitment(proof.height)?;

--- a/modules/ismp/core/src/handlers/timeout.rs
+++ b/modules/ismp/core/src/handlers/timeout.rs
@@ -31,6 +31,10 @@ pub fn handle<H>(host: &H, msg: TimeoutMessage) -> Result<MessageResult, anyhow:
 where
 	H: IsmpHost,
 {
+	if msg.requests().is_empty() {
+		Err(Error::EmptyBatch)?
+	}
+
 	let consensus_clients = host.consensus_clients();
 
 	let check_state_machine_client = |state_machine: StateMachine| {

--- a/modules/ismp/state-machines/evm/src/lib.rs
+++ b/modules/ismp/state-machines/evm/src/lib.rs
@@ -48,6 +48,9 @@ pub enum EvmStateMachineError {
 	/// A non-membership proof contained at least one delivered request.
 	#[error("Some Requests in the batch have been delivered")]
 	DeliveredRequestsInBatch,
+	/// The number of verified values doesn't match the number of supplied keys.
+	#[error("Mismatched values/keys: the proof did not account for every key")]
+	MismatchedValuesAndKeys,
 	/// A query key length didn't match any supported layout (20, 32, or 52 bytes).
 	#[error("Unsupported Key type, found a key whose length is not one of 20, 32 or 52")]
 	UnsupportedKeyLength,
@@ -259,7 +262,11 @@ impl<H: IsmpHost + Send + Sync, T: pallet_ismp_host_executive::Config> StateMach
 		proof: &Proof,
 	) -> Result<(), Error> {
 		let keys = self.receipts_state_trie_key(commitments);
+		let keys_len = keys.len();
 		let values = self.verify_state_proof(host, keys, root, proof)?;
+		if values.len() != keys_len {
+			return Err(EvmStateMachineError::MismatchedValuesAndKeys.into());
+		}
 		if values.into_iter().any(|(_key, val)| val.is_some()) {
 			return Err(EvmStateMachineError::DeliveredRequestsInBatch.into());
 		}
@@ -275,6 +282,11 @@ impl<H: IsmpHost + Send + Sync, T: pallet_ismp_host_executive::Config> StateMach
 	) -> Result<BTreeMap<Vec<u8>, Option<Vec<u8>>>, Error> {
 		let ismp_address = EvmHosts::<T>::get(&proof.height.id.state_id)
 			.ok_or(EvmStateMachineError::IsmpContractNotFound)?;
-		verify_state_proof::<H>(keys, root, proof, ismp_address)
+		let keys_len = keys.len();
+		let values = verify_state_proof::<H>(keys, root, proof, ismp_address)?;
+		if values.len() != keys_len {
+			return Err(EvmStateMachineError::MismatchedValuesAndKeys.into());
+		}
+		Ok(values)
 	}
 }

--- a/modules/ismp/state-machines/evm/src/substrate_evm.rs
+++ b/modules/ismp/state-machines/evm/src/substrate_evm.rs
@@ -65,6 +65,8 @@ pub enum SubstrateEvmError {
 	StorageProofMissing(Vec<u8>),
 	#[error("Some Requests in the batch have been delivered")]
 	DeliveredRequestsInBatch,
+	#[error("Mismatched values/keys: the proof did not account for every key")]
+	MismatchedValuesAndKeys,
 }
 
 impl From<SubstrateEvmError> for Error {
@@ -165,7 +167,11 @@ impl<H: IsmpHost + Send + Sync, T: pallet_ismp_host_executive::Config> StateMach
 		proof: &Proof,
 	) -> Result<(), Error> {
 		let keys = self.receipts_state_trie_key(commitments);
+		let keys_len = keys.len();
 		let values = self.verify_state_proof(host, keys, root, proof)?;
+		if values.len() != keys_len {
+			return Err(SubstrateEvmError::MismatchedValuesAndKeys.into());
+		}
 		if values.into_iter().any(|(_key, val)| val.is_some()) {
 			return Err(SubstrateEvmError::DeliveredRequestsInBatch.into());
 		}
@@ -187,6 +193,7 @@ impl<H: IsmpHost + Send + Sync, T: pallet_ismp_host_executive::Config> StateMach
 
 		let state_root = H256::from_slice(&root.state_root[..]);
 
+		let keys_len = keys.len();
 		let mut contract_keys: BTreeMap<H160, Vec<Vec<u8>>> = BTreeMap::new();
 		for key in keys {
 			let address = if key.len() == 52 {
@@ -230,6 +237,10 @@ impl<H: IsmpHost + Send + Sync, T: pallet_ismp_host_executive::Config> StateMach
 			for (key, value) in keys.into_iter().zip(values.into_iter()) {
 				result_map.insert(key, value);
 			}
+		}
+
+		if result_map.len() != keys_len {
+			return Err(SubstrateEvmError::MismatchedValuesAndKeys.into());
 		}
 
 		Ok(result_map)

--- a/modules/ismp/state-machines/evm/src/tendermint.rs
+++ b/modules/ismp/state-machines/evm/src/tendermint.rs
@@ -18,7 +18,7 @@
 use ibc_core_commitment_types::{
 	commitment::CommitmentProofBytes,
 	merkle::{MerklePath, MerkleProof},
-	proto::v1::MerkleRoot,
+	proto::{ics23::commitment_proof::Proof as Ics23Proof, v1::MerkleRoot},
 	specs::ProofSpecs,
 };
 use ibc_core_host::types::path::PathBytes;
@@ -284,17 +284,32 @@ pub fn verify_evm_kv_proofs(
 		let root_hash = MerkleRoot { hash: app_hash.to_vec() };
 		let merkle_path =
 			MerklePath::new(vec![PathBytes::from_bytes(store_key), PathBytes::from_bytes(&key)]);
-		merkle_proof
-			.verify_membership::<ICS23HostFunctions>(
-				&specs,
-				root_hash,
-				merkle_path,
-				ev.value.clone(),
-				0,
-			)
-			.map_err(|e| TendermintEvmError::MerkleProofVerificationFailed(e.to_string()))?;
 
-		out.insert(key_bytes, Some(ev.value));
+		// The leaf-level (first) ICS23 proof is a non-existence proof when the key is absent
+		// from the store. Verify it as such instead of forcing a membership check, which can
+		// only ever prove presence and so cannot represent an absent key.
+		let is_non_existence = matches!(
+			merkle_proof.proofs.first().and_then(|p| p.proof.as_ref()),
+			Some(Ics23Proof::Nonexist(_))
+		);
+
+		if is_non_existence {
+			merkle_proof
+				.verify_non_membership::<ICS23HostFunctions>(&specs, root_hash, merkle_path)
+				.map_err(|e| TendermintEvmError::MerkleProofVerificationFailed(e.to_string()))?;
+			out.insert(key_bytes, None);
+		} else {
+			merkle_proof
+				.verify_membership::<ICS23HostFunctions>(
+					&specs,
+					root_hash,
+					merkle_path,
+					ev.value.clone(),
+					0,
+				)
+				.map_err(|e| TendermintEvmError::MerkleProofVerificationFailed(e.to_string()))?;
+			out.insert(key_bytes, Some(ev.value));
+		}
 	}
 
 	Ok(out)

--- a/modules/ismp/state-machines/evm/src/tendermint.rs
+++ b/modules/ismp/state-machines/evm/src/tendermint.rs
@@ -54,9 +54,6 @@ pub enum TendermintEvmError {
 	/// A query key length didn't match any supported layout (32 or 52 bytes).
 	#[error("Only 32-byte or 52-byte keys are supported")]
 	UnsupportedKeyLength,
-	/// A non-membership proof contained at least one delivered request.
-	#[error("Some Requests in the batch have been delivered")]
-	DeliveredRequestsInBatch,
 	/// The number of verified values doesn't match the number of supplied keys.
 	#[error("Mismatched values/keys: the proof did not account for every key")]
 	MismatchedValuesAndKeys,
@@ -165,20 +162,61 @@ impl<H: IsmpHost + Send + Sync, T: pallet_ismp_host_executive::Config> StateMach
 
 	fn verify_non_membership(
 		&self,
-		host: &dyn IsmpHost,
+		_host: &dyn IsmpHost,
 		commitments: Vec<H256>,
 		root: StateCommitment,
 		proof: &Proof,
 	) -> Result<(), Error> {
+		let default_contract_address = EvmHosts::<T>::get(&proof.height.id.state_id)
+			.ok_or(TendermintEvmError::IsmpContractNotFound)?;
+
 		let keys = self.receipts_state_trie_key(commitments);
-		let keys_len = keys.len();
-		let values = self.verify_state_proof(host, keys, root, proof)?;
-		if values.len() != keys_len {
-			return Err(TendermintEvmError::MismatchedValuesAndKeys.into());
+
+		let store_key_str = store_key_for(proof.height.id.state_id);
+		let store_key = store_key_str.as_bytes();
+		let app_hash: [u8; 32] = root.state_root.0;
+
+		let proofs: Vec<crate::types::EvmKVProof> = codec::Decode::decode(&mut &proof.proof[..])
+			.map_err(|e| TendermintEvmError::ProofDecodeError(e.to_string()))?;
+
+		// Only support 32-byte or 52-byte keys
+		if keys.iter().any(|k| !(k.len() == 32 || k.len() == 52)) {
+			return Err(TendermintEvmError::UnsupportedKeyLength.into());
 		}
-		if values.into_iter().any(|(_key, val)| val.is_some()) {
-			return Err(TendermintEvmError::DeliveredRequestsInBatch.into());
+
+		if proofs.len() != keys.len() {
+			return Err(TendermintEvmError::MismatchedProofsAndKeys.into());
 		}
+
+		for (key_bytes, ev) in keys.into_iter().zip(proofs.into_iter()) {
+			// Determine contract address and 32-byte slot based on key length
+			let (addr, slot): (H160, [u8; 32]) = if key_bytes.len() == 32 {
+				(default_contract_address, key_bytes.clone().try_into().expect("32 bytes"))
+			} else {
+				// 52 bytes: first 20 bytes are contract address, last 32 bytes are the slot
+				let addr = H160::from_slice(&key_bytes[..20]);
+				let mut slot_arr = [0u8; 32];
+				slot_arr.copy_from_slice(&key_bytes[20..]);
+				(addr, slot_arr)
+			};
+
+			let key = storage_key_for(proof.height.id.state_id, &addr.0, slot);
+
+			let commitment_proof = CommitmentProofBytes::try_from(ev.proof.clone())
+				.map_err(|e| TendermintEvmError::InvalidCommitmentProof(e.to_string()))?;
+			let merkle_proof = MerkleProof::try_from(&commitment_proof)
+				.map_err(|e| TendermintEvmError::InvalidCommitmentProof(e.to_string()))?;
+			let specs = ProofSpecs::cosmos();
+			let root_hash = MerkleRoot { hash: app_hash.to_vec() };
+			let merkle_path = MerklePath::new(vec![
+				PathBytes::from_bytes(store_key),
+				PathBytes::from_bytes(&key),
+			]);
+			merkle_proof
+				.verify_non_membership::<ICS23HostFunctions>(&specs, root_hash, merkle_path)
+				.map_err(|e| TendermintEvmError::MerkleProofVerificationFailed(e.to_string()))?;
+		}
+
 		Ok(())
 	}
 

--- a/modules/ismp/state-machines/evm/src/tendermint.rs
+++ b/modules/ismp/state-machines/evm/src/tendermint.rs
@@ -57,6 +57,9 @@ pub enum TendermintEvmError {
 	/// A non-membership proof contained at least one delivered request.
 	#[error("Some Requests in the batch have been delivered")]
 	DeliveredRequestsInBatch,
+	/// The number of verified values doesn't match the number of supplied keys.
+	#[error("Mismatched values/keys: the proof did not account for every key")]
+	MismatchedValuesAndKeys,
 	/// SCALE decoding the EVM KV proof bundle failed.
 	#[error("Failed to decode proof bundle: {0}")]
 	ProofDecodeError(String),
@@ -168,7 +171,11 @@ impl<H: IsmpHost + Send + Sync, T: pallet_ismp_host_executive::Config> StateMach
 		proof: &Proof,
 	) -> Result<(), Error> {
 		let keys = self.receipts_state_trie_key(commitments);
+		let keys_len = keys.len();
 		let values = self.verify_state_proof(host, keys, root, proof)?;
+		if values.len() != keys_len {
+			return Err(TendermintEvmError::MismatchedValuesAndKeys.into());
+		}
 		if values.into_iter().any(|(_key, val)| val.is_some()) {
 			return Err(TendermintEvmError::DeliveredRequestsInBatch.into());
 		}
@@ -185,7 +192,12 @@ impl<H: IsmpHost + Send + Sync, T: pallet_ismp_host_executive::Config> StateMach
 		let contract_address = EvmHosts::<T>::get(&proof.height.id.state_id)
 			.ok_or(TendermintEvmError::IsmpContractNotFound)?;
 
-		verify_evm_kv_proofs(keys, contract_address, root, proof)
+		let keys_len = keys.len();
+		let values = verify_evm_kv_proofs(keys, contract_address, root, proof)?;
+		if values.len() != keys_len {
+			return Err(TendermintEvmError::MismatchedValuesAndKeys.into());
+		}
+		Ok(values)
 	}
 }
 

--- a/modules/ismp/state-machines/pharos/src/lib.rs
+++ b/modules/ismp/state-machines/pharos/src/lib.rs
@@ -52,6 +52,9 @@ pub enum PharosStateMachineError {
 	/// A non-membership proof contained at least one delivered request.
 	#[error("Some Requests in the batch have been delivered")]
 	DeliveredRequestsInBatch,
+	/// The number of verified values doesn't match the number of supplied keys.
+	#[error("Mismatched values/keys: the proof did not account for every key")]
+	MismatchedValuesAndKeys,
 	/// No storage proof for the requested ISMP commitment slot.
 	#[error("Missing storage proof for commitment key")]
 	MissingCommitmentStorageProof,
@@ -161,7 +164,11 @@ impl<H: IsmpHost + Send + Sync, T: pallet_ismp_host_executive::Config> StateMach
 		proof: &Proof,
 	) -> Result<(), Error> {
 		let keys = self.receipts_state_trie_key(commitments);
+		let keys_len = keys.len();
 		let values = self.verify_state_proof(host, keys, root, proof)?;
+		if values.len() != keys_len {
+			return Err(PharosStateMachineError::MismatchedValuesAndKeys.into());
+		}
 		if values.into_iter().any(|(_key, val)| val.is_some()) {
 			return Err(PharosStateMachineError::DeliveredRequestsInBatch.into());
 		}
@@ -177,7 +184,12 @@ impl<H: IsmpHost + Send + Sync, T: pallet_ismp_host_executive::Config> StateMach
 	) -> Result<BTreeMap<Vec<u8>, Option<Vec<u8>>>, Error> {
 		let ismp_address = EvmHosts::<T>::get(&proof.height.id.state_id)
 			.ok_or(PharosStateMachineError::IsmpContractNotFound)?;
-		verify_state_proof::<H>(keys, root, proof, ismp_address)
+		let keys_len = keys.len();
+		let values = verify_state_proof::<H>(keys, root, proof, ismp_address)?;
+		if values.len() != keys_len {
+			return Err(PharosStateMachineError::MismatchedValuesAndKeys.into());
+		}
+		Ok(values)
 	}
 }
 


### PR DESCRIPTION
State proof verification could silently treat a key as absent when a malformed or malicious proof omitted it. The EVM-family state machine clients now assert that verify_state_proof returns a value for every supplied key, both in verify_state_proof and verify_non_membership.