### PR TITLE
[runtime] Minor fixes across runtime crates

### DIFF
--- a/docs/content/developers/network/collator.mdx
+++ b/docs/content/developers/network/collator.mdx
@@ -49,7 +49,7 @@ but does **not** need to set session keys — that's the Controller's job.
     - It's the account that accrues Reputation.
     - It's the account that sets Session Keys (required for block production).
     - This is the account you use as your relayer or prover signer.
-    - It must be linked to a Stash via `collatorManager.register` before the Stash can be selected as a Collator.
+    - It must approve being paired with your Stash via `collatorManager.approveController`, and the Stash then completes the link with `collatorManager.register`, before the Stash can be selected as a Collator. The two-signer flow prevents another account from squatting your Controller address.
 
 **Why Two Accounts?** This separation allows you to keep your bonded funds secure in a cold wallet while using a hot wallet for
 operational duties. If your Controller is compromised, an attacker cannot access your bonded funds — they can only perform
@@ -342,12 +342,30 @@ brings the fisherman task online so the node is contributing to L2 fraud detecti
 ### Step 3: Link your Controller to your Stash
 
 You must now create the on-chain link between your Stash account and your operational Controller account. This must be done before registering as a candidate, as `ValidatorRegistration` requires the controller to be linked first.
-**Action**: Call the collatorManager.register extrinsic
+
+Linking is a **two-step, two-signer** flow: the Controller first publishes its consent to be paired with a specific Stash, and the Stash then consumes that consent to complete the pairing. This prevents another account from squatting your Controller address.
+
+#### Step 3a: Approve the pairing from your Controller account
+
+**Action**: Call the `collatorManager.approveController` extrinsic from your **Controller** account.
 
 - Navigate to `Developer -> Extrinsics` in the Polkadot-JS UI.
-- Select your Stash account.
+- Select your **Controller** account.
+- Choose the `collatorManager` pallet and the `approveController` extrinsic.
+- In the `stash` field, enter your **Stash** account address.
+- Sign and submit the transaction.
+
+This records a single-use, on-chain consent saying: "I am the Controller and I authorise this Stash to bind me." The approval is specific to that one `(stash, controller)` pair and is consumed by the next step. If you change your mind before the Stash consumes it, you can retract the approval by calling `collatorManager.revokeControllerApproval(stash)` from the Controller.
+
+#### Step 3b: Register the Controller from your Stash account
+
+**Action**: Call the `collatorManager.register` extrinsic from your **Stash** account.
+
+- Navigate to `Developer -> Extrinsics` in the Polkadot-JS UI.
+- Select your **Stash** account.
 - Choose the `collatorManager` pallet and the `register` extrinsic.
 - In the `controller` field, select your `Controller` account (the one with the reputation and session keys).
+- Sign and submit. The transaction will consume the matching approval from Step 3a and fail with `ControllerApprovalMissing` if no approval is on record for this `(stash, controller)` pair.
 
 <figure>
   <img src="/register_controller.png" alt="Registering Your Controller" />
@@ -355,6 +373,10 @@ You must now create the on-chain link between your Stash account and your operat
 </figure>
 
 This tells the network: "Designate this Controller to perform collator duties on behalf of my Stash account."
+
+#### Rotating to a new Controller later
+
+The same two-step consent applies if you ever rotate your Controller via `collatorManager.setController`: the **new** Controller must first call `approveController(stash)` from its own origin, and only then can the Stash call `setController(new_controller)` to consume that approval and switch.
 
 ### Step 4: Register as a Candidate By Bonding Funds from your Stash Account
 

--- a/modules/consensus/grandpa/verifier/src/error.rs
+++ b/modules/consensus/grandpa/verifier/src/error.rs
@@ -47,6 +47,15 @@ pub enum Error {
 	/// header.
 	#[error("Invalid proof, parachain header not found")]
 	ParachainHeaderNotFound,
+	/// A `parachain_headers` map entry references a relay-chain hash that
+	/// is in the finalized ancestry route (`headers.ancestry`) but whose
+	/// header is not present in `finality_proof.unknown_headers`. The
+	/// trusted latest relay hash is the canonical instance of this:
+	/// `AncestryChain::ancestry` includes the base hash even when the
+	/// base header is not in the map. The verifier used to `.expect` the
+	/// header here and panic; it now surfaces a typed error.
+	#[error("Parachain header proof references a relay hash with no relay-chain header in unknown_headers")]
+	RelayHeaderNotInUnknownHeaders,
 	/// A parachain header in the state proof failed to SCALE-decode.
 	#[error("Error decoding header: {0}")]
 	DecodeHeader(String),

--- a/modules/consensus/grandpa/verifier/src/lib.rs
+++ b/modules/consensus/grandpa/verifier/src/lib.rs
@@ -128,8 +128,14 @@ where
 			// seems relay hash isn't in the finalized chain.
 			continue;
 		}
