### PR TITLE
[tesseract]: submit beefy proofs with a pool-aware nonce to avoid stale nonce rejections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28523,7 +28523,7 @@ dependencies = [
 
 [[package]]
 name = "tesseract-prover"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/modules/utils/subxt/src/lib.rs
+++ b/modules/utils/subxt/src/lib.rs
@@ -69,7 +69,7 @@ pub mod signer {
 	use anyhow::Context;
 	use polkadot_sdk::sp_core::{sr25519, Pair};
 	use subxt::{
-		config::{ExtrinsicParams, HashFor},
+		config::{DefaultExtrinsicParamsBuilder, ExtrinsicParams, HashFor},
 		tx::{DefaultParams, Signer, TxInBlock, TxProgress, TxStatus},
 		utils::{AccountId32, MultiSignature},
 		OnlineClient,
@@ -129,6 +129,44 @@ pub mod signer {
 		let params = DefaultParams::default_params();
 		let ext = client.tx().create_signed(payload, signer, params).await?;
 		let progress = ext.submit_and_watch().await.context("Failed to submit signed extrinsic")?;
+		await_extrinsic::<T>(progress, wait_for_finalization).await
+	}
+
+	/// Like [`send_extrinsic`], but submits with an explicit `nonce` rather than letting subxt
+	/// fetch one from the chain.
+	///
+	/// subxt sources the auto nonce from the latest *finalized* block (via its internal
+	/// `inject_account_nonce_and_block`). On a parachain, finality trails the best chain by
+	/// several blocks, so a submitter that only waits for in-block (not finalization) before its
+	/// next submission reuses an already-spent nonce and the node rejects it as
+	/// `InvalidTransaction::Stale`. Passing a pool-aware nonce (e.g. from `system_accountNextIndex`)
+	/// avoids that. This uses `create_partial_offline`, which — unlike `create_signed` — does not
+	/// overwrite the nonce we set.
+	pub async fn send_extrinsic_with_nonce<T, Tx: Payload>(
+		client: &OnlineClient<T>,
+		signer: &InMemorySigner<T>,
+		payload: &Tx,
+		nonce: u64,
+		wait_for_finalization: bool,
+	) -> Result<HashFor<T>, anyhow::Error>
+	where
+		T: subxt::Config<ExtrinsicParams = SubstrateExtrinsicParams<T>>,
+		T::AccountId: Into<T::Address> + Clone + 'static,
+		T::Signature: From<MultiSignature> + Send + Sync,
+	{
+		let params = DefaultExtrinsicParamsBuilder::<T>::new().nonce(nonce).build();
+		let mut partial = client.tx().create_partial_offline(payload, params)?;
+		let ext = partial.sign(signer);
+		let progress = ext.submit_and_watch().await.context("Failed to submit signed extrinsic")?;
+		await_extrinsic::<T>(progress, wait_for_finalization).await
+	}
+
+	/// Drive a submitted extrinsic to inclusion (or finalization), assert it executed
+	/// successfully, and return the hash of the block it landed in.
+	async fn await_extrinsic<T: subxt::Config>(
+		progress: TxProgress<T, OnlineClient<T>>,
+		wait_for_finalization: bool,
+	) -> Result<HashFor<T>, anyhow::Error> {
 		let ext_hash = progress.extrinsic_hash();
 
 		let extrinsic = if wait_for_finalization {

--- a/parachain/simtests/Cargo.toml
+++ b/parachain/simtests/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 subxt = { workspace = true, default-features = true }
 anyhow.workspace = true
 futures = "0.3.28"
-tokio = { workspace = true, features = ["macros"] }
+tokio = { workspace = true, features = ["macros", "time"] }
 indicatif = "0.17.8"
 
 codec = { workspace = true, features = ["derive"], default-features = true }

--- a/parachain/simtests/src/lib.rs
+++ b/parachain/simtests/src/lib.rs
@@ -5,3 +5,4 @@ mod pallet_beefy_consensus_proofs;
 mod pallet_fishermen;
 mod pallet_ismp;
 mod pallet_mmr;
+mod pool_aware_nonce;

--- a/parachain/simtests/src/pool_aware_nonce.rs
+++ b/parachain/simtests/src/pool_aware_nonce.rs
@@ -1,0 +1,149 @@
+//! Simnode regression test for the pool-aware nonce used by the BEEFY prover's on-chain
+//! proof backend (`tesseract/consensus/beefy/src/backend/onchain.rs`).
+//!
+//! The prover submits proofs but only waits for **in-block** (not finalization) before its
+//! next submission, for speed. subxt sources its automatic nonce from the latest **finalized**
+//! block; on the parachain, finality trails the best chain by several blocks, so the auto nonce
+//! is frequently already spent by the previous proof and the node rejects the resubmission with
+//! `Invalid Transaction (1010)` (`InvalidTransaction::Stale` in the node's txpool). The fix
+//! fetches a pool-aware nonce via `system_accountNextIndex` and submits it explicitly through
+//! `subxt_utils::send_extrinsic_with_nonce`, which uses `create_partial_offline` so subxt does
+//! not overwrite the nonce from the finalized view.
+//!
+//! This test reproduces the exact condition deterministically on a manual-seal simnode: it
+//! lands an extrinsic in a best-but-unfinalized block, shows the finalized-sourced nonce is now
+//! stale while the pool-aware nonce leads it, confirms that submitting with the stale nonce is
+//! rejected (the production bug), and that submitting with the pool-aware nonce lands cleanly
+//! (the fix). Requires a running gargantua simnode; run with `--ignored`.
+
+#![cfg(test)]
+
+use std::{env, time::Duration};
+
+use anyhow::{anyhow, Context};
+use polkadot_sdk::*;
+use primitive_types::H256;
+use sc_consensus_manual_seal::CreatedBlock;
+use sp_core::{crypto::Ss58Codec, Bytes};
+use sp_keyring::sr25519::Keyring;
+use subxt::{
+	dynamic::Value,
+	ext::subxt_rpcs::{rpc_params, RpcClient},
+	OnlineClient,
+};
+use subxt_utils::{send_extrinsic_with_nonce, Hyperbridge, InMemorySigner};
+
+/// Create a block on the manual-seal simnode. `finalize = false` advances the best chain
+/// without moving the finalized head — precisely the state that used to make the prover
+/// reuse a stale nonce.
+async fn create_block(rpc: &RpcClient, finalize: bool) -> Result<H256, anyhow::Error> {
+	let block: CreatedBlock<H256> = rpc
+		.request("engine_createBlock", rpc_params![true, finalize])
+		.await
+		.map_err(|e| anyhow!("engine_createBlock failed: {e:?}"))?;
+	Ok(block.hash)
+}
+
+/// Block until the submitted extrinsic is sitting in the node's pool, so the block we seal
+/// actually contains it rather than racing an empty block in ahead of submission.
+async fn wait_until_pending(rpc: &RpcClient) -> Result<(), anyhow::Error> {
+	for _ in 0..200 {
+		let pending: Vec<Bytes> =
+			rpc.request("author_pendingExtrinsics", rpc_params![]).await.unwrap_or_default();
+		if !pending.is_empty() {
+			return Ok(());
+		}
+		tokio::time::sleep(Duration::from_millis(25)).await;
+	}
+	Err(anyhow!("extrinsic never entered the pool"))
+}
+
+/// Submit `payload` signed by `signer` with an explicit `nonce`, sealing one non-finalized
+/// block so the manual-seal node includes it. `send_extrinsic_with_nonce` waits for in-block,
+/// so the seal has to happen concurrently — we drive both on the same task with `join!`.
+async fn submit_with_nonce_sealing(
+	client: &OnlineClient<Hyperbridge>,
+	rpc: &RpcClient,
+	signer: &InMemorySigner<Hyperbridge>,
+	payload: &subxt::tx::DynamicPayload,
+	nonce: u64,
+) -> Result<H256, anyhow::Error> {
+	let submit_fut = send_extrinsic_with_nonce(client, signer, payload, nonce, false);
+	let seal_fut = async {
+		wait_until_pending(rpc).await?;
+		create_block(rpc, false).await
+	};
+	let (submit_res, seal_res) = tokio::join!(submit_fut, seal_fut);
+	let block = seal_res?;
+	submit_res?;
+	Ok(block)
+}
+
+/// A distinct `System::remark` call per submission, so successive extrinsics hash differently.
+fn remark(tag: &[u8]) -> subxt::tx::DynamicPayload {
+	subxt::dynamic::tx("System", "remark", vec![Value::from_bytes(tag)])
+}
+
+#[tokio::test]
+#[ignore]
+async fn pool_aware_nonce_survives_finalization_lag() -> Result<(), anyhow::Error> {
+	let port = env::var("PORT").unwrap_or_else(|_| "9990".into());
+	let url = format!("ws://127.0.0.1:{port}");
+	let (client, rpc_client) = subxt_utils::client::ws_client::<Hyperbridge>(&url, u32::MAX).await?;
+
+	// Bob is endowed in the gargantua dev genesis, so a client-side signed extrinsic is valid
+	// and funded. Signing client-side (rather than via `simnode_authorExtrinsic`) is the point:
+	// it exercises the prover's own nonce sourcing.
+	let signer = InMemorySigner::<Hyperbridge>::new(Keyring::Bob.pair());
+	let bob_ss58 = Keyring::Bob.to_account_id().to_ss58check();
+
+	// Baseline next nonce. Prior tiers finalize their blocks, so best == finalized here and the
+	// pool-aware nonce equals the finalized nonce at the start.
+	let next0: u64 = rpc_client
+		.request("system_accountNextIndex", rpc_params![bob_ss58.clone()])
+		.await
+		.map_err(|e| anyhow!("system_accountNextIndex failed: {e:?}"))?;
+
+	// 1. Land a first extrinsic in a *best but unfinalized* block — the exact condition the
+	//    prover hits: the proof is in-block, but finality (subxt's auto-nonce source) lags.
+	submit_with_nonce_sealing(&client, &rpc_client, &signer, &remark(b"nonce-test-1"), next0)
+		.await
+		.context("first submission should land in a block")?;
+
+	// 2. Finality has not advanced, so subxt's finalized-sourced nonce is stale while the
+	//    pool-aware nonce reflects the best chain.
+	let finalized_nonce = client.tx().account_nonce(&signer.account_id).await?;
+	let pool_nonce: u64 = rpc_client
+		.request("system_accountNextIndex", rpc_params![bob_ss58.clone()])
+		.await
+		.map_err(|e| anyhow!("system_accountNextIndex failed: {e:?}"))?;
+	assert_eq!(finalized_nonce, next0, "finalized nonce must not advance without finalization");
+	assert_eq!(pool_nonce, next0 + 1, "pool-aware nonce must reflect the unfinalized best block");
+
+	// 3. Bug reproduction: submitting with the stale finalized nonce — what subxt's `create_signed`
+	//    auto path would pick — is rejected by the node (surfaces to the prover as the production
+	//    `Invalid Transaction (1010)`). It fails at submission, so no block needs sealing.
+	let stale_res =
+		send_extrinsic_with_nonce(&client, &signer, &remark(b"nonce-test-stale"), finalized_nonce, false)
+			.await;
+	assert!(
+		stale_res.is_err(),
+		"submitting with the stale finalized nonce ({finalized_nonce}) must be rejected, got {stale_res:?}",
+	);
+
+	// 4. The fix: submitting with the pool-aware nonce lands cleanly despite the finality lag.
+	let last_block =
+		submit_with_nonce_sealing(&client, &rpc_client, &signer, &remark(b"nonce-test-2"), pool_nonce)
+			.await
+			.context("submission with the pool-aware nonce should succeed despite finality lag")?;
+
+	// Finalize the last sealed block (and its ancestors) so we don't leave `best > finalized`
+	// for subsequent `--test-threads=1` simnode tests.
+	let finalized: bool = rpc_client
+		.request("engine_finalizeBlock", rpc_params![last_block])
+		.await
+		.map_err(|e| anyhow!("engine_finalizeBlock failed: {e:?}"))?;
+	assert!(finalized, "finalizing the last sealed block should succeed");
+
+	Ok(())
+}

--- a/tesseract/consensus/beefy/src/backend/onchain.rs
+++ b/tesseract/consensus/beefy/src/backend/onchain.rs
@@ -26,18 +26,18 @@ use codec::Decode;
 use futures::Stream;
 use ismp::{consensus::StateMachineId, host::StateMachine};
 use polkadot_sdk::*;
-use sp_core::sr25519;
+use sp_core::{sr25519, Pair};
 use sp_runtime::{generic::Header, traits::Header as _};
 use std::{pin::Pin, sync::Arc};
 use subxt::{
-	config::ExtrinsicParams,
+	config::{substrate::SubstrateExtrinsicParams, ExtrinsicParams},
 	dynamic::Value,
 	ext::subxt_rpcs::{rpc_params, RpcClient},
 	tx::DefaultParams,
 	utils::{AccountId32, MultiSignature},
 	OnlineClient,
 };
-use subxt_utils::{send_extrinsic, InMemorySigner};
+use subxt_utils::{send_extrinsic_with_nonce, InMemorySigner};
 use tokio::sync::RwLock;
 
 /// Proof backend that submits proofs directly to `pallet-beefy-consensus-proofs`
@@ -76,7 +76,7 @@ impl<P: subxt::Config> OnchainBackend<P> {
 
 impl<P> OnchainBackend<P>
 where
-	P: subxt::Config + Send + Sync,
+	P: subxt::Config<ExtrinsicParams = SubstrateExtrinsicParams<P>> + Send + Sync,
 	P::Signature: From<MultiSignature> + Send + Sync,
 	P::AccountId: From<AccountId32> + Into<P::Address> + Clone + 'static + Send + Sync,
 	<P::ExtrinsicParams as ExtrinsicParams<P>>::Params: Send + Sync + DefaultParams,
@@ -90,9 +90,23 @@ where
 		let tx = subxt::dynamic::tx("BeefyConsensusProofs", "submit_proof", vec![payload_value]);
 
 		let signer = InMemorySigner::<P>::new(self.signer.clone());
+
+		// Fetch a pool-aware nonce rather than letting subxt pick one. subxt sources the auto
+		// nonce from the latest *finalized* block, which on the parachain trails the best chain
+		// by several blocks; since we only wait for in-block (not finalization) below, that auto
+		// nonce is frequently already spent by our previous proof and the node rejects the
+		// submission as `InvalidTransaction::Stale`. `system_accountNextIndex` accounts for the
+		// best block plus pending pool transactions, so it never lags behind our own submissions.
+		let account = AccountId32::from(self.signer.public().0);
+		let nonce: u64 = self
+			.rpc_client
+			.request("system_accountNextIndex", rpc_params![account.to_string()])
+			.await
+			.map_err(|e| anyhow!("system_accountNextIndex failed: {e}"))?;
+
 		// Don't wait for finalization: in-block is enough — the prover loop sleeps a block
 		// below before reading state, and uncle proofs need to race the next prover.
-		let result = send_extrinsic(&self.client, &signer, &tx, None, false).await;
+		let result = send_extrinsic_with_nonce(&self.client, &signer, &tx, nonce, false).await;
 
 		// Wait one block so that load_state() on the next iteration sees the
 		// state advance written by the pallet in the previous block.
@@ -136,7 +150,7 @@ where
 #[async_trait::async_trait]
 impl<P> ProofBackend for OnchainBackend<P>
 where
-	P: subxt::Config + Send + Sync,
+	P: subxt::Config<ExtrinsicParams = SubstrateExtrinsicParams<P>> + Send + Sync,
 	P::Signature: From<MultiSignature> + Send + Sync,
 	P::AccountId: From<AccountId32> + Into<P::Address> + Clone + 'static + Send + Sync,
 	<P::ExtrinsicParams as ExtrinsicParams<P>>::Params: Send + Sync + DefaultParams,

--- a/tesseract/consensus/beefy/src/lib.rs
+++ b/tesseract/consensus/beefy/src/lib.rs
@@ -20,7 +20,7 @@ use primitive_types::H256;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use subxt::{
-	config::{ExtrinsicParams, HashFor},
+	config::{substrate::SubstrateExtrinsicParams, ExtrinsicParams, HashFor},
 	tx::DefaultParams,
 	utils::{AccountId32, MultiSignature},
 };
@@ -60,7 +60,7 @@ impl BeefyConfig {
 	) -> Result<BeefyHost<R, P, zk_beefy::LocalProver, dyn backend::ProofBackend>, anyhow::Error>
 	where
 		R: subxt::Config + Send + Sync + Clone,
-		P: subxt::Config + Send + Sync + Clone,
+		P: subxt::Config<ExtrinsicParams = SubstrateExtrinsicParams<P>> + Send + Sync + Clone,
 		<P::ExtrinsicParams as ExtrinsicParams<P>>::Params: Send + Sync + DefaultParams,
 		P::Signature: From<MultiSignature> + Send + Sync,
 		P::AccountId: From<AccountId32> + Into<P::Address> + Clone + 'static + Send + Sync,

--- a/tesseract/prover/Cargo.toml
+++ b/tesseract/prover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tesseract-prover"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 description = "Standalone BEEFY consensus prover daemon"
 authors = ["Polytope Labs <hello@polytope.technology>"]


### PR DESCRIPTION
## Problem

The testnet beefy prover (`prover-testnet-beefy-prover-1`) repeatedly fails to submit consensus proofs, logging `Prover error: Failed to submit signed extrinsic` / `Invalid Transaction (1010)`. With `txpool=trace` enabled on the submission node, every one of the prover's own `submit_and_watch` failures resolves to `InvalidTransaction::Stale` — the submitted nonce is already spent on-chain. The proofs still land eventually, but only after several ~10s retries per round, and the noise is much worse while catching up after a restart.

## Root cause

subxt 0.42 sources the auto nonce from the **latest finalized block** (`inject_account_nonce_and_block` uses `latest_finalized_block_ref()`). The beefy backend deliberately waits only for **in-block** (not finalization) before its next submission, for speed. On the parachain, finality trails the best chain by ~5 blocks (~30s), so the previous proof's nonce — already consumed in the best chain — has not yet shown up in the finalized view that subxt reads. The next submission reuses that nonce and the node rejects it as `Stale`. It only succeeds once finality catches up.

This is specific to the in-block fast path: every other `send_extrinsic` caller waits for finalization, so their next submission reads an already-advanced finalized nonce and never hits this.

## Fix

Submit beefy proofs with an explicit, pool-aware nonce instead of subxt's finalized-block auto nonce.

- `modules/utils/subxt`: add `send_extrinsic_with_nonce`, which sets the nonce via `DefaultExtrinsicParamsBuilder::nonce` and submits through `create_partial_offline` (the path that does **not** re-inject/overwrite the nonce, unlike `create_signed`). Shared post-submit logic factored into `await_extrinsic`; `send_extrinsic` keeps its existing signature and behavior, so its other callers are untouched.
- `tesseract/consensus/beefy` (`onchain.rs`): fetch the nonce via the `system_accountNextIndex` RPC (best block + pending pool, so it never lags our own in-flight submissions) and pass it to `send_extrinsic_with_nonce`. Added the `ExtrinsicParams = SubstrateExtrinsicParams<P>` bound to the affected impls and propagated it to `into_client`; it terminates at the concrete `KeccakSubstrateChain`.

Mortality is unchanged (immortal on both paths) — the only behavioral change is the nonce source.

## Testing

- `cargo check` passes for `subxt-utils`, `tesseract-beefy`, `tesseract-prover`, and `tesseract-substrate`.
- Diagnosis confirmed against the live testnet node via `txpool=trace`: prover `submit_and_watch` failures were exclusively `InvalidTransaction::Stale`, self-resolving roughly in line with the parachain's finality lag.