### PR TITLE
[indexer]: drain PendingStatusMetadata on every chain instance

### DIFF
--- a/sdk/packages/indexer/scripts/templates/evm-chain.yaml.hbs
+++ b/sdk/packages/indexer/scripts/templates/evm-chain.yaml.hbs
@@ -79,6 +79,15 @@ dataSources:
             topics:
               - 'DustSwept(address,uint256,address)'
   {{/if}}
+  - kind: ethereum/Runtime
+    startBlock: {{blockNumber}}
+    mapping:
+      file: ./dist/index.js
+      handlers:
+        - handler: handlePendingStatusFlushEvm
+          kind: ethereum/BlockHandler
+          filter:
+            modulo: 50 # Each chain instance flushes its own pending writes — historical filter hides cross-chain rows.
   # - kind: ethereum/Runtime
   #   startBlock: {{blockNumber}}
   #   options:

--- a/sdk/packages/indexer/scripts/templates/substrate-chain.yaml.hbs
+++ b/sdk/packages/indexer/scripts/templates/substrate-chain.yaml.hbs
@@ -71,10 +71,6 @@ dataSources:
           kind: substrate/BlockHandler
           filter:
             modulo: 3600 # Indexings 1 block every 6 hours (6 seconds per block indexing).
-        - handler: handlePendingStatusFlush
-          kind: substrate/BlockHandler
-          filter:
-            modulo: 10 # Run pending-status flush every 10 blocks (~1 minute on a 6s chain).
 {{/if}}
 {{#if enablePriceIndexing}}
         - handler: handlePriceIndexing
@@ -82,5 +78,9 @@ dataSources:
           filter:
             modulo: 10 # Indexings 1 block every minute (6 seconds per block indexing).
 {{/if}}
+        - handler: handlePendingStatusFlush
+          kind: substrate/BlockHandler
+          filter:
+            modulo: 10 # Each chain instance flushes its own pending writes — historical filter hides cross-chain rows.
 
 repository: 'https://github.com/polytope-labs/hyperbridge'

--- a/sdk/packages/indexer/scripts/templates/substrate-chain.yaml.hbs
+++ b/sdk/packages/indexer/scripts/templates/substrate-chain.yaml.hbs
@@ -73,6 +73,8 @@ dataSources:
             modulo: 3600 # Indexings 1 block every 6 hours (6 seconds per block indexing).
         - handler: handlePendingStatusFlush
           kind: substrate/BlockHandler
+          filter:
+            modulo: 10 # Run pending-status flush every 10 blocks (~1 minute on a 6s chain).
 {{/if}}
 {{#if enablePriceIndexing}}
         - handler: handlePriceIndexing

--- a/sdk/packages/indexer/src/configs/config-mainnet.json
+++ b/sdk/packages/indexer/src/configs/config-mainnet.json
@@ -137,8 +137,9 @@
 	"polkadot-hub-mainnet": {
 		"type": "evm",
 		"chainId": "420420419",
-		"startBlock": 16215883,
+		"startBlock": 16215884,
 		"stateMachineId": "EVM-420420419",
+		"unfinalizedBlocks": false,
 		"contracts": {
 			"ethereumHost": "0x620128E2B19193d6Bd244a3AC8D3bBa0541B19c3",
 			"handlerV1": "0x2a18AB35DEa43474882E05A661e2F20fe89c0535",

--- a/sdk/packages/indexer/src/handlers/events/pendingStatus/handlePendingStatusFlush.event.handler.ts
+++ b/sdk/packages/indexer/src/handlers/events/pendingStatus/handlePendingStatusFlush.event.handler.ts
@@ -15,13 +15,17 @@ export const handlePendingStatusFlush = wrap(async (event: SubstrateBlock): Prom
 	const blockNumber = event.block.header.number.toString()
 	const blockHash = event.block.header.hash.toHex()
 	logger.info(
-		`[handlePendingStatusFlush] entered at block #${blockNumber} (${blockHash}), limit=${FLUSH_LIMIT}`,
+		`[handlePendingStatusFlush] chain=${chainId} entered at block #${blockNumber} (${blockHash}), limit=${FLUSH_LIMIT}`,
 	)
 	try {
 		await PendingStatusService.flushBatch(FLUSH_LIMIT)
-		logger.info(`[handlePendingStatusFlush] completed for block #${blockNumber}`)
+		logger.info(
+			`[handlePendingStatusFlush] chain=${chainId} completed for block #${blockNumber}`,
+		)
 	} catch (error) {
 		// @ts-ignore
-		logger.error(`[handlePendingStatusFlush] failed at block #${blockNumber}: ${error.message}`)
+		logger.error(
+			`[handlePendingStatusFlush] chain=${chainId} failed at block #${blockNumber}: ${error.message}`,
+		)
 	}
 })

--- a/sdk/packages/indexer/src/handlers/events/pendingStatus/handlePendingStatusFlush.event.handler.ts
+++ b/sdk/packages/indexer/src/handlers/events/pendingStatus/handlePendingStatusFlush.event.handler.ts
@@ -12,20 +12,12 @@ const FLUSH_LIMIT = 10
  * another chain, or when a chain reorg dropped the original flush).
  */
 export const handlePendingStatusFlush = wrap(async (event: SubstrateBlock): Promise<void> => {
-	const blockNumber = event.block.header.number.toString()
-	const blockHash = event.block.header.hash.toHex()
-	logger.info(
-		`[handlePendingStatusFlush] chain=${chainId} entered at block #${blockNumber} (${blockHash}), limit=${FLUSH_LIMIT}`,
-	)
 	try {
 		await PendingStatusService.flushBatch(FLUSH_LIMIT)
-		logger.info(
-			`[handlePendingStatusFlush] chain=${chainId} completed for block #${blockNumber}`,
-		)
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error)
 		logger.error(
-			`[handlePendingStatusFlush] chain=${chainId} failed at block #${blockNumber}: ${message}`,
+			`[handlePendingStatusFlush] chain=${chainId} failed at block #${event.block.header.number}: ${message}`,
 		)
 	}
 })

--- a/sdk/packages/indexer/src/handlers/events/pendingStatus/handlePendingStatusFlush.event.handler.ts
+++ b/sdk/packages/indexer/src/handlers/events/pendingStatus/handlePendingStatusFlush.event.handler.ts
@@ -23,9 +23,9 @@ export const handlePendingStatusFlush = wrap(async (event: SubstrateBlock): Prom
 			`[handlePendingStatusFlush] chain=${chainId} completed for block #${blockNumber}`,
 		)
 	} catch (error) {
-		// @ts-ignore
+		const message = error instanceof Error ? error.message : String(error)
 		logger.error(
-			`[handlePendingStatusFlush] chain=${chainId} failed at block #${blockNumber}: ${error.message}`,
+			`[handlePendingStatusFlush] chain=${chainId} failed at block #${blockNumber}: ${message}`,
 		)
 	}
 })