-		let relay_chain_header =
-			headers.header(&hash).expect("Headers have been checked by AncestryChain; qed");
+		// `AncestryChain::ancestry` includes the base hash in its returned route even
+		// when the base header is absent from `unknown_headers` — most notably the
+		// trusted latest relay hash. A previous `.expect` here panicked the runtime
+		// on attacker-controlled `parachain_headers` whose key matched the trusted
+		// latest hash. Surface a typed error instead so the proof is rejected.
+		let relay_chain_header = headers
+			.header(&hash)
+			.ok_or(Error::RelayHeaderNotInUnknownHeaders)?;
 		let state_proof = proof.state_proof;
 		let mut keys = BTreeMap::new();
 		for para_id in proof.para_ids {

--- a/modules/ismp/state-machines/evm/src/tendermint.rs
+++ b/modules/ismp/state-machines/evm/src/tendermint.rs
@@ -200,7 +200,19 @@ impl<H: IsmpHost + Send + Sync, T: pallet_ismp_host_executive::Config> StateMach
 				(addr, slot_arr)
 			};
 
-			let key = storage_key_for(proof.height.id.state_id, &addr.0, slot);
+			// `receipts_state_trie_key` returns the raw EVM storage slot for
+			// `_requestReceipts[commitment]`. Ethermint-style Tendermint EVM stores
+			// expose EVM storage under IAVL keys of the form
+			// `prefix || address || keccak256(slot)` (see the prover's
+			// `abci_query_key` docs and `DefaultEvmKeys::storage_key`), so the raw
+			// slot must be keccak256-hashed before being folded into the IAVL key.
+			// `commitment_state_trie_key` already applies this hash inside its
+			// `req_commitment_key` closure for the membership path; this rehash
+			// keeps the non-membership path consistent so a present receipt is
+			// queried under the IAVL key that genuinely backs it rather than under
+			// an unhashed key that never exists in the tree.
+			let hashed_slot = ICS23HostFunctions::keccak256(&slot).0;
+			let key = storage_key_for(proof.height.id.state_id, &addr.0, hashed_slot);
 
 			let commitment_proof = CommitmentProofBytes::try_from(ev.proof.clone())
 				.map_err(|e| TendermintEvmError::InvalidCommitmentProof(e.to_string()))?;

--- a/modules/pallets/collator-manager/src/lib.rs
+++ b/modules/pallets/collator-manager/src/lib.rs
@@ -129,6 +129,23 @@ pub mod pallet {
 	pub type Stash<T: Config> =
 		StorageMap<_, Blake2_128Concat, T::AccountId, T::AccountId, OptionQuery>;
 
+	/// Pending controller-side approvals authorising a specific stash to bind
+	/// the controller. A non-empty entry at `(stash, controller)` is the
+	/// controller's signed consent to be paired by that stash.
+	///
+	/// Cleared on consumption by `register` / `set_controller`, or explicitly
+	/// via `revoke_controller_approval`.
+	#[pallet::storage]
+	pub type ControllerApprovals<T: Config> = StorageDoubleMap<
+		_,
+		Blake2_128Concat,
+		T::AccountId, // stash
+		Blake2_128Concat,
+		T::AccountId, // controller
+		(),
+		OptionQuery,
+	>;
+
 	/// The reward value for collators
 	#[pallet::storage]
 	#[pallet::getter(fn collator_reward)]
@@ -149,6 +166,10 @@ pub mod pallet {
 		NoController,
 		/// The specified controller account is already paired with another stash.
 		AlreadyPaired,
+		/// The controller has not approved being paired with the calling stash.
+		ControllerApprovalMissing,
+		/// There is no pending controller approval to revoke for the given pair.
+		NoPendingApproval,
 	}
 
 	#[pallet::event]
@@ -196,6 +217,20 @@ pub mod pallet {
 			/// The reward amount.
 			amount: <T as pallet::Config>::Balance,
 		},
+		/// A controller account has approved being paired with a specific stash.
+		ControllerApprovalGranted {
+			/// The controller account granting approval.
+			controller: T::AccountId,
+			/// The stash account the controller has authorised.
+			stash: T::AccountId,
+		},
+		/// A previously-granted controller approval was revoked.
+		ControllerApprovalRevoked {
+			/// The controller account that revoked approval.
+			controller: T::AccountId,
+			/// The stash account whose approval was revoked.
+			stash: T::AccountId,
+		},
 	}
 
 	#[pallet::call]
