### PR TITLE
[sdk]: clear stale reverse mapping in setEidMapping

### DIFF
--- a/sdk/packages/lz-endpoint/contracts/HyperbridgeLzEndpoint.sol
+++ b/sdk/packages/lz-endpoint/contracts/HyperbridgeLzEndpoint.sol
@@ -136,13 +136,21 @@ contract HyperbridgeLzEndpoint is HyperApp, Ownable, Pausable, ILayerZeroEndpoin
     }
 
     /**
-     * @notice Registers a bidirectional mapping between a LZ eid and an ISMP state machine ID
+     * @notice Registers a bidirectional mapping between a LZ eid and an ISMP state machine ID.
+     * @dev Pass empty `stateMachineId` to disable the EID. Re-mapping an EID clears the prior
+     * state machine's reverse entry so revoked sources cannot keep impersonating the EID.
      * @param lzEid The LayerZero endpoint ID
      * @param stateMachineId The ISMP state machine identifier (e.g., StateMachine.evm(1))
      */
     function setEidMapping(uint32 lzEid, bytes calldata stateMachineId) external onlyOwner {
+        bytes memory previous = _eidToStateMachine[lzEid];
+        if (previous.length != 0) {
+            delete _stateMachineToEid[keccak256(previous)];
+        }
         _eidToStateMachine[lzEid] = stateMachineId;
-        _stateMachineToEid[keccak256(stateMachineId)] = lzEid;
+        if (stateMachineId.length != 0) {
+            _stateMachineToEid[keccak256(stateMachineId)] = lzEid;
+        }
     }
 
     /// @inheritdoc HyperApp

--- a/sdk/packages/lz-endpoint/test/HyperbridgeLzEndpointConfigTest.sol
+++ b/sdk/packages/lz-endpoint/test/HyperbridgeLzEndpointConfigTest.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+
+import {HyperbridgeLzEndpoint} from "../contracts/HyperbridgeLzEndpoint.sol";
+
+/// @dev Fork-free unit tests for `setEidMapping` cleanup semantics (HYPERBR-427).
+contract HyperbridgeLzEndpointConfigTest is Test {
+    HyperbridgeLzEndpoint internal endpoint;
+
+    uint32 internal constant EID_A = 101;
+    uint32 internal constant EID_B = 102;
+
+    bytes internal constant SM_A = hex"01020304";
+    bytes internal constant SM_B = hex"05060708";
+
+    function setUp() public {
+        endpoint = new HyperbridgeLzEndpoint(address(this));
+    }
+
+    function testRemapClearsPriorReverseEntry() public {
+        endpoint.setEidMapping(EID_A, SM_A);
+        assertEq(endpoint.eidFor(SM_A), EID_A);
+
+        endpoint.setEidMapping(EID_A, SM_B);
+
+        assertEq(endpoint.eidFor(SM_A), 0, "stale reverse entry must be cleared");
+        assertEq(endpoint.eidFor(SM_B), EID_A, "new reverse entry must be set");
+        assertEq(keccak256(endpoint.eidMapping(EID_A)), keccak256(SM_B));
+    }
+
+    function testDisableClearsReverseAndAvoidsEmptyKeyResidue() public {
+        endpoint.setEidMapping(EID_A, SM_A);
+        endpoint.setEidMapping(EID_A, hex"");
+
+        assertEq(endpoint.eidFor(SM_A), 0, "old reverse entry must be cleared on disable");
+        assertEq(endpoint.eidFor(hex""), 0, "empty-bytes reverse key must not be written");
+        assertEq(endpoint.eidMapping(EID_A).length, 0, "forward mapping must be empty");
+        assertFalse(endpoint.isSupportedEid(EID_A), "EID must report unsupported after disable");
+    }
+
+    function testSetEidMappingIsIdempotent() public {
+        endpoint.setEidMapping(EID_A, SM_A);
+        endpoint.setEidMapping(EID_A, SM_A);
+
+        assertEq(endpoint.eidFor(SM_A), EID_A);
+        assertEq(keccak256(endpoint.eidMapping(EID_A)), keccak256(SM_A));
+        assertTrue(endpoint.isSupportedEid(EID_A));
+    }
+
+    function testReassignStateMachineAcrossEidsPointsReverseToLatest() public {
+        endpoint.setEidMapping(EID_A, SM_A);
+        endpoint.setEidMapping(EID_B, SM_A);
+
+        assertEq(endpoint.eidFor(SM_A), EID_B, "reverse must point to the latest EID");
+        assertEq(keccak256(endpoint.eidMapping(EID_A)), keccak256(SM_A));
+        assertEq(keccak256(endpoint.eidMapping(EID_B)), keccak256(SM_A));
+    }
+}


### PR DESCRIPTION
## Summary
- `HyperbridgeLzEndpoint.setEidMapping` previously overwrote the forward map `_eidToStateMachine[lzEid]` and added a new reverse map entry, but never deleted the prior state machine's reverse entry. Inbound source authorization in `onAccept` reads only `_stateMachineToEid[keccak256(request.source)]`, so a remapped or "disabled" EID continued to authorize messages from the previously-trusted state machine (incomplete revocation).
- `setEidMapping` now reads the prior state machine, deletes its reverse entry if non-empty, writes the new forward, and writes the new reverse only when `stateMachineId` is non-empty. Clean disable path with no `keccak256("")` residue.

## Tests
Added fork-free unit tests at `sdk/packages/lz-endpoint/test/HyperbridgeLzEndpointConfigTest.sol` covering:
- [x] `testRemapClearsPriorReverseEntry` — `setEidMapping(101, A)` → `setEidMapping(101, B)` leaves `eidFor(A) == 0` and `eidFor(B) == 101`.
- [x] `testDisableClearsReverseAndAvoidsEmptyKeyResidue` — `setEidMapping(101, A)` → `setEidMapping(101, hex"")` clears `eidFor(A)`, does not populate `eidFor(hex"")`, and `isSupportedEid(101)` is false.
- [x] `testSetEidMappingIsIdempotent` — same args twice ends in byte-identical state.
- [x] `testReassignStateMachineAcrossEidsPointsReverseToLatest` — admin remap of the same state machine across two EIDs leaves the reverse pointing to the latest EID; sanity check for behavior under admin mistake.

All 4 tests pass locally:
```
[PASS] testDisableClearsReverseAndAvoidsEmptyKeyResidue() (gas: 52399)
[PASS] testReassignStateMachineAcrossEidsPointsReverseToLatest() (gas: 90358)
[PASS] testRemapClearsPriorReverseEntry() (gas: 72670)
[PASS] testSetEidMappingIsIdempotent() (gas: 67532)
```

Split into a separate file from `HyperbridgeLzEndpointTest.sol` because the new tests are pure config-state checks and don't need the mainnet fork (`MAINNET_FORK_URL`) that the existing E2E tests require.