### PR TITLE
[evm]: clean up nits

### DIFF
--- a/evm/src/consensus/ConsensusRouter.sol
+++ b/evm/src/consensus/ConsensusRouter.sol
@@ -24,10 +24,10 @@ import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
  * @notice Routes consensus verification to the appropriate BEEFY verifier based on a
  * single-byte proof type prefix:
  *
- *   0x00 (Naive)      -> EcdsaBeefy: Verifies all secp256k1 signatures and authority set
+ *   0x00 (Ecdsa)      -> EcdsaBeefy: Verifies all secp256k1 signatures and authority set
  *                        membership proofs on-chain. Most gas-expensive but fully trustless.
  *
- *   0x01 (ZK)         -> SP1Beefy: Delegates signature verification, authority set membership,
+ *   0x01 (SP1)         -> SP1Beefy: Delegates signature verification, authority set membership,
  *                        and MMR leaf inclusion to an SP1 zero-knowledge proof. Cheapest on-chain
  *                        verification at the cost of off-chain proving.
  *
@@ -86,7 +86,6 @@ contract ConsensusRouter is IConsensusV2, ERC165 {
         returns (bytes memory, IntermediateState[] memory, uint256)
     {
         if (encodedProof.length == 0) revert EmptyProof();
-
         uint8 proofTypeByte = uint8(encodedProof[0]);
 
         if (proofTypeByte > uint8(type(ProofType).max)) {
@@ -94,10 +93,7 @@ contract ConsensusRouter is IConsensusV2, ERC165 {
         }
 
         ProofType proofType = ProofType(proofTypeByte);
-
-        // Strip the first byte
         bytes calldata actualProof = encodedProof[1:];
-
         if (proofType == ProofType.Sp1) {
             return IConsensusV2(address(sp1Beefy)).verify(previousState, actualProof);
         } else if (proofType == ProofType.Ecdsa) {

--- a/evm/src/consensus/EcdsaBeefy.sol
+++ b/evm/src/consensus/EcdsaBeefy.sol
@@ -88,8 +88,7 @@ contract EcdsaBeefy is IConsensusV2, ERC165 {
      * @dev See {IERC165-supportsInterface}.
      */
     function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
-        return interfaceId == type(IConsensusV2).interfaceId
-            || super.supportsInterface(interfaceId);
+        return interfaceId == type(IConsensusV2).interfaceId || super.supportsInterface(interfaceId);
     }
 
     /// @dev IConsensusV2 entry point. Decodes the proof, verifies consensus, and returns
@@ -103,27 +102,15 @@ contract EcdsaBeefy is IConsensusV2, ERC165 {
         (RelayChainProof memory relay, ParachainProof memory parachain) =
             abi.decode(proof, (RelayChainProof, ParachainProof));
 
-        (BeefyConsensusState memory newState, IntermediateState[] memory intermediates) =
-            verifyConsensus(consensusState, BeefyConsensusProof(relay, parachain));
-
-        return (abi.encode(newState), intermediates, newState.nextAuthoritySet.id);
-    }
-
-    // @dev Verify the consensus proof and return the new trusted consensus state and any intermediate states finalized
-    // by this consensus proof.
-    function verifyConsensus(BeefyConsensusState memory trustedState, BeefyConsensusProof memory proof)
-        internal
-        pure
-        returns (BeefyConsensusState memory, IntermediateState[] memory)
-    {
         // Stale proofs are a no-op: return the previous state with no intermediates so the caller
         // can treat replays as idempotent rather than having to guard against reverts.
-        if (trustedState.latestHeight >= proof.relay.signedCommitment.commitment.blockNumber) {
-            return (trustedState, new IntermediateState[](0));
+        if (consensusState.latestHeight >= relay.signedCommitment.commitment.blockNumber) {
+            return (abi.encode(consensusState), new IntermediateState[](0), consensusState.nextAuthoritySet.id);
         }
-        (BeefyConsensusState memory state, bytes32 headsRoot) = verifyMmrUpdateProof(trustedState, proof.relay);
-        IntermediateState[] memory intermediate = verifyParachainHeaderProof(headsRoot, proof.parachain);
-        return (state, intermediate);
+        (BeefyConsensusState memory newState, bytes32 headsRoot) = verifyMmrUpdateProof(consensusState, relay);
+        IntermediateState[] memory intermediates = verifyParachainHeaderProof(headsRoot, parachain);
+
+        return (abi.encode(newState), intermediates, newState.nextAuthoritySet.id);
     }
 
     /**

--- a/sdk/packages/core/contracts/apps/HyperFungibleToken.sol
+++ b/sdk/packages/core/contracts/apps/HyperFungibleToken.sol
@@ -42,6 +42,8 @@ import {HyperApp} from "./HyperApp.sol";
  * enabling composable cross-chain interactions (e.g., transfer-and-swap).
  */
 contract HyperFungibleToken is ERC20, ERC165, HyperApp, Ownable, Pausable {
+    using SafeERC20 for IERC20;
+
     /**
      * @title SendParams
      * @notice Parameters for initiating a cross-chain token transfer
@@ -90,11 +92,8 @@ contract HyperFungibleToken is ERC20, ERC165, HyperApp, Ownable, Pausable {
         bytes data;
     }
 
-    using SafeERC20 for IERC20;
-
     /// @notice Thrown when the provided bytes are too short to extract an address
     error InvalidAddress(uint256 length);
-
 
     /// @notice Thrown when attempting to send to or receive from an unconfigured chain
     error UnsupportedChain();
@@ -273,7 +272,13 @@ contract HyperFungibleToken is ERC20, ERC165, HyperApp, Ownable, Pausable {
             commitment = dispatchWithFeeToken(request);
         }
 
-        emit Sent(msg.sender, params.to, string(params.dest), params.amount, commitment);
+        emit Sent({
+            from: msg.sender,
+            to: params.to,
+            dest: string(params.dest),
+            amount: params.amount,
+            commitment: commitment
+        });
     }
 
     /**
@@ -298,7 +303,12 @@ contract HyperFungibleToken is ERC20, ERC165, HyperApp, Ownable, Pausable {
             ICallDispatcher(_dispatcher).dispatch(message.data);
         }
 
-        emit Received(message.from, beneficiary, string(request.source), message.amount);
+        emit Received({
+            from: message.from,
+            to: beneficiary,
+            source: string(request.source),
+            amount: message.amount
+        });
     }
 
     /**
@@ -311,15 +321,15 @@ contract HyperFungibleToken is ERC20, ERC165, HyperApp, Ownable, Pausable {
         Message memory message = abi.decode(incoming.request.body, (Message));
         address refundee = _toAddr(message.from);
         _mint(refundee, message.amount);
-        emit Refunded(refundee, message.amount);
+        emit Refunded({to: refundee, amount: message.amount});
     }
 
     /// @notice Extracts an address from the first 20 bytes of a bytes memory value
     function _toAddr(bytes memory b) internal pure returns (address addr) {
-        if (b.length < 20) revert InvalidAddress(b.length);
-        assembly {
-            addr := mload(add(b, 20))
-        }
+        if (b.length != 20) revert InvalidAddress(b.length);
+        // casting to 'bytes20' is safe because we already checked length
+        // forge-lint: disable-next-line(unsafe-typecast)
+        return address(bytes20(b));
     }
 
     /// @notice Pauses ERC20 transfers

--- a/sdk/packages/core/contracts/apps/WrappedHyperFungibleToken.sol
+++ b/sdk/packages/core/contracts/apps/WrappedHyperFungibleToken.sol
@@ -46,6 +46,8 @@ import {HyperFungibleToken} from "./HyperFungibleToken.sol";
  * enabling composable cross-chain interactions (e.g., transfer-and-swap).
  */
 contract WrappedHyperFungibleToken is ERC165, HyperApp, Ownable, Pausable {
+    using SafeERC20 for IERC20;
+
     /**
      * @title WrappedConfigOptions
      * @notice Configuration parameters for WrappedHyperFungibleToken
@@ -60,8 +62,6 @@ contract WrappedHyperFungibleToken is ERC165, HyperApp, Ownable, Pausable {
         /// @notice Whether the underlying token is WETH (enables native ETH refunds on timeout)
         bool isWeth;
     }
-
-    using SafeERC20 for IERC20;
 
     /// @notice Thrown when the provided bytes are too short to extract an address
     error InvalidAddress(uint256 length);
@@ -254,7 +254,7 @@ contract WrappedHyperFungibleToken is ERC165, HyperApp, Ownable, Pausable {
 
     /**
      * @notice Locks underlying tokens and dispatches a cross-chain transfer message
-     * @dev If `_isWeth` is true, wraps native tokens via the underlying's WETH
+     * @dev If `_isWeth` is true and msg.value is sufficient, wraps native tokens via the underlying's WETH
      * deposit function (reverts if the underlying is not WETH). The remainder of msg.value
      * after wrapping is forwarded as native payment for dispatch fees.
      *
@@ -265,7 +265,7 @@ contract WrappedHyperFungibleToken is ERC165, HyperApp, Ownable, Pausable {
      */
     function send(HyperFungibleToken.SendParams calldata params) external payable whenNotPaused {
         uint256 msgValue = msg.value;
-        if (_isWeth) {
+        if (_isWeth && msgValue >= params.amount) {
             msgValue = msgValue - params.amount;
             IWETH(_underlying).deposit{value: params.amount}();
         } else {
@@ -273,7 +273,6 @@ contract WrappedHyperFungibleToken is ERC165, HyperApp, Ownable, Pausable {
         }
 
         DispatchPost memory request = _buildDispatchPost(params);
-
         bytes32 commitment;
         if (msgValue > 0) {
             commitment = IDispatcher(_host).dispatch{value: msgValue}(request);
@@ -281,7 +280,13 @@ contract WrappedHyperFungibleToken is ERC165, HyperApp, Ownable, Pausable {
             commitment = dispatchWithFeeToken(request);
         }
 
-        emit Sent(msg.sender, params.to, string(params.dest), params.amount, commitment);
+        emit Sent({
+            from: msg.sender,
+            to: params.to,
+            dest: string(params.dest),
+            amount: params.amount,
+            commitment: commitment
+        });
     }
 
     /**
@@ -313,7 +318,12 @@ contract WrappedHyperFungibleToken is ERC165, HyperApp, Ownable, Pausable {
             ICallDispatcher(_dispatcher).dispatch(message.data);
         }
 
-        emit Received(message.from, beneficiary, string(request.source), message.amount);
+        emit Received({
+            from: message.from,
+            to: beneficiary,
+            source: string(request.source),
+            amount: message.amount
+        });
     }
 
     /**
@@ -334,7 +344,7 @@ contract WrappedHyperFungibleToken is ERC165, HyperApp, Ownable, Pausable {
             IERC20(_underlying).safeTransfer(refundee, message.amount);
         }
 
-        emit Refunded(refundee, message.amount);
+        emit Refunded({to: refundee, amount: message.amount});
     }
 
     /// @notice Accepts native ETH transfers, required for receiving ETH from WETH.withdraw()
@@ -342,10 +352,10 @@ contract WrappedHyperFungibleToken is ERC165, HyperApp, Ownable, Pausable {
 
     /// @notice Extracts an address from the first 20 bytes of a bytes memory value
     function _toAddr(bytes memory b) internal pure returns (address addr) {
-        if (b.length < 20) revert InvalidAddress(b.length);
-        assembly {
-            addr := mload(add(b, 20))
-        }
+        if (b.length != 20) revert InvalidAddress(b.length);
+        // casting to 'bytes20' is safe because we already checked length
+        // forge-lint: disable-next-line(unsafe-typecast)
+        return address(bytes20(b));
     }
 
     /// @notice ERC165 interface detection


### PR DESCRIPTION
## Summary

Cosmetic and small-correctness cleanup across EVM consensus and HyperFungibleToken contracts.

### `evm/src/consensus/ConsensusRouter.sol`
- Fix proof-type names in the routing comment (`Naive` → `Ecdsa`, `ZK` → `SP1`) to match the actual `ProofType` enum.
- Remove redundant blank lines in `verify`.

### `evm/src/consensus/EcdsaBeefy.sol`
- Inline the single-use `verifyConsensus` helper into `verify`, also handling the stale-proof short-circuit directly.
- Minor formatting (`supportsInterface` return on one line).

### `sdk/packages/core/contracts/apps/HyperFungibleToken.sol` and `WrappedHyperFungibleToken.sol`
- Move `using SafeERC20 for IERC20;` to the top of each contract (style/consistency).
- Emit `Sent` / `Received` / `Refunded` with named argument syntax for readability.
- Replace inline assembly in `_toAddr` with `address(bytes20(b))` and tighten the length check from `b.length < 20` to `b.length != 20` (rejects trailing junk).

### `WrappedHyperFungibleToken.send`
- Only wrap native via WETH when `msg.value >= params.amount`; previously the unconditional subtraction could underflow when callers funded the transfer with the underlying ERC20 instead of native value.