### PR TITLE
[runtime] Filter transfers of reputation token

### DIFF
--- a/modules/pallets/messaging-incentives/src/lib.rs
+++ b/modules/pallets/messaging-incentives/src/lib.rs
@@ -118,14 +118,20 @@ impl<T: Config> Pallet<T>
 where
 	T::AccountId: From<[u8; 32]>,
 {
-	/// Same minimum-byte rule as the bandwidth gate (`max(body, 32)`)
-	/// so undersized payloads can't game the mint by being charged 0.
+	/// Same minimum-byte rule as the bandwidth gate (`max(body, 32)`),
+	/// applied **per request** so packing requests into one envelope
+	/// vs. splitting them across many produces identical mints.
+	/// Applying the floor once per envelope would let a relayer inflate
+	/// the mint by splitting (each split picks up its own 32-byte floor).
 	fn message_bytes(message: &Message) -> u32 {
-		let raw = match message {
-			Message::Request(req) => req.requests.iter().map(|p| p.body.len()).sum::<usize>(),
+		match message {
+			Message::Request(req) => req
+				.requests
+				.iter()
+				.map(|p| core::cmp::max(p.body.len() as u32, 32))
+				.sum::<u32>(),
 			_ => 0,
-		};
-		core::cmp::max(raw as u32, 32)
+		}
 	}
 
 	/// Recover the relayer's account from the sr25519 signature on a

--- a/modules/pallets/testsuite/src/runtime.rs
+++ b/modules/pallets/testsuite/src/runtime.rs
@@ -203,7 +203,7 @@ parameter_types! {
 
 #[derive_impl(frame_system::config_preludes::ParaChainDefaultConfig as frame_system::DefaultConfig)]
 impl frame_system::Config for Test {
-	type BaseCallFilter = frame_support::traits::Everything;
+	type BaseCallFilter = ReputationCallFilter;
 	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeCall = RuntimeCall;
 	type Hash = H256;
@@ -322,6 +322,26 @@ parameter_types! {
 }
 pub type ReputationAsset =
 	frame_support::traits::tokens::fungible::ItemOf<Assets, ReputationAssetId, AccountId32>;
+
+/// Mirror of the runtime `ReputationCallFilter` — rejects user-facing
+/// `Assets` transfer extrinsics targeting the reputation asset so the
+/// mock exercises the same soulbound semantics as nexus/gargantua.
+pub struct ReputationCallFilter;
+impl frame_support::traits::Contains<RuntimeCall> for ReputationCallFilter {
+	fn contains(call: &RuntimeCall) -> bool {
+		let rep = ReputationAssetId::get();
+		match call {
+			RuntimeCall::Assets(
+				pallet_assets::Call::transfer { id, .. } |
+				pallet_assets::Call::transfer_keep_alive { id, .. } |
+				pallet_assets::Call::transfer_all { id, .. } |
+				pallet_assets::Call::approve_transfer { id, .. } |
+				pallet_assets::Call::transfer_approved { id, .. },
+			) => *id != rep,
+			_ => true,
+		}
+	}
+}
 
 sp_runtime::impl_opaque_keys! {
 	pub struct SessionKeys {

--- a/modules/pallets/testsuite/src/tests/pallet_messaging_incentives.rs
+++ b/modules/pallets/testsuite/src/tests/pallet_messaging_incentives.rs
@@ -5,7 +5,18 @@
 //! is set by governance and zero disables minting.
 
 use codec::Encode;
-use polkadot_sdk::{frame_support::traits::fungibles::Inspect, sp_runtime::Weight};
+use polkadot_sdk::{
+	frame_support::{
+		dispatch::GetDispatchInfo,
+		traits::{
+			fungible::Mutate as FungibleMutate,
+			fungibles::{Inspect, Mutate},
+			tokens::{Fortitude, Precision, Preservation},
+		},
+	},
+	frame_system, pallet_assets,
+	sp_runtime::{traits::Dispatchable, Weight},
+};
 use sp_core::{crypto::AccountId32, keccak_256, sr25519, ByteArray, Pair};
 
 use ismp::{
@@ -20,7 +31,8 @@ use pallet_messaging_incentives::MintPerByte;
 
 use crate::{
 	runtime::{
-		new_test_ext, Assets, MessagingRelayerIncentives, ReputationAssetId, RuntimeOrigin, Test,
+		new_test_ext, Assets, MessagingRelayerIncentives, ReputationAsset, ReputationAssetId,
+		RuntimeCall, RuntimeOrigin, Test, BOB,
 	},
 	tests::common::setup_relayer_and_asset,
 };
@@ -142,6 +154,137 @@ fn set_mint_per_byte_requires_admin_origin() {
 		MessagingRelayerIncentives::set_mint_per_byte(RuntimeOrigin::signed(alice), 5)
 			.expect_err("non-admin must be rejected");
 		assert_eq!(MintPerByte::<Test>::get(), 0);
+	});
+}
+
+/// Each `on_executed` call mints to the relayer; the soulbound semantics
+/// live in the runtime call filter, not in the mint path, so successive
+/// mints to the same account must accumulate normally.
+#[test]
+fn on_executed_mints_accumulate_across_deliveries() {
+	new_test_ext().execute_with(|| {
+		let relayer_pair = sr25519::Pair::from_seed(&[11u8; 32]);
+		let relayer_account = AccountId32::new(relayer_pair.public().0);
+		setup_relayer_and_asset(&relayer_account);
+
+		MessagingRelayerIncentives::set_mint_per_byte(RuntimeOrigin::root(), 1).unwrap();
+
+		let body = vec![0u8; 100];
+		MessagingRelayerIncentives::on_executed(
+			vec![signed_request(&relayer_pair, body.clone())],
+			vec![],
+		)
+		.unwrap();
+		assert_eq!(relayer_balance(&relayer_account), 100);
+
+		MessagingRelayerIncentives::on_executed(
+			vec![signed_request(&relayer_pair, body)],
+			vec![],
+		)
+		.unwrap();
+		assert_eq!(relayer_balance(&relayer_account), 200);
+	});
+}
+
+/// Reputation is burned by `pallet-collator-manager` on each session
+/// rotation to reset accumulated rewards. Soulbound enforcement lives at
+/// the dispatch layer (`ReputationCallFilter`) rather than at the asset
+/// layer, so programmatic `fungible::Mutate::burn_from` must keep working
+/// — otherwise the rotation reset would silently no-op and reputation
+/// would accumulate forever, breaking the per-session ranking.
+#[test]
+fn programmatic_burn_still_works_on_reputation_holder() {
+	new_test_ext().execute_with(|| {
+		let relayer_pair = sr25519::Pair::from_seed(&[12u8; 32]);
+		let relayer_account = AccountId32::new(relayer_pair.public().0);
+		setup_relayer_and_asset(&relayer_account);
+
+		MessagingRelayerIncentives::set_mint_per_byte(RuntimeOrigin::root(), 1).unwrap();
+		MessagingRelayerIncentives::on_executed(
+			vec![signed_request(&relayer_pair, vec![0u8; 200])],
+			vec![],
+		)
+		.unwrap();
+		assert_eq!(relayer_balance(&relayer_account), 200);
+
+		// Mirrors `pallet-collator-manager::new_session` — burn the full
+		// balance to reset reputation across sessions.
+		ReputationAsset::burn_from(
+			&relayer_account,
+			200,
+			Preservation::Expendable,
+			Precision::Exact,
+			Fortitude::Polite,
+		)
+		.expect("programmatic burn must succeed on a reputation holder");
+
+		assert_eq!(relayer_balance(&relayer_account), 0);
+	});
+}
+
+/// The whole point of the soulbound treatment: a relayer that earned
+/// reputation cannot dispatch a transfer of it to another account. The
+/// rejection must come from the runtime call filter (so an unsigned
+/// holder-driven dispatch fails); we verify that by routing through
+/// `RuntimeCall::dispatch`, which is what production extrinsics use.
+#[test]
+fn dispatched_transfer_of_reputation_is_filtered() {
+	new_test_ext().execute_with(|| {
+		let relayer_pair = sr25519::Pair::from_seed(&[13u8; 32]);
+		let relayer_account = AccountId32::new(relayer_pair.public().0);
+		setup_relayer_and_asset(&relayer_account);
+
+		MessagingRelayerIncentives::set_mint_per_byte(RuntimeOrigin::root(), 1).unwrap();
+		MessagingRelayerIncentives::on_executed(
+			vec![signed_request(&relayer_pair, vec![0u8; 100])],
+			vec![],
+		)
+		.unwrap();
+		assert_eq!(relayer_balance(&relayer_account), 100);
+
+		let call = RuntimeCall::Assets(pallet_assets::Call::transfer {
+			id: ReputationAssetId::get(),
+			target: BOB.clone().into(),
+			amount: 50,
+		});
+		// Bring `weigh_data` into scope so we exercise the same dispatch path
+		// the runtime uses; assert the filter rejects rather than the inner call.
+		let _ = call.get_dispatch_info();
+		let err = call
+			.dispatch(RuntimeOrigin::signed(relayer_account.clone()))
+			.expect_err("reputation transfer must be filtered");
+		assert_eq!(err.error, frame_system::Error::<Test>::CallFiltered.into());
+
+		assert_eq!(relayer_balance(&relayer_account), 100);
+		assert_eq!(relayer_balance(&BOB), 0);
+	});
+}
+
+/// A non-reputation asset must NOT be filtered — the call filter only
+/// targets the reputation asset id.
+#[test]
+fn dispatched_transfer_of_other_asset_not_filtered() {
+	new_test_ext().execute_with(|| {
+		use polkadot_sdk::frame_support::assert_ok;
+
+		let other_asset = sp_core::H256::repeat_byte(0x42);
+		assert_ok!(Assets::force_create(
+			RuntimeOrigin::root(),
+			other_asset,
+			crate::runtime::ALICE,
+			true,
+			1,
+		));
+		Assets::set_balance(other_asset, &crate::runtime::ALICE, 1_000);
+
+		let call = RuntimeCall::Assets(pallet_assets::Call::transfer {
+			id: other_asset,
+			target: BOB.clone().into(),
+			amount: 100,
+		});
+		call.dispatch(RuntimeOrigin::signed(crate::runtime::ALICE))
+			.expect("non-reputation asset transfer must pass the filter");
+		assert_eq!(Assets::balance(other_asset, &BOB), 100);
 	});
 }
 

--- a/parachain/runtimes/gargantua/src/lib.rs
+++ b/parachain/runtimes/gargantua/src/lib.rs
@@ -377,7 +377,7 @@ impl frame_system::Config for Runtime {
 	/// The weight of database operations that the runtime can invoke.
 	type DbWeight = RocksDbWeight;
 	/// The basic call filter to use in dispatchable.
-	type BaseCallFilter = InsideBoth<Everything, TxPause>;
+	type BaseCallFilter = InsideBoth<ReputationCallFilter, InsideBoth<Everything, TxPause>>;
 	/// Weight information for the extrinsics of this pallet.
 	type SystemWeightInfo = weights::frame_system::WeightInfo<Runtime>;
 	/// Block & extrinsics weights: base values and limits.
@@ -761,6 +761,30 @@ pub type ReputationAsset =
 
 parameter_types! {
 	pub const ReputationAssetId: H256 = H256([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1]);
+}
+
+/// Reputation tokens are soulbound — credited via the incentive pallets
+/// and consumed only by `pallet-collator-manager`'s per-session reset.
+/// The holder must not be able to send them anywhere, so this filter
+/// rejects every dispatched `Assets` call that could move balance out
+/// of a holder's account when the target asset is the reputation asset.
+/// Programmatic `fungible::Mutate` (mint / burn from runtime pallets)
+/// bypasses dispatch and is therefore unaffected.
+pub struct ReputationCallFilter;
+impl frame_support::traits::Contains<RuntimeCall> for ReputationCallFilter {
+	fn contains(call: &RuntimeCall) -> bool {
+		let rep = ReputationAssetId::get();
+		match call {
+			RuntimeCall::Assets(
+				pallet_assets::Call::transfer { id, .. } |
+				pallet_assets::Call::transfer_keep_alive { id, .. } |
+				pallet_assets::Call::transfer_all { id, .. } |
+				pallet_assets::Call::approve_transfer { id, .. } |
+				pallet_assets::Call::transfer_approved { id, .. },
+			) => *id != rep,
+			_ => true,
+		}
+	}
 }
 
 parameter_types! {

--- a/parachain/runtimes/nexus/src/lib.rs
+++ b/parachain/runtimes/nexus/src/lib.rs
@@ -69,7 +69,7 @@ use frame_support::{
 	dispatch::DispatchClass,
 	genesis_builder_helper::{build_state, get_preset},
 	parameter_types,
-	traits::{ConstU32, ConstU64, ConstU8, InstanceFilter},
+	traits::{ConstU32, ConstU64, ConstU8, Contains, InsideBoth, InstanceFilter},
 	weights::{
 		constants::WEIGHT_REF_TIME_PER_SECOND, ConstantMultiplier, Weight, WeightToFeeCoefficient,
 		WeightToFeeCoefficients, WeightToFeePolynomial,
@@ -382,7 +382,7 @@ impl frame_system::Config for Runtime {
 	/// The weight of database operations that the runtime can invoke.
 	type DbWeight = RocksDbWeight;
 	/// The basic call filter to use in dispatchable.
-	type BaseCallFilter = TxPause;
+	type BaseCallFilter = InsideBoth<ReputationCallFilter, TxPause>;
 	/// Weight information for the extrinsics of this pallet.
 	type SystemWeightInfo = weights::frame_system::WeightInfo<Runtime>;
 	/// Block & extrinsics weights: base values and limits.
@@ -700,6 +700,36 @@ pub type ReputationAsset =
 
 parameter_types! {
 	pub const ReputationAssetId: H256 = H256([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1]);
+}
+
+/// Reputation tokens are soulbound — credited via the incentive pallets
+/// and consumed only by `pallet-collator-manager`'s per-session reset.
+/// The holder must not be able to send them anywhere, so this filter
+/// rejects every dispatched `Assets` call that could move balance out
+/// of a holder's account when the target asset is the reputation asset.
+/// Programmatic `fungible::Mutate` (mint / burn from runtime pallets)
+/// bypasses dispatch and is therefore unaffected.
+///
+/// `force_transfer` is left allowed because it already requires the
+/// asset's admin origin (privileged escape hatch). `cancel_approval` is
+/// allowed because `approve_transfer` is blocked, so there shouldn't be
+/// any approvals to cancel; if one slips through, letting the holder
+/// undo it is strictly safer.
+pub struct ReputationCallFilter;
+impl Contains<RuntimeCall> for ReputationCallFilter {
+	fn contains(call: &RuntimeCall) -> bool {
+		let rep = ReputationAssetId::get();
+		match call {
+			RuntimeCall::Assets(
+				pallet_assets::Call::transfer { id, .. } |
+				pallet_assets::Call::transfer_keep_alive { id, .. } |
+				pallet_assets::Call::transfer_all { id, .. } |
+				pallet_assets::Call::approve_transfer { id, .. } |
+				pallet_assets::Call::transfer_approved { id, .. },
+			) => *id != rep,
+			_ => true,
+		}
+	}
 }
 
 /// A way to pay from treasury


### PR DESCRIPTION
## Why a runtime call filter, not a per-account asset freeze

We want reputation to be **non-transferable for the holder** but **fully usable by the runtime** — minted by the incentive pallets, and burned each session by `pallet-collator-manager::new_session` to reset the per-session ranking.

The obvious-looking option, `pallet_assets`'s per-account freeze (`AccountStatus::Frozen` set on the holder's `AssetAccount`), doesn't fit. In `pallet_assets`, every balance-decreasing path — `transfer*`, `burn_from`, anything that flows through `decrease_balance` — gates on the same `can_decrease` check that rejects frozen accounts. `Fortitude::Force` is ignored, and there's no privileged "burn anyway" entry point. So a per-account freeze would also block `pallet-collator-manager`'s session-reset burn. That burn's return value is only inspected with `if result.is_ok()`, so it would fail silently and reputation would accumulate across sessions instead of resetting — the opposite of the intended ranking semantics.

The fix lives at the dispatch layer instead. `ReputationCallFilter` is a `Contains<RuntimeCall>` that rejects the user-facing `Assets` extrinsics — `transfer`, `transfer_keep_alive`, `transfer_all`, `approve_transfer`, `transfer_approved` — when the target asset id is `ReputationAssetId`. It's wired into `frame_system::Config::BaseCallFilter` via `InsideBoth` so it composes with the existing `TxPause` filter without replacing it.

Two properties fall out of putting the check at dispatch:

- **Holders can't move the token.** Any signed extrinsic carrying one of the filtered `Assets` variants is short-circuited with `frame_system::Error::CallFiltered` before `do_transfer` runs. The four soulbound-relevant invariants are pinned by tests in the testsuite.
- **Runtime code is untouched.** `fungible::Mutate::mint_into` (incentives pallets) and `fungible::Mutate::burn_from` (collator-manager session reset) call into `pallet_assets` directly — they don't go through `RuntimeCall::dispatch`, so they bypass the filter and keep working exactly as before. No new error variants, no `if is_frozen` dance at every mint site, no coupling between unrelated pallets and the soulbound policy.

`force_transfer` is intentionally left allowed: it already requires the asset's admin (`ForceOrigin`) signed origin, which is a privileged escape hatch we don't want to take away.