### PR TITLE
[tests] Fix testsuite build errors

### DIFF
--- a/modules/pallets/testsuite/src/tests/pallet_ismp_relayer.rs
+++ b/modules/pallets/testsuite/src/tests/pallet_ismp_relayer.rs
@@ -822,14 +822,14 @@ fn test_accumulate_fees_rejects_replay_from_other_chain() {
 			keys.push(*request);
 		}
 
-		let source_state_proof = SubstrateStateProof::OverlayProof(StateMachineProof {
+		let source_state_proof = StateMachineProof {
 			hasher: HashAlgorithm::Keccak,
 			storage_proof: source_recorder.drain().into_iter().map(|f| f.data).collect::<Vec<_>>(),
-		});
-		let dest_state_proof = SubstrateStateProof::OverlayProof(StateMachineProof {
+		};
+		let dest_state_proof = StateMachineProof {
 			hasher: HashAlgorithm::Keccak,
 			storage_proof: dest_recorder.drain().into_iter().map(|f| f.data).collect::<Vec<_>>(),
-		});
+		};
 
 		let host = Ismp::default();
 		for chain in [StateMachine::Kusama(2000), StateMachine::Kusama(2001)] {


### PR DESCRIPTION


test_accumulate_fees_rejects_replay_from_other_chain was added in a6654956 before SubstrateStateProof was removed, so it still referenced the dead enum variant. Build the StateMachineProof directly to match the surrounding tests and the post-refactor proof wire format.