### PR TITLE
[node]: fix rollup watcher quorum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9286,7 +9286,7 @@ dependencies = [
 
 [[package]]
 name = "hyperbridge"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "clap",
  "futures",

--- a/parachain/node/Cargo.toml
+++ b/parachain/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperbridge"
-version = "1.8.0"
+version = "1.9.0"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 description = "The Hyperbridge coprocessor node"
 repository = "https://github.com/polytope-labs/hyperbridge"

--- a/parachain/node/fisherman/src/lib.rs
+++ b/parachain/node/fisherman/src/lib.rs
@@ -179,12 +179,18 @@ async fn spawn_rollup_watchers(
 		let Some(consensus) = &per_chain.consensus else { continue };
 		// L2 RPCs come from the messaging EVM config (same endpoints messaging uses for inbound).
 		let AnyConfig::Evm(evm_cfg) = &per_chain.messaging else { continue };
-		let l2_providers = match tesseract_evm::create_provider(&evm_cfg.rpc_urls) {
-			Ok(p) => vec![Arc::new(p)],
+		// One independent provider per configured RPC URL — the quorum must fan out across
+		// distinct backends. `create_provider` would instead merge every URL into a single
+		// first-Ok-wins FallbackService, collapsing the advertised 2/3·N+1 quorum into a
+		// quorum-of-one where a single lagging (`Ok(None)`) or poisoned RPC response could
+		// permanently blacklist an honest L2 route. Config validation already guarantees
+		// >= 2 distinct-host URLs per supported L2 (see config::MIN_RPC_URLS_PER_L2).
+		let l2_providers = match tesseract_evm::create_providers_per_url(&evm_cfg.rpc_urls) {
+			Ok(providers) => providers,
 			Err(e) => {
 				log::warn!(
 					target: LOG_TARGET,
-					"fisherman: skipping {state_machine} — failed to build L2 provider: {e:?}",
+					"fisherman: skipping {state_machine} — failed to build L2 providers: {e:?}",
 				);
 				continue;
 			},

--- a/tesseract/messaging/evm/src/lib.rs
+++ b/tesseract/messaging/evm/src/lib.rs
@@ -75,6 +75,50 @@ pub fn create_provider(urls: &[String]) -> Result<RootProvider, anyhow::Error> {
 	}
 }
 
+/// Create one independent [`RootProvider`] per URL, for callers that run a
+/// quorum/byzantine check and must fan out across *distinct* transports.
+///
+/// Unlike [`create_provider`], which merges multiple URLs into a single
+/// first-`Ok`-wins [`alloy::transports::layers::FallbackService`] transport,
+/// this returns a separate provider per endpoint. A 2/3·N+1 quorum built on top
+/// of these therefore genuinely polls every configured backend independently,
+/// instead of collapsing N endpoints into a quorum-of-one where a single lagging
+/// or poisoned RPC response (e.g. an `Ok(None)` from a backend that hasn't
+/// imported the block yet) single-handedly decides the outcome.
+pub fn create_providers_per_url(urls: &[String]) -> Result<Vec<Arc<RootProvider>>, anyhow::Error> {
+	if urls.is_empty() {
+		return Err(anyhow::anyhow!("At least one RPC URL must be provided"));
+	}
+	urls.iter()
+		.map(|u| Ok(Arc::new(RootProvider::new_http(u.parse()?))))
+		.collect()
+}
+
+#[cfg(test)]
+mod create_provider_tests {
+	use super::create_providers_per_url;
+
+	/// The quorum watchers must fan out across every configured backend. Building
+	/// one provider per URL (rather than merging them into a single
+	/// FallbackService) is what keeps `quorum_threshold(N)` meaningful instead of
+	/// collapsing to a quorum-of-one.
+	#[test]
+	fn create_providers_per_url_returns_one_provider_per_url() {
+		let urls = vec![
+			"https://a.example/rpc".to_string(),
+			"https://b.example/rpc".to_string(),
+			"https://c.example/rpc".to_string(),
+		];
+		let providers = create_providers_per_url(&urls).expect("valid urls build providers");
+		assert_eq!(providers.len(), urls.len());
+	}
+
+	#[test]
+	fn create_providers_per_url_rejects_empty() {
+		assert!(create_providers_per_url(&[]).is_err());
+	}
+}
+
 /// Recommended fillers for transaction sending (gas, blob gas, nonce, chain ID)
 type RecommendedFills =
 	JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>;

--- a/tesseract/messaging/fisherman/src/quorum.rs
+++ b/tesseract/messaging/fisherman/src/quorum.rs
@@ -118,3 +118,89 @@ pub fn decide<T>(outcomes: Vec<FetchOutcome<T>>, agrees: impl Fn(&T) -> bool) ->
 		QuorumDecision::Mismatch
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn quorum_threshold_is_supermajority() {
+		assert_eq!(quorum_threshold(1), 1);
+		assert_eq!(quorum_threshold(2), 2);
+		assert_eq!(quorum_threshold(3), 3);
+		assert_eq!(quorum_threshold(4), 3);
+		assert_eq!(quorum_threshold(5), 4);
+		assert_eq!(quorum_threshold(6), 5);
+	}
+
+	/// A single lagging RPC (one `Missing`) among a genuine N-way fan-out must NOT
+	/// trigger a blacklist — it falls through to `InsufficientQuorum` (abstain).
+	/// This is exactly the false-positive the quorum-of-one regression produced
+	/// when all N URLs were collapsed into a single provider.
+	#[test]
+	fn single_lagging_rpc_among_quorum_abstains() {
+		let outcomes =
+			vec![FetchOutcome::Found(1u8), FetchOutcome::Found(1u8), FetchOutcome::Missing];
+		assert!(matches!(
+			decide(outcomes, |v| *v == 1),
+			QuorumDecision::InsufficientQuorum
+		));
+	}
+
+	/// But when a real quorum of providers reports the block missing we DO act —
+	/// we don't abstain when the quorum genuinely returns the block as missing.
+	#[test]
+	fn quorum_of_missing_blacklists() {
+		let outcomes: Vec<FetchOutcome<u8>> =
+			vec![FetchOutcome::Missing, FetchOutcome::Missing, FetchOutcome::Missing];
+		assert!(matches!(
+			decide(outcomes, |_| true),
+			QuorumDecision::MissingFromQuorum
+		));
+	}
+
+	/// Below quorum on the missing side, abstain rather than blacklist: two of
+	/// three missing is not enough when the threshold is three.
+	#[test]
+	fn sub_quorum_missing_abstains() {
+		let outcomes =
+			vec![FetchOutcome::Missing, FetchOutcome::Missing, FetchOutcome::Found(1u8)];
+		assert!(matches!(
+			decide(outcomes, |v| *v == 1),
+			QuorumDecision::InsufficientQuorum
+		));
+	}
+
+	/// Documents the hazard the fix removes: a *single* outcome makes
+	/// `quorum_threshold(1) == 1`, so one `Missing` (or one disagreeing `Found`)
+	/// is by itself a "quorum". Collapsing N RPC URLs into one provider is what
+	/// produced this 1-element outcome vector in the rollup watcher.
+	#[test]
+	fn single_outcome_is_a_quorum_of_one() {
+		let missing: Vec<FetchOutcome<u8>> = vec![FetchOutcome::Missing];
+		assert!(matches!(
+			decide(missing, |_| true),
+			QuorumDecision::MissingFromQuorum
+		));
+		let wrong = vec![FetchOutcome::Found(2u8)];
+		assert!(matches!(decide(wrong, |v| *v == 1), QuorumDecision::Mismatch));
+	}
+
+	#[test]
+	fn unanimous_agreement_verifies() {
+		let outcomes =
+			vec![FetchOutcome::Found(1u8), FetchOutcome::Found(1u8), FetchOutcome::Found(1u8)];
+		assert!(matches!(decide(outcomes, |v| *v == 1), QuorumDecision::Verified));
+	}
+
+	/// Transport errors are non-signals and never on their own drive a decision.
+	#[test]
+	fn all_errored_is_insufficient_quorum() {
+		let outcomes: Vec<FetchOutcome<u8>> =
+			vec![FetchOutcome::Errored, FetchOutcome::Errored, FetchOutcome::Errored];
+		assert!(matches!(
+			decide(outcomes, |_| true),
+			QuorumDecision::InsufficientQuorum
+		));
+	}
+}


### PR DESCRIPTION


The L1 rollup-claim watchers (opstack/arbitrum) advertise a 2/3·N+1 supermajority quorum over N independent L2 RPC endpoints, but spawn_rollup_watchers merged every configured rpc_url into a single first-Ok-wins FallbackService provider wrapped in a 1-element vector. With one outcome, quorum_threshold(1) == 1, so a single lagging backend returning Ok(None) (Missing) or one poisoned response (Mismatch) was enough to permanently and irreversibly blacklist an honest Optimism / Arbitrum route.

Add tesseract_evm::create_providers_per_url, which builds one independent RootProvider per URL (mirroring the byzantine watcher), and use it in the rollup watcher so the quorum genuinely fans out across distinct backends. A genuine quorum-of-missing still blacklists; a single lagging node now falls to InsufficientQuorum and abstains.

Adds unit tests for the per-URL fan-out and the quorum decision logic, and bumps the hyperbridge node minor version to 1.9.0.