### PR TITLE
[docs]: switch Polkadot testnet links to blockscout-testnet

### DIFF
--- a/docs/content/developers/evm/contract-addresses/testnet.mdx
+++ b/docs/content/developers/evm/contract-addresses/testnet.mdx
@@ -15,15 +15,15 @@ The current testnet environment for the Hyperbridge network.
 
 ### Polkadot Asset Hub (Paseo)
 
-| `IsmpHost` | [`0xEB944071A9Bf22810757C5BcFf7a2aE9663a311D`](https://polkadot.testnet.routescan.io/address/0xEB944071A9Bf22810757C5BcFf7a2aE9663a311D) |
+| `IsmpHost` | [`0xEB944071A9Bf22810757C5BcFf7a2aE9663a311D`](https://blockscout-testnet.polkadot.io/address/0xEB944071A9Bf22810757C5BcFf7a2aE9663a311D) |
 |:------------|:-----|
-| `HandlerV2` | [`0x53184b424971d4b5944fdf6f52f18c3fcc4d0925`](https://polkadot.testnet.routescan.io/address/0x53184b424971d4b5944fdf6f52f18c3fcc4d0925) |
-| `ConsensusClient` | [`0xBd02fd8331E54e795DdD37f915694DEe54bB5a00`](https://polkadot.testnet.routescan.io/address/0xBd02fd8331E54e795DdD37f915694DEe54bB5a00) |
-| `HostManager` | [`0xb05fd51329b4dd28cf07e273efb496edd243dbee`](https://polkadot.testnet.routescan.io/address/0xb05fd51329b4dd28cf07e273efb496edd243dbee) |
-| `CallDispatcher` | [`0x2b332088275bc9e3c26d81b2975de2483320c181`](https://polkadot.testnet.routescan.io/address/0x2b332088275bc9e3c26d81b2975de2483320c181) |
-| `BandwidthManager` | [`0xFe6D81417CFe618aCaA34dF23376c738900290DE`](https://polkadot.testnet.routescan.io/address/0xFe6D81417CFe618aCaA34dF23376c738900290DE) |
-| `TokenFaucet` | [`0xcb00f5b86aac5e2fdca9dc7f34d9bfe00b967c18`](https://polkadot.testnet.routescan.io/address/0xcb00f5b86aac5e2fdca9dc7f34d9bfe00b967c18) |
-| `FeeToken (USD.h)` | [`0xBe97E73126d66188d72FBf99029126d0340a7f18`](https://polkadot.testnet.routescan.io/address/0xBe97E73126d66188d72FBf99029126d0340a7f18) |
+| `HandlerV2` | [`0x53184b424971d4b5944fdf6f52f18c3fcc4d0925`](https://blockscout-testnet.polkadot.io/address/0x53184b424971d4b5944fdf6f52f18c3fcc4d0925) |
+| `ConsensusClient` | [`0xBd02fd8331E54e795DdD37f915694DEe54bB5a00`](https://blockscout-testnet.polkadot.io/address/0xBd02fd8331E54e795DdD37f915694DEe54bB5a00) |
+| `HostManager` | [`0xb05fd51329b4dd28cf07e273efb496edd243dbee`](https://blockscout-testnet.polkadot.io/address/0xb05fd51329b4dd28cf07e273efb496edd243dbee) |
+| `CallDispatcher` | [`0x2b332088275bc9e3c26d81b2975de2483320c181`](https://blockscout-testnet.polkadot.io/address/0x2b332088275bc9e3c26d81b2975de2483320c181) |
+| `BandwidthManager` | [`0xFe6D81417CFe618aCaA34dF23376c738900290DE`](https://blockscout-testnet.polkadot.io/address/0xFe6D81417CFe618aCaA34dF23376c738900290DE) |
+| `TokenFaucet` | [`0xcb00f5b86aac5e2fdca9dc7f34d9bfe00b967c18`](https://blockscout-testnet.polkadot.io/address/0xcb00f5b86aac5e2fdca9dc7f34d9bfe00b967c18) |
+| `FeeToken (USD.h)` | [`0xBe97E73126d66188d72FBf99029126d0340a7f18`](https://blockscout-testnet.polkadot.io/address/0xBe97E73126d66188d72FBf99029126d0340a7f18) |
 | `ConsensusStateId` | `PAS0` |
 | `StateMachine` | `EVM-420420417` |
 


### PR DESCRIPTION
## Summary
- Repoints the 8 Polkadot Asset Hub (Paseo) contract address links in the testnet docs from `polkadot.testnet.routescan.io` to `blockscout-testnet.polkadot.io` so they resolve against the official blockscout instance.
- All 8 contracts are now verified on blockscout-testnet (separate ops change), so the new links land directly on the verified source view.

## Test plan
- [ ] Visit each updated link in `content/developers/evm/contract-addresses/testnet.mdx` (Polkadot Asset Hub section) and confirm the blockscout page loads and shows verified source.