### PR TITLE
[evm]: IntentGatewayV2 fixes

### DIFF
--- a/evm/script/DeployIntentGateway.s.sol
+++ b/evm/script/DeployIntentGateway.s.sol
@@ -9,6 +9,7 @@ import {BaseScript} from "./BaseScript.sol";
 import {CallDispatcher} from "../src/utils/CallDispatcher.sol";
 import {SolverAccount} from "../src/apps/intentsv2/SolverAccount.sol";
 import {VWAPOracle} from "../src/utils/VWAPOracle.sol";
+import {StateMachine} from "@hyperbridge/core/libraries/StateMachine.sol";
 
 contract DeployScript is BaseScript {
     using strings for *;
@@ -25,6 +26,36 @@ contract DeployScript is BaseScript {
         address priceOracle = address(0);
         // address priceOracle = deployPriceOracle(address(intentGateway));
 
+        Deployment[] memory deployments = new Deployment[](7);
+        deployments[0] = Deployment({
+            chain: StateMachine.evm(1), // ethereum
+            gateway: address(intentGateway)
+        });
+        deployments[1] = Deployment({
+            chain: StateMachine.evm(10), // optimism 
+            gateway: address(intentGateway)
+        });
+        deployments[2] = Deployment({
+            chain: StateMachine.evm(42161), // arbitrum
+            gateway: address(intentGateway)
+        });
+        deployments[3] = Deployment({
+            chain: StateMachine.evm(8453), // base
+            gateway: address(intentGateway)
+        });
+        deployments[4] = Deployment({
+            chain: StateMachine.evm(56), // bsc
+            gateway: address(intentGateway)
+        });
+        deployments[5] = Deployment({
+            chain: StateMachine.evm(100), // gnosis
+            gateway: address(intentGateway)
+        });
+        deployments[6] = Deployment({
+            chain: StateMachine.evm(137), // polygon
+            gateway: address(intentGateway)
+        });
+
         intentGateway.init(
             Params({
                 host: HOST_ADDRESS,
@@ -34,7 +65,7 @@ contract DeployScript is BaseScript {
                 protocolFeeBps: 30, // 0.3%
                 priceOracle: address(priceOracle)
             }),
-            new Deployment[](0)
+            deployments
         );
 
         vm.stopBroadcast();

--- a/evm/script/DeployIntentGateway.s.sol
+++ b/evm/script/DeployIntentGateway.s.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.17;
 import "forge-std/Script.sol";
 import "stringutils/strings.sol";
 
-import {IntentGatewayV2, Params} from "../src/apps/IntentGatewayV2.sol";
+import {IntentGatewayV2, Params, Deployment} from "../src/apps/IntentGatewayV2.sol";
 import {BaseScript} from "./BaseScript.sol";
 import {CallDispatcher} from "../src/utils/CallDispatcher.sol";
 import {SolverAccount} from "../src/apps/intentsv2/SolverAccount.sol";
@@ -25,7 +25,7 @@ contract DeployScript is BaseScript {
         address priceOracle = address(0);
         // address priceOracle = deployPriceOracle(address(intentGateway));
 
-        intentGateway.setParams(
+        intentGateway.init(
             Params({
                 host: HOST_ADDRESS,
                 dispatcher: config.get("CALL_DISPATCHER").toAddress(),
@@ -33,7 +33,8 @@ contract DeployScript is BaseScript {
                 surplusShareBps: 5_000, // 50%
                 protocolFeeBps: 30, // 0.3%
                 priceOracle: address(priceOracle)
-            })
+            }),
+            new Deployment[](0)
         );
 
         vm.stopBroadcast();

--- a/evm/src/apps/IntentGatewayV2.sol
+++ b/evm/src/apps/IntentGatewayV2.sol
@@ -38,7 +38,7 @@ import {
     FillOptions,
     SelectOptions,
     CancelOptions,
-    NewDeployment
+    Deployment
 } from "@hyperbridge/core/apps/IntentGatewayV2.sol";
 
 /**
@@ -94,12 +94,16 @@ contract IntentGatewayV2 is IntrinsicIntents, ExtrinsicIntents {
      *
      * @param p The initial gateway configuration parameters.
      */
-    function setParams(Params memory p) public {
+    function init(Params memory p, Deployment[] memory deployments) public {
         if (msg.sender != _admin) revert Unauthorized();
 
+        uint256 deploymentsLength = deployments.length;
+        for (uint256 i = 0; i < deploymentsLength; i++) {
+            _addDeployment(deployments[i]);
+        }
         _validateParams(p);
-        _admin = address(0);
         _params = p;
+        _admin = address(0);
     }
 
     /**
@@ -357,8 +361,8 @@ contract IntentGatewayV2 is IntrinsicIntents, ExtrinsicIntents {
 
         emit OrderPlaced({
             user: order.user,
-            source: order.source,
-            destination: order.destination,
+            source: string(order.source),
+            destination: string(order.destination),
             deadline: order.deadline,
             nonce: order.nonce,
             fees: order.fees,

--- a/evm/src/apps/IntentGatewayV2.sol
+++ b/evm/src/apps/IntentGatewayV2.sol
@@ -93,6 +93,7 @@ contract IntentGatewayV2 is IntrinsicIntents, ExtrinsicIntents {
      * Subsequent parameter updates must come through Hyperbridge governance via the `onAccept` callback.
      *
      * @param p The initial gateway configuration parameters.
+     * @param deployments The initial gateway cross-chain peers
      */
     function init(Params memory p, Deployment[] memory deployments) public {
         if (msg.sender != _admin) revert Unauthorized();

--- a/evm/src/apps/intentsv2/ExtrinsicIntents.sol
+++ b/evm/src/apps/intentsv2/ExtrinsicIntents.sol
@@ -27,7 +27,7 @@ import {
     WithdrawalRequest,
     FillOptions,
     CancelOptions,
-    NewDeployment
+    Deployment
 } from "@hyperbridge/core/apps/IntentGatewayV2.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -294,7 +294,7 @@ abstract contract ExtrinsicIntents is IntentsBase, HyperApp {
         // only hyperbridge is permitted to perform these actions
         if (keccak256(incoming.request.source) != keccak256(IDispatcher(host()).hyperbridge())) revert Unauthorized();
         if (kind == RequestKind.NewDeployment) {
-            _addDeployment(abi.decode(incoming.request.body[1:], (NewDeployment)));
+            _addDeployment(abi.decode(incoming.request.body[1:], (Deployment)));
         } else if (kind == RequestKind.UpdateParams) {
             _updateParams(abi.decode(incoming.request.body[1:], (ParamsUpdate)));
         } else if (kind == RequestKind.SweepDust) {

--- a/evm/src/apps/intentsv2/IntentsBase.sol
+++ b/evm/src/apps/intentsv2/IntentsBase.sol
@@ -23,7 +23,7 @@ import {
     SweepDust,
     WithdrawalRequest,
     SelectOptions,
-    NewDeployment
+    Deployment
 } from "@hyperbridge/core/apps/IntentGatewayV2.sol";
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -183,6 +183,11 @@ abstract contract IntentsBase is EIP712 {
      */
     error UnknownOrder();
 
+    /*
+     * @dev Thrown when the cross-chain peer is unknown.
+    */
+    error UnknownInstance();
+
     /**
      * @dev Emitted when a new intent order is placed and input tokens are escrowed.
      * @param user The order creator's address encoded as bytes32.
@@ -199,8 +204,8 @@ abstract contract IntentsBase is EIP712 {
      */
     event OrderPlaced(
         bytes32 user,
-        bytes source,
-        bytes destination,
+        string source,
+        string destination,
         uint256 deadline,
         uint256 nonce,
         uint256 fees,
@@ -253,10 +258,10 @@ abstract contract IntentsBase is EIP712 {
 
     /**
      * @dev Emitted when a new gateway instance is registered for a remote state machine.
-     * @param stateMachineId The state machine identifier for the new deployment.
+     * @param chain The state machine identifier for the new deployment.
      * @param gateway The address of the deployed gateway on that chain.
      */
-    event NewDeploymentAdded(bytes stateMachineId, address gateway);
+    event DeploymentAdded(string chain, address gateway);
 
     /**
      * @dev Emitted when surplus tokens are retained by the protocol. This includes
@@ -277,10 +282,10 @@ abstract contract IntentsBase is EIP712 {
 
     /**
      * @dev Emitted when a destination-specific protocol fee override is set via governance.
-     * @param stateMachineId The destination state machine identifier.
+     * @param chain The destination state machine identifier.
      * @param feeBps The protocol fee in basis points for orders targeting this destination.
      */
-    event DestinationProtocolFeeUpdated(bytes32 indexed stateMachineId, uint256 feeBps);
+    event DestinationProtocolFeeUpdated(string chain, uint256 feeBps);
 
     /**
      * @dev Returns the address of the Hyperbridge host contract. This function is virtual
@@ -309,7 +314,8 @@ abstract contract IntentsBase is EIP712 {
      */
     function _instance(bytes calldata stateMachineId) internal view returns (address) {
         address gateway = _instances[keccak256(stateMachineId)];
-        return gateway == address(0) ? address(this) : gateway;
+        if (gateway == address(0)) revert UnknownInstance();
+        return gateway;
     }
 
     /**
@@ -469,9 +475,9 @@ abstract contract IntentsBase is EIP712 {
      *
      * @param body The deployment info containing the state machine ID and gateway address.
      */
-    function _addDeployment(NewDeployment memory body) internal {
-        _instances[keccak256(body.stateMachineId)] = body.gateway;
-        emit NewDeploymentAdded({stateMachineId: body.stateMachineId, gateway: body.gateway});
+    function _addDeployment(Deployment memory body) internal {
+        _instances[keccak256(body.chain)] = body.gateway;
+        emit DeploymentAdded({chain: string(body.chain), gateway: body.gateway});
     }
 
     /**
@@ -506,15 +512,15 @@ abstract contract IntentsBase is EIP712 {
         _params = update.params;
 
         for (uint256 i; i < update.destinationFees.length;) {
-            bytes32 stateMachineId = update.destinationFees[i].stateMachineId;
+            bytes memory chain = update.destinationFees[i].chain;
             uint256 feeBps = update.destinationFees[i].destinationFeeBps;
             if (feeBps >= 10_000) revert InvalidInput();
-            _destinationProtocolFees[stateMachineId] = feeBps;
+            _destinationProtocolFees[keccak256(chain)] = feeBps;
 
             unchecked {
                 ++i;
             }
-            emit DestinationProtocolFeeUpdated(stateMachineId, feeBps);
+            emit DestinationProtocolFeeUpdated(string(chain), feeBps);
         }
     }
 

--- a/evm/src/core/HandlerV2.sol
+++ b/evm/src/core/HandlerV2.sol
@@ -275,7 +275,7 @@ contract HandlerV2 is IHandlerV2, ERC165, Context {
             if (meta.sender == address(0)) revert UnknownMessage();
 
             bytes[] memory keys = new bytes[](1);
-            keys[0] = bytes.concat(REQUEST_RECEIPTS_STORAGE_PREFIX, bytes.concat(requestCommitment));
+            keys[0] = bytes.concat(REQUEST_RECEIPTS_STORAGE_PREFIX, requestCommitment);
 
             // verify state trie non-membership proofs
             PolkadotTrie.StorageValue memory entry = PolkadotTrie.VerifyProof(state.stateRoot, message.proof, keys)[0];
@@ -310,7 +310,7 @@ contract HandlerV2 is IHandlerV2, ERC165, Context {
             if (meta.sender == address(0)) revert UnknownMessage();
 
             bytes[] memory keys = new bytes[](1);
-            keys[0] = bytes.concat(REQUEST_RECEIPTS_STORAGE_PREFIX, bytes.concat(commitment));
+            keys[0] = bytes.concat(RESPONSE_RECEIPTS_STORAGE_PREFIX, commitment);
 
             // verify state trie non-membership proofs
             PolkadotTrie.StorageValue memory entry = PolkadotTrie.VerifyProof(state.stateRoot, message.proof, keys)[0];

--- a/evm/tests/foundry/IntentGatewayV2SameChainTest.sol
+++ b/evm/tests/foundry/IntentGatewayV2SameChainTest.sol
@@ -24,7 +24,8 @@ import {
     PaymentInfo,
     DispatchInfo,
     FillOptions,
-    CancelOptions
+    CancelOptions,
+    Deployment
 } from "../../src/apps/IntentGatewayV2.sol";
 import {IntentsBase} from "../../src/apps/intentsv2/IntentsBase.sol";
 import {ICallDispatcher, Call} from "@hyperbridge/core/interfaces/ICallDispatcher.sol";
@@ -82,7 +83,7 @@ contract IntentGatewayV2SameChainTest is MainnetForkBaseTest {
             protocolFeeBps: 0, // No protocol fees for most tests
             priceOracle: address(0)
         });
-        intentGateway.setParams(intentParams);
+        intentGateway.init(intentParams, new Deployment[](0));
 
         // Fund test accounts
         _fundTestAccounts();
@@ -183,7 +184,7 @@ contract IntentGatewayV2SameChainTest is MainnetForkBaseTest {
             protocolFeeBps: PROTOCOL_FEE_BPS,
             priceOracle: address(0)
         });
-        gatewayWithFees.setParams(intentParams);
+        gatewayWithFees.init(intentParams, new Deployment[](0));
 
         uint256 inputAmount = 1000 * 1e6; // 1000 USDC
         uint256 outputAmount = 900 * 1e18; // 900 DAI
@@ -1388,7 +1389,7 @@ contract IntentGatewayV2SameChainTest is MainnetForkBaseTest {
 
     function testPartialFill_WithProtocolFee() public {
         IntentGatewayV2 gatewayWithFees = new IntentGatewayV2(address(this));
-        gatewayWithFees.setParams(
+        gatewayWithFees.init(
             Params({
                 host: address(host),
                 dispatcher: address(dispatcher),
@@ -1397,7 +1398,7 @@ contract IntentGatewayV2SameChainTest is MainnetForkBaseTest {
                 protocolFeeBps: PROTOCOL_FEE_BPS,
                 priceOracle: address(0)
             })
-        );
+        , new Deployment[](0));
 
         uint256 inputAmount = 1000 * 1e6;
         uint256 outputAmount = 900 * 1e18;
@@ -1963,7 +1964,7 @@ contract IntentGatewayV2SameChainTest is MainnetForkBaseTest {
             protocolFeeBps: PROTOCOL_FEE_BPS,
             priceOracle: address(0)
         });
-        gatewayWithFees.setParams(intentParams);
+        gatewayWithFees.init(intentParams, new Deployment[](0));
 
         TokenInfo[] memory inputs = new TokenInfo[](2);
         inputs[0] = TokenInfo({token: bytes32(uint256(uint160(address(usdc)))), amount: 600 * 1e6});
@@ -2307,7 +2308,7 @@ contract IntentGatewayV2SameChainTest is MainnetForkBaseTest {
             protocolFeeBps: PROTOCOL_FEE_BPS, // 30 bps
             priceOracle: address(0)
         });
-        gatewayWithFees.setParams(intentParams);
+        gatewayWithFees.init(intentParams, new Deployment[](0));
 
         FeeOnTransferToken fot = new FeeOnTransferToken(100); // 1% transfer fee
         fot.mint(user, 10000 * 1e18);

--- a/evm/tests/foundry/IntentGatewayV2Test.sol
+++ b/evm/tests/foundry/IntentGatewayV2Test.sol
@@ -28,7 +28,7 @@ import {
     DispatchInfo,
     FillOptions,
     CancelOptions,
-    NewDeployment,
+    Deployment,
     WithdrawalRequest,
     SelectOptions
 } from "../../src/apps/IntentGatewayV2.sol";
@@ -77,7 +77,15 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
             protocolFeeBps: 0,
             priceOracle: address(0)
         });
-        intentGateway.setParams(intentParams);
+        // Register the gateway's cross-chain peers. In these tests the peer on every
+        // remote chain is simulated by this same contract instance, so each chain maps
+        // back to `intentGateway`. `_instance` now reverts UnknownInstance for unregistered
+        // chains, so peers must be seeded explicitly.
+        Deployment[] memory deployments = new Deployment[](3);
+        deployments[0] = Deployment({chain: host.host(), gateway: address(intentGateway)});
+        deployments[1] = Deployment({chain: bytes("SOURCE_CHAIN"), gateway: address(intentGateway)});
+        deployments[2] = Deployment({chain: bytes("DEST_CHAIN"), gateway: address(intentGateway)});
+        intentGateway.init(intentParams, deployments);
 
         // Fund test accounts
         _fundTestAccounts();
@@ -507,7 +515,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
             protocolFeeBps: 0,
             priceOracle: address(0)
         });
-        zeroFeeGateway.setParams(zeroFeeParams);
+        zeroFeeGateway.init(zeroFeeParams, new Deployment[](0));
 
         uint256 inputAmount = 1000 * 1e6;
 
@@ -787,7 +795,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
             protocolFeeBps: 0,
             priceOracle: address(0)
         });
-        customGateway.setParams(customParams);
+        customGateway.init(customParams, new Deployment[](0));
 
         uint256 solverOutputAmount = 2100 * 1e18;
 
@@ -865,7 +873,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
             protocolFeeBps: 0,
             priceOracle: address(0)
         });
-        customGateway.setParams(customParams);
+        customGateway.init(customParams, new Deployment[](0));
 
         uint256 solverOutputAmount = 2100 * 1e18; // 100 DAI surplus
 
@@ -928,7 +936,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
             protocolFeeBps: 0,
             priceOracle: address(0)
         });
-        customGateway.setParams(customParams);
+        customGateway.init(customParams, new Deployment[](0));
 
         uint256 solverOutputAmount = 2100 * 1e18; // 100 DAI surplus
 
@@ -1000,7 +1008,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         // Compare: without calldata and 50% split, protocol gets 50 DAI
         //          with calldata and 50% split, protocol gets 100 DAI (all surplus)
         IntentGatewayV2 customGateway = new IntentGatewayV2(address(this));
-        customGateway.setParams(
+        customGateway.init(
             Params({
                 host: address(host),
                 dispatcher: address(dispatcher),
@@ -1009,7 +1017,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
                 protocolFeeBps: 0,
                 priceOracle: address(0)
             })
-        );
+        , new Deployment[](0));
 
         // Setup order WITH calldata
         TokenInfo[] memory inputs = new TokenInfo[](1);
@@ -1376,7 +1384,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         });
 
         IntentGatewayV2 gatewayWithSelection = new IntentGatewayV2(address(this));
-        gatewayWithSelection.setParams(newParams);
+        gatewayWithSelection.init(newParams, new Deployment[](0));
 
         uint256 inputAmount = 1000 * 1e6;
 
@@ -1447,7 +1455,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         });
 
         IntentGatewayV2 gatewayWithSelection = new IntentGatewayV2(address(this));
-        gatewayWithSelection.setParams(newParams);
+        gatewayWithSelection.init(newParams, new Deployment[](0));
 
         uint256 inputAmount = 1000 * 1e6;
 
@@ -2365,7 +2373,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         bytes memory stateMachineId = bytes("NEW_CHAIN");
         address gateway = address(0x1234);
 
-        NewDeployment memory deployment = NewDeployment({stateMachineId: stateMachineId, gateway: gateway});
+        Deployment memory deployment = Deployment({chain: stateMachineId, gateway: gateway});
 
         bytes memory body = bytes.concat(bytes1(uint8(IntentsBase.RequestKind.NewDeployment)), abi.encode(deployment));
 
@@ -2384,18 +2392,18 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         vm.prank(address(host));
         intentGateway.onAccept(IncomingPostRequest({relayer: address(0), request: request}));
 
-        // Check NewDeploymentAdded event
+        // Check DeploymentAdded event
         Vm.Log[] memory entries = vm.getRecordedLogs();
         bool eventFound = false;
 
         for (uint256 i = 0; i < entries.length; i++) {
-            if (entries[i].topics[0] == keccak256("NewDeploymentAdded(bytes,address)")) {
+            if (entries[i].topics[0] == keccak256("DeploymentAdded(string,address)")) {
                 eventFound = true;
                 break;
             }
         }
 
-        assertTrue(eventFound, "NewDeploymentAdded event should be emitted");
+        assertTrue(eventFound, "DeploymentAdded event should be emitted");
 
         // Verify instance was stored
         assertEq(intentGateway.instance(stateMachineId), gateway, "Gateway instance should be stored");
@@ -2471,9 +2479,9 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         bytes memory arbitrumStateMachineId = bytes("ARBITRUM");
         bytes memory optimismStateMachineId = bytes("OPTIMISM");
 
-        destinationFees[0] = DestinationFee({stateMachineId: keccak256(arbitrumStateMachineId), destinationFeeBps: 50});
+        destinationFees[0] = DestinationFee({destinationFeeBps: 50, chain: arbitrumStateMachineId});
 
-        destinationFees[1] = DestinationFee({stateMachineId: keccak256(optimismStateMachineId), destinationFeeBps: 150});
+        destinationFees[1] = DestinationFee({destinationFeeBps: 150, chain: optimismStateMachineId});
 
         ParamsUpdate memory update = ParamsUpdate({params: newParams, destinationFees: destinationFees});
 
@@ -2509,7 +2517,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
                 paramsUpdatedFound = true;
             }
 
-            if (entries[i].topics[0] == keccak256("DestinationProtocolFeeUpdated(bytes32,uint256)")) {
+            if (entries[i].topics[0] == keccak256("DestinationProtocolFeeUpdated(string,uint256)")) {
                 destinationFeeEventsFound++;
             }
         }
@@ -2560,7 +2568,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         uint256 destinationFeeEventsFound = 0;
 
         for (uint256 i = 0; i < entries.length; i++) {
-            if (entries[i].topics[0] == keccak256("DestinationProtocolFeeUpdated(bytes32,uint256)")) {
+            if (entries[i].topics[0] == keccak256("DestinationProtocolFeeUpdated(string,uint256)")) {
                 destinationFeeEventsFound++;
             }
         }
@@ -2583,11 +2591,10 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         });
 
         bytes memory arbitrumStateMachineId = bytes("ARBITRUM");
-        bytes32 hashedStateMachineId = keccak256(arbitrumStateMachineId);
         uint256 feeBps = 75;
 
         DestinationFee[] memory destinationFees = new DestinationFee[](1);
-        destinationFees[0] = DestinationFee({stateMachineId: hashedStateMachineId, destinationFeeBps: feeBps});
+        destinationFees[0] = DestinationFee({destinationFeeBps: feeBps, chain: arbitrumStateMachineId});
 
         ParamsUpdate memory update = ParamsUpdate({params: newParams, destinationFees: destinationFees});
 
@@ -2604,7 +2611,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         });
 
         vm.expectEmit(true, false, false, true);
-        emit IntentsBase.DestinationProtocolFeeUpdated(hashedStateMachineId, feeBps);
+        emit IntentsBase.DestinationProtocolFeeUpdated(string(arbitrumStateMachineId), feeBps);
 
         vm.prank(address(host));
         intentGateway.onAccept(IncomingPostRequest({relayer: address(0), request: request}));
@@ -2621,16 +2628,15 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
             protocolFeeBps: 100, // 1% default
             priceOracle: address(0)
         });
-        customGateway.setParams(customParams);
+        customGateway.init(customParams, new Deployment[](0));
 
         // Set destination-specific fee via governance
         bytes memory destinationChain = bytes("ARBITRUM");
-        bytes32 destinationHash = keccak256(destinationChain);
 
         DestinationFee[] memory destinationFees = new DestinationFee[](1);
         destinationFees[0] = DestinationFee({
-            stateMachineId: destinationHash,
-            destinationFeeBps: 50 // 0.5% for this destination
+            destinationFeeBps: 50, // 0.5% for this destination
+            chain: destinationChain
         });
 
         ParamsUpdate memory update = ParamsUpdate({params: customParams, destinationFees: destinationFees});
@@ -2713,7 +2719,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
             protocolFeeBps: 100, // 1% default
             priceOracle: address(0)
         });
-        customGateway.setParams(customParams);
+        customGateway.init(customParams, new Deployment[](0));
 
         // Place order to destination without specific fee set
         uint256 inputAmount = 1000 * 1e6; // 1000 USDC
@@ -2769,13 +2775,13 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
     function testInstance() public {
         bytes memory stateMachineId = bytes("TEST_CHAIN");
 
-        // Before adding deployment, should return this contract's address
-        address instance = intentGateway.instance(stateMachineId);
-        assertEq(instance, address(intentGateway), "Should return self address by default");
+        // Before adding a deployment, an unregistered chain reverts UnknownInstance.
+        vm.expectRevert(IntentsBase.UnknownInstance.selector);
+        intentGateway.instance(stateMachineId);
 
         // Add a new deployment
         address gateway = address(0xABCD);
-        NewDeployment memory deployment = NewDeployment({stateMachineId: stateMachineId, gateway: gateway});
+        Deployment memory deployment = Deployment({chain: stateMachineId, gateway: gateway});
 
         bytes memory body = bytes.concat(bytes1(uint8(IntentsBase.RequestKind.NewDeployment)), abi.encode(deployment));
 
@@ -2793,7 +2799,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         intentGateway.onAccept(IncomingPostRequest({relayer: address(0), request: request}));
 
         // Now should return the stored gateway
-        instance = intentGateway.instance(stateMachineId);
+        address instance = intentGateway.instance(stateMachineId);
         assertEq(instance, gateway, "Should return stored gateway address");
     }
 
@@ -2908,7 +2914,10 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
             protocolFeeBps: 100, // 1%
             priceOracle: address(0)
         });
-        customGateway.setParams(customParams);
+        // Register the local chain peer so the later RedeemEscrow onAccept authenticates.
+        Deployment[] memory deployments = new Deployment[](1);
+        deployments[0] = Deployment({chain: host.host(), gateway: address(customGateway)});
+        customGateway.init(customParams, deployments);
 
         uint256 inputAmount = 1000 * 1e6; // 1000 USDC
         uint256 expectedProtocolFee = (inputAmount * 100) / 10000; // 10 USDC
@@ -2955,7 +2964,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
             if (
                 entries[i].topics[0]
                     == keccak256(
-                        "OrderPlaced(bytes32,bytes,bytes,uint256,uint256,uint256,address,bytes32,(bytes32,uint256)[],(bytes32,uint256)[],(bytes32,uint256)[])"
+                        "OrderPlaced(bytes32,string,string,uint256,uint256,uint256,address,bytes32,(bytes32,uint256)[],(bytes32,uint256)[],(bytes32,uint256)[])"
                     )
             ) {
                 orderPlacedFound = true;
@@ -3034,7 +3043,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
             protocolFeeBps: 1000, // 10%
             priceOracle: address(0)
         });
-        customGateway.setParams(customParams);
+        customGateway.init(customParams, new Deployment[](0));
 
         uint256 inputAmount = 1000 * 1e6; // 1000 USDC
         uint256 expectedProtocolFee = (inputAmount * 1000) / 10000; // 100 USDC
@@ -3114,7 +3123,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
             protocolFeeBps: 0, // 0%
             priceOracle: address(0)
         });
-        customGateway.setParams(customParams);
+        customGateway.init(customParams, new Deployment[](0));
 
         uint256 inputAmount = 1000 * 1e6; // 1000 USDC
 
@@ -3170,7 +3179,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
             protocolFeeBps: 200, // 2%
             priceOracle: address(0)
         });
-        customGateway.setParams(customParams);
+        customGateway.init(customParams, new Deployment[](0));
 
         uint256 usdcAmount = 1000 * 1e6; // 1000 USDC
         uint256 daiAmount = 500 * 1e18; // 500 DAI
@@ -3267,7 +3276,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
             protocolFeeBps: 500, // 5%
             priceOracle: address(0)
         });
-        customGateway.setParams(customParams);
+        customGateway.init(customParams, new Deployment[](0));
 
         uint256 inputAmount = 1000 * 1e6; // 1000 USDC
         uint256 expectedProtocolFee = (inputAmount * 500) / 10000; // 50 USDC
@@ -3303,7 +3312,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
             if (
                 entries[i].topics[0]
                     == keccak256(
-                        "OrderPlaced(bytes32,bytes,bytes,uint256,uint256,uint256,address,bytes32,(bytes32,uint256)[],(bytes32,uint256)[],(bytes32,uint256)[])"
+                        "OrderPlaced(bytes32,string,string,uint256,uint256,uint256,address,bytes32,(bytes32,uint256)[],(bytes32,uint256)[],(bytes32,uint256)[])"
                     )
             ) {
                 // Decode the event - note this is complex due to dynamic arrays
@@ -3430,7 +3439,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
             priceOracle: address(0)
         });
         vm.expectRevert(IntentsBase.InvalidInput.selector);
-        gw.setParams(p);
+        gw.init(p, new Deployment[](0));
     }
 
     /// @notice setParams rejects EOA dispatcher (no code).
@@ -3445,7 +3454,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
             priceOracle: address(0)
         });
         vm.expectRevert(IntentsBase.InvalidInput.selector);
-        gw.setParams(p);
+        gw.init(p, new Deployment[](0));
     }
 
     /// @notice setParams rejects surplusShareBps > 10000.
@@ -3460,7 +3469,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
             priceOracle: address(0)
         });
         vm.expectRevert(IntentsBase.InvalidInput.selector);
-        gw.setParams(p);
+        gw.init(p, new Deployment[](0));
     }
 
     /// @notice setParams rejects protocolFeeBps >= 10000.
@@ -3475,7 +3484,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
             priceOracle: address(0)
         });
         vm.expectRevert(IntentsBase.InvalidInput.selector);
-        gw.setParams(p);
+        gw.init(p, new Deployment[](0));
     }
 
     /// @notice setParams rejects non-contract priceOracle.
@@ -3490,13 +3499,13 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
             priceOracle: address(0xbeef)
         });
         vm.expectRevert(IntentsBase.InvalidInput.selector);
-        gw.setParams(p);
+        gw.init(p, new Deployment[](0));
     }
 
     /// @notice updateParams via governance rejects destinationFeeBps >= 10000.
     function testRevert_UpdateParams_DestinationFeeBpsTooHigh() public {
         DestinationFee[] memory fees = new DestinationFee[](1);
-        fees[0] = DestinationFee({stateMachineId: keccak256("ARBITRUM"), destinationFeeBps: 10000});
+        fees[0] = DestinationFee({destinationFeeBps: 10000, chain: bytes("ARBITRUM")});
 
         ParamsUpdate memory update = ParamsUpdate({
             params: Params({

--- a/evm/tests/foundry/IntrinsicIntentsReentrancyTest.sol
+++ b/evm/tests/foundry/IntrinsicIntentsReentrancyTest.sol
@@ -23,7 +23,8 @@ import {
     TokenInfo,
     PaymentInfo,
     DispatchInfo,
-    FillOptions
+    FillOptions,
+    Deployment
 } from "../../src/apps/IntentGatewayV2.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
@@ -132,7 +133,7 @@ contract IntrinsicIntentsReentrancyTest is MainnetForkBaseTest {
         legitimateSolver = makeAddr("legitimateSolver");
 
         intentGateway = new IntentGatewayV2(address(this));
-        intentGateway.setParams(
+        intentGateway.init(
             Params({
                 host:            address(host),
                 dispatcher:      address(dispatcher),
@@ -141,7 +142,7 @@ contract IntrinsicIntentsReentrancyTest is MainnetForkBaseTest {
                 protocolFeeBps:  0,
                 priceOracle:     address(0)
             })
-        );
+        , new Deployment[](0));
 
         maliciousBeneficiary = new ReentrantBeneficiary(payable(address(intentGateway)));
 

--- a/evm/tests/foundry/account/SolverAccountTest.sol
+++ b/evm/tests/foundry/account/SolverAccountTest.sol
@@ -11,7 +11,8 @@ import {
     TokenInfo,
     Params,
     DispatchInfo,
-    PaymentInfo
+    PaymentInfo,
+    Deployment
 } from "@hyperbridge/core/apps/IntentGatewayV2.sol";
 import {PackedUserOperation} from "@openzeppelin/contracts/interfaces/draft-IERC4337.sol";
 
@@ -49,7 +50,7 @@ contract SolverAccountTest is Test {
             protocolFeeBps: 0,
             priceOracle: address(0)
         });
-        intentGateway.setParams(params);
+        intentGateway.init(params, new Deployment[](0));
 
         // Deploy SolverAccount at a temporary address to get bytecode
         SolverAccount tempAccount = new SolverAccount(address(intentGateway));

--- a/modules/pallets/intents-coprocessor/src/lib.rs
+++ b/modules/pallets/intents-coprocessor/src/lib.rs
@@ -281,7 +281,7 @@ pub mod pallet {
 
 				// Prepare cross-chain request to notify existing gateway
 				let new_deployment = types::NewDeployment {
-					state_machine_id: state_machine.to_string().into_bytes(),
+					chain: state_machine.to_string().into_bytes(),
 					gateway,
 				};
 				let request = RequestKind::AddDeployment(new_deployment);

--- a/modules/pallets/intents-coprocessor/src/types.rs
+++ b/modules/pallets/intents-coprocessor/src/types.rs
@@ -56,8 +56,8 @@ pub struct DestinationFee {
 	/// The percentage of fee (in basis points) charged for the destination chain
 	/// 10000 = 100%, 5000 = 50%, etc.
 	pub destination_fee_bps: U256,
-	/// The state machine ID associated with the destination fee
-	pub state_machine_id: H256,
+	/// The raw state machine ID bytes for the destination chain (hashed on-chain)
+	pub chain: Vec<u8>,
 }
 
 /// Parameter update request from users/governance (optional fields pattern)
@@ -93,8 +93,8 @@ pub struct CompleteParamsUpdate {
 /// Request to add a new Intent Gateway deployment
 #[derive(Clone, Debug, Encode, Decode, DecodeWithMemTracking, TypeInfo, PartialEq, Eq)]
 pub struct NewDeployment {
-	/// Identifier for the state machine
-	pub state_machine_id: Vec<u8>,
+	/// The raw state machine ID bytes for the deployment chain
+	pub chain: Vec<u8>,
 	/// The gateway contract address
 	pub gateway: H160,
 }
@@ -203,7 +203,7 @@ mod sol_types {
 		/// Solidity representation of DestinationFee
 		struct DestinationFee {
 			uint256 destinationFeeBps;
-			bytes32 stateMachineId;
+			bytes chain;
 		}
 
 		/// Solidity representation of ParamsUpdate
@@ -214,7 +214,7 @@ mod sol_types {
 
 		/// Solidity representation of NewDeployment
 		struct NewDeployment {
-			bytes stateMachineId;
+			bytes chain;
 			address gateway;
 		}
 
@@ -263,7 +263,7 @@ impl From<DestinationFee> for sol_types::DestinationFee {
 		use alloy_primitives::U256 as AlloyU256;
 		sol_types::DestinationFee {
 			destinationFeeBps: AlloyU256::from_limbs(fee.destination_fee_bps.0),
-			stateMachineId: fee.state_machine_id.0.into(),
+			chain: fee.chain.into(),
 		}
 	}
 }
@@ -320,7 +320,7 @@ impl RequestKind {
 			RequestKind::AddDeployment(deployment) => {
 				use alloy_primitives::Address;
 				let deployment_sol = sol_types::NewDeployment {
-					stateMachineId: deployment.state_machine_id.clone().into(),
+					chain: deployment.chain.clone().into(),
 					gateway: Address::from_slice(&deployment.gateway.0),
 				};
 

--- a/sdk/packages/core/contracts/apps/IntentGatewayV2.sol
+++ b/sdk/packages/core/contracts/apps/IntentGatewayV2.sol
@@ -114,7 +114,7 @@ struct DestinationFee {
     /// 10000 = 100%, 5000 = 50%, etc.
     uint256 destinationFeeBps;
     /// @dev The state machine ID associated with the destination fee.
-    bytes32 stateMachineId;
+    bytes chain;
 }
 
 /**
@@ -182,9 +182,9 @@ struct CancelOptions {
 /**
  * @dev Request from hyperbridge for adding a new deployment of IntentGateway
  */
-struct NewDeployment {
+struct Deployment {
     /// @dev Identifier for the state machine.
-    bytes stateMachineId;
+    bytes chain;
     /// @dev An address variable to store the gateway identifier.
     address gateway;
 }

--- a/sdk/packages/sdk/src/abis/IntentGatewayV2.ts
+++ b/sdk/packages/sdk/src/abis/IntentGatewayV2.ts
@@ -1165,7 +1165,7 @@ export const ABI = [
 	},
 	{
 		type: "function",
-		name: "setParams",
+		name: "init",
 		inputs: [
 			{
 				name: "p",
@@ -1204,6 +1204,23 @@ export const ABI = [
 					},
 				],
 			},
+			{
+				name: "deployments",
+				type: "tuple[]",
+				internalType: "struct Deployment[]",
+				components: [
+					{
+						name: "chain",
+						type: "bytes",
+						internalType: "bytes",
+					},
+					{
+						name: "gateway",
+						type: "address",
+						internalType: "address",
+					},
+				],
+			},
 		],
 		outputs: [],
 		stateMutability: "nonpayable",
@@ -1213,10 +1230,10 @@ export const ABI = [
 		name: "DestinationProtocolFeeUpdated",
 		inputs: [
 			{
-				name: "stateMachineId",
-				type: "bytes32",
-				indexed: true,
-				internalType: "bytes32",
+				name: "chain",
+				type: "string",
+				indexed: false,
+				internalType: "string",
 			},
 			{
 				name: "feeBps",
@@ -1341,13 +1358,13 @@ export const ABI = [
 	},
 	{
 		type: "event",
-		name: "NewDeploymentAdded",
+		name: "DeploymentAdded",
 		inputs: [
 			{
-				name: "stateMachineId",
-				type: "bytes",
+				name: "chain",
+				type: "string",
 				indexed: false,
-				internalType: "bytes",
+				internalType: "string",
 			},
 			{
 				name: "gateway",
@@ -1425,15 +1442,15 @@ export const ABI = [
 			},
 			{
 				name: "source",
-				type: "bytes",
+				type: "string",
 				indexed: false,
-				internalType: "bytes",
+				internalType: "string",
 			},
 			{
 				name: "destination",
-				type: "bytes",
+				type: "string",
 				indexed: false,
-				internalType: "bytes",
+				internalType: "string",
 			},
 			{
 				name: "deadline",
@@ -1663,6 +1680,11 @@ export const ABI = [
 	{
 		type: "error",
 		name: "Cancelled",
+		inputs: [],
+	},
+	{
+		type: "error",
+		name: "UnknownInstance",
 		inputs: [],
 	},
 	{

--- a/sdk/packages/sdk/src/types/index.ts
+++ b/sdk/packages/sdk/src/types/index.ts
@@ -578,8 +578,8 @@ export interface DecodedOrderPlacedLog extends Log {
 	eventName: string
 	args: {
 		user: HexString
-		source: Hex
-		destination: Hex
+		source: string
+		destination: string
 		deadline: bigint
 		nonce: bigint
 		fees: bigint
@@ -649,13 +649,13 @@ export interface CancelOptions {
 }
 
 /**
- * Represents a new deployment of IntentGateway
+ * Represents a deployment of IntentGateway
  */
-export interface NewDeployment {
+export interface Deployment {
 	/**
-	 * Identifier for the state machine
+	 * The raw state machine ID bytes for the deployment chain (hashed on-chain)
 	 */
-	stateMachineId: HexString
+	chain: HexString
 
 	/**
 	 * The gateway identifier


### PR DESCRIPTION
## Summary

EVM fixes to the IntentGatewayV2 / intents-v2 stack, plus the test and deploy-script changes needed to match them.

- Renamed `NewDeployment` struct → `Deployment` (field `stateMachineId` → `chain`, raw bytes hashed internally).
- `setParams(Params)` replaced by one-time `init(Params, Deployment[])` for seeding initial cross-chain peers.
- `_instance` no longer falls back to `address(this)`; unregistered chains now revert `UnknownInstance()`.
- `DestinationFee` now carries raw `chain` bytes; events reshaped (`OrderPlaced` uses `string` source/destination, `DeploymentAdded`, `DestinationProtocolFeeUpdated(string,uint256)`).

## Tests

Updated the foundry suites (`IntentGatewayV2Test`, `IntentGatewayV2SameChainTest`, `IntrinsicIntentsReentrancyTest`, `SolverAccountTest`) to the new types/auth: migrated `setParams` → `init`, seeded peer deployments where cross-chain resolution is exercised, and corrected stale event signatures.

`forge test`: **257 passed, 0 failed, 2 skipped** (21 suites).

## Note

The SDK interface `sdk/packages/core/contracts/apps/IntentGatewayV2.sol` still declares the pre-rename event signatures and drifts from the `IntentsBase` implementation events — not a compile error, but worth realigning separately.

