### PR TITLE
[tesseract]: refetch runtime version before each signed extrinsic

### DIFF
--- a/modules/utils/subxt/src/lib.rs
+++ b/modules/utils/subxt/src/lib.rs
@@ -114,6 +114,25 @@ pub mod signer {
 		}
 	}
 
+	/// Re-fetch the chain's current [`RuntimeVersion`] and refresh the client's cached copy.
+	///
+	/// `OnlineClient` caches the runtime version (spec & transaction version) at construction.
+	/// After a runtime upgrade that cache goes stale, so the `CheckSpecVersion` signed extension
+	/// signs over the wrong `spec_version` and the node rejects the extrinsic with a bad-proof
+	/// error. Calling this before every signed submission keeps signing in step with the node's
+	/// current runtime.
+	async fn refresh_runtime_version<T: subxt::Config>(
+		client: &OnlineClient<T>,
+	) -> Result<(), anyhow::Error> {
+		let runtime_version = client
+			.backend()
+			.current_runtime_version()
+			.await
+			.context("Failed to fetch current runtime version")?;
+		client.set_runtime_version(runtime_version);
+		Ok(())
+	}
+
 	pub async fn send_extrinsic<T: subxt::Config, Tx: Payload>(
 		client: &OnlineClient<T>,
 		signer: &InMemorySigner<T>,
@@ -126,6 +145,7 @@ pub mod signer {
 		T::Signature: From<MultiSignature> + Send + Sync,
 		<T::ExtrinsicParams as ExtrinsicParams<T>>::Params: Send + Sync + DefaultParams,
 	{
+		refresh_runtime_version(client).await?;
 		let params = DefaultParams::default_params();
 		let ext = client.tx().create_signed(payload, signer, params).await?;
 		let progress = ext.submit_and_watch().await.context("Failed to submit signed extrinsic")?;
@@ -154,6 +174,7 @@ pub mod signer {
 		T::AccountId: Into<T::Address> + Clone + 'static,
 		T::Signature: From<MultiSignature> + Send + Sync,
 	{
+		refresh_runtime_version(client).await?;
 		let params = DefaultExtrinsicParamsBuilder::<T>::new().nonce(nonce).build();
 		let mut partial = client.tx().create_partial_offline(payload, params)?;
 		let ext = partial.sign(signer);


### PR DESCRIPTION
## Problem

`subxt`'s `OnlineClient` caches the chain's `RuntimeVersion` (spec & transaction version) at construction. After a runtime upgrade that cache goes stale, so the `CheckSpecVersion`/`CheckTxVersion` signed extensions sign over the wrong `spec_version` and the node rejects the extrinsic with a bad-proof error — until the relayer is restarted.

## Change

Add `refresh_runtime_version`, which refetches the chain's current `RuntimeVersion` via `backend().current_runtime_version()` and applies it with `set_runtime_version()`. It runs before every signed submission, in both:

- `send_extrinsic` (before `create_signed`)
- `send_extrinsic_with_nonce` (before `create_partial_offline`)

## Scope

Only the runtime version is refreshed, not metadata. All production submissions use `subxt::dynamic::tx`, which resolves pallet/call indices against cached metadata — but Hyperbridge runtime upgrades do not change pallet or call indices, so the cached metadata stays valid and only the signed `spec_version` needs refreshing.