### PR TITLE
[runtime] Raise nexus block weight limit to 2s for SP1 beefy proofs

### DIFF
--- a/parachain/runtimes/nexus/src/lib.rs
+++ b/parachain/runtimes/nexus/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("nexus"),
 	impl_name: Cow::Borrowed("nexus"),
 	authoring_version: 1,
-	spec_version: 7_100,
+	spec_version: 7_200,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -284,9 +284,9 @@ const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(5);
 /// `Operational` extrinsics.
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 
-/// We allow for 0.5 of a second of compute with a 12 second average block time.
+/// We allow for 2 seconds of compute with a 12 second average block time.
 const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(
-	WEIGHT_REF_TIME_PER_SECOND.saturating_div(2),
+	WEIGHT_REF_TIME_PER_SECOND.saturating_mul(2),
 	cumulus_primitives_core::relay_chain::MAX_POV_SIZE as u64,
 );
 


### PR DESCRIPTION
## Summary

SP1 BEEFY consensus proofs (`pallet-beefy-consensus-proofs::submit_proof`) are rejected on nexus mainnet with `1010: Invalid Transaction: Transaction would exhaust the block limits` (`InvalidTransaction::ExhaustsResources`), while the same proofs are accepted on gargantua testnet.

### Root cause

`submit_proof` has a benchmarked weight of `ref_time ≈ 608_064_578_000 ps` (~0.608s) — the SP1 Groth16 verification. The block weight limits differed between the runtimes:

| | `MAXIMUM_BLOCK_WEIGHT` | Normal-class budget (75%) |
|---|---|---|
| nexus (before) | `WEIGHT_REF_TIME_PER_SECOND / 2` = 0.5s | 0.375s |
| gargantua | `WEIGHT_REF_TIME_PER_SECOND * 2` = 2.0s | 1.5s |

At ~0.608s, a single `submit_proof` exceeds nexus's 0.375s normal-class budget (and even the full 0.5s block), so `CheckWeight` rejects it up front — no SP1 proof can ever be included. It fits comfortably under gargantua's 1.5s budget. This surfaced after nexus was restricted to SP1-only (the cheaper NAIVE path is gone).

## Change

- Raise nexus `MAXIMUM_BLOCK_WEIGHT` from 0.5s to **2s** (`WEIGHT_REF_TIME_PER_SECOND * 2`), matching gargantua, so SP1 `submit_proof` fits with headroom.
- Bump `spec_version` 7100 → 7200.