### PR TITLE
[node] Defer fisherman startup until the local node is synced

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9285,7 +9285,7 @@ dependencies = [
 
 [[package]]
 name = "hyperbridge"
-version = "1.6.1"
+version = "1.7.0"
 dependencies = [
  "clap",
  "futures",

--- a/parachain/node/Cargo.toml
+++ b/parachain/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperbridge"
-version = "1.6.1"
+version = "1.7.0"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 description = "The Hyperbridge coprocessor node"
 repository = "https://github.com/polytope-labs/hyperbridge"

--- a/parachain/node/fisherman/src/lib.rs
+++ b/parachain/node/fisherman/src/lib.rs
@@ -12,20 +12,29 @@
 //! On a normal collator that URL points back at this node, so [`spawn`]
 //! must run after `sc_service::spawn_tasks` has opened the RPC port. Doing
 //! it earlier blocks the task that is supposed to open that port.
+//!
+//! The RPC port being open is not enough: until the node has finished
+//! syncing, that RPC serves stale chain state and the fisherman would build
+//! its providers against it. [`spawn_when_synced`] holds the spawn back
+//! behind a sync-status poll so the providers are only constructed once the
+//! local node has caught up.
 
 pub mod config;
 
-use std::{path::Path, sync::Arc};
+use std::{future::Future, path::Path, path::PathBuf, sync::Arc, time::Duration};
 
 use anyhow::{anyhow, Context};
 use ismp::host::StateMachine;
-use polkadot_sdk::sc_service::TaskManager;
+use polkadot_sdk::sc_service::{SpawnEssentialTaskHandle, TaskManager};
 use tesseract::config::HyperbridgeConfig;
 use tesseract_config::AnyConfig;
 use tesseract_primitives::IsmpProvider;
 use tesseract_substrate::{config::KeccakSubstrateChain, SubstrateClient};
 
 pub const LOG_TARGET: &str = "fisherman";
+
+/// Interval between sync-status polls while the fisherman startup is deferred.
+const SYNC_POLL_INTERVAL: Duration = Duration::from_secs(15);
 
 /// Read the tesseract toml at `path` and run the sync preflight checks.
 /// Performs no network I/O so the call is safe to make before any chain
@@ -39,10 +48,42 @@ pub async fn load_and_validate(path: &Path) -> anyhow::Result<()> {
 	Ok(())
 }
 
+/// Spawn a watcher that holds the fisherman back until the local node has
+/// finished syncing, then runs [`spawn`].
+///
+/// The config has already been checked by [`load_and_validate`], so only the
+/// network-dependent startup is deferred. `is_synced` is polled every
+/// [`SYNC_POLL_INTERVAL`] and the fisherman starts on the first poll that
+/// reports the node synced. The watcher itself is a non-essential task that
+/// exits once the fisherman is running; the per-L2 tasks spawned by [`spawn`]
+/// stay essential.
+pub fn spawn_when_synced<C, Fut>(task_manager: &TaskManager, path: PathBuf, is_synced: C)
+where
+	C: Fn() -> Fut + Send + 'static,
+	Fut: Future<Output = bool> + Send + 'static,
+{
+	let spawn_handle = task_manager.spawn_essential_handle();
+	task_manager.spawn_handle().spawn("fisherman-sync-watcher", "fisherman", async move {
+		log::info!(
+			target: LOG_TARGET,
+			"deferring fisherman startup until the local node has finished syncing",
+		);
+		while !is_synced().await {
+			log::debug!(target: LOG_TARGET, "local node still syncing; fisherman startup deferred");
+			tokio::time::sleep(SYNC_POLL_INTERVAL).await;
+		}
+		log::info!(target: LOG_TARGET, "local node synced; starting fisherman");
+		if let Err(e) = spawn(&path, spawn_handle).await {
+			log::error!(target: LOG_TARGET, "fisherman failed to start after the node synced: {e:?}");
+		}
+	});
+}
+
 /// Build the hyperbridge and per L2 providers and spawn one
 /// [`tesseract_fisherman::fish`] task per supported L2. Must run after
-/// `sc_service::spawn_tasks` has brought the local RPC server up.
-pub async fn spawn(path: &Path, task_manager: &TaskManager) -> anyhow::Result<()> {
+/// `sc_service::spawn_tasks` has brought the local RPC server up and the
+/// node has finished syncing (see [`spawn_when_synced`]).
+pub async fn spawn(path: &Path, spawn_handle: SpawnEssentialTaskHandle) -> anyhow::Result<()> {
 	let path_str = path
 		.to_str()
 		.ok_or_else(|| anyhow!("tesseract config path is not valid UTF-8: {}", path.display()))?;
@@ -78,7 +119,7 @@ pub async fn spawn(path: &Path, task_manager: &TaskManager) -> anyhow::Result<()
 			.await
 			.with_context(|| format!("constructing IsmpProvider for L2 {state_machine}"))?;
 
-		tesseract_fisherman::fish(hyperbridge.clone(), l2, task_manager, hyperbridge_state_machine)
+		tesseract_fisherman::fish(hyperbridge.clone(), l2, &spawn_handle, hyperbridge_state_machine)
 			.await
 			.with_context(|| format!("spawning fisherman task for L2 {state_machine}"))?;
 		spawned += 1;

--- a/parachain/node/src/command.rs
+++ b/parachain/node/src/command.rs
@@ -449,17 +449,21 @@ pub fn run() -> Result<()> {
 
 						// start_simnode has brought the local RPC up, so the
 						// fisherman dial against `[hyperbridge].rpc_ws` is
-						// safe even when it loops back to this node. Mirrors
-						// the production wiring in service.rs so simnode tests
-						// exercise the same spawn path.
+						// safe even when it loops back to this node. Simnode
+						// is a single instant-seal node with nothing to sync,
+						// so the spawn runs directly rather than behind the
+						// production sync watcher.
 						if let Some(path) = fisherman_path {
-							hyperbridge_fisherman::spawn(&path, &task_manager).await.map_err(
-								|e| {
-									sc_service::Error::Other(format!(
-										"failed to spawn fisherman task: {e:?}"
-									))
-								},
-							)?;
+							hyperbridge_fisherman::spawn(
+								&path,
+								task_manager.spawn_essential_handle(),
+							)
+							.await
+							.map_err(|e| {
+								sc_service::Error::Other(format!(
+									"failed to spawn fisherman task: {e:?}"
+								))
+							})?;
 						}
 
 						Ok(task_manager)

--- a/parachain/node/src/service.rs
+++ b/parachain/node/src/service.rs
@@ -337,12 +337,23 @@ where
 		tracing_execute_block: None,
 	})?;
 
-	// The local RPC server is up now, so the fisherman can safely dial
-	// `[hyperbridge].rpc_ws` even when it points back at this node.
+	// The local RPC server is up now, but until this node has finished
+	// syncing that RPC serves stale chain state. Defer the fisherman spawn
+	// behind a sync-status watcher so it dials `[hyperbridge].rpc_ws` and
+	// builds its providers only once the node has caught up. The config was
+	// already validated above, so a bad config still fails fast.
 	if let Some(path) = fisherman_path {
-		hyperbridge_fisherman::spawn(&path, &task_manager).await.map_err(|e| {
-			sc_service::Error::Other(format!("failed to spawn fisherman task: {e:?}"))
-		})?;
+		let sync_service = sync_service.clone();
+		hyperbridge_fisherman::spawn_when_synced(&task_manager, path, move || {
+			let sync_service = sync_service.clone();
+			async move {
+				sync_service.num_connected_peers() > 0 &&
+					matches!(
+						sync_service.status().await,
+						Ok(status) if !status.state.is_major_syncing()
+					)
+			}
+		});
 	}
 
 	if let Some(hwbench) = hwbench {

--- a/parachain/simtests/src/pallet_fishermen.rs
+++ b/parachain/simtests/src/pallet_fishermen.rs
@@ -506,7 +506,8 @@ async fn fisherman_task_spawns_against_simnode_and_mock_l2_rpcs() -> Result<()> 
 	let l2 = build_l2_provider(vec![mock_a.url(), mock_b.url()], hyperbridge.clone()).await?;
 
 	let task_manager = TaskManager::new(tokio::runtime::Handle::current(), None)?;
-	tesseract_fisherman::fish(hyperbridge, l2, &task_manager, coprocessor).await?;
+	tesseract_fisherman::fish(hyperbridge, l2, &task_manager.spawn_essential_handle(), coprocessor)
+		.await?;
 
 	tokio::time::sleep(Duration::from_secs(3)).await;
 
@@ -615,7 +616,8 @@ async fn fisherman_task_detects_disagreement_and_submits_veto() -> Result<()> {
 	let l2 = build_l2_provider(vec![mock_a.url(), mock_b.url()], hyperbridge.clone()).await?;
 
 	let task_manager = TaskManager::new(tokio::runtime::Handle::current(), None)?;
-	tesseract_fisherman::fish(hyperbridge, l2, &task_manager, coprocessor).await?;
+	tesseract_fisherman::fish(hyperbridge, l2, &task_manager.spawn_essential_handle(), coprocessor)
+		.await?;
 
 	// Give the task a moment to subscribe and capture its baseline height.
 	tokio::time::sleep(Duration::from_secs(2)).await;

--- a/tesseract/messaging/fisherman/src/lib.rs
+++ b/tesseract/messaging/fisherman/src/lib.rs
@@ -22,13 +22,13 @@ use std::sync::Arc;
 use anyhow::anyhow;
 use futures::StreamExt;
 use ismp::host::StateMachine;
-use polkadot_sdk::sc_service::TaskManager;
+use polkadot_sdk::sc_service::SpawnEssentialTaskHandle;
 use tesseract_primitives::IsmpProvider;
 
 pub async fn fish(
 	chain_a: Arc<dyn IsmpProvider>,
 	chain_b: Arc<dyn IsmpProvider>,
-	task_manager: &TaskManager,
+	spawn_handle: &SpawnEssentialTaskHandle,
 	coprocessor: StateMachine,
 ) -> Result<(), anyhow::Error> {
 	{
@@ -36,7 +36,7 @@ pub async fn fish(
 		let chain_b = chain_b.clone();
 		let coprocessor = coprocessor.clone();
 		let name = format!("fisherman-{}-{}", chain_a.name(), chain_b.name());
-		task_manager.spawn_essential_handle().spawn_blocking(
+		spawn_handle.spawn_blocking(
 			Box::leak(Box::new(name.clone())),
 			"fisherman",
 			async move {


### PR DESCRIPTION
The collator-side fisherman builds its providers by dialing the local node's RPC. While the node is still syncing that RPC will return an error and the fisherman spawn task will fail causing the node startup to halt.

Validate the tesseract config up front as before, but defer the actual fisherman spawn behind a sync-status watcher that polls every 15s and only starts the per-L2 tasks once the node reports it has finished syncing. Bump the node version to 1.7.0.