@@ -214,14 +249,25 @@ pub mod pallet {
 		}
 
 		/// Registers a controller account for a bonded stash.
+		///
 		/// The origin must be a stash account, which must have already bonded funds
-		/// via `pallet-collator-selection`
+		/// via `pallet-collator-selection`. The supplied `controller` must have
+		/// previously authorised the pairing by calling `approve_controller` from
+		/// the controller's own origin — without this two-step consent, an
+		/// arbitrary stash could squat any unpaired controller address, blocking
+		/// the legitimate operator and (if the controller carried session keys
+		/// and reputation) consuming that reputation on selection.
 		#[pallet::call_index(1)]
 		#[pallet::weight(<T as pallet::Config>::WeightInfo::register())]
 		pub fn register(origin: OriginFor<T>, controller: T::AccountId) -> DispatchResult {
 			let stash = ensure_signed(origin)?;
 			ensure!(!Controller::<T>::contains_key(&stash), Error::<T>::AlreadyRegistered);
 			ensure!(!Stash::<T>::contains_key(&controller), Error::<T>::AlreadyPaired);
+			// Controller must have signed an approval for this specific stash.
+			ensure!(
+				ControllerApprovals::<T>::take(&stash, &controller).is_some(),
+				Error::<T>::ControllerApprovalMissing
+			);
 
 			Controller::<T>::insert(&stash, &controller);
 			Stash::<T>::insert(&controller, &stash);
@@ -231,7 +277,11 @@ pub mod pallet {
 		}
 
 		/// Change the controller account for a registered stash.
-		/// The origin must be the stash account
+		///
+		/// The origin must be the stash account, and the proposed `new_controller`
+		/// must have previously authorised the rotation by calling
+		/// `approve_controller` from its own origin (mirroring the consent flow
+		/// required by `register`).
 		#[pallet::call_index(2)]
 		#[pallet::weight(<T as pallet::Config>::WeightInfo::set_controller())]
 		pub fn set_controller(
@@ -241,6 +291,10 @@ pub mod pallet {
 			let stash = ensure_signed(origin)?;
 			let old_controller = Controller::<T>::get(&stash).ok_or(Error::<T>::NotStash)?;
 			ensure!(!Stash::<T>::contains_key(&new_controller), Error::<T>::AlreadyPaired);
+			ensure!(
+				ControllerApprovals::<T>::take(&stash, &new_controller).is_some(),
+				Error::<T>::ControllerApprovalMissing
+			);
 
 			Controller::<T>::insert(&stash, &new_controller);
 			Stash::<T>::remove(&old_controller);
@@ -258,6 +312,44 @@ pub mod pallet {
 			let controller = Controller::<T>::take(&stash).ok_or(Error::<T>::NotStash)?;
 			Stash::<T>::remove(&controller);
 			Self::deposit_event(Event::Deregistered { stash });
+			Ok(())
+		}
+
+		/// Authorise `stash` to bind the caller as its controller.
+		///
+		/// The origin is the controller account granting consent. A subsequent
+		/// `register(controller)` or `set_controller(controller)` call from
+		/// `stash` consumes this approval and completes the pairing. The
+		/// approval is single-use and per-(stash, controller).
+		///
+		/// Approvals may be retracted before consumption via
+		/// `revoke_controller_approval`.
+		#[pallet::call_index(4)]
+		#[pallet::weight(<T as pallet::Config>::WeightInfo::register())]
+		pub fn approve_controller(
+			origin: OriginFor<T>,
+			stash: T::AccountId,
+		) -> DispatchResult {
+			let controller = ensure_signed(origin)?;
+			ControllerApprovals::<T>::insert(&stash, &controller, ());
+			Self::deposit_event(Event::ControllerApprovalGranted { controller, stash });
+			Ok(())
+		}
+
+		/// Revoke a previously-granted controller approval for the given stash.
+		/// The origin must be the controller that issued the approval.
+		#[pallet::call_index(5)]
+		#[pallet::weight(<T as pallet::Config>::WeightInfo::deregister())]
+		pub fn revoke_controller_approval(
+			origin: OriginFor<T>,
+			stash: T::AccountId,
+		) -> DispatchResult {
+			let controller = ensure_signed(origin)?;
+			ensure!(
+				ControllerApprovals::<T>::take(&stash, &controller).is_some(),
+				Error::<T>::NoPendingApproval,
+			);
+			Self::deposit_event(Event::ControllerApprovalRevoked { controller, stash });
 			Ok(())
 		}
 	}

--- a/modules/pallets/consensus-incentives/src/impls.rs
+++ b/modules/pallets/consensus-incentives/src/impls.rs
@@ -16,6 +16,7 @@
 //! Implementation blocks for pallet-consensus-incentives.
 
 use crate::*;
+use alloc::collections::BTreeMap;
 use crypto_utils::verification::Signature;
 use frame_support::traits::tokens::Preservation;
 use ismp::{
@@ -108,19 +109,39 @@ where
 		});
 
 		if let Some(relayer_account) = maybe_relayer_account {
+			// When a batch contains multiple `StateMachineUpdated` events for the
+			// same `state_machine_id` (sequential consensus updates for the same
+			// chain), `calculate_reward` reads the same persisted
+			// `(latest_commitment_height, previous_commitment_height)` pair on
+			// every iteration and pays the same block-span reward N times.
+			// Collapse the per-state-machine event stream to the single highest
+			// `latest_height` so each state machine receives one reward per
+			// batch, sized by the actual span of its commitment advance.
+			let mut highest_per_state_machine: BTreeMap<StateMachineId, u64> = BTreeMap::new();
 			for event in events {
 				if let IsmpEvent::StateMachineUpdated(update) = event {
-					let state_machine_height = StateMachineHeight {
-						id: update.state_machine_id.clone(),
-						height: update.latest_height,
-					};
-
-					let _ = Self::process_message(
-						state_machine_height,
-						update.state_machine_id,
-						relayer_account.clone().into(),
-					);
+					highest_per_state_machine
+						.entry(update.state_machine_id)
+						.and_modify(|h| {
+							if update.latest_height > *h {
+								*h = update.latest_height;
+							}
+						})
+						.or_insert(update.latest_height);
 				}
+			}
+
+			for (state_machine_id, latest_height) in highest_per_state_machine {
+				let state_machine_height = StateMachineHeight {
+					id: state_machine_id.clone(),
+					height: latest_height,
+				};
+
+				let _ = Self::process_message(
+					state_machine_height,
+					state_machine_id,
+					relayer_account.clone().into(),
+				);
 			}
 		}
 

--- a/modules/pallets/testsuite/src/tests/pallet_collator_manager.rs
+++ b/modules/pallets/testsuite/src/tests/pallet_collator_manager.rs
@@ -57,6 +57,36 @@ fn register_candidate(who: <Test as frame_system::Config>::AccountId) {
 	assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(who.clone())));
 }
 
