### PR TITLE
[runtime]: move allowed beefy proof type gating into ismp-beefy

### DIFF
--- a/modules/ismp/clients/beefy/src/consensus.rs
+++ b/modules/ismp/clients/beefy/src/consensus.rs
@@ -81,6 +81,9 @@ where
 				.map_err(|e| BeefyError::DecodeConsensusState(format!("{e:?}")))?;
 
 		let proof_type = proof.first().ok_or(BeefyError::EmptyProof)?;
+		if !C::allowed_proof_types().contains(proof_type) {
+			return Err(BeefyError::UnknownProofType(*proof_type).into());
+		}
 		let payload = &proof[1..];
 
 		let (new_state, verified_parachains) = match *proof_type {

--- a/modules/ismp/clients/beefy/src/lib.rs
+++ b/modules/ismp/clients/beefy/src/lib.rs
@@ -19,6 +19,7 @@ extern crate alloc;
 extern crate core;
 pub mod consensus;
 
+pub use beefy_verifier_primitives::{PROOF_TYPE_NAIVE, PROOF_TYPE_SP1};
 pub use consensus::{BEEFY_CONSENSUS_ID, BeefyConsensusClient};
 
 use polkadot_sdk::*;
@@ -46,4 +47,10 @@ pub trait BeefyClientConfig {
 
 	/// Returns the SP1 verification key hash.
 	fn sp1_vkey_hash() -> primitive_types::H256;
+
+	/// Allowed proof types. Controls which consensus proof formats this client will
+	/// accept. On mainnet set to `&[PROOF_TYPE_SP1]`, on testnets set to
+	/// `&[PROOF_TYPE_NAIVE, PROOF_TYPE_SP1]`. A proof whose type byte is not listed is
+	/// rejected with [`beefy_verifier::error::Error::UnknownProofType`] before verification.
+	fn allowed_proof_types() -> &'static [u8];
 }

--- a/modules/pallets/beefy-consensus-proofs/src/lib.rs
+++ b/modules/pallets/beefy-consensus-proofs/src/lib.rs
@@ -133,12 +133,6 @@ pub mod pallet {
 		#[pallet::constant]
 		type UnbondingPeriod: Get<u64>;
 
-		/// Allowed proof types. Controls which consensus proof formats the pallet
-		/// will accept. On mainnet set to `&[PROOF_TYPE_SP1]`, on testnets set to
-		/// `&[PROOF_TYPE_NAIVE, PROOF_TYPE_SP1]`.
-		#[pallet::constant]
-		type AllowedProofTypes: Get<&'static [u8]>;
-
 		/// Maximum number of uncle provers rewarded per parachain height, in addition to
 		/// the first prover. Total provers per height are therefore `MaxUncleProvers + 1`,
 		/// occupying positions `0..=MaxUncleProvers` (position 0 is always the first prover).
@@ -443,10 +437,11 @@ pub mod pallet {
 			// Size is enforced by the `BoundedVec<u8, T::MaxProofSize>` parameter on
 			// `submit_proof` — oversized payloads fail SCALE decoding inside the txpool
 			// and never reach this dispatch.
+			// The set of accepted proof types is gated by `ismp-beefy`'s
+			// `BeefyClientConfig::allowed_proof_types` during `verify_and_apply`; here we only
+			// need the type byte to drive canonical re-encoding. Unknown bytes still fall
+			// through to the `_ => UnknownProofType` arm of the match below.
 			let proof_type = *proof.first().ok_or(Error::<T>::UnknownProofType)?;
-			if !T::AllowedProofTypes::get().contains(&proof_type) {
-				Err(Error::<T>::UnknownProofType)?
-			}
 
 			// Decode the ABI payload then re-encode it canonically and hash *that* instead
 			// of the raw input. `alloy_sol_types::abi_decode_params` silently ignores

--- a/modules/pallets/testsuite/src/runtime.rs
+++ b/modules/pallets/testsuite/src/runtime.rs
@@ -438,6 +438,10 @@ impl ismp_beefy::BeefyClientConfig for Test {
 	fn sp1_vkey_hash() -> primitive_types::H256 {
 		Default::default()
 	}
+
+	fn allowed_proof_types() -> &'static [u8] {
+		&[ismp_beefy::PROOF_TYPE_NAIVE, ismp_beefy::PROOF_TYPE_SP1]
+	}
 }
 
 parameter_types! {

--- a/parachain/runtimes/gargantua/src/ismp.rs
+++ b/parachain/runtimes/gargantua/src/ismp.rs
@@ -237,6 +237,11 @@ impl ismp_beefy::BeefyClientConfig for Runtime {
 	fn sp1_vkey_hash() -> sp_core::H256 {
 		pallet_beefy_consensus_proofs::Sp1VkeyHash::<Runtime>::get()
 	}
+
+	fn allowed_proof_types() -> &'static [u8] {
+		// Testnet: accept both the naive ECDSA and SP1 ZK proof formats.
+		&[ismp_beefy::PROOF_TYPE_NAIVE, ismp_beefy::PROOF_TYPE_SP1]
+	}
 }
 
 /// True when the account is registered with `pallet-collator-selection` as

--- a/parachain/runtimes/gargantua/src/lib.rs
+++ b/parachain/runtimes/gargantua/src/lib.rs
@@ -778,13 +778,6 @@ parameter_types! {
 	pub const MaxBeefyUncleProvers: u32 = 5;
 }
 
-parameter_types! {
-	pub const AllowedBeefyProofTypes: &'static [u8] = &[
-		pallet_beefy_consensus_proofs::types::PROOF_TYPE_NAIVE,
-		pallet_beefy_consensus_proofs::types::PROOF_TYPE_SP1,
-	];
-}
-
 impl pallet_beefy_consensus_proofs::Config for Runtime {
 	type AdminOrigin = EnsureRoot<AccountId>;
 	type Currency = Balances;
@@ -793,7 +786,6 @@ impl pallet_beefy_consensus_proofs::Config for Runtime {
 	type MaxStoredProofs = MaxStoredBeefyProofs;
 	type ConsensusStateId = BeefyConsensusStateId;
 	type UnbondingPeriod = BeefyUnbondingPeriod;
-	type AllowedProofTypes = AllowedBeefyProofTypes;
 	type MaxUncleProvers = MaxBeefyUncleProvers;
 	type ReputationAsset = ReputationAsset;
 	type WeightInfo = weights::pallet_beefy_consensus_proofs::WeightInfo<Runtime>;

--- a/parachain/runtimes/nexus/src/ismp.rs
+++ b/parachain/runtimes/nexus/src/ismp.rs
@@ -210,6 +210,11 @@ impl ismp_beefy::BeefyClientConfig for Runtime {
 	fn sp1_vkey_hash() -> sp_core::H256 {
 		pallet_beefy_consensus_proofs::Sp1VkeyHash::<Runtime>::get()
 	}
+
+	fn allowed_proof_types() -> &'static [u8] {
+		// Mainnet: only accept SP1 ZK proofs.
+		&[ismp_beefy::PROOF_TYPE_SP1]
+	}
 }
 
 impl pallet_consensus_incentives::Config for Runtime {

--- a/parachain/runtimes/nexus/src/lib.rs
+++ b/parachain/runtimes/nexus/src/lib.rs
@@ -235,7 +235,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("nexus"),
 	impl_name: Cow::Borrowed("nexus"),
 	authoring_version: 1,
-	spec_version: 7_200,
+	spec_version: 7_300,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/parachain/runtimes/nexus/src/lib.rs
+++ b/parachain/runtimes/nexus/src/lib.rs
@@ -922,12 +922,6 @@ parameter_types! {
 	pub const MaxBeefyUncleProvers: u32 = 5;
 }
 
-parameter_types! {
-	pub const AllowedBeefyProofTypes: &'static [u8] = &[
-		pallet_beefy_consensus_proofs::types::PROOF_TYPE_SP1,
-	];
-}
-
 impl pallet_beefy_consensus_proofs::Config for Runtime {
 	type AdminOrigin = EnsureRoot<AccountId>;
 	type Currency = Balances;
@@ -936,7 +930,6 @@ impl pallet_beefy_consensus_proofs::Config for Runtime {
 	type MaxStoredProofs = MaxStoredBeefyProofs;
 	type ConsensusStateId = BeefyConsensusStateId;
 	type UnbondingPeriod = BeefyUnbondingPeriod;
-	type AllowedProofTypes = AllowedBeefyProofTypes;
 	type MaxUncleProvers = MaxBeefyUncleProvers;
 	type ReputationAsset = ReputationAsset;
 	type WeightInfo = weights::pallet_beefy_consensus_proofs::WeightInfo<Runtime>;


### PR DESCRIPTION
## What

Moves the "allowed proof types" gating for BEEFY consensus proofs out of `pallet-beefy-consensus-proofs` and into the `ismp-beefy` consensus client, where the proof-type dispatch already lives.

## Why

The pallet exposed an `AllowedProofTypes` config item and checked it in `submit_proof`, while `ismp-beefy`'s `BeefyConsensusClient::verify_consensus` independently dispatched on the proof-type byte and accepted every known type. Keeping the allow-list next to the verification logic puts the policy in one place and means any consumer of the consensus client (not just the pallet) is gated consistently.

## Changes

- `ismp-beefy`: add `allowed_proof_types() -> &'static [u8]` to the `BeefyClientConfig` trait and enforce it in `verify_consensus` (rejecting disallowed types with `UnknownProofType` before verification). Re-export `PROOF_TYPE_NAIVE` / `PROOF_TYPE_SP1` from `beefy-verifier-primitives`.
- `pallet-beefy-consensus-proofs`: remove the `AllowedProofTypes` config item and the upfront gating check in `do_submit_proof`. The pallet still rejects unknown type bytes via its canonical re-encoding match.
- Runtimes: implement `allowed_proof_types()` in each `BeefyClientConfig` impl — gargantua (testnet) allows `NAIVE` + `SP1`, nexus (mainnet) allows `SP1` only — and drop the now-unused `AllowedBeefyProofTypes` param and `type AllowedProofTypes` lines. Test runtime allows both.

Per-runtime behaviour is preserved. `cargo check` passes for `ismp-beefy`, `pallet-beefy-consensus-proofs`, `gargantua-runtime`, `nexus-runtime`, and `pallet-ismp-testsuite`.
