### PR TITLE
[runtime] StateMachineClient::verify_state_proof now takes the concrete H256 trie root instead of the full StateCommitment struct

### DIFF
--- a/modules/consensus/tendermint/prover/src/tests/integration_tests.rs
+++ b/modules/consensus/tendermint/prover/src/tests/integration_tests.rs
@@ -17,7 +17,7 @@ mod tests {
 	use evm_state_machine::{tendermint::verify_evm_kv_proofs, types::EvmKVProof};
 
 	use ismp::{
-		consensus::{StateCommitment, StateMachineHeight, StateMachineId},
+		consensus::{StateMachineHeight, StateMachineId},
 		host::StateMachine,
 		messaging::Proof as IsmpProof,
 	};
@@ -667,10 +667,7 @@ mod tests {
 			proof: encoded_proofs,
 		};
 
-		let state_commitment =
-			StateCommitment { timestamp: 0, overlay_root: None, state_root: app_hash };
-
-		let _ = verify_evm_kv_proofs(vec![key52], contract, state_commitment, &ismp_proof)?;
+		let _ = verify_evm_kv_proofs(vec![key52], contract, app_hash, &ismp_proof)?;
 		println!("EVM state proof verification passed for slot: {}", hex::encode(&slot.0));
 		Ok(())
 	}

--- a/modules/ismp/core/src/consensus.rs
+++ b/modules/ismp/core/src/consensus.rs
@@ -195,12 +195,17 @@ pub trait StateMachineClient {
 		proof: &Proof,
 	) -> Result<(), Error>;
 
-	/// Verify the state of proof of some arbitrary data. Should return the verified data
+	/// Verify the state of proof of some arbitrary data. Should return the verified data.
+	///
+	/// The caller passes the concrete trie `root` the proof must be verified against, rather
+	/// than the full [`StateCommitment`]. This ensures the root is bound to the calling
+	/// context (e.g. the global state trie for GET responses, the ISMP child trie for relayer
+	/// fee accumulation) and cannot be selected by a relayer-supplied proof.
 	fn verify_state_proof(
 		&self,
 		host: &dyn IsmpHost,
 		keys: Vec<Vec<u8>>,
-		root: StateCommitment,
+		root: H256,
 		proof: &Proof,
 	) -> Result<BTreeMap<Vec<u8>, Option<Vec<u8>>>, Error>;
 }

--- a/modules/ismp/core/src/handlers/response.rs
+++ b/modules/ismp/core/src/handlers/response.rs
@@ -83,7 +83,7 @@ where
 			let wrapped_req = Request::Get(request.clone());
 			let keys = request.keys.clone();
 			let values = state_machine
-				.verify_state_proof(host, keys, state, &proof)?
+				.verify_state_proof(host, keys, state.state_root, &proof)?
 				.into_iter()
 				.map(|(key, value)| StorageValue { key, value })
 				.collect();

