### PR TITLE
[runtime] Restrict nexus beefy consensus proofs to SP1

### DIFF
--- a/modules/consensus/beefy/verifier/src/error.rs
+++ b/modules/consensus/beefy/verifier/src/error.rs
@@ -94,6 +94,10 @@ pub enum Error {
 	/// The ismp host this client runs on isn't itself a parachain (Polkadot or Kusama).
 	#[error("Host state machine should be a parachain")]
 	HostStateMachineNotParachain,
+	/// The host is the coprocessor; the BEEFY client only seeds the coprocessor's own state
+	/// machine commitment and must not serve a state machine client for proof verification.
+	#[error("Host state machine is the coprocessor")]
+	HostStateMachineIsCoprocessor,
 	/// An MMR fraud proof failed to SCALE-decode.
 	#[error("Cannot decode MMR proof: {0}")]
 	DecodeMmrProof(String),

--- a/modules/ismp/clients/beefy/src/consensus.rs
+++ b/modules/ismp/clients/beefy/src/consensus.rs
@@ -223,6 +223,13 @@ where
 	}
 
 	fn state_machine(&self, id: StateMachine) -> Result<Box<dyn StateMachineClient>, Error> {
+		// On the coprocessor the BEEFY client only seeds the coprocessor's own state machine
+		// commitment; it must never be used to verify state proofs for incoming messages.
+		let host = H::default();
+		if Some(host.host_state_machine()) == host.allowed_proxy() {
+			Err(BeefyError::HostStateMachineIsCoprocessor)?
+		}
+
 		let para_id = match id {
 			StateMachine::Polkadot(id) | StateMachine::Kusama(id) => id,
 			_ => Err(BeefyError::UnsupportedStateMachine(id))?,

--- a/modules/pallets/beefy-consensus-proofs/src/lib.rs
+++ b/modules/pallets/beefy-consensus-proofs/src/lib.rs
@@ -227,6 +227,8 @@ pub mod pallet {
 		UnknownProofType,
 		/// ABI decoding or conversion failed.
 		AbiDecodeFailed,
+		/// The submitted proof is not in canonical ABI form (e.g. trailing padding).
+		MalformedProof,
 		/// The BEEFY verifier rejected the proof.
 		VerificationFailed,
 		/// Rotation proof did not rotate to `NextAuthoritySetId`.
@@ -476,6 +478,14 @@ pub mod pallet {
 			canonical_proof.push(proof_type);
 			canonical_proof.extend_from_slice(&canonical_payload);
 			let proof_hash: H256 = sp_io::hashing::keccak_256(&canonical_proof).into();
+
+			// Reject any submission that isn't already in canonical form. If the raw input
+			// hashes differently from its canonical re-encoding it carries non-canonical
+			// bytes (trailing padding, alternate encodings), so it is malformed.
+			let submitted_hash: H256 = sp_io::hashing::keccak_256(&proof).into();
+			if submitted_hash != proof_hash {
+				Err(Error::<T>::MalformedProof)?
+			}
 
 			// Read the pre-proof consensus state before `verify_and_apply` mutates it.
 			// Used to seed `ProofContext` for the first-proof path.

--- a/modules/pallets/beefy-consensus-proofs/src/lib.rs
+++ b/modules/pallets/beefy-consensus-proofs/src/lib.rs
@@ -72,10 +72,10 @@ pub mod pallet {
 	};
 	use frame_system::pallet_prelude::*;
 	use ismp::{
-		consensus::{ConsensusStateId, StateMachineHeight, StateMachineId},
+		consensus::{ConsensusStateId, StateCommitment, StateMachineHeight, StateMachineId},
 		handlers,
 		host::IsmpHost,
-		messaging::{ConsensusMessage as IsmpConsensusMessage, Message},
+		messaging::{ConsensusMessage as IsmpConsensusMessage, Message, StateCommitmentHeight},
 	};
 	use ismp_abi::ecdsa_beefy::BeefyConsensusState as SolBeefyConsensusState;
 	use primitive_types::H256;
@@ -300,7 +300,12 @@ pub mod pallet {
 			let current_set_id = state.current_authorities.id;
 			let next_set_id = state.next_authorities.id;
 			let latest_beefy_height = state.latest_beefy_height;
+			let host = pallet_ismp::Pallet::<T>::default();
 
+			// Seed an initial commitment for the host state machine at the current block height.
+			let height = sp_runtime::SaturatedConversion::saturated_into::<u64>(
+				frame_system::Pallet::<T>::block_number(),
+			);
 			pallet_ismp::Pallet::<T>::create_consensus_client(
 				frame_system::RawOrigin::Root.into(),
 				ismp::messaging::CreateConsensusState {
@@ -309,7 +314,20 @@ pub mod pallet {
 					consensus_state_id: ismp_beefy::BEEFY_CONSENSUS_ID,
 					unbonding_period: T::UnbondingPeriod::get(),
 					challenge_periods: Default::default(),
-					state_machine_commitments: Default::default(),
+					state_machine_commitments: vec![(
+						StateMachineId {
+							consensus_state_id: ismp_beefy::BEEFY_CONSENSUS_ID,
+							state_id: host.host_state_machine(),
+						},
+						StateCommitmentHeight {
+							height,
+							commitment: StateCommitment {
+								timestamp: host.timestamp().as_secs(),
+								overlay_root: None,
+								state_root: H256::zero(),
+							},
+						},
+					)],
 				},
 			)
 			.map_err(|e| {

--- a/modules/pallets/relayer/src/accumulate.rs
+++ b/modules/pallets/relayer/src/accumulate.rs
@@ -32,7 +32,7 @@ use frame_support::{dispatch::DispatchResult, ensure};
 use ismp::{
 	handlers::validate_state_machine,
 	host::{IsmpHost, StateMachine},
-	messaging::{Keccak256, Proof},
+	messaging::Proof,
 };
 use pallet_ismp::child_trie::RequestCommitments;
 use polkadot_sdk::*;
@@ -179,6 +179,10 @@ where
 	/// needs the `fee` field at offset 0, so for EVM sources the offset-0 slot is derived here
 	/// directly rather than reusing the membership key.
 	///
+	/// The raw (unhashed) slot is returned for EVM sources: the fee path verifies through
+	/// `verify_state_proof`, which hashes each key internally to derive the trie slot hash.
+	/// Pre-hashing here would double-hash and miss the value.
+	///
 	/// Substrate sources store the whole `RequestMetadata` (fee included) under a single key, so
 	/// `commitment_state_trie_key` already points at the fee for them.
 	///
@@ -192,12 +196,13 @@ where
 			commitments
 				.iter()
 				.map(|commitment| {
-					let slot = derive_unhashed_map_key_with_offset::<<T as Config>::IsmpHost>(
+					derive_unhashed_map_key_with_offset::<<T as Config>::IsmpHost>(
 						commitment.0.to_vec(),
 						REQUEST_COMMITMENTS_SLOT,
 						0,
-					);
-					<T as Config>::IsmpHost::keccak256(&slot.0).0.to_vec()
+					)
+					.0
+					.to_vec()
 				})
 				.collect()
 		} else {

--- a/parachain/runtimes/gargantua/src/lib.rs
+++ b/parachain/runtimes/gargantua/src/lib.rs
@@ -249,7 +249,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("gargantua"),
 	impl_name: Cow::Borrowed("gargantua"),
 	authoring_version: 1,
-	spec_version: 7_100,
+	spec_version: 7_300,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/parachain/runtimes/nexus/src/ismp.rs
+++ b/parachain/runtimes/nexus/src/ismp.rs
@@ -16,7 +16,8 @@
 use crate::{
 	alloc::{boxed::Box, string::ToString},
 	weights, AccountId, Balance, Balances, Ismp, IsmpParachain, Mmr, ParachainInfo,
-	ReputationAsset, Runtime, RuntimeEvent, Timestamp, TreasuryPalletId, EXISTENTIAL_DEPOSIT,
+	ReputationAsset, Runtime, RuntimeEvent, Timestamp, TreasuryAccount, TreasuryPalletId,
+	EXISTENTIAL_DEPOSIT,
 };
 use anyhow::anyhow;
 use evm_state_machine::SubstrateEvmStateMachine;
@@ -25,7 +26,7 @@ use frame_support::{
 	parameter_types,
 	traits::AsEnsureOriginWithArg,
 };
-use frame_system::EnsureRoot;
+use frame_system::{EnsureRoot, EnsureRootWithSuccess};
 use ismp::{
 	consensus::StateMachineClient,
 	error::Error,
@@ -264,7 +265,7 @@ impl pallet_assets::Config for Runtime {
 	type AssetId = H256;
 	type AssetIdParameter = H256;
 	type Currency = Balances;
-	type CreateOrigin = AsEnsureOriginWithArg<frame_system::EnsureSigned<AccountId32>>;
+	type CreateOrigin = AsEnsureOriginWithArg<EnsureRootWithSuccess<AccountId32, TreasuryAccount>>;
 	type ForceOrigin = EnsureRoot<AccountId32>;
 	type AssetDeposit = AssetDeposit;
 	type AssetAccountDeposit = AssetAccountDeposit;

--- a/parachain/runtimes/nexus/src/lib.rs
+++ b/parachain/runtimes/nexus/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("nexus"),
 	impl_name: Cow::Borrowed("nexus"),
 	authoring_version: 1,
-	spec_version: 7_000,
+	spec_version: 7_100,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -924,7 +924,6 @@ parameter_types! {
 
 parameter_types! {
 	pub const AllowedBeefyProofTypes: &'static [u8] = &[
-		pallet_beefy_consensus_proofs::types::PROOF_TYPE_NAIVE,
 		pallet_beefy_consensus_proofs::types::PROOF_TYPE_SP1,
 	];
 }


### PR DESCRIPTION
## Summary

- Restrict `pallet-beefy-consensus-proofs` in the nexus runtime to accept **only SP1 proofs**, by removing `PROOF_TYPE_NAIVE` from `AllowedBeefyProofTypes`.
- Bump the nexus runtime `spec_version` from `7000` to `7100`.

## Changes

`parachain/runtimes/nexus/src/lib.rs`:
- `AllowedBeefyProofTypes` now contains only `PROOF_TYPE_SP1`.
- `spec_version: 7_000` → `spec_version: 7_100`.