### PR TITLE
[evm]: Add nonReentrant guard to IntentGatewayV2 order methods

### DIFF
--- a/evm/src/apps/IntentGatewayV2.sol
+++ b/evm/src/apps/IntentGatewayV2.sol
@@ -22,6 +22,7 @@ import {ICallDispatcher, Call} from "@hyperbridge/core/interfaces/ICallDispatche
 import {IDispatcher} from "@hyperbridge/core/interfaces/IDispatcher.sol";
 import {IIntentPriceOracle} from "@hyperbridge/core/apps/IntentPriceOracle.sol";
 import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+import {ReentrancyGuardTransient} from "@openzeppelin/contracts/utils/ReentrancyGuardTransient.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IUniswapV2Router02} from "@uniswap/v2-periphery/contracts/interfaces/IUniswapV2Router02.sol";
@@ -56,7 +57,7 @@ import {
  *           \       /
  *        IntentGatewayV2
  */
-contract IntentGatewayV2 is IntrinsicIntents, ExtrinsicIntents {
+contract IntentGatewayV2 is IntrinsicIntents, ExtrinsicIntents, ReentrancyGuardTransient {
     using SafeERC20 for IERC20;
 
     /**
@@ -152,7 +153,7 @@ contract IntentGatewayV2 is IntrinsicIntents, ExtrinsicIntents {
      * @param order The order struct. `user`, `source`, and `nonce` are overwritten by this function.
      * @param graffiti Unused on-chain; available for off-chain indexing or solver metadata.
      */
-    function placeOrder(Order memory order, bytes32 graffiti) public payable {
+    function placeOrder(Order memory order, bytes32 graffiti) public payable nonReentrant {
         if (order.inputs.length == 0) revert InvalidInput();
 
         // Reject duplicate output tokens 
@@ -403,7 +404,7 @@ contract IntentGatewayV2 is IntrinsicIntents, ExtrinsicIntents {
      * @param order The order to fill. Must match the exact order that was placed.
      * @param options Fill options including output token amounts and fee parameters.
      */
-    function fillOrder(Order calldata order, FillOptions calldata options) public payable {
+    function fillOrder(Order calldata order, FillOptions calldata options) public payable nonReentrant {
         if (order.deadline < block.number) revert Expired();
         bytes32 commitment = keccak256(abi.encode(order));
 
@@ -460,7 +461,7 @@ contract IntentGatewayV2 is IntrinsicIntents, ExtrinsicIntents {
      * @param order The order to cancel. Must match the exact order that was placed.
      * @param options Cancel options including proof height and relayer fee for cross-chain cancels.
      */
-    function cancelOrder(Order calldata order, CancelOptions calldata options) public payable {
+    function cancelOrder(Order calldata order, CancelOptions calldata options) public payable nonReentrant {
         bytes32 commitment = keccak256(abi.encode(order));
 
         if (_filled[commitment] != address(0)) revert Filled();


### PR DESCRIPTION
## Summary

Adds OpenZeppelin's reentrancy guard to the three external state-mutating entry points of `IntentGatewayV2`: `placeOrder`, `fillOrder`, and `cancelOrder`. All three move tokens and make external calls (CallDispatcher, Uniswap V2, native refunds, ERC-20 transfers), so they are guarded against reentrancy.

## Changes

- `evm/src/apps/IntentGatewayV2.sol`
  - Import and inherit `ReentrancyGuardTransient` (OZ 5.4.0).
  - Apply `nonReentrant` to `placeOrder`, `fillOrder`, `cancelOrder`.

## Notes

- Used the **transient** guard variant: the contract already uses EIP-1153 transient storage and pins `pragma ^0.8.24`, so its deployment targets are already Cancun-capable — no new EVM requirement, and lower gas than the storage-based guard. The guard's ERC-7201 namespaced transient slot does not collide with `placeOrder`'s token-address-keyed transient slots.
- The Tron port (`evm/tron/contracts/apps/IntentGatewayV2.sol`) is intentionally untouched — the TVM does not support transient storage.

## Testing

- `forge build` compiles cleanly.