### PR TITLE
[indexer]: Drain PendingStatusMetadata via Hyperbridge block handler

### DIFF
--- a/sdk/packages/indexer/scripts/templates/substrate-chain.yaml.hbs
+++ b/sdk/packages/indexer/scripts/templates/substrate-chain.yaml.hbs
@@ -71,6 +71,8 @@ dataSources:
           kind: substrate/BlockHandler
           filter:
             modulo: 3600 # Indexings 1 block every 6 hours (6 seconds per block indexing).
+        - handler: handlePendingStatusFlush
+          kind: substrate/BlockHandler
 {{/if}}
 {{#if enablePriceIndexing}}
         - handler: handlePriceIndexing

--- a/sdk/packages/indexer/src/handlers/events/pendingStatus/handlePendingStatusFlush.event.handler.ts
+++ b/sdk/packages/indexer/src/handlers/events/pendingStatus/handlePendingStatusFlush.event.handler.ts
@@ -1,0 +1,21 @@
+import { SubstrateBlock } from "@subql/types"
+import { PendingStatusService } from "@/services/pendingStatus.service"
+import { wrap } from "@/utils/event.utils"
+
+const FLUSH_LIMIT = 10
+
+/**
+ * On each newly indexed Hyperbridge block, attempt to flush up to
+ * FLUSH_LIMIT pending status rows whose parent entity now exists. Picks up
+ * any rows the per-request `flushPendingStatuses(commitment)` calls missed
+ * (e.g. when the status event was indexed after the request was created on
+ * another chain, or when a chain reorg dropped the original flush).
+ */
+export const handlePendingStatusFlush = wrap(async (_event: SubstrateBlock): Promise<void> => {
+	try {
+		await PendingStatusService.flushBatch(FLUSH_LIMIT)
+	} catch (error) {
+		// @ts-ignore
+		logger.error(`[handlePendingStatusFlush] failed ${error.message}`)
+	}
+})

--- a/sdk/packages/indexer/src/mappings/mappingHandlers.ts
+++ b/sdk/packages/indexer/src/mappings/mappingHandlers.ts
@@ -32,6 +32,9 @@ export { handleSubstrateGetRequestTimeoutHandledEvent } from "@/handlers/events/
 export { handlePriceIndexing } from "@/handlers/events/price/handlePriceIndexing.event.handler"
 export { handleBridgeTokenSupplyIndexing } from "@/handlers/events/supply/handleBridgeTokenSupplyIndexing.event.handler"
 
+// Pending Status Flush Handler
+export { handlePendingStatusFlush } from "@/handlers/events/pendingStatus/handlePendingStatusFlush.event.handler"
+
 export { handleRelayerRewardedEvent } from "@/handlers/events/incentives/relayerRewarded.event.handler"
 export { handleFeeRewardedEvent } from "@/handlers/events/incentives/feeRewarded.event.handler"
 

--- a/sdk/packages/indexer/src/services/pendingStatus.service.ts
+++ b/sdk/packages/indexer/src/services/pendingStatus.service.ts
@@ -1,0 +1,116 @@
+import {
+	GetRequestStatusMetadata,
+	GetRequestV2,
+	OrderStatus,
+	PendingStatusMetadata,
+	RequestStatusMetadata,
+	RequestV2,
+	Status,
+} from "@/configs/src/types"
+import { IOrderV3 } from "@/configs/src/types/models/IOrderV3"
+import { IOrderV3StatusMetadata } from "@/configs/src/types/models/IOrderV3StatusMetadata"
+
+// Entity types we know how to materialize a real *StatusMetadata for.
+// Must match the `ENTITY_TYPE` constants in the per-service handlers that
+// write PendingStatusMetadata rows.
+const ENTITY_TYPES = ["RequestV2", "GetRequestV2", "IOrderV3"] as const
+type KnownEntityType = (typeof ENTITY_TYPES)[number]
+
+export class PendingStatusService {
+	/**
+	 * Scan a small batch of pending status rows across the known entity types
+	 * and materialize the real *StatusMetadata for any whose parent now exists,
+	 * deleting the pending row. Rows whose parent is still missing are left
+	 * untouched for a future tick.
+	 *
+	 * `limit` caps the total rows examined per call, distributed across the
+	 * entity types so a backlog on one type cannot starve the others. We
+	 * cannot order by `createdAt` because that column isn't indexed on the
+	 * existing table; rows we successfully flush are deleted, so even with
+	 * arbitrary ordering the queue drains over successive blocks.
+	 */
+	static async flushBatch(limit: number): Promise<void> {
+		const perType = Math.max(1, Math.ceil(limit / ENTITY_TYPES.length))
+
+		for (const entityType of ENTITY_TYPES) {
+			const batch = await PendingStatusMetadata.getByEntityType(entityType, {
+				limit: perType,
+			})
+
+			for (const pending of batch) {
+				await this.materialize(pending, entityType)
+			}
+		}
+	}
+
+	private static async materialize(
+		pending: PendingStatusMetadata,
+		entityType: KnownEntityType,
+	): Promise<void> {
+		switch (entityType) {
+			case "RequestV2": {
+				const parent = await RequestV2.get(pending.commitment)
+				if (!parent) return
+				const statusMetadata = RequestStatusMetadata.create({
+					id: `${pending.commitment}.${pending.status}`,
+					requestId: pending.commitment,
+					status: pending.status as Status,
+					chain: pending.chain,
+					timestamp: pending.timestamp,
+					blockNumber: pending.blockNumber,
+					blockHash: pending.blockHash,
+					transactionHash: pending.transactionHash,
+					createdAt: pending.createdAt,
+				})
+				await statusMetadata.save()
+				await PendingStatusMetadata.remove(pending.id)
+				logger.info(
+					`[PendingStatusService] Flushed RequestV2 ${pending.commitment} status ${pending.status}`,
+				)
+				return
+			}
+			case "GetRequestV2": {
+				const parent = await GetRequestV2.get(pending.commitment)
+				if (!parent) return
+				const statusMetadata = GetRequestStatusMetadata.create({
+					id: `${pending.commitment}.${pending.status}`,
+					requestId: pending.commitment,
+					status: pending.status as Status,
+					chain: pending.chain,
+					timestamp: pending.timestamp,
+					blockNumber: pending.blockNumber,
+					blockHash: pending.blockHash,
+					transactionHash: pending.transactionHash,
+					createdAt: pending.createdAt,
+				})
+				await statusMetadata.save()
+				await PendingStatusMetadata.remove(pending.id)
+				logger.info(
+					`[PendingStatusService] Flushed GetRequestV2 ${pending.commitment} status ${pending.status}`,
+				)
+				return
+			}
+			case "IOrderV3": {
+				const parent = await IOrderV3.get(pending.commitment)
+				if (!parent) return
+				const statusMetadata = IOrderV3StatusMetadata.create({
+					id: `${pending.commitment}.${pending.status}`,
+					orderId: pending.commitment,
+					status: pending.status as OrderStatus,
+					chain: pending.chain,
+					timestamp: pending.timestamp,
+					blockNumber: pending.blockNumber,
+					filler: pending.filler,
+					transactionHash: pending.transactionHash,
+					createdAt: pending.createdAt,
+				})
+				await statusMetadata.save()
+				await PendingStatusMetadata.remove(pending.id)
+				logger.info(
+					`[PendingStatusService] Flushed IOrderV3 ${pending.commitment} status ${pending.status}`,
+				)
+				return
+			}
+		}
+	}
+}


### PR DESCRIPTION
Per-service flushPendingStatuses(commitment) only fires inside the createOrUpdate "create" branch, so any pending row written after its parent (re-org replay, idempotent re-index, cross-chain race) sticks in the table forever. Add a substrate/BlockHandler that runs on every Hyperbridge block and tries to materialize up to FLUSH_LIMIT pending rows whose parent now exists. Budget is split across the three known entity types (RequestV2, GetRequestV2, IOrderV3) so a backlog on one type cannot starve the others.