--- a/modules/ismp/state-machines/evm/src/lib.rs
+++ b/modules/ismp/state-machines/evm/src/lib.rs
@@ -132,7 +132,7 @@ pub fn verify_membership<H: Keccak256 + Send + Sync>(
 
 pub fn verify_state_proof<H: Keccak256 + Send + Sync>(
 	keys: Vec<Vec<u8>>,
-	root: StateCommitment,
+	root: H256,
 	proof: &Proof,
 	ismp_address: H160,
 ) -> Result<BTreeMap<Vec<u8>, Option<Vec<u8>>>, Error> {
@@ -182,7 +182,7 @@ pub fn verify_state_proof<H: Keccak256 + Send + Sync>(
 		let contract_root = get_contract_account::<H>(
 			evm_state_proof.contract_proof.clone(),
 			&contract_address,
-			root.state_root,
+			root,
 		)?
 		.storage_root
 		.0
@@ -201,7 +201,7 @@ pub fn verify_state_proof<H: Keccak256 + Send + Sync>(
 		let account = get_contract_account::<H>(
 			evm_state_proof.contract_proof.clone(),
 			&contract_address[..],
-			root.state_root,
+			root,
 		)?;
 
 		// Using rlp encoding for uniformity, storage values from state proofs are rlp encoded
@@ -263,7 +263,7 @@ impl<H: IsmpHost + Send + Sync, T: pallet_ismp_host_executive::Config> StateMach
 	) -> Result<(), Error> {
 		let keys = self.receipts_state_trie_key(commitments);
 		let keys_len = keys.len();
-		let values = self.verify_state_proof(host, keys, root, proof)?;
+		let values = self.verify_state_proof(host, keys, root.state_root, proof)?;
 		if values.len() != keys_len {
 			return Err(EvmStateMachineError::MismatchedValuesAndKeys.into());
 		}
@@ -277,7 +277,7 @@ impl<H: IsmpHost + Send + Sync, T: pallet_ismp_host_executive::Config> StateMach
 		&self,
 		host: &dyn IsmpHost,
 		keys: Vec<Vec<u8>>,
-		root: StateCommitment,
+		root: H256,
 		proof: &Proof,
 	) -> Result<BTreeMap<Vec<u8>, Option<Vec<u8>>>, Error> {
 		let ismp_address = EvmHosts::<T>::get(&proof.height.id.state_id)

--- a/modules/ismp/state-machines/evm/src/substrate_evm.rs
+++ b/modules/ismp/state-machines/evm/src/substrate_evm.rs
@@ -168,7 +168,7 @@ impl<H: IsmpHost + Send + Sync, T: pallet_ismp_host_executive::Config> StateMach
 	) -> Result<(), Error> {
 		let keys = self.receipts_state_trie_key(commitments);
 		let keys_len = keys.len();
-		let values = self.verify_state_proof(host, keys, root, proof)?;
+		let values = self.verify_state_proof(host, keys, root.state_root, proof)?;
 		if values.len() != keys_len {
 			return Err(SubstrateEvmError::MismatchedValuesAndKeys.into());
 		}
@@ -182,7 +182,7 @@ impl<H: IsmpHost + Send + Sync, T: pallet_ismp_host_executive::Config> StateMach
 		&self,
 		_host: &dyn IsmpHost,
 		keys: Vec<Vec<u8>>,
-		root: StateCommitment,
+		root: H256,
 		proof: &Proof,
 	) -> Result<BTreeMap<Vec<u8>, Option<Vec<u8>>>, Error> {
 		let ismp_host_address = EvmHosts::<T>::get(&proof.height.id.state_id)
@@ -191,7 +191,7 @@ impl<H: IsmpHost + Send + Sync, T: pallet_ismp_host_executive::Config> StateMach
 		let proof: SubstrateEvmProof =
 			Decode::decode(&mut &proof.proof[..]).map_err(SubstrateEvmError::ProofDecodeError)?;
 
-		let state_root = H256::from_slice(&root.state_root[..]);
+		let state_root = root;
 
 		let keys_len = keys.len();
 		let mut contract_keys: BTreeMap<H160, Vec<Vec<u8>>> = BTreeMap::new();

--- a/modules/ismp/state-machines/evm/src/tendermint.rs
+++ b/modules/ismp/state-machines/evm/src/tendermint.rs
@@ -224,7 +224,7 @@ impl<H: IsmpHost + Send + Sync, T: pallet_ismp_host_executive::Config> StateMach
 		&self,
 		_host: &dyn IsmpHost,
 		keys: Vec<Vec<u8>>,
-		root: StateCommitment,
+		root: H256,
 		proof: &Proof,
 	) -> Result<BTreeMap<Vec<u8>, Option<Vec<u8>>>, Error> {
 		let contract_address = EvmHosts::<T>::get(&proof.height.id.state_id)
@@ -243,12 +243,12 @@ impl<H: IsmpHost + Send + Sync, T: pallet_ismp_host_executive::Config> StateMach
 pub fn verify_evm_kv_proofs(
 	mut keys: Vec<Vec<u8>>,
 	default_contract_address: H160,
-	root: StateCommitment,
+	root: H256,
 	proof: &Proof,
 ) -> Result<BTreeMap<Vec<u8>, Option<Vec<u8>>>, Error> {
 	let store_key_str = store_key_for(proof.height.id.state_id);
 	let store_key = store_key_str.as_bytes();
-	let app_hash: [u8; 32] = root.state_root.0;
+	let app_hash: [u8; 32] = root.0;
 	let proofs: Vec<crate::types::EvmKVProof> = codec::Decode::decode(&mut &proof.proof[..])
 		.map_err(|e| TendermintEvmError::ProofDecodeError(e.to_string()))?;
 	// Only support 32-byte or 52-byte keys

--- a/modules/ismp/state-machines/pharos/src/lib.rs
+++ b/modules/ismp/state-machines/pharos/src/lib.rs
@@ -165,7 +165,7 @@ impl<H: IsmpHost + Send + Sync, T: pallet_ismp_host_executive::Config> StateMach
 	) -> Result<(), Error> {
 		let keys = self.receipts_state_trie_key(commitments);
 		let keys_len = keys.len();
-		let values = self.verify_state_proof(host, keys, root, proof)?;
+		let values = self.verify_state_proof(host, keys, root.state_root, proof)?;
 		if values.len() != keys_len {
 			return Err(PharosStateMachineError::MismatchedValuesAndKeys.into());
 		}
@@ -179,7 +179,7 @@ impl<H: IsmpHost + Send + Sync, T: pallet_ismp_host_executive::Config> StateMach
 		&self,
 		_host: &dyn IsmpHost,
 		keys: Vec<Vec<u8>>,
-		root: StateCommitment,
+		root: H256,
 		proof: &Proof,
 	) -> Result<BTreeMap<Vec<u8>, Option<Vec<u8>>>, Error> {
 		let ismp_address = EvmHosts::<T>::get(&proof.height.id.state_id)
@@ -238,13 +238,13 @@ pub fn verify_membership<H: Keccak256 + Send + Sync>(
 /// Verify state proof and return key-value map.
 pub fn verify_state_proof<H: Keccak256 + Send + Sync>(
 	keys: Vec<Vec<u8>>,
-	root: StateCommitment,
+	root: H256,
 	proof: &Proof,
 	ismp_address: H160,
 ) -> Result<BTreeMap<Vec<u8>, Option<Vec<u8>>>, Error> {
 	let pharos_proof = decode_pharos_state_proof(proof)?;
 
-	let state_root = H256::from_slice(&root.state_root[..]);
+	let state_root = root;
 
 	// Pharos uses a flat trie — storage proofs verify directly against state_root.
 	let mut map = BTreeMap::new();

--- a/modules/ismp/state-machines/substrate/src/lib.rs
+++ b/modules/ismp/state-machines/substrate/src/lib.rs
@@ -270,18 +270,14 @@ where
 		&self,
 		_host: &dyn IsmpHost,
 		keys: Vec<Vec<u8>>,
-		root: StateCommitment,
+		root: H256,
 		proof: &Proof,
 	) -> Result<BTreeMap<Vec<u8>, Option<Vec<u8>>>, Error> {
+		// The trie root is supplied by the caller, bound to the calling context. The
+		// `SubstrateStateProof` variant tag is no longer used to select the root, so a relayer
+		// can no longer steer verification at the wrong trie.
 		let state_proof: SubstrateStateProof = codec::Decode::decode(&mut &*proof.proof)
 			.map_err(SubstrateStateMachineError::ProofDecodeError)?;
-		let root = match &state_proof {
-			SubstrateStateProof::OverlayProof { .. } => match T::Coprocessor::get() {
-				Some(id) if id == proof.height.id.state_id => root.state_root,
-				_ => root.overlay_root.ok_or(SubstrateStateMachineError::MissingChildTrieRoot)?,
-			},
-			SubstrateStateProof::StateProof { .. } => root.state_root,
-		};
 		let data = match state_proof.hasher() {
 			HashAlgorithm::Keccak => {
 				let db =

--- a/modules/ismp/state-machines/substrate/src/lib.rs
+++ b/modules/ismp/state-machines/substrate/src/lib.rs
@@ -57,10 +57,6 @@ pub enum SubstrateStateMachineError {
 	/// Failed to SCALE-decode the supplied proof.
 	#[error("Failed to decode proof: {0:?}")]
 	ProofDecodeError(codec::Error),
-	/// Caller supplied a `StateProof` variant for a membership/non-membership check
-	/// that must be served from the ISMP child trie via an `OverlayProof`.
-	#[error("Expected Overlay Proof")]
-	ExpectedOverlayProof,
 	/// The state commitment doesn't include the child trie root, and the request
 	/// state machine is not the coprocessor.
 	#[error("Child trie root is not available for provided state commitment")]
@@ -94,40 +90,17 @@ pub enum HashAlgorithm {
 }
 
 /// The substrate state machine proof. This will be a base-16 merkle patricia proof.
-/// It's [`TrieLayout`](sp_trie::TrieLayout) will be the [`LayoutV0`]
+/// It's [`TrieLayout`](sp_trie::TrieLayout) will be the [`LayoutV0`].
+///
+/// This is the proof format for all substrate state proofs, regardless of which trie they
+/// verify against. The trie root the proof is checked against is chosen by the verifying
+/// context (see [`StateMachineClient::verify_state_proof`]), not encoded in the proof itself.
 #[derive(Debug, Encode, Decode, Clone)]
 pub struct StateMachineProof {
 	/// Algorithm to use for state proof verification
 	pub hasher: HashAlgorithm,
 	/// Intermediate trie nodes in the key path from the root to their relevant values.
 	pub storage_proof: Vec<Vec<u8>>,
-}
-
-/// Holds the relevant data needed for state proof verification
-#[derive(Debug, Encode, Decode, Clone)]
-pub enum SubstrateStateProof {
-	/// Uses overlay root for verification
-	OverlayProof(StateMachineProof),
-	/// Uses state root for verification
-	StateProof(StateMachineProof),
-}
-
-impl SubstrateStateProof {
-	/// Returns hash algo
-	pub fn hasher(&self) -> HashAlgorithm {
-		match self {
-			Self::OverlayProof(proof) => proof.hasher,
-			Self::StateProof(proof) => proof.hasher,
-		}
-	}
-
-	/// Returns storage proof
-	pub fn storage_proof(self) -> Vec<Vec<u8>> {
-		match self {
-			Self::OverlayProof(proof) => proof.storage_proof,
-			Self::StateProof(proof) => proof.storage_proof,
-		}
-	}
 }
 
 /// The [`StateMachineClient`] implementation for substrate state machines. Assumes requests are
@@ -157,12 +130,13 @@ where
 		state: StateCommitment,
 		proof: &Proof,
 	) -> Result<(), Error> {
-		let state_proof: SubstrateStateProof = codec::Decode::decode(&mut &*proof.proof)
-			.map_err(SubstrateStateMachineError::ProofDecodeError)?;
-		if !matches!(state_proof, SubstrateStateProof::OverlayProof { .. }) {
-			return Err(SubstrateStateMachineError::ExpectedOverlayProof.into());
-		}
+		let StateMachineProof { hasher, storage_proof } =
+			codec::Decode::decode(&mut &*proof.proof)
+				.map_err(SubstrateStateMachineError::ProofDecodeError)?;
 
+		// ISMP request/receipt commitments live in the ISMP child trie, so membership is
+		// verified against the overlay root — unless the request originates from the
+		// coprocessor itself, whose ISMP storage is part of its global state.
 		let root = match T::Coprocessor::get() {
 			Some(id) if id == proof.height.id.state_id => state.state_root,
 			_ => state.overlay_root.ok_or(SubstrateStateMachineError::MissingChildTrieRoot)?,
@@ -174,10 +148,9 @@ where
 				.ok_or_else(|| SubstrateStateMachineError::MissingMembershipValue(key.clone()))
 				.map(|v| (key, v))
 		};
-		match state_proof.hasher() {
+		match hasher {
 			HashAlgorithm::Keccak => {
-				let db =
-					StorageProof::new(state_proof.storage_proof()).into_memory_db::<Keccak256>();
+				let db = StorageProof::new(storage_proof).into_memory_db::<Keccak256>();
 				let trie = TrieDBBuilder::<LayoutV0<Keccak256>>::new(&db, &root).build();
 				for key in keys {
 					let value = trie
@@ -187,8 +160,7 @@ where
 				}
 			},
 			HashAlgorithm::Blake2 => {
-				let db =
-					StorageProof::new(state_proof.storage_proof()).into_memory_db::<BlakeTwo256>();
+				let db = StorageProof::new(storage_proof).into_memory_db::<BlakeTwo256>();
 				let trie = TrieDBBuilder::<LayoutV0<BlakeTwo256>>::new(&db, &root).build();
 				for key in keys {
 					let value = trie
@@ -217,12 +189,13 @@ where
 		root: StateCommitment,
 		proof: &Proof,
 	) -> Result<(), Error> {
-		let state_proof: SubstrateStateProof = codec::Decode::decode(&mut &*proof.proof)
-			.map_err(SubstrateStateMachineError::ProofDecodeError)?;
-		if !matches!(state_proof, SubstrateStateProof::OverlayProof { .. }) {
-			return Err(SubstrateStateMachineError::ExpectedOverlayProof.into());
-		}
+		let StateMachineProof { hasher, storage_proof } =
+			codec::Decode::decode(&mut &*proof.proof)
+				.map_err(SubstrateStateMachineError::ProofDecodeError)?;
 
+		// Request receipts live in the ISMP child trie, so non-membership is verified against
+		// the overlay root — unless the request originates from the coprocessor itself, whose
+		// ISMP storage is part of its global state.
 		let root = match T::Coprocessor::get() {
 			Some(id) if id == proof.height.id.state_id => root.state_root,
 			_ => root.overlay_root.ok_or(SubstrateStateMachineError::MissingChildTrieRoot)?,
@@ -238,10 +211,9 @@ where
 			}
 		};
 
-		match state_proof.hasher() {
+		match hasher {
 			HashAlgorithm::Keccak => {
-				let db =
-					StorageProof::new(state_proof.storage_proof()).into_memory_db::<Keccak256>();
+				let db = StorageProof::new(storage_proof).into_memory_db::<Keccak256>();
 				let trie = TrieDBBuilder::<LayoutV0<Keccak256>>::new(&db, &root).build();
 				for key in keys {
 					let value = trie
@@ -251,8 +223,7 @@ where
 				}
 			},
 			HashAlgorithm::Blake2 => {
-				let db =
-					StorageProof::new(state_proof.storage_proof()).into_memory_db::<BlakeTwo256>();
+				let db = StorageProof::new(storage_proof).into_memory_db::<BlakeTwo256>();
 				let trie = TrieDBBuilder::<LayoutV0<BlakeTwo256>>::new(&db, &root).build();
 				for key in keys {
 					let value = trie
@@ -273,15 +244,14 @@ where
 		root: H256,
 		proof: &Proof,
 	) -> Result<BTreeMap<Vec<u8>, Option<Vec<u8>>>, Error> {
-		// The trie root is supplied by the caller, bound to the calling context. The
-		// `SubstrateStateProof` variant tag is no longer used to select the root, so a relayer
-		// can no longer steer verification at the wrong trie.
-		let state_proof: SubstrateStateProof = codec::Decode::decode(&mut &*proof.proof)
-			.map_err(SubstrateStateMachineError::ProofDecodeError)?;
-		let data = match state_proof.hasher() {
+		// The trie root is supplied by the caller, bound to the calling context, so a relayer
+		// cannot steer verification at the wrong trie.
+		let StateMachineProof { hasher, storage_proof } =
+			codec::Decode::decode(&mut &*proof.proof)
+				.map_err(SubstrateStateMachineError::ProofDecodeError)?;
+		let data = match hasher {
 			HashAlgorithm::Keccak => {
-				let db =
-					StorageProof::new(state_proof.storage_proof()).into_memory_db::<Keccak256>();
+				let db = StorageProof::new(storage_proof).into_memory_db::<Keccak256>();
 				let trie = TrieDBBuilder::<LayoutV0<Keccak256>>::new(&db, &root).build();
 				keys.into_iter()
 					.map(|key| {
@@ -293,8 +263,7 @@ where
 					.collect::<Result<BTreeMap<_, _>, _>>()?
 			},
 			HashAlgorithm::Blake2 => {
-				let db =
-					StorageProof::new(state_proof.storage_proof()).into_memory_db::<BlakeTwo256>();
+				let db = StorageProof::new(storage_proof).into_memory_db::<BlakeTwo256>();
 				let trie = TrieDBBuilder::<LayoutV0<BlakeTwo256>>::new(&db, &root).build();
 				keys.into_iter()
 					.map(|key| {

--- a/modules/ismp/testsuite/src/mocks.rs
+++ b/modules/ismp/testsuite/src/mocks.rs
@@ -136,7 +136,7 @@ impl StateMachineClient for MockStateMachineClient {
 		&self,
 		_host: &dyn IsmpHost,
 		_keys: Vec<Vec<u8>>,
-		_root: StateCommitment,
+		_root: H256,
 		_proof: &Proof,
 	) -> Result<BTreeMap<Vec<u8>, Option<Vec<u8>>>, Error> {
 		Ok(Default::default())

--- a/modules/pallets/relayer/src/accumulate.rs
+++ b/modules/pallets/relayer/src/accumulate.rs
@@ -28,7 +28,7 @@ use alloy_primitives::Address;
 use codec::Encode;
 use crypto_utils::verification::Signature;
 use evm_state_machine::{derive_unhashed_map_key_with_offset, presets::REQUEST_COMMITMENTS_SLOT};
-use frame_support::{dispatch::DispatchResult, ensure};
+use frame_support::{dispatch::DispatchResult, ensure, traits::Get};
 use ismp::{
 	handlers::validate_state_machine,
 	host::{IsmpHost, StateMachine},
@@ -207,8 +207,22 @@ where
 		let state = host
 			.state_machine_commitment(proof.height)
 			.map_err(|_| Error::<T>::ProofValidationError)?;
+		// Select the trie root explicitly instead of letting the relayer-supplied proof choose
+		// it via its variant tag. Fee accumulation reads ISMP request/receipt metadata, which
+		// lives in the global state trie on EVM chains and in the ISMP child trie (overlay
+		// root) on substrate chains — except for the coprocessor itself, whose ISMP storage is
+		// part of its global state.
+		let state_id = proof.height.id.state_id;
+		let root = if state_id.is_evm() {
+			state.state_root
+		} else {
+			match <T as pallet_ismp::Config>::Coprocessor::get() {
+				Some(id) if id == state_id => state.state_root,
+				_ => state.overlay_root.ok_or(Error::<T>::ProofValidationError)?,
+			}
+		};
 		let result = state_machine
-			.verify_state_proof(&host, keys, state, proof)
+			.verify_state_proof(&host, keys, root, proof)
 			.map_err(|_| Error::<T>::ProofValidationError)?;
 
 		Ok(result)

--- a/modules/pallets/relayer/src/accumulate.rs
+++ b/modules/pallets/relayer/src/accumulate.rs
@@ -28,7 +28,7 @@ use alloy_primitives::Address;
 use codec::Encode;
 use crypto_utils::verification::Signature;
 use evm_state_machine::{derive_unhashed_map_key_with_offset, presets::REQUEST_COMMITMENTS_SLOT};
-use frame_support::{dispatch::DispatchResult, ensure, traits::Get};
+use frame_support::{dispatch::DispatchResult, ensure};
 use ismp::{
 	handlers::validate_state_machine,
 	host::{IsmpHost, StateMachine},
@@ -208,18 +208,13 @@ where
 			.state_machine_commitment(proof.height)
 			.map_err(|_| Error::<T>::ProofValidationError)?;
 		// Select the trie root explicitly instead of letting the relayer-supplied proof choose
-		// it via its variant tag. Fee accumulation reads ISMP request/receipt metadata, which
-		// lives in the global state trie on EVM chains and in the ISMP child trie (overlay
-		// root) on substrate chains — except for the coprocessor itself, whose ISMP storage is
-		// part of its global state.
-		let state_id = proof.height.id.state_id;
-		let root = if state_id.is_evm() {
+		// it. Fee accumulation reads ISMP request/receipt metadata, which lives in the global
+		// state trie on EVM chains and in the ISMP child trie (overlay root) on substrate
+		// chains.
+		let root = if proof.height.id.state_id.is_evm() {
 			state.state_root
 		} else {
-			match <T as pallet_ismp::Config>::Coprocessor::get() {
-				Some(id) if id == state_id => state.state_root,
-				_ => state.overlay_root.ok_or(Error::<T>::ProofValidationError)?,
-			}
+			state.overlay_root.ok_or(Error::<T>::ProofValidationError)?
 		};
 		let result = state_machine
 			.verify_state_proof(&host, keys, root, proof)

--- a/modules/pallets/state-coprocessor/src/impls.rs
+++ b/modules/pallets/state-coprocessor/src/impls.rs
@@ -132,7 +132,7 @@ where
 		let mut total_bytes: u32 = 0;
 		for req in requests {
 			let values: Vec<StorageValue> = dest_state_machine
-				.verify_state_proof(&host, req.keys.clone(), state_root, &response)?
+				.verify_state_proof(&host, req.keys.clone(), state_root.state_root, &response)?
 				.into_iter()
 				.map(|(key, value)| StorageValue { key, value })
 				.collect();

--- a/modules/pallets/testsuite/src/runtime.rs
+++ b/modules/pallets/testsuite/src/runtime.rs
@@ -650,7 +650,7 @@ impl StateMachineClient for MockStateMachine {
 		&self,
 		_host: &dyn IsmpHost,
 		_keys: Vec<Vec<u8>>,
-		_root: StateCommitment,
+		_root: H256,
 		_proof: &Proof,
 	) -> Result<BTreeMap<Vec<u8>, Option<Vec<u8>>>, IsmpError> {
 		Ok(Default::default())

--- a/modules/pallets/testsuite/src/tests/pallet_ismp.rs
+++ b/modules/pallets/testsuite/src/tests/pallet_ismp.rs
@@ -28,7 +28,7 @@ use sp_core::{crypto::AccountId32, ByteArray, Pair, H256};
 use sp_runtime::traits::AccountIdConversion;
 
 use ismp::{
-	consensus::{StateCommitment, StateMachineClient, StateMachineHeight, StateMachineId},
+	consensus::{StateMachineHeight, StateMachineId},
 	dispatcher::{DispatchGet, DispatchRequest, FeeMetadata, IsmpDispatcher},
 	host::{IsmpHost, StateMachine},
 	messaging::{hash_request, Message, Proof, RequestMessage, ResponseMessage, TimeoutMessage},
@@ -46,10 +46,6 @@ use pallet_ismp::{
 	FundMessageParams, MessageCommitment, RELAYER_FEE_ACCOUNT,
 };
 use pallet_ismp_relayer::withdrawal::Signature;
-use substrate_state_machine::{
-	HashAlgorithm, StateMachineProof, SubstrateStateMachine, SubstrateStateMachineError,
-	SubstrateStateProof,
-};
 
 use crate::runtime::*;
 
@@ -608,51 +604,4 @@ fn should_charge_fee_for_request() {
 		assert_eq!(final_signer_balance, initial_balance - expected_fee);
 		assert_eq!(final_treasury_balance, initial_treasury_balance + expected_fee);
 	});
-}
-
-#[test]
-fn substrate_verify_non_membership_requires_overlay_proof_variant() {
-	let mut ext = new_test_ext();
-
-	ext.execute_with(|| {
-		let host = Ismp::default();
-		let state_machine = SubstrateStateMachine::<Test>::default();
-		let height = StateMachineHeight {
-			id: StateMachineId {
-				state_id: StateMachine::Kusama(2000),
-				consensus_state_id: MOCK_CONSENSUS_STATE_ID,
-			},
-			height: 1,
-		};
-		let commitment = StateCommitment {
-			timestamp: 0,
-			overlay_root: Some(H256::zero()),
-			state_root: H256::zero(),
-		};
-
-		let inner = StateMachineProof { hasher: HashAlgorithm::Blake2, storage_proof: vec![] };
-
-		let rejected = state_machine.verify_non_membership(
-			&host,
-			vec![],
-			commitment.clone(),
-			&Proof { height, proof: SubstrateStateProof::StateProof(inner.clone()).encode() },
-		);
-		let err = rejected.expect_err("non-membership against a StateProof must be rejected");
-		let ismp::error::Error::AnyHow(anyhow_err) = err else {
-			panic!("expected AnyHow error, got {err:?}");
-		};
-		assert!(matches!(
-			anyhow_err.0.downcast_ref::<SubstrateStateMachineError>(),
-			Some(SubstrateStateMachineError::ExpectedOverlayProof)
-		));
-
-		let accepted = state_machine.verify_non_membership(
-			&host,
-			vec![],
-			commitment,
-			&Proof { height, proof: SubstrateStateProof::OverlayProof(inner).encode() },
-		);
-		assert!(accepted.is_ok());
-	})
 }

--- a/modules/pallets/testsuite/src/tests/pallet_ismp_relayer.rs
+++ b/modules/pallets/testsuite/src/tests/pallet_ismp_relayer.rs
@@ -38,7 +38,7 @@ use pallet_ismp_relayer::{
 use sp_core::{keccak_256, Pair, H256, U256};
 use sp_trie::LayoutV0;
 use std::time::Duration;
-use substrate_state_machine::{HashAlgorithm, StateMachineProof, SubstrateStateProof};
+use substrate_state_machine::{HashAlgorithm, StateMachineProof};
 use trie_db::{Recorder, Trie, TrieDBBuilder, TrieDBMutBuilder, TrieMut};
 
 use crate::runtime::{
@@ -127,15 +127,11 @@ fn test_accumulate_fees() {
 			source_recorder.drain().into_iter().map(|f| f.data).collect::<Vec<_>>();
 		let dest_keys_proof = dest_recorder.drain().into_iter().map(|f| f.data).collect::<Vec<_>>();
 
-		let source_state_proof = SubstrateStateProof::OverlayProof(StateMachineProof {
-			hasher: HashAlgorithm::Keccak,
-			storage_proof: source_keys_proof,
-		});
+		let source_state_proof =
+			StateMachineProof { hasher: HashAlgorithm::Keccak, storage_proof: source_keys_proof };
 
-		let dest_state_proof = SubstrateStateProof::OverlayProof(StateMachineProof {
-			hasher: HashAlgorithm::Keccak,
-			storage_proof: dest_keys_proof,
-		});
+		let dest_state_proof =
+			StateMachineProof { hasher: HashAlgorithm::Keccak, storage_proof: dest_keys_proof };
 
 		let host = Ismp::default();
 		host.store_state_machine_commitment(
@@ -350,14 +346,10 @@ fn test_accumulate_fees_rejects_mixed_delivery_addresses() {
 			source_recorder.drain().into_iter().map(|f| f.data).collect::<Vec<_>>();
 		let dest_keys_proof = dest_recorder.drain().into_iter().map(|f| f.data).collect::<Vec<_>>();
 
-		let source_state_proof = SubstrateStateProof::OverlayProof(StateMachineProof {
-			hasher: HashAlgorithm::Keccak,
-			storage_proof: source_keys_proof,
-		});
-		let dest_state_proof = SubstrateStateProof::OverlayProof(StateMachineProof {
-			hasher: HashAlgorithm::Keccak,
-			storage_proof: dest_keys_proof,
-		});
+		let source_state_proof =
+			StateMachineProof { hasher: HashAlgorithm::Keccak, storage_proof: source_keys_proof };
+		let dest_state_proof =
+			StateMachineProof { hasher: HashAlgorithm::Keccak, storage_proof: dest_keys_proof };
 
 		let host = Ismp::default();
 		host.store_state_machine_commitment(
@@ -606,15 +598,11 @@ fn test_accumulate_fees_evm_signatures() {
 			source_recorder.drain().into_iter().map(|f| f.data).collect::<Vec<_>>();
 		let dest_keys_proof = dest_recorder.drain().into_iter().map(|f| f.data).collect::<Vec<_>>();
 
-		let source_state_proof = SubstrateStateProof::OverlayProof(StateMachineProof {
-			hasher: HashAlgorithm::Keccak,
-			storage_proof: source_keys_proof,
-		});
+		let source_state_proof =
+			StateMachineProof { hasher: HashAlgorithm::Keccak, storage_proof: source_keys_proof };
 
-		let dest_state_proof = SubstrateStateProof::OverlayProof(StateMachineProof {
-			hasher: HashAlgorithm::Keccak,
-			storage_proof: dest_keys_proof,
-		});
+		let dest_state_proof =
+			StateMachineProof { hasher: HashAlgorithm::Keccak, storage_proof: dest_keys_proof };
 
 		let host = Ismp::default();
 		host.store_state_machine_commitment(

--- a/parachain/simtests/src/pallet_ismp.rs
+++ b/parachain/simtests/src/pallet_ismp.rs
@@ -30,7 +30,7 @@ use ismp::{
 };
 use pallet_ismp::child_trie::{self};
 use primitive_types::H256;
-use substrate_state_machine::{HashAlgorithm, StateMachineProof, SubstrateStateProof};
+use substrate_state_machine::{HashAlgorithm, StateMachineProof};
 use subxt_utils::{
 	state_machine_commitment_storage_key, state_machine_update_time_storage_key,
 	values::{
@@ -269,11 +269,7 @@ async fn test_txpool_should_reject_duplicate_requests() -> Result<(), anyhow::Er
 	let update_time: u64 = Decode::decode(&mut &*item)?;
 	assert_eq!(now.as_secs(), update_time);
 
-	let proof = SubstrateStateProof::OverlayProof(StateMachineProof {
-		hasher: HashAlgorithm::Keccak,
-		storage_proof: proof,
-	})
-	.encode();
+	let proof = StateMachineProof { hasher: HashAlgorithm::Keccak, storage_proof: proof }.encode();
 	let proof = Proof { height, proof };
 
 	let signature = Signature::Sr25519 {
@@ -574,11 +570,7 @@ async fn test_force_credited_bandwidth_satisfies_gate() -> Result<(), anyhow::Er
 	assert!(finalized);
 	progress.wait_for_finalized_success().await?;
 
-	let proof = SubstrateStateProof::OverlayProof(StateMachineProof {
-		hasher: HashAlgorithm::Keccak,
-		storage_proof: proof,
-	})
-	.encode();
+	let proof = StateMachineProof { hasher: HashAlgorithm::Keccak, storage_proof: proof }.encode();
 	let proof = Proof { height, proof };
 
 	let signature = Signature::Sr25519 {

--- a/sdk/packages/sdk/src/chains/evm.ts
+++ b/sdk/packages/sdk/src/chains/evm.ts
@@ -57,7 +57,7 @@ import {
 	EvmStateProof,
 	getContractCallInputs,
 	MmrProof,
-	SubstrateStateProof,
+	SubstrateStateMachineProof,
 	generateRootWithProof,
 } from "@/utils"
 
@@ -496,7 +496,7 @@ export class EvmChain implements IChain {
 				return encoded
 			})
 			.with({ kind: "TimeoutPostRequest" }, (timeout) => {
-				const proof = SubstrateStateProof.dec(timeout.proof.proof).value.storageProof.map((item) =>
+				const proof = SubstrateStateMachineProof.dec(timeout.proof.proof).storageProof.map((item) =>
 					toHex(new Uint8Array(item)),
 				)
 				const encoded = encodeFunctionData({

--- a/sdk/packages/sdk/src/chains/substrate.ts
+++ b/sdk/packages/sdk/src/chains/substrate.ts
@@ -19,7 +19,7 @@ import {
 	GetRequestsWithProof,
 	type IStateMachine,
 	Message,
-	SubstrateStateProof,
+	SubstrateStateMachineProof,
 	isEvmChain,
 	isSubstrateChain,
 	replaceWebsocketWithHttp,
@@ -231,15 +231,12 @@ export class SubstrateChain implements IChain {
 					: message.Responses.map(responseCommitmentStorageKey)
 			const proof: any = await this.rpcClient.call("ismp_queryChildTrieProof", [Number(at), childTrieKeys])
 			const basicProof = BasicProof.dec(toHex(proof.proof))
-			const encoded = SubstrateStateProof.enc({
-				tag: "OverlayProof",
-				value: {
-					hasher: {
-						tag: this.params.hasher,
-						value: undefined,
-					},
-					storageProof: basicProof,
+			const encoded = SubstrateStateMachineProof.enc({
+				hasher: {
+					tag: this.params.hasher,
+					value: undefined,
 				},
+				storageProof: basicProof,
 			})
 			return toHex(encoded)
 		}
@@ -310,15 +307,12 @@ export class SubstrateChain implements IChain {
 		const encodedKeys = keys.map((key) => Array.from(hexToBytes(key)))
 		const proof: any = await this.rpcClient.call("ismp_queryChildTrieProof", [Number(at), encodedKeys])
 		const basicProof = BasicProof.dec(toHex(proof.proof))
-		const encoded = SubstrateStateProof.enc({
-			tag: "OverlayProof",
-			value: {
-				hasher: {
-					tag: this.params.hasher,
-					value: undefined,
-				},
-				storageProof: basicProof,
+		const encoded = SubstrateStateMachineProof.enc({
+			hasher: {
+				tag: this.params.hasher,
+				value: undefined,
 			},
+			storageProof: basicProof,
 		})
 		return toHex(encoded)
 	}

--- a/sdk/packages/sdk/src/utils/substrate.ts
+++ b/sdk/packages/sdk/src/utils/substrate.ts
@@ -43,6 +43,10 @@ export const SubstrateHashing = Enum({
 	Blake2: _void,
 })
 
+/**
+ * The proof format for all substrate state proofs. The trie root the proof is verified
+ * against is chosen by the verifying context on-chain, not encoded in the proof itself.
+ */
 export const SubstrateStateMachineProof = Struct({
 	/**
 	 * The hasher used to hash the state machine state.
@@ -52,17 +56,6 @@ export const SubstrateStateMachineProof = Struct({
 	 * Proof of the state machine state.
 	 */
 	storageProof: Vector(Vector(u8)),
-})
-
-export const SubstrateStateProof = Enum({
-	/*
-	 * Uses overlay root for verification
-	 */
-	OverlayProof: SubstrateStateMachineProof,
-	/*
-	 * Uses state root for verification
-	 */
-	StateProof: SubstrateStateMachineProof,
 })
 
 export const BasicProof = Vector(Vector(u8))

--- a/tesseract/messaging/integration-test/src/lib.rs
+++ b/tesseract/messaging/integration-test/src/lib.rs
@@ -18,7 +18,7 @@ use std::{
 	collections::{BTreeMap, HashMap},
 	sync::Arc,
 };
-use substrate_state_machine::{HashAlgorithm, StateMachineProof, SubstrateStateProof};
+use substrate_state_machine::{HashAlgorithm, StateMachineProof};
 use subxt::{
 	ext::codec::{Decode, Encode},
 	utils::AccountId32,
@@ -63,10 +63,8 @@ async fn relay_get_response_message(
 			chain_b_client.client.rpc().read_proof(keys, dest_chain_block_hash).await?;
 		let proof = value_proof.proof.into_iter().map(|bytes| bytes.0).collect::<Vec<Vec<u8>>>();
 
-		let proof_of_value = SubstrateStateProof::StateProof(StateMachineProof {
-			hasher: HashAlgorithm::Keccak,
-			storage_proof: proof,
-		});
+		let proof_of_value =
+			StateMachineProof { hasher: HashAlgorithm::Keccak, storage_proof: proof };
 		let proof = Proof {
 			height: StateMachineHeight {
 				id: chain_b_client.state_machine_id(),

--- a/tesseract/messaging/substrate/src/provider.rs
+++ b/tesseract/messaging/substrate/src/provider.rs
@@ -52,7 +52,7 @@ use pallet_ismp::{
 use pallet_ismp_host_executive::HostParam;
 use pallet_ismp_relayer::withdrawal::Signature;
 use pallet_ismp_rpc::BlockNumberOrHash;
-use substrate_state_machine::{StateMachineProof, SubstrateStateProof};
+use substrate_state_machine::StateMachineProof;
 use subxt_utils::{
 	host_params_storage_key, send_extrinsic, state_machine_commitment_storage_key,
 	state_machine_update_time_storage_key,
@@ -269,10 +269,7 @@ where
 				let response: pallet_ismp_rpc::Proof =
 					self.rpc_client.request("ismp_queryChildTrieProof", params).await?;
 				let storage_proof: Vec<Vec<u8>> = Decode::decode(&mut &*response.proof)?;
-				let proof = SubstrateStateProof::OverlayProof(StateMachineProof {
-					hasher: self.hashing.clone(),
-					storage_proof,
-				});
+				let proof = StateMachineProof { hasher: self.hashing.clone(), storage_proof };
 				Ok(proof.encode())
 			},
 			s => Err(anyhow::anyhow!("Unsupported state machine {s:?}!")),
@@ -290,10 +287,7 @@ where
 				let response: pallet_ismp_rpc::Proof =
 					self.rpc_client.request("ismp_queryChildTrieProof", params).await?;
 				let storage_proof: Vec<Vec<u8>> = Decode::decode(&mut &*response.proof)?;
-				let proof = SubstrateStateProof::OverlayProof(StateMachineProof {
-					hasher: self.hashing.clone(),
-					storage_proof,
-				});
+				let proof = StateMachineProof { hasher: self.hashing.clone(), storage_proof };
 				Ok(proof.encode())
 			},
 			StateProofQueryType::Arbitrary(keys) => {
@@ -302,10 +296,7 @@ where
 					self.rpc_client.request("ismp_queryStateProof", params).await?;
 
 				let storage_proof: Vec<Vec<u8>> = Decode::decode(&mut &*response.proof)?;
-				let proof = SubstrateStateProof::StateProof(StateMachineProof {
-					hasher: self.hashing.clone(),
-					storage_proof,
-				});
+				let proof = StateMachineProof { hasher: self.hashing.clone(), storage_proof };
 				Ok(proof.encode())
 			},
 		}


### PR DESCRIPTION
Core change: StateMachineClient::verify_state_proof now takes the concrete H256 trie root instead of the full StateCommitment struct. The caller picks the root for its context, so the relayer-supplied SubstrateStateProof variant tag can no longer steer verification at the wrong trie.

Trait (consensus.rs): root: StateCommitment → root: H256.
Substrate impl: deleted the variant-tag-based root selection — it now uses the caller's root directly.
EVM / SubstrateEvm / Tendermint / Pharos impls + free helpers (verify_state_proof, verify_evm_kv_proofs): updated to H256; their internal verify_non_membership calls pass root.state_root.
Mocks (ismp-testsuite, pallet-ismp-testsuite): signature updated.
Callers:

GET response paths (handlers/response.rs, state-coprocessor/impls.rs) pass state.state_root — global trie.
Relayer fee accumulation (verify_withdrawal_proof) now selects the root explicitly: state_root for EVM chains, overlay_root for substrate chains (the ISMP child trie), with the coprocessor exception mirroring verify_membership. 