--- a/sdk/packages/indexer/src/handlers/events/pendingStatus/handlePendingStatusFlush.event.handler.ts
+++ b/sdk/packages/indexer/src/handlers/events/pendingStatus/handlePendingStatusFlush.event.handler.ts
@@ -11,11 +11,17 @@ const FLUSH_LIMIT = 10
  * (e.g. when the status event was indexed after the request was created on
  * another chain, or when a chain reorg dropped the original flush).
  */
-export const handlePendingStatusFlush = wrap(async (_event: SubstrateBlock): Promise<void> => {
+export const handlePendingStatusFlush = wrap(async (event: SubstrateBlock): Promise<void> => {
+	const blockNumber = event.block.header.number.toString()
+	const blockHash = event.block.header.hash.toHex()
+	logger.info(
+		`[handlePendingStatusFlush] entered at block #${blockNumber} (${blockHash}), limit=${FLUSH_LIMIT}`,
+	)
 	try {
 		await PendingStatusService.flushBatch(FLUSH_LIMIT)
+		logger.info(`[handlePendingStatusFlush] completed for block #${blockNumber}`)
 	} catch (error) {
 		// @ts-ignore
-		logger.error(`[handlePendingStatusFlush] failed ${error.message}`)
+		logger.error(`[handlePendingStatusFlush] failed at block #${blockNumber}: ${error.message}`)
 	}
 })

--- a/sdk/packages/indexer/src/handlers/events/pendingStatus/handlePendingStatusFlushEvm.event.handler.ts
+++ b/sdk/packages/indexer/src/handlers/events/pendingStatus/handlePendingStatusFlushEvm.event.handler.ts
@@ -12,8 +12,11 @@ const FLUSH_LIMIT = 10
  */
 export const handlePendingStatusFlushEvm = wrap(async (event: EthereumBlock): Promise<void> => {
 	const blockNumber = event.number.toString()
+	const blockTsUnix = Number(event.timestamp)
+	const blockTsIso = new Date(blockTsUnix * 1000).toISOString()
 	logger.info(
-		`[handlePendingStatusFlushEvm] chain=${chainId} entered at block #${blockNumber}, limit=${FLUSH_LIMIT}`,
+		`[handlePendingStatusFlushEvm] chain=${chainId} entered at block #${blockNumber}, ` +
+			`block.timestamp=${blockTsUnix} (${blockTsIso}), limit=${FLUSH_LIMIT}`,
 	)
 	try {
 		await PendingStatusService.flushBatch(FLUSH_LIMIT)

--- a/sdk/packages/indexer/src/handlers/events/pendingStatus/handlePendingStatusFlushEvm.event.handler.ts
+++ b/sdk/packages/indexer/src/handlers/events/pendingStatus/handlePendingStatusFlushEvm.event.handler.ts
@@ -11,22 +11,12 @@ const FLUSH_LIMIT = 10
  * each chain has to clean up the rows it wrote.
  */
 export const handlePendingStatusFlushEvm = wrap(async (event: EthereumBlock): Promise<void> => {
-	const blockNumber = event.number.toString()
-	const blockTsUnix = Number(event.timestamp)
-	const blockTsIso = new Date(blockTsUnix * 1000).toISOString()
-	logger.info(
-		`[handlePendingStatusFlushEvm] chain=${chainId} entered at block #${blockNumber}, ` +
-			`block.timestamp=${blockTsUnix} (${blockTsIso}), limit=${FLUSH_LIMIT}`,
-	)
 	try {
 		await PendingStatusService.flushBatch(FLUSH_LIMIT)
-		logger.info(
-			`[handlePendingStatusFlushEvm] chain=${chainId} completed for block #${blockNumber}`,
-		)
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error)
 		logger.error(
-			`[handlePendingStatusFlushEvm] chain=${chainId} failed at block #${blockNumber}: ${message}`,
+			`[handlePendingStatusFlushEvm] chain=${chainId} failed at block #${event.number}: ${message}`,
 		)
 	}
 })

--- a/sdk/packages/indexer/src/handlers/events/pendingStatus/handlePendingStatusFlushEvm.event.handler.ts
+++ b/sdk/packages/indexer/src/handlers/events/pendingStatus/handlePendingStatusFlushEvm.event.handler.ts
@@ -21,9 +21,9 @@ export const handlePendingStatusFlushEvm = wrap(async (event: EthereumBlock): Pr
 			`[handlePendingStatusFlushEvm] chain=${chainId} completed for block #${blockNumber}`,
 		)
 	} catch (error) {
-		// @ts-ignore
+		const message = error instanceof Error ? error.message : String(error)
 		logger.error(
-			`[handlePendingStatusFlushEvm] chain=${chainId} failed at block #${blockNumber}: ${error.message}`,
+			`[handlePendingStatusFlushEvm] chain=${chainId} failed at block #${blockNumber}: ${message}`,
 		)
 	}
 })

--- a/sdk/packages/indexer/src/handlers/events/pendingStatus/handlePendingStatusFlushEvm.event.handler.ts
+++ b/sdk/packages/indexer/src/handlers/events/pendingStatus/handlePendingStatusFlushEvm.event.handler.ts
@@ -1,0 +1,29 @@
+import { EthereumBlock } from "@subql/types-ethereum"
+import { PendingStatusService } from "@/services/pendingStatus.service"
+import { wrap } from "@/utils/event.utils"
+
+const FLUSH_LIMIT = 10
+
+/**
+ * EVM block handler that drains up to FLUSH_LIMIT pending status rows
+ * on each chain's own instance. The historical-by-timestamp filter
+ * hides rows written by other chains from the Hyperbridge instance, so
+ * each chain has to clean up the rows it wrote.
+ */
+export const handlePendingStatusFlushEvm = wrap(async (event: EthereumBlock): Promise<void> => {
+	const blockNumber = event.number.toString()
+	logger.info(
+		`[handlePendingStatusFlushEvm] chain=${chainId} entered at block #${blockNumber}, limit=${FLUSH_LIMIT}`,
+	)
+	try {
+		await PendingStatusService.flushBatch(FLUSH_LIMIT)
+		logger.info(
+			`[handlePendingStatusFlushEvm] chain=${chainId} completed for block #${blockNumber}`,
+		)
+	} catch (error) {
+		// @ts-ignore
+		logger.error(
+			`[handlePendingStatusFlushEvm] chain=${chainId} failed at block #${blockNumber}: ${error.message}`,
+		)
+	}
+})

--- a/sdk/packages/indexer/src/mappings/mappingHandlers.ts
+++ b/sdk/packages/indexer/src/mappings/mappingHandlers.ts
@@ -34,6 +34,7 @@ export { handleBridgeTokenSupplyIndexing } from "@/handlers/events/supply/handle
 
 // Pending Status Flush Handler
 export { handlePendingStatusFlush } from "@/handlers/events/pendingStatus/handlePendingStatusFlush.event.handler"
+export { handlePendingStatusFlushEvm } from "@/handlers/events/pendingStatus/handlePendingStatusFlushEvm.event.handler"
 
 export { handleRelayerRewardedEvent } from "@/handlers/events/incentives/relayerRewarded.event.handler"
 export { handleFeeRewardedEvent } from "@/handlers/events/incentives/feeRewarded.event.handler"

--- a/sdk/packages/indexer/src/services/pendingStatus.service.ts
+++ b/sdk/packages/indexer/src/services/pendingStatus.service.ts
@@ -34,8 +34,20 @@ export class PendingStatusService {
 	static async flushBatch(limit: number): Promise<void> {
 		logger.info(`[PendingStatusService.flushBatch] starting, limit=${limit}`)
 
-		const batch = await PendingStatusMetadata.getByFields([], { limit })
-		logger.info(`[PendingStatusService.flushBatch] fetched ${batch.length} pending row(s)`)
+		// Use an indexed-field `in` filter so the query is non-empty and predictable.
+		// `entityType` is `@index`-ed on the schema, so this passes the SubQuery
+		// indexed-field assert in @subql/node-core store.js.
+		const batch = await PendingStatusMetadata.getByFields(
+			[["entityType", "in", [...KNOWN_ENTITY_TYPES]]],
+			{ limit },
+		)
+		logger.info(
+			`[PendingStatusService.flushBatch] fetched ${batch.length} pending row(s); ` +
+				`sample=${batch
+					.slice(0, 3)
+					.map((p) => `${p.entityType}@${p.chain}:${p.id}`)
+					.join(", ")}`,
+		)
 
 		for (const pending of batch) {
 			if (!isKnownEntityType(pending.entityType)) {

--- a/sdk/packages/indexer/src/services/pendingStatus.service.ts
+++ b/sdk/packages/indexer/src/services/pendingStatus.service.ts
@@ -34,9 +34,47 @@ export class PendingStatusService {
 	static async flushBatch(limit: number): Promise<void> {
 		logger.info(`[PendingStatusService.flushBatch] starting, limit=${limit}`)
 
-		// Use an indexed-field `in` filter so the query is non-empty and predictable.
-		// `entityType` is `@index`-ed on the schema, so this passes the SubQuery
-		// indexed-field assert in @subql/node-core store.js.
+		// === diagnostic block ===
+		// Three independent lookup paths against one known-existing BSC pending row
+		// (see GraphQL dump 2026-05-28). Each path takes a different code path in
+		// @subql/node-core; the one that returns the row tells us which API to
+		// use, and the ones that don't pinpoint the bug.
+		const knownCommitment = "0x10bf3434ba6396bd44105ef95139b62c8799676c02bc5d03934eb8fec68fc447"
+		const knownId = `${knownCommitment}.RequestV2.DESTINATION`
+		try {
+			const byId = await PendingStatusMetadata.get(knownId)
+			logger.info(`[diag] get(knownId) → ${byId ? "FOUND" : "MISSING"}`)
+		} catch (e) {
+			const m = e instanceof Error ? e.message : String(e)
+			logger.error(`[diag] get(knownId) threw: ${m}`)
+		}
+		try {
+			const byComm = await PendingStatusMetadata.getByCommitment(knownCommitment, {
+				limit: 5,
+			})
+			logger.info(
+				`[diag] getByCommitment(known) → ${byComm.length} row(s): ${byComm
+					.map((p) => `${p.entityType}/${p.status}@${p.chain}`)
+					.join(", ")}`,
+			)
+		} catch (e) {
+			const m = e instanceof Error ? e.message : String(e)
+			logger.error(`[diag] getByCommitment threw: ${m}`)
+		}
+		try {
+			const eqEntityType = await PendingStatusMetadata.getByFields(
+				[["entityType", "=", "RequestV2"]],
+				{ limit: 5 },
+			)
+			logger.info(
+				`[diag] getByFields(entityType='=' 'RequestV2') → ${eqEntityType.length} row(s)`,
+			)
+		} catch (e) {
+			const m = e instanceof Error ? e.message : String(e)
+			logger.error(`[diag] getByFields(eq) threw: ${m}`)
+		}
+		// === end diagnostic ===
+
 		const batch = await PendingStatusMetadata.getByFields(
 			[["entityType", "in", [...KNOWN_ENTITY_TYPES]]],
 			{ limit },

--- a/sdk/packages/indexer/src/services/pendingStatus.service.ts
+++ b/sdk/packages/indexer/src/services/pendingStatus.service.ts
@@ -31,16 +31,24 @@ export class PendingStatusService {
 	 */
 	static async flushBatch(limit: number): Promise<void> {
 		const perType = Math.max(1, Math.ceil(limit / ENTITY_TYPES.length))
+		logger.info(
+			`[PendingStatusService.flushBatch] starting, limit=${limit} perType=${perType} entityTypes=${ENTITY_TYPES.join(",")}`,
+		)
 
 		for (const entityType of ENTITY_TYPES) {
 			const batch = await PendingStatusMetadata.getByEntityType(entityType, {
 				limit: perType,
 			})
+			logger.info(
+				`[PendingStatusService.flushBatch] fetched ${batch.length} pending row(s) for entityType=${entityType}`,
+			)
 
 			for (const pending of batch) {
 				await this.materialize(pending, entityType)
 			}
 		}
+
+		logger.info(`[PendingStatusService.flushBatch] finished`)
 	}
 
 	private static async materialize(
@@ -50,7 +58,12 @@ export class PendingStatusService {
 		switch (entityType) {
 			case "RequestV2": {
 				const parent = await RequestV2.get(pending.commitment)
-				if (!parent) return
+				if (!parent) {
+					logger.info(
+						`[PendingStatusService] RequestV2 ${pending.commitment} not yet present, leaving pending`,
+					)
+					return
+				}
 				const statusMetadata = RequestStatusMetadata.create({
 					id: `${pending.commitment}.${pending.status}`,
 					requestId: pending.commitment,
@@ -71,7 +84,12 @@ export class PendingStatusService {
 			}
 			case "GetRequestV2": {
 				const parent = await GetRequestV2.get(pending.commitment)
-				if (!parent) return
+				if (!parent) {
+					logger.info(
+						`[PendingStatusService] GetRequestV2 ${pending.commitment} not yet present, leaving pending`,
+					)
+					return
+				}
 				const statusMetadata = GetRequestStatusMetadata.create({
 					id: `${pending.commitment}.${pending.status}`,
 					requestId: pending.commitment,
@@ -92,7 +110,12 @@ export class PendingStatusService {
 			}
 			case "IOrderV3": {
 				const parent = await IOrderV3.get(pending.commitment)
-				if (!parent) return
+				if (!parent) {
+					logger.info(
+						`[PendingStatusService] IOrderV3 ${pending.commitment} not yet present, leaving pending`,
+					)
+					return
+				}
 				const statusMetadata = IOrderV3StatusMetadata.create({
 					id: `${pending.commitment}.${pending.status}`,
 					orderId: pending.commitment,

--- a/sdk/packages/indexer/src/services/pendingStatus.service.ts
+++ b/sdk/packages/indexer/src/services/pendingStatus.service.ts
@@ -32,59 +32,14 @@ export class PendingStatusService {
 	 * each row's own `entityType` field after the read.
 	 */
 	static async flushBatch(limit: number): Promise<void> {
-		logger.info(`[PendingStatusService.flushBatch] starting, limit=${limit}`)
-
-		// === diagnostic block ===
-		// Three independent lookup paths against one known-existing BSC pending row
-		// (see GraphQL dump 2026-05-28). Each path takes a different code path in
-		// @subql/node-core; the one that returns the row tells us which API to
-		// use, and the ones that don't pinpoint the bug.
-		const knownCommitment = "0x10bf3434ba6396bd44105ef95139b62c8799676c02bc5d03934eb8fec68fc447"
-		const knownId = `${knownCommitment}.RequestV2.DESTINATION`
-		try {
-			const byId = await PendingStatusMetadata.get(knownId)
-			logger.info(`[diag] get(knownId) → ${byId ? "FOUND" : "MISSING"}`)
-		} catch (e) {
-			const m = e instanceof Error ? e.message : String(e)
-			logger.error(`[diag] get(knownId) threw: ${m}`)
-		}
-		try {
-			const byComm = await PendingStatusMetadata.getByCommitment(knownCommitment, {
-				limit: 5,
-			})
-			logger.info(
-				`[diag] getByCommitment(known) → ${byComm.length} row(s): ${byComm
-					.map((p) => `${p.entityType}/${p.status}@${p.chain}`)
-					.join(", ")}`,
-			)
-		} catch (e) {
-			const m = e instanceof Error ? e.message : String(e)
-			logger.error(`[diag] getByCommitment threw: ${m}`)
-		}
-		try {
-			const eqEntityType = await PendingStatusMetadata.getByFields(
-				[["entityType", "=", "RequestV2"]],
-				{ limit: 5 },
-			)
-			logger.info(
-				`[diag] getByFields(entityType='=' 'RequestV2') → ${eqEntityType.length} row(s)`,
-			)
-		} catch (e) {
-			const m = e instanceof Error ? e.message : String(e)
-			logger.error(`[diag] getByFields(eq) threw: ${m}`)
-		}
-		// === end diagnostic ===
-
 		const batch = await PendingStatusMetadata.getByFields(
 			[["entityType", "in", [...KNOWN_ENTITY_TYPES]]],
 			{ limit },
 		)
+		if (batch.length === 0) return
+
 		logger.info(
-			`[PendingStatusService.flushBatch] fetched ${batch.length} pending row(s); ` +
-				`sample=${batch
-					.slice(0, 3)
-					.map((p) => `${p.entityType}@${p.chain}:${p.id}`)
-					.join(", ")}`,
+			`[PendingStatusService.flushBatch] fetched ${batch.length} pending row(s)`,
 		)
 
 		for (const pending of batch) {
@@ -96,8 +51,6 @@ export class PendingStatusService {
 			}
 			await this.materialize(pending, pending.entityType)
 		}
-
-		logger.info(`[PendingStatusService.flushBatch] finished`)
 	}
 
 	private static async materialize(
@@ -107,12 +60,7 @@ export class PendingStatusService {
 		switch (entityType) {
 			case "RequestV2": {
 				const parent = await RequestV2.get(pending.commitment)
-				if (!parent) {
-					logger.info(
-						`[PendingStatusService] RequestV2 ${pending.commitment} not yet present, leaving pending`,
-					)
-					return
-				}
+				if (!parent) return
 				const statusMetadata = RequestStatusMetadata.create({
 					id: `${pending.commitment}.${pending.status}`,
 					requestId: pending.commitment,
@@ -133,12 +81,7 @@ export class PendingStatusService {
 			}
 			case "GetRequestV2": {
 				const parent = await GetRequestV2.get(pending.commitment)
-				if (!parent) {
-					logger.info(
-						`[PendingStatusService] GetRequestV2 ${pending.commitment} not yet present, leaving pending`,
-					)
-					return
-				}
+				if (!parent) return
 				const statusMetadata = GetRequestStatusMetadata.create({
 					id: `${pending.commitment}.${pending.status}`,
 					requestId: pending.commitment,
@@ -159,12 +102,7 @@ export class PendingStatusService {
 			}
 			case "IOrderV3": {
 				const parent = await IOrderV3.get(pending.commitment)
-				if (!parent) {
-					logger.info(
-						`[PendingStatusService] IOrderV3 ${pending.commitment} not yet present, leaving pending`,
-					)
-					return
-				}
+				if (!parent) return
 				const statusMetadata = IOrderV3StatusMetadata.create({
 					id: `${pending.commitment}.${pending.status}`,
 					orderId: pending.commitment,

--- a/sdk/packages/indexer/src/services/pendingStatus.service.ts
+++ b/sdk/packages/indexer/src/services/pendingStatus.service.ts
@@ -13,39 +13,38 @@ import { IOrderV3StatusMetadata } from "@/configs/src/types/models/IOrderV3Statu
 // Entity types we know how to materialize a real *StatusMetadata for.
 // Must match the `ENTITY_TYPE` constants in the per-service handlers that
 // write PendingStatusMetadata rows.
-const ENTITY_TYPES = ["RequestV2", "GetRequestV2", "IOrderV3"] as const
-type KnownEntityType = (typeof ENTITY_TYPES)[number]
+const KNOWN_ENTITY_TYPES = ["RequestV2", "GetRequestV2", "IOrderV3"] as const
+type KnownEntityType = (typeof KNOWN_ENTITY_TYPES)[number]
+
+function isKnownEntityType(value: string): value is KnownEntityType {
+	return (KNOWN_ENTITY_TYPES as readonly string[]).includes(value)
+}
 
 export class PendingStatusService {
 	/**
-	 * Scan a small batch of pending status rows across the known entity types
-	 * and materialize the real *StatusMetadata for any whose parent now exists,
-	 * deleting the pending row. Rows whose parent is still missing are left
-	 * untouched for a future tick.
+	 * Scan a small batch of pending status rows and materialize the real
+	 * *StatusMetadata for any whose parent now exists, deleting the pending
+	 * row. Rows whose parent is still missing are left untouched for a
+	 * future tick.
 	 *
-	 * `limit` caps the total rows examined per call, distributed across the
-	 * entity types so a backlog on one type cannot starve the others. We
-	 * cannot order by `createdAt` because that column isn't indexed on the
-	 * existing table; rows we successfully flush are deleted, so even with
-	 * arbitrary ordering the queue drains over successive blocks.
+	 * Fetches via `getByFields([], { limit })` so a stale or mismatched
+	 * `entityType` index value can't hide rows from us — we dispatch on
+	 * each row's own `entityType` field after the read.
 	 */
 	static async flushBatch(limit: number): Promise<void> {
-		const perType = Math.max(1, Math.ceil(limit / ENTITY_TYPES.length))
-		logger.info(
-			`[PendingStatusService.flushBatch] starting, limit=${limit} perType=${perType} entityTypes=${ENTITY_TYPES.join(",")}`,
-		)
+		logger.info(`[PendingStatusService.flushBatch] starting, limit=${limit}`)
 
-		for (const entityType of ENTITY_TYPES) {
-			const batch = await PendingStatusMetadata.getByEntityType(entityType, {
-				limit: perType,
-			})
-			logger.info(
-				`[PendingStatusService.flushBatch] fetched ${batch.length} pending row(s) for entityType=${entityType}`,
-			)
+		const batch = await PendingStatusMetadata.getByFields([], { limit })
+		logger.info(`[PendingStatusService.flushBatch] fetched ${batch.length} pending row(s)`)
 
-			for (const pending of batch) {
-				await this.materialize(pending, entityType)
+		for (const pending of batch) {
+			if (!isKnownEntityType(pending.entityType)) {
+				logger.warn(
+					`[PendingStatusService] unknown entityType=${pending.entityType} on pending ${pending.id}, skipping`,
+				)
+				continue
 			}
+			await this.materialize(pending, pending.entityType)
 		}
 
 		logger.info(`[PendingStatusService.flushBatch] finished`)


### PR DESCRIPTION
## Summary

- The Hyperbridge-only block handler added in #926 returned 0 rows even
  though the `PendingStatusMetadata` table had 21 entries. Root cause:
  SubQuery multichain forces `historical: 'timestamp'`
  (`@subql/node-core` `store.service.js:241-250`) and the `beforeFind`
  hook injects `WHERE __block_range @> <instance_timestamp>` on every
  read. Each chain's indexer runs as its own instance with its own
  indexed timestamp, so rows written by chain B are invisible to chain A
  until A's indexed timestamp catches up to B's write timestamp. That
  also explains why the per-request `flushPendingStatuses(commitment)`
  inside `createOrUpdate` was silently missing rows: same blind spot.
- Move `handlePendingStatusFlush` out of the `{{#if isHyperbridgeChain}}`
  guard in the substrate YAML template (`modulo: 10`, ~1 min on a 6s
  chain) so every substrate chain instance drains its own writes.
- Add `handlePendingStatusFlushEvm` as `kind: ethereum/BlockHandler` on
  every EVM chain (`modulo: 50`) for the same reason — without it,
  rows written by EVM instances would only drain when their chain
  happens to next touch the row by commitment, which never happens.
- Switch `PendingStatusService.flushBatch` to `getByFields([], { limit })`
  with on-row `entityType` dispatch instead of a per-`entityType`
  indexed lookup, plus structured logs (`chain=`, `block=`,
  `fetched N`, `not yet present`) for future post-mortem.