+/// Two-step pairing helper: the controller publishes its consent, then the
+/// stash consumes it via `register`. Centralises the new approval flow so the
+/// pre-existing tests don't have to repeat the pattern at every call site.
+fn link_stash_to_controller(
+	stash: <Test as frame_system::Config>::AccountId,
+	controller: <Test as frame_system::Config>::AccountId,
+) {
+	assert_ok!(CollatorManager::approve_controller(
+		RuntimeOrigin::signed(controller.clone()),
+		stash.clone(),
+	));
+	assert_ok!(CollatorManager::register(RuntimeOrigin::signed(stash), controller));
+}
+
+/// Rotation helper: the new controller publishes consent, then the stash
+/// completes the rotation via `set_controller`.
+fn rotate_controller(
+	stash: <Test as frame_system::Config>::AccountId,
+	new_controller: <Test as frame_system::Config>::AccountId,
+) {
+	assert_ok!(CollatorManager::approve_controller(
+		RuntimeOrigin::signed(new_controller.clone()),
+		stash.clone(),
+	));
+	assert_ok!(CollatorManager::set_controller(
+		RuntimeOrigin::signed(stash),
+		new_controller,
+	));
+}
+
 fn set_session_keys(who: <Test as frame_system::Config>::AccountId) {
 	System::<Test>::inc_providers(&who);
 	let pair = Pair::from_seed(who.as_ref());
@@ -90,12 +120,8 @@ fn test_new_collators_are_selected_based_on_reputation() {
 			),
 		]);
 
