### PR TITLE
[node]: fix collator startup hang when tesseract config is passed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9302,6 +9302,7 @@ dependencies = [
  "tesseract-primitives",
  "tesseract-substrate",
  "tokio",
+ "toml 0.7.8",
  "url",
 ]
 

--- a/parachain/node/fisherman/Cargo.toml
+++ b/parachain/node/fisherman/Cargo.toml
@@ -9,7 +9,8 @@ publish = false
 [dependencies]
 anyhow = { workspace = true, default-features = true }
 log = "0.4"
-tokio = { workspace = true, features = ["sync", "rt", "time", "macros"] }
+tokio = { workspace = true, features = ["sync", "rt", "time", "macros", "fs"] }
+toml = "0.7.4"
 url = "2"
 
 ismp = { workspace = true, default-features = true }

--- a/parachain/node/fisherman/src/config.rs
+++ b/parachain/node/fisherman/src/config.rs
@@ -1,33 +1,119 @@
 // Copyright (C) Polytope Labs Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Validation of the consolidated relayer's [`HyperbridgeConfig`] for use by
-//! the collator-side fisherman. The toml is parsed by
-//! [`tesseract::config::HyperbridgeConfig::parse_conf`] — there's no
-//! parallel schema here. This module only encodes the rules that the
-//! collator path layers on top: a signer must be set, every supported L2 in
-//! [`tesseract_evm::registry`] must be present, and every L2 needs at least
-//! two `rpc_urls` so the byzantine handler has providers to quorum across.
+//! Collator side validation of the operator's tesseract toml.
 //!
-//! Rules are deliberately stricter than the relayer's: running fisherman is
-//! not optional for collators.
+//! Two entry points. [`preflight`] inspects the raw toml and is safe to run
+//! before chain init, so the binary can fail fast on a bad config without
+//! touching the network. [`validate`] runs the full check on a parsed
+//! [`HyperbridgeConfig`] and is invoked from [`crate::spawn`] once the
+//! local RPC server is up.
+//!
+//! Rules layered on top of the relayer schema: the signer must be set,
+//! every supported L2 in [`tesseract_evm::registry`] must be configured,
+//! and every L2 needs at least two distinct host `rpc_urls` so the
+//! byzantine handler has independent providers to quorum across.
 
 use std::collections::HashSet;
 
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use ismp::host::StateMachine;
 use tesseract::config::HyperbridgeConfig;
 use tesseract_config::AnyConfig;
 use tesseract_evm::registry::{
 	is_supported_l2, SUPPORTED_L2_CHAIN_IDS_MAINNET, SUPPORTED_L2_CHAIN_IDS_TESTNET,
 };
+use toml::{Table, Value};
 use url::Url;
 
 const MIN_RPC_URLS_PER_L2: usize = 2;
 
