### PR TITLE
[evm]: disallow partial fills for intent orders with calldata

### DIFF
--- a/evm/src/apps/intentsv2/IntentsBase.sol
+++ b/evm/src/apps/intentsv2/IntentsBase.sol
@@ -188,6 +188,12 @@ abstract contract IntentsBase is EIP712 {
     */
     error UnknownInstance();
 
+    /*
+     * @dev Thrown when a solver attempts to partially fill an order that carries
+     * output calldata. Such orders must be filled completely in a single fill.
+    */
+    error PartialFillNotAllowed();
+
     /**
      * @dev Emitted when a new intent order is placed and input tokens are escrowed.
      * @param user The order creator's address encoded as bytes32.

--- a/evm/src/apps/intentsv2/IntrinsicIntents.sol
+++ b/evm/src/apps/intentsv2/IntrinsicIntents.sol
@@ -44,6 +44,9 @@ abstract contract IntrinsicIntents is IntentsBase {
      * and emits OrderFilled.
      * On partial fill: releases proportional escrow and emits PartialFill.
      *
+     * Orders that carry output calldata cannot be partially filled — they must be
+     * completed in a single fill, otherwise the call reverts with PartialFillNotAllowed.
+     *
      * @param order The order to fill.
      * @param options The fill options containing the solver's output token amounts.
      * @param commitment The keccak256 hash of the ABI-encoded order.
@@ -119,6 +122,11 @@ abstract contract IntrinsicIntents is IntentsBase {
             escrowedInputs[i] = TokenInfo({token: order.inputs[i].token, amount: escrowedAmount});
             outputFills[i] = TokenInfo({token: outputToken, amount: fillAmount});
         }
+
+        // Orders carrying output calldata must be filled completely in a single fill.
+        // The attached call is only executed on a full fill, so a partial fill would
+        // leave the intended side effect unexecuted while releasing proportional escrow.
+        if (order.output.call.length > 0 && !isFullyFilled) revert PartialFillNotAllowed();
 
         WithdrawalRequest memory body = WithdrawalRequest({
             commitment: commitment, tokens: escrowedInputs, beneficiary: bytes32(uint256(uint160(msg.sender)))

--- a/evm/tests/foundry/IntentGatewayV2SameChainTest.sol
+++ b/evm/tests/foundry/IntentGatewayV2SameChainTest.sol
@@ -1457,7 +1457,10 @@ contract IntentGatewayV2SameChainTest is MainnetForkBaseTest {
         );
     }
 
-    function testPartialFill_CalldataOnlyAfterFullFill() public {
+    /// @notice Orders carrying output calldata cannot be partially filled: any fill that
+    /// does not complete the order reverts with PartialFillNotAllowed. A single full fill
+    /// succeeds and executes the attached calldata.
+    function testPartialFill_CalldataOrderRequiresFullFill() public {
         uint256 inputAmount = 1000 * 1e6;
         uint256 outputAmount = 1000 * 1e18;
 
@@ -1497,28 +1500,27 @@ contract IntentGatewayV2SameChainTest is MainnetForkBaseTest {
         order.source = host.host();
         order.nonce = 0;
 
-        // Partial fill — calldata should NOT execute
+        // Partial fill — must revert, partial fills are disallowed for calldata orders.
         vm.startPrank(solver);
         dai.approve(address(intentGateway), 500 * 1e18);
         TokenInfo[] memory outputs1 = new TokenInfo[](1);
         outputs1[0] = TokenInfo({token: bytes32(uint256(uint160(address(dai)))), amount: 500 * 1e18});
+        vm.expectRevert(IntentsBase.PartialFillNotAllowed.selector);
         intentGateway.fillOrder(order, FillOptions({relayerFee: 0, nativeDispatchFee: 0, outputs: outputs1}));
         vm.stopPrank();
 
-        // Allowance should still be 0 (calldata not executed yet)
+        // No escrow released and calldata not executed.
         assertEq(
             dai.allowance(address(intentGateway.params().dispatcher), address(intentGateway)),
             0,
-            "Calldata should not execute on partial fill"
+            "Calldata should not execute on rejected partial fill"
         );
 
-        // Complete the fill — calldata should execute
-        address solver2 = makeAddr("solver2");
-        deal(address(dai), solver2, 100000 * 1e18);
-        vm.startPrank(solver2);
-        dai.approve(address(intentGateway), 500 * 1e18);
+        // Full fill in a single transaction — calldata executes.
+        vm.startPrank(solver);
+        dai.approve(address(intentGateway), outputAmount);
         TokenInfo[] memory outputs2 = new TokenInfo[](1);
-        outputs2[0] = TokenInfo({token: bytes32(uint256(uint160(address(dai)))), amount: 500 * 1e18});
+        outputs2[0] = TokenInfo({token: bytes32(uint256(uint160(address(dai)))), amount: outputAmount});
         intentGateway.fillOrder(order, FillOptions({relayerFee: 0, nativeDispatchFee: 0, outputs: outputs2}));
         vm.stopPrank();
 


### PR DESCRIPTION
## Summary

Orders carrying output calldata (`order.output.call`) can now only be filled completely in a single fill. Any same-chain fill that does not fully complete such an order reverts with a new `PartialFillNotAllowed` error.

## Why

The attached call is only executed on a full fill. Previously a partial fill of a calldata order silently released proportional escrow to the solver while leaving the intended side effect (the call) unexecuted, deferring it to whichever solver eventually completed the order. Disallowing partial fills for these orders keeps escrow release and call execution atomic.

Partial fills only ever occur on the same-chain path (`_fillSameChain`); cross-chain fills are already all-or-nothing, so no change was needed there.

## Changes

- `IntentsBase.sol`: add `PartialFillNotAllowed()` error.
- `IntrinsicIntents.sol`: revert in `_fillSameChain` when `order.output.call.length > 0 && !isFullyFilled`.
- Rewrote `testPartialFill_CalldataOnlyAfterFullFill` → `testPartialFill_CalldataOrderRequiresFullFill`: asserts a partial fill of a calldata order reverts, and a single full fill succeeds and executes the calldata.

## Testing

`forge test --match-contract IntentGatewayV2SameChainTest` — 43 passed, 0 failed (including all 12 partial-fill tests; non-calldata partial fills are unaffected).