-		assert_ok!(CollatorManager::register(
-			RuntimeOrigin::signed(charlie_stash.clone()),
-			CHARLIE
-		));
-
-		assert_ok!(CollatorManager::register(RuntimeOrigin::signed(dave_stash.clone()), DAVE));
+		link_stash_to_controller(charlie_stash.clone(), CHARLIE);
+		link_stash_to_controller(dave_stash.clone(), DAVE);
 
 		set_session_keys(CHARLIE);
 		set_session_keys(DAVE);
@@ -148,10 +174,7 @@ fn test_reuse_previous_collators_if_not_enough_candidates() {
 		set_reputation_balance(&BOB, 30 * UNIT);
 		set_reputation_balance(&CHARLIE, 40 * UNIT);
 
-		assert_ok!(CollatorManager::register(
-			RuntimeOrigin::signed(charlie_stash.clone()),
-			CHARLIE
-		));
+		link_stash_to_controller(charlie_stash.clone(), CHARLIE);
 
 		set_session_keys(CHARLIE);
 		register_candidate(charlie_stash.clone());
@@ -258,7 +281,7 @@ fn test_collator_candidate_bonding_works_with_vesting_tokens() {
 		set_vesting_schedule(&CHARLIE, bond_amount * 2);
 		assert_eq!(pallet_collator_selection::CandidateList::<Test>::get().len(), 0);
 
-		assert_ok!(CollatorManager::register(RuntimeOrigin::signed(CHARLIE), DAVE));
+		link_stash_to_controller(CHARLIE, DAVE);
 		set_session_keys(DAVE);
 		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(CHARLIE)));
 		assert_eq!(pallet_collator_selection::CandidateList::<Test>::get().len(), 1);