-/// Enforce the collator-side rules. Returns the first violation as `Err`.
-/// The signer must be set in `[hyperbridge].signer` — operators provide it
-/// explicitly, it is not sourced from the local keystore.
+/// Validate the operator's tesseract toml without parsing it through
+/// [`HyperbridgeConfig::parse_conf`]. The full parser dials each RPC to
+/// resolve chain metadata, and on a collator `[hyperbridge].rpc_ws`
+/// usually points at the same node, which has not opened its RPC port yet
+/// at this point in startup. Reading the raw toml lets us still catch the
+/// common operator mistakes (missing file, malformed toml, blank signer,
+/// partial L2 coverage) without any network I/O.
+pub fn preflight(toml_str: &str) -> anyhow::Result<()> {
+	let table: Table = toml_str.parse().context("tesseract config is not valid TOML")?;
+
+	let hyperbridge = table
+		.get("hyperbridge")
+		.and_then(Value::as_table)
+		.ok_or_else(|| anyhow!("missing [hyperbridge] table in tesseract config"))?;
+	let signer = hyperbridge.get("signer").and_then(Value::as_str).ok_or_else(|| {
+		anyhow!(
+			"[hyperbridge].signer is required for the fisherman; set it to the seed/URI of the account that should sign veto extrinsics"
+		)
+	})?;
+	if signer.trim().is_empty() {
+		return Err(anyhow!(
+			"[hyperbridge].signer is empty; set it to the seed/URI of the account that should sign veto extrinsics"
+		));
+	}
+
+	let mut configured_l2s: Vec<u64> = Vec::new();
+	for (name, raw) in &table {
+		if name == "hyperbridge" || name == "relayer" {
+			continue;
+		}
+		let Some(chain_table) = raw.as_table() else { continue };
+		// Substrate chains have rpc_ws, EVM chains have rpc_urls. The
+		// fisherman only cares about EVM L2s, so skip anything else.
+		let Some(rpc_urls) = chain_table.get("rpc_urls").and_then(Value::as_array) else {
+			continue;
+		};
+
+		// Without an explicit state_machine in the toml the chain id is
+		// only known after resolve, so defer to the post resolve check.
+		let Some(chain_id) = chain_table
+			.get("state_machine")
+			.and_then(Value::as_str)
+			.and_then(parse_evm_chain_id)
+		else {
+			continue;
+		};
+
+		if !is_supported_l2(chain_id) {
+			continue;
+		}
+
+		let urls: Vec<String> = rpc_urls
+			.iter()
+			.map(|v| {
+				v.as_str()
+					.map(str::to_string)
+					.ok_or_else(|| anyhow!("[{name}].rpc_urls entries must be strings"))
+			})
+			.collect::<anyhow::Result<_>>()?;
+		if urls.len() < MIN_RPC_URLS_PER_L2 {
+			return Err(anyhow!(
+				"L2 chain (chain_id {chain_id}) has only {} rpc_urls, need at least {} different RPC providers for quorum",
+				urls.len(),
+				MIN_RPC_URLS_PER_L2,
+			));
+		}
+		ensure_distinct_hosts(chain_id, &urls)?;
+		configured_l2s.push(chain_id);
+	}
+
+	require_complete_set(&configured_l2s, SUPPORTED_L2_CHAIN_IDS_MAINNET, "mainnet")?;
+	require_complete_set(&configured_l2s, SUPPORTED_L2_CHAIN_IDS_TESTNET, "testnet")?;
+	Ok(())
+}
+
+/// Pull the chain id out of an `"EVM-<chain_id>"` state machine string.
+/// Returns `None` for any other variant (Polkadot, Kusama, Substrate, and
+/// so on) since the fisherman only cares about EVM L2s.
+fn parse_evm_chain_id(state_machine: &str) -> Option<u64> {
+	state_machine.strip_prefix("EVM-")?.parse().ok()
+}
+
+/// Enforce the collator side rules on a parsed [`HyperbridgeConfig`].
+/// Returns the first violation as `Err`. The signer must be set in
+/// `[hyperbridge].signer`; operators provide it explicitly and it is not
+/// sourced from the local keystore.
 pub fn validate(config: &HyperbridgeConfig) -> anyhow::Result<()> {
 	if config.hyperbridge.substrate.signer.as_deref().map_or(true, str::is_empty) {
 		return Err(anyhow!(
@@ -59,9 +145,9 @@ pub fn validate(config: &HyperbridgeConfig) -> anyhow::Result<()> {
 	Ok(())
 }
 
-/// Reject if any two URLs in `urls` resolve to the same host. Same host =
-/// same provider as far as the byzantine quorum is concerned, so allowing
-/// duplicates would silently shrink the effective fan-out.
+/// Reject if any two URLs in `urls` resolve to the same host. Same host
+/// means the same provider as far as the byzantine quorum is concerned,
+/// so allowing duplicates would silently shrink the effective fan out.
 fn ensure_distinct_hosts(chain_id: u64, urls: &[String]) -> anyhow::Result<()> {
 	let mut seen: HashSet<String> = HashSet::with_capacity(urls.len());
 	for url in urls {
@@ -77,10 +163,10 @@ fn ensure_distinct_hosts(chain_id: u64, urls: &[String]) -> anyhow::Result<()> {
 	Ok(())
 }
 
-/// Lower-cased host portion of an RPC URL. Two URLs with the same host are
-/// treated as the same provider — different paths or API keys on the same
-/// vendor (e.g. two Alchemy endpoints) don't add quorum value, so the byzantine
-/// handler shouldn't be tricked into thinking they do.
+/// Lower cased host portion of an RPC URL. Two URLs with the same host
+/// are treated as the same provider; different paths or API keys on the
+/// same vendor (two Alchemy endpoints, say) do not add quorum value, so
+/// the byzantine handler should not be tricked into thinking they do.
 fn rpc_host(url: &str) -> Option<String> {
 	Url::parse(url).ok()?.host_str().map(str::to_ascii_lowercase)
 }
@@ -95,7 +181,7 @@ fn require_complete_set(configured: &[u64], set: &[u64], label: &str) -> anyhow:
 	let missing: Vec<u64> = set.iter().copied().filter(|c| !configured.contains(c)).collect();
 	if !missing.is_empty() {
 		return Err(anyhow!(
-			"{label} L2 coverage is partial — missing chain_ids {missing:?}. Running fisherman requires all supported L2s to be configured"
+			"{label} L2 coverage is partial, missing chain_ids {missing:?}. Running fisherman requires all supported L2s to be configured"
 		));
 	}
 	Ok(())

--- a/parachain/node/fisherman/src/lib.rs
+++ b/parachain/node/fisherman/src/lib.rs
@@ -1,18 +1,17 @@
 // Copyright (C) Polytope Labs Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Collator-side fisherman wrapper. Parses the consolidated relayer's
-//! [`HyperbridgeConfig`], constructs a Hyperbridge [`IsmpProvider`] and one
-//! per-L2 [`IsmpProvider`] from the existing canonical config types, and
-//! hands each pair to [`tesseract_fisherman::fish`] — the same task
-//! implementation the relayer used to spawn. Multi-RPC quorum and 3-attempt
-//! retry on transport errors live inside [`tesseract_evm::byzantine`], not
-//! here.
+//! Collator side fisherman. Parses the operator's tesseract toml, builds a
+//! hyperbridge provider and one provider per supported L2, and hands each
+//! pair to [`tesseract_fisherman::fish`].
 //!
-//! The signer used to sign veto extrinsics comes from
-//! `[hyperbridge].signer` in the tesseract config — the same field the
-//! relayer uses. Operators must set it explicitly; the collator's AURA
-//! keystore is not consulted.
+//! Startup ordering matters. [`load_and_validate`] only reads the file and
+//! checks fields, so it is safe to call before chain init and gives the
+//! operator a fast error on a bad config. [`spawn`] parses the toml through
+//! [`HyperbridgeConfig::parse_conf`], which dials `[hyperbridge].rpc_ws`.
+//! On a normal collator that URL points back at this node, so [`spawn`]
+//! must run after `sc_service::spawn_tasks` has opened the RPC port. Doing
+//! it earlier blocks the task that is supposed to open that port.
 
 pub mod config;
 
@@ -28,15 +27,21 @@ use tesseract_substrate::{config::KeccakSubstrateChain, SubstrateClient};
 
 pub const LOG_TARGET: &str = "fisherman";
 
-/// Parse the operator's tesseract toml at `path` (same shape the relayer
-/// consumes), validate it for collator use, build the Hyperbridge provider
-/// and per-L2 providers, and spawn one [`tesseract_fisherman::fish`] task
-/// per supported L2.
-///
-/// Errors here fail the collator at startup. The downstream tasks use
-/// `spawn_essential_handle`, so any internal panic tears the node down —
-/// which is the desired behavior: a collator that can't fish is a collator
-/// that shouldn't be producing blocks.
+/// Read the tesseract toml at `path` and run the sync preflight checks.
+/// Performs no network I/O so the call is safe to make before any chain
+/// init runs.
+pub async fn load_and_validate(path: &Path) -> anyhow::Result<()> {
+	let toml_str = tokio::fs::read_to_string(path)
+		.await
+		.with_context(|| format!("reading tesseract config at {}", path.display()))?;
+	config::preflight(&toml_str)
+		.with_context(|| format!("validating tesseract config at {}", path.display()))?;
+	Ok(())
+}
+
+/// Build the hyperbridge and per L2 providers and spawn one
+/// [`tesseract_fisherman::fish`] task per supported L2. Must run after
+/// `sc_service::spawn_tasks` has brought the local RPC server up.
 pub async fn spawn(path: &Path, task_manager: &TaskManager) -> anyhow::Result<()> {
 	let path_str = path
 		.to_str()
@@ -44,12 +49,15 @@ pub async fn spawn(path: &Path, task_manager: &TaskManager) -> anyhow::Result<()
 	let config = HyperbridgeConfig::parse_conf(path_str)
 		.await
 		.with_context(|| format!("parsing tesseract config at {}", path.display()))?;
-
 	config::validate(&config)?;
 
-	let hyperbridge_substrate = config.hyperbridge.substrate.clone().resolve().await.context(
-		"resolving hyperbridge SubstrateConfig (rpc_ws / state_machine lookup) for fisherman",
-	)?;
+	let hyperbridge_substrate = config
+		.hyperbridge
+		.substrate
+		.clone()
+		.resolve()
+		.await
+		.context("resolving hyperbridge SubstrateConfig for fisherman")?;
 	let hyperbridge_state_machine = hyperbridge_substrate.state_machine();
 	let hb_client = SubstrateClient::<KeccakSubstrateChain>::new(hyperbridge_substrate)
 		.await
@@ -70,11 +78,6 @@ pub async fn spawn(path: &Path, task_manager: &TaskManager) -> anyhow::Result<()
 			.await
 			.with_context(|| format!("constructing IsmpProvider for L2 {state_machine}"))?;
 
-		// Match the relayer's argument order: `chain_a` is the chain we
-		// subscribe to for `StateMachineUpdated` events (hyperbridge), and
-		// `chain_b` is the L2 whose `check_for_byzantine_attack` runs the
-		// quorum across its rpc providers and sends a veto on hyperbridge
-		// (the counterparty).
 		tesseract_fisherman::fish(hyperbridge.clone(), l2, task_manager, hyperbridge_state_machine)
 			.await
 			.with_context(|| format!("spawning fisherman task for L2 {state_machine}"))?;

--- a/parachain/node/src/cli.rs
+++ b/parachain/node/src/cli.rs
@@ -60,19 +60,22 @@ pub enum Subcommand {
 	TryRuntime,
 
 	/// Runs the node with signature verification override and manual seal.
-	Simnode(SimnodeCli),
+	Simnode(SimnodeCommand),
 }
 
+/// Wrapper around `sc_simnode::cli::SimnodeCli` that adds the hyperbridge
+/// specific flags. Named distinctly from the inner type so clap's
+/// argument group derivation does not collide on the shared `SimnodeCli`
+/// group name.
 #[derive(Debug, clap::Parser)]
-pub struct SimnodeCli {
+pub struct SimnodeCommand {
 	#[arg(long)]
 	pub instant: bool,
-	/// Path to a tesseract relayer toml config. Mirrors the top-level flag
-	/// of the same name; required because `args_conflicts_with_subcommands`
-	/// on the root `Cli` makes top-level options unreachable when running a
-	/// subcommand. When simnode runs as a `--validator`, the fisherman task
-	/// is spawned from this config — same path the production collator
-	/// uses.
+	/// Path to a tesseract relayer toml config. Duplicated at the
+	/// subcommand level because `args_conflicts_with_subcommands` on the
+	/// root `Cli` makes top level options unreachable when running a
+	/// subcommand. When simnode runs as a `--validator` the fisherman is
+	/// spawned from this config, matching the production collator path.
 	#[arg(long)]
 	pub tesseract_config: Option<PathBuf>,
 	#[command(flatten)]

--- a/parachain/node/src/command.rs
+++ b/parachain/node/src/command.rs
@@ -380,6 +380,33 @@ pub fn run() -> Result<()> {
 						let watcher_sender = bid_sender.clone();
 						let is_authority = config.role.is_authority();
 
+						// Preflight the config now and defer the spawn until
+						// after start_simnode opens the RPC. Same rationale as
+						// the production path in service.rs.
+						let fisherman_path = if is_authority {
+							match tesseract_config.as_ref() {
+								Some(path) => {
+									hyperbridge_fisherman::load_and_validate(path)
+										.await
+										.map_err(|e| {
+											sc_service::Error::Other(format!(
+												"invalid tesseract config: {e:?}"
+											))
+										})?;
+									Some(path.clone())
+								},
+								None => None,
+							}
+						} else {
+							if tesseract_config.is_some() {
+								log::info!(
+									target: "fisherman",
+									"--tesseract-config provided to a non-authority simnode; ignoring (fisherman only runs on collators)",
+								);
+							}
+							None
+						};
+
 						let task_manager = sc_simnode::parachain::start_simnode::<
 							crate::simnode::GargantuaRuntimeInfo,
 							_,
@@ -420,25 +447,19 @@ pub fn run() -> Result<()> {
 							),
 						);
 
-						// Mirror the production wiring: only authorities run the
-						// fisherman, and only when --tesseract-config is set. Lets
-						// simnode-based integration tests exercise the same spawn
-						// path used by real collators.
-						if is_authority {
-							if let Some(path) = tesseract_config.as_ref() {
-								hyperbridge_fisherman::spawn(path, &task_manager).await.map_err(
-									|e| {
-										sc_service::Error::Other(format!(
-											"failed to spawn fisherman task: {e:?}"
-										))
-									},
-								)?;
-							}
-						} else if tesseract_config.is_some() {
-							log::info!(
-								target: "fisherman",
-								"--tesseract-config provided to a non-authority simnode; ignoring (fisherman only runs on collators)",
-							);
+						// start_simnode has brought the local RPC up, so the
+						// fisherman dial against `[hyperbridge].rpc_ws` is
+						// safe even when it loops back to this node. Mirrors
+						// the production wiring in service.rs so simnode tests
+						// exercise the same spawn path.
+						if let Some(path) = fisherman_path {
+							hyperbridge_fisherman::spawn(&path, &task_manager).await.map_err(
+								|e| {
+									sc_service::Error::Other(format!(
+										"failed to spawn fisherman task: {e:?}"
+									))
+								},
+							)?;
 						}
 
 						Ok(task_manager)

--- a/parachain/node/src/service.rs
+++ b/parachain/node/src/service.rs
@@ -220,23 +220,31 @@ where
 	let transaction_pool = params.transaction_pool.clone();
 	let import_queue_service = params.import_queue.service();
 
-	// Collators are required to run the fisherman task; non-authorities skip
-	// it. Errors here abort node startup.
-	if validator {
+	// Collators run the fisherman, non authorities skip it. Preflight the
+	// config now so a misconfigured operator fails before any chain init.
+	// The actual provider construction is deferred until after
+	// `sc_service::spawn_tasks` opens the local RPC port, because the
+	// fisherman dials `[hyperbridge].rpc_ws` and on a normal collator that
+	// URL points back at this same node.
+	let fisherman_path = if validator {
 		let path = tesseract_config.clone().ok_or_else(|| {
 			sc_service::Error::Other(
 				"--tesseract-config is required when running as a collator/authority".to_string(),
 			)
 		})?;
-		hyperbridge_fisherman::spawn(&path, &task_manager).await.map_err(|e| {
-			sc_service::Error::Other(format!("failed to spawn fisherman task: {e:?}"))
-		})?;
-	} else if tesseract_config.is_some() {
-		log::info!(
-			target: "fisherman",
-			"--tesseract-config provided to a non-authority node; ignoring (fisherman only runs on collators)",
-		);
-	}
+		hyperbridge_fisherman::load_and_validate(&path)
+			.await
+			.map_err(|e| sc_service::Error::Other(format!("invalid tesseract config: {e:?}")))?;
+		Some(path)
+	} else {
+		if tesseract_config.is_some() {
+			log::info!(
+				target: "fisherman",
+				"--tesseract-config provided to a non-authority node; ignoring (fisherman only runs on collators)",
+			);
+		}
+		None
+	};
 
 	let (network, system_rpc_tx, tx_handler_controller, sync_service) =
 		build_network(BuildNetworkParams {
@@ -328,6 +336,14 @@ where
 		telemetry: telemetry.as_mut(),
 		tracing_execute_block: None,
 	})?;
+
+	// The local RPC server is up now, so the fisherman can safely dial
+	// `[hyperbridge].rpc_ws` even when it points back at this node.
+	if let Some(path) = fisherman_path {
+		hyperbridge_fisherman::spawn(&path, &task_manager).await.map_err(|e| {
+			sc_service::Error::Other(format!("failed to spawn fisherman task: {e:?}"))
+		})?;
+	}
 
 	if let Some(hwbench) = hwbench {
 		sc_sysinfo::print_hwbench(&hwbench);

--- a/parachain/runtimes/nexus/src/ismp.rs
+++ b/parachain/runtimes/nexus/src/ismp.rs
@@ -39,7 +39,7 @@ use pallet_assets::BenchmarkHelper;
 use pallet_ismp::{dispatcher::FeeMetadata, ModuleId};
 use polkadot_sdk::*;
 use sp_core::{crypto::AccountId32, H256};
-use sp_runtime::{traits::Zero, Weight};
+use sp_runtime::Weight;
 use sp_std::prelude::*;
 #[cfg(feature = "runtime-benchmarks")]
 use staging_xcm::latest::Location;
@@ -176,18 +176,16 @@ impl pallet_call_decompressor::Config for Runtime {
 	type MaxCallSize = ConstU32<3>;
 }
 
-/// True when the account is a bonded controller account registered with
-/// `pallet-collator-manager`. Controllers are paired with a stash that has
-/// bonded funds; `deregister` removes both entries in the same block, so an
-/// account present in `Stash` whose paired stash still holds a non-zero
-/// bond is a legitimate fisherman.
+/// True when the account is in the active collator set for the current
+/// session. The set comes from `pallet_session::Validators<Runtime>`,
+/// which `pallet-collator-manager`'s `SessionManager::new_session`
+/// populates with controller accounts. Registered but idle controllers
+/// and rotated out ex collators cannot sign vetoes; only the validators
+/// producing blocks for the current session can.
 pub struct IsCollator;
 impl frame_support::traits::Contains<AccountId> for IsCollator {
 	fn contains(account: &AccountId) -> bool {
-		let Some(stash) = pallet_collator_manager::Stash::<Runtime>::get(account) else {
-			return false;
-		};
-		!pallet_collator_manager::Bonded::<Runtime>::get(&stash).is_zero()
+		pallet_session::Validators::<Runtime>::get().contains(account)
 	}
 }
 

--- a/parachain/runtimes/nexus/src/lib.rs
+++ b/parachain/runtimes/nexus/src/lib.rs
@@ -843,20 +843,19 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 	fn filter(&self, c: &RuntimeCall) -> bool {
 		match self {
 			ProxyType::Any => true,
-			ProxyType::NonTransfer => {
-				!matches!(c, RuntimeCall::Balances { .. } | RuntimeCall::Assets { .. })
-			},
+			ProxyType::NonTransfer =>
+				!matches!(c, RuntimeCall::Balances { .. } | RuntimeCall::Assets { .. }),
 			ProxyType::CancelProxy => matches!(
 				c,
-				RuntimeCall::Proxy(pallet_proxy::Call::reject_announcement { .. })
-					| RuntimeCall::Utility { .. }
-					| RuntimeCall::Multisig { .. }
+				RuntimeCall::Proxy(pallet_proxy::Call::reject_announcement { .. }) |
+					RuntimeCall::Utility { .. } |
+					RuntimeCall::Multisig { .. }
 			),
 			ProxyType::Collator => matches!(
 				c,
-				RuntimeCall::CollatorSelection { .. }
-					| RuntimeCall::Utility { .. }
-					| RuntimeCall::Multisig { .. }
+				RuntimeCall::CollatorSelection { .. } |
+					RuntimeCall::Utility { .. } |
+					RuntimeCall::Multisig { .. }
 			),
 		}
 	}


### PR DESCRIPTION
The collator hung at startup with `--tesseract-config` because the fisherman dialed [hyperbridge].rpc_ws, which points back at the node's own RPC, before that port was open; the spawn now runs after sc_service::spawn_tasks and a sync preflight checks the config up front so a bad config still fails fast.

Nexus `IsCollator` now reads `pallet_session::Validators` so only collators in the active session set can submit vetoes. The simnode subcommand wrapper was also renamed to `SimnodeCommand` to clear a clap argument group name collision with `sc_simnode::cli::SimnodeCli`.