### PR TITLE
[tesseract]: Default the uniswap pricing to zero on revert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28033,7 +28033,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tesseract"
-version = "2.0.1"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/tesseract/messaging/evm/src/gas_oracle.rs
+++ b/tesseract/messaging/evm/src/gas_oracle.rs
@@ -151,7 +151,15 @@ pub async fn get_current_gas_cost_in_usd(
 		},
 		chain => Err(anyhow!("Unknown chain: {chain:?}"))?,
 	}
-	let token_usd = get_price_from_uniswap_router(ismp_host_address, client).await?;
+	// A reverting Uniswap pool (e.g. ds-math-sub-underflow on chains whose
+	// wrapper has thin liquidity, or a `WETH()` call that returns no data on
+	// chains without a canonical WETH on this router) should not poison gas
+	// estimation. Fee profitability calculations downstream see a zero USD
+	// price for native gas in that case, which is fine for delivery — the
+	// raw `gas_price` we just fetched from the node still flows through to
+	// the actual transaction submission.
+	let token_usd =
+		get_price_from_uniswap_router(ismp_host_address, client).await.unwrap_or_default();
 
 	let unit_wei = get_cost_of_one_wei(token_usd);
 	let gas_price_cost = convert_27_decimals_to_18_decimals(unit_wei * gas_price)?;

--- a/tesseract/relayer/Cargo.toml
+++ b/tesseract/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tesseract"
-version = "2.0.1"
+version = "2.1.0"
 edition = "2021"
 description = "Consolidated Hyperbridge relayer — inbound and outbound consensus + messaging"
 authors = ["Polytope Labs <hello@polytope.technology>"]


### PR DESCRIPTION
Some chains route the gas-oracle's USD-conversion path through Uniswap wrappers whose pools occasionally revert (ds-math-sub-underflow on thin liquidity, missing WETH() on Gnosis-style routers, etc.). Bubbling those errors out of `get_current_gas_cost_in_usd` blocks delivery on otherwise-healthy chains. The raw `gas_price` we read directly from the node is still correct — only the downstream profitability comparison loses precision when `token_usd` is zero, which fails open rather than blocking submission.