@@ -311,10 +334,7 @@ fn register_controller_works() {
 
 		assert_ok!(CollatorManager::reserve(&stash, 100 * UNIT));
 
-		assert_ok!(CollatorManager::register(
-			RuntimeOrigin::signed(stash.clone()),
-			controller.clone()
-		));
+		link_stash_to_controller(stash.clone(), controller.clone());
 
 		assert_eq!(
 			pallet_collator_manager::Controller::<Test>::get(&stash),
@@ -331,15 +351,9 @@ fn set_controller_works() {
 		let old_controller = BOB;
 		let new_controller = CHARLIE;
 		assert_ok!(CollatorManager::reserve(&stash, 100 * UNIT));
-		assert_ok!(CollatorManager::register(
-			RuntimeOrigin::signed(stash.clone()),
-			old_controller.clone()
-		));
+		link_stash_to_controller(stash.clone(), old_controller.clone());
 
-		assert_ok!(CollatorManager::set_controller(
-			RuntimeOrigin::signed(stash.clone()),
-			new_controller.clone()
-		));
+		rotate_controller(stash.clone(), new_controller.clone());
 
 		assert_eq!(
 			pallet_collator_manager::Controller::<Test>::get(&stash),
@@ -356,10 +370,7 @@ fn deregister_works() {
 		let stash = ALICE;
 		let controller = BOB;
 		assert_ok!(CollatorManager::reserve(&stash, 100 * UNIT));
-		assert_ok!(CollatorManager::register(
-			RuntimeOrigin::signed(stash.clone()),
-			controller.clone()
-		));
+		link_stash_to_controller(stash.clone(), controller.clone());
 
 		assert_ok!(CollatorManager::deregister(RuntimeOrigin::signed(stash.clone())));
 
@@ -384,10 +395,7 @@ fn validator_registration_returns_false_when_controller_has_no_session_keys() {
 		let controller = BOB;
 
 		assert_ok!(CollatorManager::reserve(&stash, 100 * UNIT));
-		assert_ok!(CollatorManager::register(
-			RuntimeOrigin::signed(stash.clone()),
-			controller.clone()
-		));
+		link_stash_to_controller(stash.clone(), controller.clone());
 
 		assert!(!CollatorManager::is_registered(&stash));
 	});
@@ -400,10 +408,7 @@ fn validator_registration_returns_true_when_controller_has_session_keys() {
 		let controller = BOB;
 
 		assert_ok!(CollatorManager::reserve(&stash, 100 * UNIT));
-		assert_ok!(CollatorManager::register(
-			RuntimeOrigin::signed(stash.clone()),
-			controller.clone()
-		));
+		link_stash_to_controller(stash.clone(), controller.clone());
 
 		set_session_keys(controller.clone());
 
@@ -419,17 +424,11 @@ fn validator_registration_returns_false_after_controller_changed_without_new_key
 		let new_controller = CHARLIE;
 
 		assert_ok!(CollatorManager::reserve(&stash, 100 * UNIT));
-		assert_ok!(CollatorManager::register(
-			RuntimeOrigin::signed(stash.clone()),
-			old_controller.clone()
-		));
+		link_stash_to_controller(stash.clone(), old_controller.clone());
 		set_session_keys(old_controller.clone());
 		assert!(CollatorManager::is_registered(&stash));
 
-		assert_ok!(CollatorManager::set_controller(
-			RuntimeOrigin::signed(stash.clone()),
-			new_controller.clone()
-		));
+		rotate_controller(stash.clone(), new_controller.clone());
 
 		assert!(!CollatorManager::is_registered(&stash));
 
@@ -458,10 +457,7 @@ fn update_bond_fails_when_new_deposit_exceeds_account_balance() {
 			))
 		));
 
-		assert_ok!(CollatorManager::register(
-			RuntimeOrigin::signed(stash.clone()),
-			controller.clone()
-		));
+		link_stash_to_controller(stash.clone(), controller.clone());
 		set_session_keys(controller);
 
 		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(stash.clone())));
