### PR TITLE
[runtime]: Tighten BEEFY participation threshold to the named authority set

### DIFF
--- a/modules/consensus/beefy/verifier/src/lib.rs
+++ b/modules/consensus/beefy/verifier/src/lib.rs
@@ -116,26 +116,21 @@ pub fn verify_mmr_update_proof<H: Keccak256 + EcdsaRecover + Send + Sync>(
 		});
 	}
 
-	if !check_participation_threshold(
-		signatures_length as u32,
-		trusted_state.current_authorities.len,
-	) && !check_participation_threshold(
-		signatures_length as u32,
-		trusted_state.next_authorities.len,
-	) {
-		return Err(Error::SuperMajorityRequired);
-	}
-
 	let commitment = mmr.signed_commitment.commitment.clone();
 
-	if commitment.validator_set_id != trusted_state.current_authorities.id &&
-		commitment.validator_set_id != trusted_state.next_authorities.id
-	{
+	// Pick the authority set the commitment claims to be signed under, then judge
+	// participation against that set alone.
+	let authority_set = if commitment.validator_set_id == trusted_state.current_authorities.id {
+		&trusted_state.current_authorities
+	} else if commitment.validator_set_id == trusted_state.next_authorities.id {
+		&trusted_state.next_authorities
+	} else {
 		return Err(Error::UnknownAuthoritySet { id: commitment.validator_set_id });
-	}
+	};
 
-	let is_current_authorities =
-		commitment.validator_set_id == trusted_state.current_authorities.id;
+	if !check_participation_threshold(signatures_length as u32, authority_set.len) {
+		return Err(Error::SuperMajorityRequired);
+	}
 
 	let mmr_root_data = commitment
 		.payload
