### PR TITLE
[runtime]: Tighten GRANDPA fraud proof predicate

### DIFF
--- a/modules/consensus/grandpa/verifier/src/error.rs
+++ b/modules/consensus/grandpa/verifier/src/error.rs
@@ -81,6 +81,10 @@ pub enum Error {
 	/// The two fraud proofs don't share an ancestor.
 	#[error("Fraud proofs are not for the same ancestor")]
 	FraudProofsDifferentAncestor,
+	/// The two finalized targets sit on the same canonical chain, so the proofs
+	/// don't witness a fork.
+	#[error("Fraud proofs are on the same branch")]
+	FraudProofsSameBranch,
 	/// A submitted justification doesn't match the trusted consensus
 	/// latest hash.
 	#[error("Justification does not match consensus latest hash")]

--- a/modules/ismp/clients/grandpa/src/consensus.rs
+++ b/modules/ismp/clients/grandpa/src/consensus.rs
@@ -311,7 +311,7 @@ where
 			.iter()
 			.min_by_key(|h| *h.number())
 			.ok_or(GrandpaError::UnknownHeadersEmpty)?;
-		first_headers
+		let first_chain = first_headers
 			.ancestry(first_base.hash(), first_target.hash())
 			.map_err(|_| GrandpaError::InvalidAncestry)?;
 
@@ -320,7 +320,7 @@ where
 			.iter()
 			.min_by_key(|h| *h.number())
 			.ok_or(GrandpaError::UnknownHeadersEmpty)?;
-		second_headers
+		let second_chain = second_headers
 			.ancestry(second_base.hash(), second_target.hash())
 			.map_err(|_| GrandpaError::InvalidAncestry)?;
 
@@ -329,6 +329,15 @@ where
 
 		if first_parent != second_parent {
 			return Err(GrandpaError::FraudProofsDifferentAncestor.into());
+		}
+
+		// Equivocation means two finalized blocks on competing branches. If one
+		// target appears in the other's ancestry then they share a canonical
+		// chain and this is just ordinary finality moving forward.
+		if first_chain.contains(&second_proof.block) ||
+			second_chain.contains(&first_proof.block)
+		{
+			return Err(GrandpaError::FraudProofsSameBranch.into());
 		}
 
 		let first_justification =


### PR DESCRIPTION
The fraud verifier on the GRANDPA consensus client treats two finality proofs as evidence of equivocation whenever their base headers share a parent, which also passes for canonical pairs where one finalized target is an ancestor of the other on the same chain. This change reuses the route that `AncestryChain::ancestry` already produces for each proof and rejects the pair when either target appears in the other's chain, returning a new `FraudProofsSameBranch` variant.