@@ -508,10 +504,7 @@ fn take_candidate_slot_replaces_a_fully_bonded_candidate() {
 		Balances::set_balance(&target_stash, target_balance);
 		Balances::set_balance(&challenger_stash, challenger_balance);
 
-		assert_ok!(CollatorManager::register(
-			RuntimeOrigin::signed(target_stash.clone()),
-			target_controller.clone()
-		));
+		link_stash_to_controller(target_stash.clone(), target_controller.clone());
 		set_session_keys(target_controller);
 
 		assert_ok!(CollatorSelection::register_as_candidate(RuntimeOrigin::signed(
@@ -536,10 +529,7 @@ fn take_candidate_slot_replaces_a_fully_bonded_candidate() {
 			.expect("target should still be a candidate");
 		assert_eq!(target_info.deposit, target_balance);
 
-		assert_ok!(CollatorManager::register(
-			RuntimeOrigin::signed(challenger_stash.clone()),
-			challenger_controller.clone()
-		));
+		link_stash_to_controller(challenger_stash.clone(), challenger_controller.clone());
 		set_session_keys(challenger_controller);
 
 		assert_ok!(CollatorSelection::take_candidate_slot(
@@ -553,6 +543,119 @@ fn take_candidate_slot_replaces_a_fully_bonded_candidate() {
 			.iter()
 			.any(|info| info.who == challenger_stash && info.deposit == challenger_balance));
 		assert!(!final_candidates.iter().any(|info| info.who == target_stash));
+	});
+}
+
+#[test]
+fn register_fails_without_controller_approval() {
+	new_test_ext().execute_with(|| {
+		let stash = ALICE;
+		let controller = BOB;
+
+		assert_err!(
+			CollatorManager::register(RuntimeOrigin::signed(stash), controller),
+			Error::<Test>::ControllerApprovalMissing,
+		);
+	});
+}
+
+#[test]
+fn register_fails_when_approval_is_for_a_different_stash() {
+	new_test_ext().execute_with(|| {
+		let stash = ALICE;
+		let other_stash = CHARLIE;
+		let controller = BOB;
+
+		// Approval is recorded for `(other_stash, controller)`, not for `(stash, controller)`.
+		assert_ok!(CollatorManager::approve_controller(
+			RuntimeOrigin::signed(controller.clone()),
+			other_stash,
+		));
+
+		assert_err!(
+			CollatorManager::register(RuntimeOrigin::signed(stash), controller),
+			Error::<Test>::ControllerApprovalMissing,
+		);
+	});
+}
+
+#[test]
+fn approval_is_single_use_and_cleared_by_register() {
+	new_test_ext().execute_with(|| {
+		let stash = ALICE;
+		let controller = BOB;
+
+		link_stash_to_controller(stash.clone(), controller.clone());
+
+		// Approval must be consumed by the successful register.
+		assert!(pallet_collator_manager::ControllerApprovals::<Test>::get(&stash, &controller)
+			.is_none());
+
+		// Deregister the pair, then attempt to re-register without a fresh approval.
+		assert_ok!(CollatorManager::deregister(RuntimeOrigin::signed(stash.clone())));
+		assert_err!(
+			CollatorManager::register(
+				RuntimeOrigin::signed(stash.clone()),
+				controller.clone(),
+			),
+			Error::<Test>::ControllerApprovalMissing,
+		);
+	});
+}
+
+#[test]
+fn set_controller_fails_without_new_controller_approval() {
+	new_test_ext().execute_with(|| {
+		let stash = ALICE;
+		let old_controller = BOB;
+		let new_controller = CHARLIE;
+
+		link_stash_to_controller(stash.clone(), old_controller);
+
+		assert_err!(
+			CollatorManager::set_controller(
+				RuntimeOrigin::signed(stash),
+				new_controller,
+			),
+			Error::<Test>::ControllerApprovalMissing,
+		);
+	});
+}
+
+#[test]
+fn revoke_controller_approval_works() {
+	new_test_ext().execute_with(|| {
+		let stash = ALICE;
+		let controller = BOB;
+
+		// Controller grants then revokes consent.
+		assert_ok!(CollatorManager::approve_controller(
+			RuntimeOrigin::signed(controller.clone()),
+			stash.clone(),
+		));
+		assert_ok!(CollatorManager::revoke_controller_approval(
+			RuntimeOrigin::signed(controller.clone()),
+			stash.clone(),
+		));
+
+		// Revoked approval must be cleared from storage.
+		assert!(pallet_collator_manager::ControllerApprovals::<Test>::get(&stash, &controller)
+			.is_none());
+
+		// Subsequent `register` from the stash now fails.
+		assert_err!(
+			CollatorManager::register(RuntimeOrigin::signed(stash.clone()), controller.clone()),
+			Error::<Test>::ControllerApprovalMissing,
+		);
+
+		// A second revoke with nothing to revoke is rejected.
+		assert_err!(
+			CollatorManager::revoke_controller_approval(
+				RuntimeOrigin::signed(controller),
+				stash,
+			),
+			Error::<Test>::NoPendingApproval,
+		);
 	});
 }
 

--- a/sdk/packages/core/contracts/apps/WrappedHyperFungibleToken.sol
+++ b/sdk/packages/core/contracts/apps/WrappedHyperFungibleToken.sol
@@ -307,9 +307,18 @@ contract WrappedHyperFungibleToken is ERC165, HyperApp, Ownable, Pausable {
         address beneficiary = _toAddr(message.to);
 
         if (_isWeth) {
+            // Try a native-ETH push first (cheap for EOAs and payable contracts);
+            // if the recipient cannot accept native value (no `receive()` / `fallback()
+            // payable`), re-wrap the withdrawn ETH and deliver the underlying WETH as
+            // an ERC-20 transfer instead. This mirrors the deposit-side flexibility of
+            // `send()` (which accepts WETH from non-payable callers via `safeTransferFrom`)
+            // so the refund path doesn't permanently lock funds for the same caller class.
             IWETH(_underlying).withdraw(message.amount);
             (bool sent,) = beneficiary.call{value: message.amount}("");
-            if (!sent) revert TransferFailed();
+            if (!sent) {
+                IWETH(_underlying).deposit{value: message.amount}();
+                IERC20(_underlying).safeTransfer(beneficiary, message.amount);
+            }
         } else {
             IERC20(_underlying).safeTransfer(beneficiary, message.amount);
         }
@@ -337,9 +346,17 @@ contract WrappedHyperFungibleToken is ERC165, HyperApp, Ownable, Pausable {
         address refundee = _toAddr(message.from);
 
         if (_isWeth) {
+            // Try a native-ETH push first; if the refundee cannot accept native value
+            // (e.g. the caller used the ERC-20 deposit path in `send()` from a
+            // non-payable contract), re-wrap the withdrawn ETH and deliver the
+            // underlying WETH as an ERC-20 transfer so the timeout still settles and
+            // funds are not permanently locked.
             IWETH(_underlying).withdraw(message.amount);
             (bool sent,) = refundee.call{value: message.amount}("");
-            if (!sent) revert TransferFailed();
+            if (!sent) {
+                IWETH(_underlying).deposit{value: message.amount}();
+                IERC20(_underlying).safeTransfer(refundee, message.amount);
+            }
         } else {
             IERC20(_underlying).safeTransfer(refundee, message.amount);
         }


### PR DESCRIPTION
### 1. `[grandpa]` typed error for missing relay-chain header (HYPERBR-703)

`verify_parachain_headers_with_grandpa_finality_proof` `.expect`ed a header lookup that only checked the hash was in the ancestry **route** — not that the header was in `unknown_headers`. Since `AncestryChain::ancestry` includes the base hash even when its header is absent, attacker-supplied `parachain_headers` keyed on the trusted latest relay hash panicked the runtime. Replace the `.expect` with `.ok_or(Error::RelayHeaderNotInUnknownHeaders)?` so the malformed proof is rejected via the normal `Result` path instead of unwinding.

### 2. `[tendermint-evm]` rehash receipt slot in `verify_non_membership` (HYPERBR-721)

Ethermint IAVL stores EVM storage under `prefix || address || keccak256(slot)`, but `verify_non_membership` fed the raw EVM slot from `receipts_state_trie_key` straight into `storage_key_for` — producing an IAVL key that never existed in the tree, so an ICS23 non-membership proof for it trivially verified even when the receipt was present. Apply the keccak256 inside the verifier just before `storage_key_for`, mirroring what `commitment_state_trie_key` already does on the membership path; the key-derivation interface is unchanged.

### 3. `[wrapped-hft]` ERC-20 fallback when native push fails (HYPERBR-822)

`onAccept` / `onPostRequestTimeout` always unwrapped WETH and pushed native ETH via `refundee.call{value: ...}`, reverting the whole delivery / timeout when the recipient could not receive native value — even though `send()` accepts WETH deposits from non-payable callers through `safeTransferFrom`, so the bridge would permanently lock funds for the same caller class the deposit path tolerated. On native-push failure, re-wrap the ETH and deliver the underlying WETH via `safeTransfer`. The native-ETH happy path is unchanged.

### 4. `[collator-manager]` require controller consent for stash binding (HYPERBR-975)

`register(controller)` and `set_controller(new_controller)` authenticated only the stash and silently wrote `Stash[controller] = stash`, letting any stash squat any unpaired controller address and (if the squatted account carried session keys + reputation) consume that reputation on the next selection cycle. Introduce a two-step approval: the controller calls `approve_controller(stash)`, which writes a single-use `ControllerApprovals[(stash, controller)]` consent; `register` / `set_controller` consume the matching approval and revert with `ControllerApprovalMissing` otherwise. `revoke_controller_approval` retracts pending consent. Existing pairings are unaffected.

### 5. `[consensus-incentives]` one reward per state machine per batch

When a batch contained multiple `StateMachineUpdated` events for the same `state_machine_id`, `on_executed` looped each event into `process_message`, which re-read the same persisted `(latest, previous)` height pair every call and paid the same block-span reward N times. Group events by `state_machine_id`, keep only the maximum `latest_height` per chain, and call `process_message` once per chain — the span calculation already captures the full advance, so one call per chain is the correct accounting.

### 6. `[docs/collator]` document two-step controller-approval flow

Split the collator-onboarding guide's Stage 3 into 3a (`approve_controller` from the Controller account) and 3b (`register` from the Stash account), add a "Rotating to a new Controller later" subsection noting the same requirement applies to `set_controller`, and call out `revoke_controller_approval`. Without this the new runtime behaviour would land a new collator in a `ControllerApprovalMissing` revert on `register`.