@@ -168,21 +163,12 @@ pub fn verify_mmr_update_proof<H: Keccak256 + EcdsaRecover + Send + Sync>(
 
 	let merkle_proof = MerkleProof::<MerkleHasher<H>>::new(mmr.authority_proof.clone());
 
-	let valid = if is_current_authorities {
-		merkle_proof.verify(
-			trusted_state.current_authorities.keyset_commitment.into(),
-			&authority_indices,
-			&authority_leaves,
-			trusted_state.current_authorities.len as usize,
-		)
-	} else {
-		merkle_proof.verify(
-			trusted_state.next_authorities.keyset_commitment.into(),
-			&authority_indices,
-			&authority_leaves,
-			trusted_state.next_authorities.len as usize,
-		)
-	};
+	let valid = merkle_proof.verify(
+		authority_set.keyset_commitment.into(),
+		&authority_indices,
+		&authority_leaves,
+		authority_set.len as usize,
+	);
 
 	if !valid {
 		Err(Error::InvalidAuthoritiesProof)?;

--- a/modules/consensus/beefy/verifier/src/test.rs
+++ b/modules/consensus/beefy/verifier/src/test.rs
@@ -27,12 +27,18 @@ use beefy_prover::{
 	util::{MerkleHasher, hash_authority_addresses},
 };
 use beefy_verifier_primitives::{
-	ConsensusMessage, MmrProof, ParachainHeader, ParachainProof, SignatureWithAuthorityIndex,
+	ConsensusMessage, ConsensusState, MmrProof, ParachainHeader, ParachainProof,
+	SignatureWithAuthorityIndex, SignedCommitment,
 };
 use ismp::messaging::Keccak256;
-use polkadot_sdk::sp_consensus_beefy::ecdsa_crypto::Signature;
+use polkadot_sdk::sp_consensus_beefy::{
+	Commitment, MmrRootHash, Payload, ValidatorSetId,
+	ecdsa_crypto::Signature,
+	mmr::{BeefyAuthoritySet, BeefyNextAuthoritySet, MmrLeaf, MmrLeafVersion},
+};
+use sp_mmr_primitives::LeafProof;
 
-use crate::{EcdsaRecover, verify_consensus};
+use crate::{EcdsaRecover, error::Error, verify_consensus, verify_mmr_update_proof};
 
 struct TestHost;
 
@@ -340,4 +346,57 @@ fn test_sp1_verify_consensus_accepts_solidity_fixture() {
 		"latest_beefy_height should advance"
 	);
 	assert_eq!(verified_headers.len(), 1, "fixture contains one parachain header");
+}
+
+fn authority_set(id: ValidatorSetId, len: u32) -> BeefyAuthoritySet<H256> {
+	BeefyAuthoritySet { id, len, keyset_commitment: H256::zero() }
+}
+
+fn dummy_mmr_proof(commitment: Commitment<u32>, signature_count: u32) -> MmrProof {
+	let signatures = (0..signature_count)
+		.map(|index| SignatureWithAuthorityIndex { index, signature: [0u8; 65] })
+		.collect();
+	MmrProof {
+		signed_commitment: SignedCommitment { commitment, signatures },
+		latest_mmr_leaf: MmrLeaf {
+			version: MmrLeafVersion::new(0, 0),
+			parent_number_and_hash: (0, H256::zero()),
+			beefy_next_authority_set: BeefyNextAuthoritySet {
+				id: 0,
+				len: 0,
+				keyset_commitment: H256::zero(),
+			},
+			leaf_extra: H256::zero(),
+		},
+		mmr_proof: LeafProof { leaf_indices: vec![0], leaf_count: 1, items: vec![] },
+		authority_proof: vec![],
+	}
+}
+
+// When current and next authority sets diverge in size, the threshold must be
+// judged against the set named by `validator_set_id` rather than passing if
+// either set's threshold is met. This mirrors the Solidity verifier and rules
+// out a commitment that only clears the smaller set's bar.
+#[test]
+fn rejects_sub_supermajority_from_named_authority_set() {
+	const CURRENT_SET_ID: ValidatorSetId = 42;
+	const NEXT_SET_ID: ValidatorSetId = 43;
+
+	let trusted_state = ConsensusState {
+		latest_beefy_height: 0,
+		beefy_activation_block: 0,
+		mmr_root_hash: H256::zero(),
+		current_authorities: authority_set(CURRENT_SET_ID, 100),
+		next_authorities: authority_set(NEXT_SET_ID, 3),
+	};
+
+	let payload = Payload::from_single_entry(*b"mh", MmrRootHash::zero().0.to_vec());
+	let commitment = Commitment { payload, block_number: 1, validator_set_id: CURRENT_SET_ID };
+
+	let mmr = dummy_mmr_proof(commitment, 3);
+
+	let result = sp_io::TestExternalities::default()
+		.execute_with(|| verify_mmr_update_proof::<TestHost>(trusted_state, mmr));
+
+	assert!(matches!(result, Err(Error::SuperMajorityRequired)));
 }

--- a/parachain/simtests/src/pallet_beefy_consensus_proofs.rs
+++ b/parachain/simtests/src/pallet_beefy_consensus_proofs.rs
@@ -25,6 +25,7 @@
 #![cfg(test)]
 
 use std::{
+	collections::BTreeMap,
 	env,
 	time::{SystemTime, UNIX_EPOCH},
 };
@@ -235,6 +236,22 @@ async fn fetch_storage_by_key<T: Decode>(
 	let decoded =
 		T::decode(&mut &bytes[..]).map_err(|e| anyhow!("decoding raw storage failed: {e:?}"))?;
 	Ok(Some(decoded))
+}
+
+/// Highest parachain height tracked across both ring buffers. The pallet writes
+/// the proven height into `MessagingProofs` for non-rotating proofs and into
+/// `RotationProofs` for rotating ones, so neither map alone is a complete view
+/// after a successful first proof.
+async fn latest_recorded_height(client: &OnlineClient<Hyperbridge>) -> Result<u64, anyhow::Error> {
+	let messaging = fetch_storage::<Vec<u64>>(client, "MessagingProofs")
+		.await?
+		.and_then(|v| v.last().copied())
+		.unwrap_or(0);
+	let rotation = fetch_storage::<BTreeMap<u64, u64>>(client, "RotationProofs")
+		.await?
+		.and_then(|m| m.values().copied().max())
+		.unwrap_or(0);
+	Ok(messaging.max(rotation))
 }
 
 #[tokio::test]
@@ -553,6 +570,13 @@ async fn test_naive_proof_happy_path() -> Result<(), anyhow::Error> {
 		"proof block {proof_block} must be ahead of trusted height {initial_height}",
 	);
 
+	// Same predicate the verifier uses to decide whether to rotate: the leaf's
+	// next-set id is strictly greater than the trusted state's next-set id. When
+	// rotation fires, the pallet routes the proof into `RotationProofs` instead
+	// of `MessagingProofs`, so we have to know in advance which bucket to check.
+	let will_rotate = consensus_message.mmr.latest_mmr_leaf.beefy_next_authority_set.id >
+		initial_state.next_authorities.id;
+
 	let abi_state: SolBeefyConsensusState = initial_state.into();
 	let abi_state_bytes = SolBeefyConsensusState::abi_encode(&abi_state);
 
@@ -598,17 +622,29 @@ async fn test_naive_proof_happy_path() -> Result<(), anyhow::Error> {
 	submit_signed(&client, &rpc_client, submit_call, Keyring::Bob).await?;
 	eprintln!("[stage] submit_proof finalized");
 
-	// First-proof path appends `latest_height` to `MessagingProofs`. A non-empty vec
-	// after `submit_proof` returns success means dispatch ran the full BEEFY check,
-	// stored a parachain commitment, and ran ring-buffer eviction. Combined with
-	// `wait_for_finalized_success` having returned ok, that's sufficient evidence
-	// the naive happy path works end-to-end.
-	let messaging_proofs: Vec<u64> =
-		fetch_storage::<Vec<u64>>(&client, "MessagingProofs").await?.unwrap_or_default();
-	assert!(
-		!messaging_proofs.is_empty(),
-		"MessagingProofs must contain the proven height after a successful first proof",
-	);
+	// The first-proof path writes the proven height into `MessagingProofs` when
+	// no rotation happened, and into `RotationProofs` when it did. A non-empty
+	// entry in the right bucket means dispatch ran the full BEEFY check, stored
+	// a parachain commitment, and ran ring-buffer eviction. Combined with
+	// `wait_for_finalized_success` having returned ok, that's sufficient
+	// evidence the naive happy path works end-to-end.
+	if will_rotate {
+		let rotation_proofs: BTreeMap<u64, u64> =
+			fetch_storage::<BTreeMap<u64, u64>>(&client, "RotationProofs")
+				.await?
+				.unwrap_or_default();
+		assert!(
+			!rotation_proofs.is_empty(),
+			"RotationProofs must contain the rotation height after a successful rotating proof",
+		);
+	} else {
+		let messaging_proofs: Vec<u64> =
+			fetch_storage::<Vec<u64>>(&client, "MessagingProofs").await?.unwrap_or_default();
+		assert!(
+			!messaging_proofs.is_empty(),
+			"MessagingProofs must contain the proven height after a successful first proof",
+		);
+	}
 
 	Ok(())
 }
@@ -674,13 +710,11 @@ async fn test_sp1_uncle_proof_dispatch_path() -> Result<(), anyhow::Error> {
 	submit_sudo(&client, &rpc_client, zero_reward).await?;
 
 	// 3. `settle_uncle_proof` looks up `ProofContext[Self::latest_height()]`. After a successful
-	//    first proof, `settle_first_proof` pushes that same height into `MessagingProofs`, so its
-	//    last entry is a faithful proxy. When Tier-3 runs in isolation `MessagingProofs` is empty
-	//    and `latest_height()` is 0, matching what we'd seed.
-	let parachain_height: u64 = fetch_storage::<Vec<u64>>(&client, "MessagingProofs")
-		.await?
-		.and_then(|v| v.last().copied())
-		.unwrap_or(0);
+	//    first proof, `settle_first_proof` pushes that height into either `MessagingProofs` or
+	//    `RotationProofs` depending on whether the proof rotated. Taking the max across both ring
+	//    buffers keeps Tier-3 in lockstep with Tier-2 regardless of which path it took, and falls
+	//    back to 0 when Tier-3 runs in isolation.
+	let parachain_height = latest_recorded_height(&client).await?;
 	eprintln!("[stage] seeding ProofContext at parachain_height={parachain_height}");
 
 	// 4. Force the BEEFY consensus state and seed the uncle snapshot via `System::set_storage`. We


### PR DESCRIPTION
The naive BEEFY verifier now picks the authority set by `validator_set_id` before checking participation, so the threshold is judged against the same set whose keys the signatures are about to verify against.