### PR TITLE
fix: publish workflow

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -1,122 +1,122 @@
 name: "Publish @hyperbridge/sdk"
 
 on:
-    push:
-        tags:
-            - "sdk-v*"
+  push:
+    tags:
+      - "sdk-v*"
 
 jobs:
-    build-and-publish:
-        runs-on: ubuntu-latest
-        defaults:
-            run:
-                working-directory: sdk
-        permissions:
-            contents: write
-            packages: write
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v4
-              with:
-                  fetch-depth: 0
+  build-and-publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: "22"
-                  registry-url: "https://registry.npmjs.org"
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
 
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v2
-              with:
-                  version: "7"
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: "latest"
 
-            - name: Install dependencies
-              run: pnpm install
+      - name: Install dependencies
+        run: pnpm install
 
-            - name: Build dependencies
-              run: pnpm --filter="@hyperbridge/sdk^..." build
+      - name: Build dependencies
+        run: pnpm --filter="@hyperbridge/sdk^..." build
 
-            - name: Build SDK
-              run: pnpm --filter="@hyperbridge/sdk" build
+      - name: Build SDK
+        run: pnpm --filter="@hyperbridge/sdk" build
 
-            - name: Publish to npm
-              run: |
-                  echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
-                  pnpm --filter="@hyperbridge/sdk" publish --no-git-checks
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to npm
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
+          pnpm --filter="@hyperbridge/sdk" publish --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-    generate-changelog:
-        runs-on: ubuntu-latest
-        needs: build-and-publish
-        defaults:
-            run:
-                working-directory: sdk
-        permissions:
-            contents: write
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v4
-              with:
-                  fetch-depth: 0
+  generate-changelog:
+    runs-on: ubuntu-latest
+    needs: build-and-publish
+    defaults:
+      run:
+        working-directory: sdk
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-            - name: Get previous tag
-              id: previous-tag
-              run: |
-                  CURRENT_TAG=${GITHUB_REF#refs/tags/}
-                  PREVIOUS_TAG=$(git tag -l "sdk-v*" --sort=-version:refname | grep -v "^${CURRENT_TAG}$" | head -n1)
-                  CLEAN_TAG=${CURRENT_TAG#sdk-}
-                  echo "previous_tag=${PREVIOUS_TAG}" >> $GITHUB_OUTPUT
-                  echo "current_tag=${CURRENT_TAG}" >> $GITHUB_OUTPUT
-                  echo "clean_tag=${CLEAN_TAG}" >> $GITHUB_OUTPUT
+      - name: Get previous tag
+        id: previous-tag
+        run: |
+          CURRENT_TAG=${GITHUB_REF#refs/tags/}
+          PREVIOUS_TAG=$(git tag -l "sdk-v*" --sort=-version:refname | grep -v "^${CURRENT_TAG}$" | head -n1)
+          CLEAN_TAG=${CURRENT_TAG#sdk-}
+          echo "previous_tag=${PREVIOUS_TAG}" >> $GITHUB_OUTPUT
+          echo "current_tag=${CURRENT_TAG}" >> $GITHUB_OUTPUT
+          echo "clean_tag=${CLEAN_TAG}" >> $GITHUB_OUTPUT
 
-            - name: Generate changelog
-              id: changelog
-              run: |
-                  CURRENT_TAG=${{ steps.previous-tag.outputs.current_tag }}
-                  PREVIOUS_TAG=${{ steps.previous-tag.outputs.previous_tag }}
-                  CLEAN_TAG=${{ steps.previous-tag.outputs.clean_tag }}
+      - name: Generate changelog
+        id: changelog
+        run: |
+          CURRENT_TAG=${{ steps.previous-tag.outputs.current_tag }}
+          PREVIOUS_TAG=${{ steps.previous-tag.outputs.previous_tag }}
+          CLEAN_TAG=${{ steps.previous-tag.outputs.clean_tag }}
 
-                  echo "Generating changelog for ${CLEAN_TAG}"
-                  echo "Previous tag: ${PREVIOUS_TAG}"
+          echo "Generating changelog for ${CLEAN_TAG}"
+          echo "Previous tag: ${PREVIOUS_TAG}"
 
-                  if [ -z "$PREVIOUS_TAG" ]; then
-                    COMMIT_RANGE="HEAD"
-                  else
-                    COMMIT_RANGE="${PREVIOUS_TAG}..${CURRENT_TAG}"
-                  fi
+          if [ -z "$PREVIOUS_TAG" ]; then
+            COMMIT_RANGE="HEAD"
+          else
+            COMMIT_RANGE="${PREVIOUS_TAG}..${CURRENT_TAG}"
+          fi
 
-                  CHANGELOG=$(git log --pretty=format:"* %s (%h)" $COMMIT_RANGE --reverse | grep -i "sdk")
+          CHANGELOG=$(git log --pretty=format:"* %s (%h)" $COMMIT_RANGE --reverse | grep -i "sdk")
 
-                  echo "# Changelog for ${CLEAN_TAG}" > CHANGELOG.md
-                  echo "" >> CHANGELOG.md
-                  echo "## Changes" >> CHANGELOG.md
-                  echo "" >> CHANGELOG.md
-                  echo "$CHANGELOG" >> CHANGELOG.md
-                  echo "" >> CHANGELOG.md
+          echo "# Changelog for ${CLEAN_TAG}" > CHANGELOG.md
+          echo "" >> CHANGELOG.md
+          echo "## Changes" >> CHANGELOG.md
+          echo "" >> CHANGELOG.md
+          echo "$CHANGELOG" >> CHANGELOG.md
+          echo "" >> CHANGELOG.md
 
-                  echo "changelog<<EOF" >> $GITHUB_OUTPUT
-                  echo "## What's Changed" >> $GITHUB_OUTPUT
-                  echo "" >> $GITHUB_OUTPUT
-                  echo "$CHANGELOG" >> $GITHUB_OUTPUT
-                  echo "EOF" >> $GITHUB_OUTPUT
+          echo "changelog<<EOF" >> $GITHUB_OUTPUT
+          echo "## What's Changed" >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+          echo "$CHANGELOG" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
-            - name: Create GitHub Release
-              uses: actions/create-release@v1
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              with:
-                  tag_name: ${{ steps.previous-tag.outputs.current_tag }}
-                  release_name: "@hyperbridge/sdk ${{ steps.previous-tag.outputs.clean_tag }}"
-                  body: ${{ steps.changelog.outputs.changelog }}
-                  draft: false
-                  prerelease: false
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.previous-tag.outputs.current_tag }}
+          release_name: "@hyperbridge/sdk ${{ steps.previous-tag.outputs.clean_tag }}"
+          body: ${{ steps.changelog.outputs.changelog }}
+          draft: false
+          prerelease: false
 
-            - name: Commit and push changelog
-              run: |
-                  git config --local user.email "action@github.com"
-                  git config --local user.name "GitHub Action"
-                  git add CHANGELOG.md
-                  git commit -m "docs: update changelog for ${{ steps.previous-tag.outputs.current_tag }}" || exit 0
-                  git push origin HEAD:main || true
+      - name: Commit and push changelog
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add CHANGELOG.md
+          git commit -m "docs: update changelog for ${{ steps.previous-tag.outputs.current_tag }}" || exit 0
+          git push origin HEAD:main || true


### PR DESCRIPTION
## Fix pnpm engine version in SDK publish workflow

### Problem
The `Publish @hyperbridge/sdk` workflow was failing during `pnpm install` because the `Setup pnpm` step was pinned to version `7`, but `sdk/package.json` specifies `engines.pnpm: >=11`.

```
ERR_PNPM_UNSUPPORTED_ENGINE: Your pnpm version is incompatible with the SDK.
Expected version: >=11 — Got: 7.33.7
```

### Fix
Updated the pnpm version in the `Setup pnpm` step from `"7"` to `"latest"` in the `build-and-publish` job.

### Changes
- `.github/workflows/publish-sdk.yml` — bumped `pnpm/action-setup` version from `7` to `latest`