### PR TITLE
[runtime]: Bind source chain to relayer redirect signature

### DIFF
--- a/modules/pallets/relayer/src/accumulate.rs
+++ b/modules/pallets/relayer/src/accumulate.rs
@@ -22,7 +22,7 @@
 //! Substrate), and the per-leaf result validation that ties source-side fee
 //! metadata to destination-side delivery receipts.
 
-use crate::{withdrawal::WithdrawalProof, Config, Error, Event, Fees, Pallet};
+use crate::{withdrawal::WithdrawalProof, Config, Error, Event, Fees, Nonce, Pallet};
 use alloc::{collections::BTreeMap, vec::Vec};
 use alloy_primitives::Address;
 use codec::Encode;
@@ -107,7 +107,8 @@ where
 		let beneficiary_address = if let Some((beneficiary_address, signature)) =
 			withdrawal_proof.beneficiary_details
 		{
-			let msg = beneficiary_message(state_machine, &beneficiary_address);
+			let nonce = Nonce::<T>::get(&delivery_address, state_machine);
+			let msg = beneficiary_message(nonce, state_machine, &beneficiary_address);
 			match &signature {
 				Signature::Evm { .. } => {
 					let eth_address =
@@ -119,10 +120,16 @@ where
 				Signature::Sr25519 { .. } | Signature::Ed25519 { .. } => {
 					// verify the signature with the delivery address from the state proof
 					let _ = signature
-						.verify(&msg, Some(delivery_address))
+						.verify(&msg, Some(delivery_address.clone()))
 						.map_err(|_| Error::<T>::InvalidSignature)?;
 				},
 			}
+
+			Nonce::<T>::try_mutate(&delivery_address, state_machine, |value| {
+				*value += 1;
+				Ok::<(), ()>(())
+			})
+			.map_err(|_: ()| Error::<T>::ErrorCompletingCall)?;
 
 			let _ = Fees::<T>::try_mutate(state_machine, beneficiary_address.clone(), |inner| {
 				*inner += total_fee;
@@ -295,10 +302,15 @@ where
 }
 
 /// Signed payload authorising a beneficiary redirect on a specific source chain.
-/// Binding the state machine keeps a signature collected on one chain from being
-/// accepted on another that happens to share the same delivery key.
-pub fn beneficiary_message(state_machine: StateMachine, beneficiary: &[u8]) -> [u8; 32] {
-	sp_io::hashing::keccak_256(&(state_machine, beneficiary).encode())
+/// Including the relayer nonce alongside the state machine keeps the signature usable for
+/// exactly one accumulate call on that chain, mirroring how `withdraw_fees` binds its signed
+/// payload.
+pub fn beneficiary_message(
+	nonce: u64,
+	state_machine: StateMachine,
+	beneficiary: &[u8],
+) -> [u8; 32] {
+	sp_io::hashing::keccak_256(&(nonce, state_machine, beneficiary).encode())
 }
 
 impl<T: Config> Pallet<T> {

--- a/modules/pallets/relayer/src/accumulate.rs
+++ b/modules/pallets/relayer/src/accumulate.rs
@@ -107,7 +107,7 @@ where
 		let beneficiary_address = if let Some((beneficiary_address, signature)) =
 			withdrawal_proof.beneficiary_details
 		{
-			let msg = sp_io::hashing::keccak_256(&beneficiary_address);
+			let msg = beneficiary_message(state_machine, &beneficiary_address);
 			match &signature {
 				Signature::Evm { .. } => {
 					let eth_address =
@@ -292,6 +292,13 @@ where
 
 		Ok((result, commitments))
 	}
+}
+
+/// Signed payload authorising a beneficiary redirect on a specific source chain.
+/// Binding the state machine keeps a signature collected on one chain from being
+/// accepted on another that happens to share the same delivery key.
+pub fn beneficiary_message(state_machine: StateMachine, beneficiary: &[u8]) -> [u8; 32] {
+	sp_io::hashing::keccak_256(&(state_machine, beneficiary).encode())
 }
 
 impl<T: Config> Pallet<T> {

--- a/modules/pallets/relayer/src/lib.rs
+++ b/modules/pallets/relayer/src/lib.rs
@@ -24,6 +24,7 @@ pub mod accumulate;
 pub mod outbound_consensus;
 pub mod withdrawal;
 
+pub use accumulate::beneficiary_message;
 pub use outbound_consensus::*;
 pub use withdrawal::message;
 

--- a/modules/pallets/testsuite/src/tests/pallet_ismp_relayer.rs
+++ b/modules/pallets/testsuite/src/tests/pallet_ismp_relayer.rs
@@ -221,7 +221,11 @@ fn test_accumulate_fees() {
 		let beneficiary_address = H256::random();
 
 		let signature = pair
-			.sign(&beneficiary_message(StateMachine::Kusama(2000), beneficiary_address.as_bytes()))
+			.sign(&beneficiary_message(
+				0,
+				StateMachine::Kusama(2000),
+				beneficiary_address.as_bytes(),
+			))
 			.to_vec();
 
 		let withdrawal_proof = WithdrawalProof {
@@ -703,6 +707,7 @@ fn test_accumulate_fees_evm_signatures() {
 
 		let signature = pair
 			.sign_prehashed(&beneficiary_message(
+				0,
 				StateMachine::Kusama(2000),
 				beneficiary_address.as_bytes(),
 			))
@@ -732,7 +737,7 @@ fn test_accumulate_fees_evm_signatures() {
 			},
 			beneficiary_details: Some((
 				beneficiary_address.0.to_vec().clone(),
-				Signature::Evm { address: eth_address, signature },
+				Signature::Evm { address: eth_address.clone(), signature },
 			)),
 		};
 
@@ -748,6 +753,11 @@ fn test_accumulate_fees_evm_signatures() {
 				beneficiary_address.0.to_vec()
 			),
 			U256::from(5000u128)
+		);
+		assert_eq!(
+			pallet_ismp_relayer::Nonce::<Test>::get(eth_address, StateMachine::Kusama(2000)),
+			1,
+			"a successful redirect must consume the signer's nonce"
 		);
 	})
 }
@@ -882,7 +892,7 @@ fn test_accumulate_fees_rejects_replay_from_other_chain() {
 		// The byte payload is reused as if captured from that chain and replayed here.
 		let foreign_chain = StateMachine::Kusama(7777);
 		let signature = pair
-			.sign_prehashed(&beneficiary_message(foreign_chain, beneficiary_address.as_bytes()))
+			.sign_prehashed(&beneficiary_message(0, foreign_chain, beneficiary_address.as_bytes()))
 			.to_vec();
 
 		let withdrawal_proof = WithdrawalProof {

--- a/modules/pallets/testsuite/src/tests/pallet_ismp_relayer.rs
+++ b/modules/pallets/testsuite/src/tests/pallet_ismp_relayer.rs
@@ -31,11 +31,11 @@ use pallet_ismp::{
 };
 use pallet_ismp_host_executive::{EvmHostParam, HostParam};
 use pallet_ismp_relayer::{
-	self as pallet_ismp_relayer, message,
+	self as pallet_ismp_relayer, beneficiary_message, message,
 	withdrawal::{Signature, WithdrawalInputData, WithdrawalProof},
 	OutboundConsensusDeliveryClaim,
 };
-use sp_core::{keccak_256, Pair, H256, U256};
+use sp_core::{Pair, H256, U256};
 use sp_trie::LayoutV0;
 use std::time::Duration;
 use substrate_state_machine::{HashAlgorithm, StateMachineProof, SubstrateStateProof};
@@ -220,7 +220,9 @@ fn test_accumulate_fees() {
 
 		let beneficiary_address = H256::random();
 
-		let signature = pair.sign(&keccak_256(beneficiary_address.as_bytes())).to_vec();
+		let signature = pair
+			.sign(&beneficiary_message(StateMachine::Kusama(2000), beneficiary_address.as_bytes()))
+			.to_vec();
 
 		let withdrawal_proof = WithdrawalProof {
 			commitments: keys,
@@ -699,7 +701,12 @@ fn test_accumulate_fees_evm_signatures() {
 
 		let beneficiary_address = H256::random();
 
-		let signature = pair.sign_prehashed(&keccak_256(beneficiary_address.as_bytes())).to_vec();
+		let signature = pair
+			.sign_prehashed(&beneficiary_message(
+				StateMachine::Kusama(2000),
+				beneficiary_address.as_bytes(),
+			))
+			.to_vec();
 
 		let withdrawal_proof = WithdrawalProof {
 			commitments: keys,
@@ -741,6 +748,183 @@ fn test_accumulate_fees_evm_signatures() {
 				beneficiary_address.0.to_vec()
 			),
 			U256::from(5000u128)
+		);
+	})
+}
+
+/// A redirect signature signed for one source chain must not satisfy verification
+/// when reused on another. The state machine is folded into the signed payload
+/// so the recovered address only matches the delivery address on the chain the
+/// signature was issued for.
+#[test]
+fn test_accumulate_fees_rejects_replay_from_other_chain() {
+	let mut ext = new_test_ext();
+	ext.execute_with(|| {
+		set_timestamp::<Test>(10_000_000_000);
+		let requests = (0u64..2)
+			.into_iter()
+			.map(|nonce| {
+				let post = PostRequest {
+					source: StateMachine::Kusama(2000),
+					dest: StateMachine::Kusama(2001),
+					nonce,
+					from: vec![],
+					to: vec![],
+					timeout_timestamp: 0,
+					body: vec![],
+				};
+				hash_request::<Ismp>(&Request::Post(post))
+			})
+			.collect::<Vec<_>>();
+
+		let pair = sp_core::ecdsa::Pair::from_seed_slice(H256::random().as_bytes()).unwrap();
+		let eth_address = pair.public().to_eth_address().unwrap().to_vec();
+
+		let mut source_root = H256::default();
+		let mut source_db = MemoryDB::<KeccakHasher>::default();
+		let mut source_trie =
+			TrieDBMutBuilder::<LayoutV0<KeccakHasher>>::new(&mut source_db, &mut source_root)
+				.build();
+		let mut dest_root = H256::default();
+		let mut dest_db = MemoryDB::<KeccakHasher>::default();
+		let mut dest_trie =
+			TrieDBMutBuilder::<LayoutV0<KeccakHasher>>::new(&mut dest_db, &mut dest_root).build();
+
+		for request in &requests {
+			let request_commitment_key = RequestCommitments::<Test>::storage_key(*request);
+			let request_receipt_key = RequestReceipts::<Test>::storage_key(*request);
+			let fee_metadata = FeeMetadata::<Test> { payer: [0; 32].into(), fee: 1000u128.into() };
+			let leaf_meta = RequestMetadata {
+				offchain: LeafIndexAndPos { leaf_index: 0, pos: 0 },
+				fee: fee_metadata,
+				claimed: false,
+			};
+			RequestCommitments::<Test>::insert(*request, leaf_meta.clone());
+			source_trie.insert(&request_commitment_key, &leaf_meta.encode()).unwrap();
+			dest_trie.insert(&request_receipt_key, &eth_address.encode()).unwrap();
+		}
+		drop(source_trie);
+		drop(dest_trie);
+
+		let mut source_recorder = Recorder::<LayoutV0<KeccakHasher>>::default();
+		let mut dest_recorder = Recorder::<LayoutV0<KeccakHasher>>::default();
+		let source_trie = TrieDBBuilder::<LayoutV0<KeccakHasher>>::new(&source_db, &source_root)
+			.with_recorder(&mut source_recorder)
+			.build();
+		let dest_trie = TrieDBBuilder::<LayoutV0<KeccakHasher>>::new(&dest_db, &dest_root)
+			.with_recorder(&mut dest_recorder)
+			.build();
+
+		let mut keys = vec![];
+		for request in requests.iter() {
+			let request_commitment_key = RequestCommitments::<Test>::storage_key(*request);
+			let request_receipt_key = RequestReceipts::<Test>::storage_key(*request);
+			source_trie.get(&request_commitment_key).unwrap();
+			dest_trie.get(&request_receipt_key).unwrap();
+			keys.push(*request);
+		}
+
+		let source_state_proof = SubstrateStateProof::OverlayProof(StateMachineProof {
+			hasher: HashAlgorithm::Keccak,
+			storage_proof: source_recorder.drain().into_iter().map(|f| f.data).collect::<Vec<_>>(),
+		});
+		let dest_state_proof = SubstrateStateProof::OverlayProof(StateMachineProof {
+			hasher: HashAlgorithm::Keccak,
+			storage_proof: dest_recorder.drain().into_iter().map(|f| f.data).collect::<Vec<_>>(),
+		});
+
+		let host = Ismp::default();
+		for chain in [StateMachine::Kusama(2000), StateMachine::Kusama(2001)] {
+			host.store_state_machine_commitment(
+				StateMachineHeight {
+					id: StateMachineId {
+						state_id: chain,
+						consensus_state_id: MOCK_CONSENSUS_STATE_ID,
+					},
+					height: 1,
+				},
+				StateCommitment {
+					timestamp: 100,
+					overlay_root: Some(if chain == StateMachine::Kusama(2000) {
+						source_root
+					} else {
+						dest_root
+					}),
+					state_root: Default::default(),
+				},
+			)
+			.unwrap();
+			host.store_state_machine_update_time(
+				StateMachineHeight {
+					id: StateMachineId {
+						state_id: chain,
+						consensus_state_id: MOCK_CONSENSUS_STATE_ID,
+					},
+					height: 1,
+				},
+				Duration::from_secs(100),
+			)
+			.unwrap();
+			host.store_challenge_period(
+				StateMachineId { state_id: chain, consensus_state_id: MOCK_CONSENSUS_STATE_ID },
+				0,
+			)
+			.unwrap();
+		}
+		host.store_consensus_state(MOCK_CONSENSUS_STATE_ID, Default::default()).unwrap();
+		host.store_consensus_state_id(MOCK_CONSENSUS_STATE_ID, MOCK_CONSENSUS_CLIENT_ID)
+			.unwrap();
+		host.store_unbonding_period(MOCK_CONSENSUS_STATE_ID, 10_000_000_000).unwrap();
+
+		let beneficiary_address = H256::random();
+
+		// A signature the relayer would have produced for a different source chain.
+		// The byte payload is reused as if captured from that chain and replayed here.
+		let foreign_chain = StateMachine::Kusama(7777);
+		let signature = pair
+			.sign_prehashed(&beneficiary_message(foreign_chain, beneficiary_address.as_bytes()))
+			.to_vec();
+
+		let withdrawal_proof = WithdrawalProof {
+			commitments: keys,
+			source_proof: Proof {
+				height: StateMachineHeight {
+					id: StateMachineId {
+						state_id: StateMachine::Kusama(2000),
+						consensus_state_id: MOCK_CONSENSUS_STATE_ID,
+					},
+					height: 1,
+				},
+				proof: source_state_proof.encode(),
+			},
+			dest_proof: Proof {
+				height: StateMachineHeight {
+					id: StateMachineId {
+						state_id: StateMachine::Kusama(2001),
+						consensus_state_id: MOCK_CONSENSUS_STATE_ID,
+					},
+					height: 1,
+				},
+				proof: dest_state_proof.encode(),
+			},
+			beneficiary_details: Some((
+				beneficiary_address.0.to_vec(),
+				Signature::Evm { address: eth_address, signature },
+			)),
+		};
+
+		let result = pallet_ismp_relayer::Pallet::<Test>::accumulate_fees(
+			RuntimeOrigin::none(),
+			withdrawal_proof,
+		);
+
+		assert!(result.is_err(), "replayed signature from a different chain must be rejected");
+		assert_eq!(
+			pallet_ismp_relayer::Fees::<Test>::get(
+				StateMachine::Kusama(2000),
+				beneficiary_address.0.to_vec()
+			),
+			U256::zero()
 		);
 	})
 }

--- a/tesseract/messaging/fees/src/lib.rs
+++ b/tesseract/messaging/fees/src/lib.rs
@@ -251,15 +251,26 @@ impl TransactionPayment {
 		}
 	}
 
-	pub async fn query_state_proofs(
+	pub async fn query_state_proofs<H: HyperbridgeClaim + Sync>(
 		&self,
 		source: Arc<dyn IsmpProvider>,
 		dest: Arc<dyn IsmpProvider>,
 		source_height: u64,
 		dest_height: u64,
 		keys: Vec<(H256, Vec<Vec<u8>>, Vec<Vec<u8>>)>,
+		hyperbridge: &H,
 	) -> Result<Vec<WithdrawalProof>, anyhow::Error> {
 		let mut proofs = vec![];
+		let source_chain = source.state_machine_id().state_id;
+		let cross_chain_type = discriminant(&source.state_machine_id().state_id) !=
+			discriminant(&dest.state_machine_id().state_id);
+		// One signature is consumed per submitted proof, so each chunk increments
+		// the locally-tracked nonce from the snapshot we read at the start.
+		let mut nonce = if cross_chain_type {
+			hyperbridge.relayer_nonce(dest.address(), source_chain).await?
+		} else {
+			0
+		};
 		// Chunk keys by 50 each
 		for chunk in keys.chunks(50) {
 			// Gather keys to be queried on the source chain
@@ -290,6 +301,16 @@ impl TransactionPayment {
 				)
 				.await?;
 
+			let beneficiary_details = if cross_chain_type {
+				let beneficiary = source.address();
+				let prehash = beneficiary_message(nonce, source_chain, &beneficiary);
+				let details = Some((beneficiary, dest.sign(&prehash)));
+				nonce += 1;
+				details
+			} else {
+				None
+			};
+
 			let proof = WithdrawalProof {
 				commitments: request_response_commitments,
 				source_proof: Proof {
@@ -303,19 +324,7 @@ impl TransactionPayment {
 					height: StateMachineHeight { id: dest.state_machine_id(), height: dest_height },
 					proof: dest_proof,
 				},
-				beneficiary_details: {
-					// If they are not the same chain type
-					if discriminant(&source.state_machine_id().state_id) !=
-						discriminant(&dest.state_machine_id().state_id)
-					{
-						let beneficiary = source.address();
-						let prehash =
-							beneficiary_message(source.state_machine_id().state_id, &beneficiary);
-						Some((beneficiary, dest.sign(&prehash)))
-					} else {
-						None
-					}
-				},
+				beneficiary_details,
 			};
 
 			proofs.push(proof)
@@ -326,13 +335,14 @@ impl TransactionPayment {
 
 	// todo: Consolidate the state proof query into a single function
 	/// Create payment claim proof for all deliveries of requests from source to dest.
-	pub async fn create_proof_from_receipts(
+	pub async fn create_proof_from_receipts<H: HyperbridgeClaim + Sync>(
 		&self,
 		source_height: u64,
 		dest_height: u64,
 		source: Arc<dyn IsmpProvider>,
 		dest: Arc<dyn IsmpProvider>,
 		receipts: Vec<TxReceipt>,
+		hyperbridge: &H,
 	) -> anyhow::Result<Vec<WithdrawalProof>> {
 		let keys = receipts
 			.iter()
@@ -343,7 +353,8 @@ impl TransactionPayment {
 			})
 			.collect::<Vec<_>>();
 
-		self.query_state_proofs(source, dest, source_height, dest_height, keys).await
+		self.query_state_proofs(source, dest, source_height, dest_height, keys, hyperbridge)
+			.await
 	}
 
 	/// Fetch all pending withdrawals from the db, returns their id so they can be deleted.
@@ -484,7 +495,7 @@ impl TransactionPayment {
 
 	/// Create payment claim proof for all deliveries of requests and responses from source to dest
 	/// a number of days The default is 30 days
-	pub async fn create_claim_proof<H: HyperbridgeClaim>(
+	pub async fn create_claim_proof<H: HyperbridgeClaim + Sync>(
 		&self,
 		source_height: u64,
 		dest_height: u64,
@@ -548,8 +559,15 @@ impl TransactionPayment {
 			}
 		});
 
-		self.query_state_proofs(source, dest, source_height, dest_height, keys_to_prove)
-			.await
+		self.query_state_proofs(
+			source,
+			dest,
+			source_height,
+			dest_height,
+			keys_to_prove,
+			hyperbridge,
+		)
+		.await
 	}
 
 	pub async fn delete_claimed_entries(&self, commitments: Vec<H256>) -> anyhow::Result<()> {

--- a/tesseract/messaging/fees/src/lib.rs
+++ b/tesseract/messaging/fees/src/lib.rs
@@ -22,11 +22,13 @@ use ismp::{
 	router::{PostRequest, Request},
 };
 use itertools::Itertools;
-use pallet_ismp_relayer::withdrawal::{Signature, WithdrawalProof};
+use pallet_ismp_relayer::{
+	beneficiary_message,
+	withdrawal::{Signature, WithdrawalProof},
+};
 use primitive_types::{H256, U256};
 use prisma_client_rust::{query_core::RawQuery, BatchItem, Direction, PrismaValue, Raw};
 use serde::{Deserialize, Serialize};
-use sp_core::keccak_256;
 use std::{collections::BTreeSet, mem::discriminant, sync::Arc};
 use tesseract_primitives::{
 	HyperbridgeClaim, IsmpProvider, StateProofQueryType, TxReceipt, WithdrawFundsResult,
@@ -240,8 +242,7 @@ impl TransactionPayment {
 			.exec()
 			.await?;
 
-		let dest_height =
-			request_entries.last().map(|data| data.height as u64).unwrap_or_default();
+		let dest_height = request_entries.last().map(|data| data.height as u64).unwrap_or_default();
 
 		if dest_height == 0 {
 			Ok(None)
@@ -307,7 +308,10 @@ impl TransactionPayment {
 					if discriminant(&source.state_machine_id().state_id) !=
 						discriminant(&dest.state_machine_id().state_id)
 					{
-						Some((source.address(), dest.sign(&keccak_256(&source.address()))))
+						let beneficiary = source.address();
+						let prehash =
+							beneficiary_message(source.state_machine_id().state_id, &beneficiary);
+						Some((beneficiary, dest.sign(&prehash)))
 					} else {
 						None
 					}

--- a/tesseract/messaging/messaging/src/lib.rs
+++ b/tesseract/messaging/messaging/src/lib.rs
@@ -624,7 +624,7 @@ pub async fn fee_accumulation<A: IsmpProvider + Clone + Clone + HyperbridgeClaim
 								"Creating withdrawal proofs from db for deliveries",
 							);
 							let proofs = tx_payment
-							.create_proof_from_receipts(source_height.into(), dest_height, source_chain.clone(), dest.clone(), receipts.clone())
+							.create_proof_from_receipts(source_height.into(), dest_height, source_chain.clone(), dest.clone(), receipts.clone(), &*hyperbridge)
 							.await?;
 							observe_challenge_period(source_chain.clone(), hyperbridge.clone(), source_height.into()).await?;
 							observe_challenge_period(dest.clone(), hyperbridge.clone(), dest_height).await?;

--- a/tesseract/messaging/primitives/src/lib.rs
+++ b/tesseract/messaging/primitives/src/lib.rs
@@ -586,6 +586,11 @@ pub trait HyperbridgeClaim {
 	) -> anyhow::Result<Vec<WithdrawFundsResult>>;
 	/// Check if this commitment has been claimed
 	async fn check_claimed(&self, commitment: H256) -> anyhow::Result<bool>;
+	/// Current relayer signature nonce stored on Hyperbridge for this `(address, chain)`
+	/// pair. Used to pin a beneficiary redirect signature to one accumulate call.
+	async fn relayer_nonce(&self, _address: Vec<u8>, _chain: StateMachine) -> anyhow::Result<u64> {
+		Ok(0)
+	}
 }
 
 #[async_trait::async_trait]

--- a/tesseract/messaging/primitives/src/lib.rs
+++ b/tesseract/messaging/primitives/src/lib.rs
@@ -588,9 +588,7 @@ pub trait HyperbridgeClaim {
 	async fn check_claimed(&self, commitment: H256) -> anyhow::Result<bool>;
 	/// Current relayer signature nonce stored on Hyperbridge for this `(address, chain)`
 	/// pair. Used to pin a beneficiary redirect signature to one accumulate call.
-	async fn relayer_nonce(&self, _address: Vec<u8>, _chain: StateMachine) -> anyhow::Result<u64> {
-		Ok(0)
-	}
+	async fn relayer_nonce(&self, address: Vec<u8>, chain: StateMachine) -> anyhow::Result<u64>;
 }
 
 #[async_trait::async_trait]

--- a/tesseract/messaging/primitives/src/mocks.rs
+++ b/tesseract/messaging/primitives/src/mocks.rs
@@ -93,6 +93,10 @@ impl<T: Codec + Send + Sync> HyperbridgeClaim for MockHost<T> {
 	async fn check_claimed(&self, _commitment: H256) -> anyhow::Result<bool> {
 		Ok(false)
 	}
+
+	async fn relayer_nonce(&self, _address: Vec<u8>, _chain: StateMachine) -> anyhow::Result<u64> {
+		Ok(0)
+	}
 }
 
 #[async_trait::async_trait]

--- a/tesseract/messaging/substrate/src/calls.rs
+++ b/tesseract/messaging/substrate/src/calls.rs
@@ -193,18 +193,8 @@ where
 			U256::from(10u128 * 10u128.pow((*fee_token_decimals).into()))
 		{
 			// withdraws funds accumulated into hyperbridge address
-			let key = relayer_nonce_storage_key(self.address.clone(), chain);
-			let block_hash = self
-				.rpc
-				.chain_get_block_hash(None)
-				.await?
-				.ok_or_else(|| anyhow!("Failed to query latest block hash"))?;
-			let raw_value = self.client.storage().at(block_hash).fetch_raw(key.clone()).await?;
-			let nonce = if let Some(raw_value) = raw_value {
-				Decode::decode(&mut &*raw_value)?
-			} else {
-				0u64
-			};
+			let nonce =
+				fetch_relayer_nonce(&self.client, &self.rpc, self.address.clone(), chain).await?;
 
 			let message = message(nonce, chain, Some(counterparty.address().clone()));
 			let signature = { self.sign(&message) };
@@ -221,15 +211,8 @@ where
 			);
 		}
 		// withdraws funds accumulated into counterparty address
-		let key = relayer_nonce_storage_key(counterparty.address(), chain);
-		let block_hash = self
-			.rpc
-			.chain_get_block_hash(None)
-			.await?
-			.ok_or_else(|| anyhow!("Failed to query latest block hash"))?;
-		let raw_value = self.client.storage().at(block_hash).fetch_raw(key.clone()).await?;
 		let nonce =
-			if let Some(raw_value) = raw_value { Decode::decode(&mut &*raw_value)? } else { 0u64 };
+			fetch_relayer_nonce(&self.client, &self.rpc, counterparty.address(), chain).await?;
 
 		let message = message(nonce, chain, None);
 		let signature = { counterparty.sign(&message) };
@@ -255,6 +238,10 @@ where
 		let leaf_meta = RequestMetadata::decode(&mut &*data.0)?;
 
 		Ok(leaf_meta.claimed)
+	}
+
+	async fn relayer_nonce(&self, address: Vec<u8>, chain: StateMachine) -> anyhow::Result<u64> {
+		fetch_relayer_nonce(&self.client, &self.rpc, address, chain).await
 	}
 }
 
@@ -314,6 +301,23 @@ async fn relayer_account_balance<C: subxt::Config>(
 	};
 
 	Ok(balance)
+}
+
+async fn fetch_relayer_nonce<C: subxt::Config>(
+	client: &OnlineClient<C>,
+	rpc: &LegacyRpcMethods<C>,
+	address: Vec<u8>,
+	chain: StateMachine,
+) -> anyhow::Result<u64> {
+	let key = relayer_nonce_storage_key(address, chain);
+	let block_hash = rpc
+		.chain_get_block_hash(None)
+		.await?
+		.ok_or_else(|| anyhow!("Failed to query latest block hash"))?;
+	let raw_value = client.storage().at(block_hash).fetch_raw(key).await?;
+	let nonce =
+		if let Some(raw_value) = raw_value { Decode::decode(&mut &*raw_value)? } else { 0u64 };
+	Ok(nonce)
 }
 
 async fn execute_withdrawal<C>(


### PR DESCRIPTION
The accumulate flow verified a beneficiary redirect signature against the bare keccak of the beneficiary address, while the withdrawal flow already signs the beneficiary alongside the destination chain and a per relayer nonce. This change folds the source state machine into the prehash through a new `beneficiary_message` helper exported from `pallet-ismp-relayer`, and updates the off chain signer in `transaction-fees` to compute the same payload. 