### PR TITLE
[chore]: Bump minor version of published crates.io crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15179,7 +15179,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-hyper-fungible-token"
-version = "2512.1.0"
+version = "2512.0.0"
 dependencies = [
  "alloy-primitives 1.5.7",
  "alloy-sol-macro 1.5.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15179,7 +15179,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-hyper-fungible-token"
-version = "2512.0.0"
+version = "2512.1.0"
 dependencies = [
  "alloy-primitives 1.5.7",
  "alloy-sol-macro 1.5.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4810,7 +4810,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-utils"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bls_on_arkworks",
@@ -8589,7 +8589,7 @@ dependencies = [
 
 [[package]]
 name = "grandpa-verifier"
-version = "2512.0.0"
+version = "2512.1.0"
 dependencies = [
  "anyhow",
  "derive_more 0.99.20",
@@ -8614,7 +8614,7 @@ dependencies = [
 
 [[package]]
 name = "grandpa-verifier-primitives"
-version = "2512.0.0"
+version = "2512.1.0"
 dependencies = [
  "anyhow",
  "finality-grandpa",
@@ -10394,7 +10394,7 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "ismp"
-version = "2512.0.0"
+version = "2512.1.0"
 dependencies = [
  "alloy-primitives 1.5.7",
  "alloy-sol-types 1.5.7",
@@ -10487,7 +10487,7 @@ version = "0.1.1"
 
 [[package]]
 name = "ismp-grandpa"
-version = "2512.0.0"
+version = "2512.1.0"
 dependencies = [
  "anyhow",
  "ckb-merkle-mountain-range",
@@ -10531,7 +10531,7 @@ dependencies = [
 
 [[package]]
 name = "ismp-parachain"
-version = "2512.2.0"
+version = "2512.3.0"
 dependencies = [
  "hex",
  "hex-literal 0.4.1",
@@ -10548,7 +10548,7 @@ dependencies = [
 
 [[package]]
 name = "ismp-parachain-runtime-api"
-version = "2512.0.0"
+version = "2512.1.0"
 dependencies = [
  "polkadot-sdk",
 ]
@@ -15296,7 +15296,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ismp"
-version = "2512.1.0"
+version = "2512.2.0"
 dependencies = [
  "anyhow",
  "crypto-utils",
@@ -15369,7 +15369,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ismp-rpc"
-version = "2512.0.0"
+version = "2512.1.0"
 dependencies = [
  "anyhow",
  "hash-db",
@@ -15389,7 +15389,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ismp-runtime-api"
-version = "2512.0.0"
+version = "2512.1.0"
 dependencies = [
  "ismp",
  "pallet-ismp",
@@ -23680,7 +23680,7 @@ dependencies = [
 
 [[package]]
 name = "serde-hex-utils"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -27013,7 +27013,7 @@ dependencies = [
 
 [[package]]
 name = "substrate-state-machine"
-version = "2512.0.0"
+version = "2512.1.0"
 dependencies = [
  "anyhow",
  "hash-db",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,7 +262,7 @@ pallet-ismp-rpc = { version = "2512.1.0", path = "modules/pallets/ismp/rpc" }
 pallet-ismp-runtime-api = { version = "2512.1.0", path = "modules/pallets/ismp/runtime-api", default-features = false }
 pallet-bandwidth = { path = "modules/pallets/bandwidth", default-features = false }
 
-pallet-hyper-fungible-token = { version = "2512.0.0", path = "modules/pallets/hyper-fungible-token", default-features = false }
+pallet-hyper-fungible-token = { version = "2512.1.0", path = "modules/pallets/hyper-fungible-token", default-features = false }
 
 substrate-state-machine = { version = "2512.1.0", path = "modules/ismp/state-machines/substrate", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -249,22 +249,22 @@ ibc-core-host = { version = "0.57.0", default-features = false }
 ibc-proto = { version = "0.52.0", default-features = false, package = "ibc-proto"}
 
 # published crates
-ismp = { version = "2512.0.0", path = "./modules/ismp/core", default-features = false }
-serde-hex-utils = { version = "0.1.0", path = "modules/utils/serde", default-features = false }
-crypto-utils = { version = "0.2.0", path = "modules/utils/crypto", default-features = false }
-grandpa-verifier-primitives = { version = "2512.0.0", path = "./modules/consensus/grandpa/primitives", default-features = false }
-grandpa-verifier = { version = "2512.0.0", path = "./modules/consensus/grandpa/verifier", default-features = false }
-ismp-grandpa = { version = "2512.0.0", path = "./modules/ismp/clients/grandpa", default-features = false }
-ismp-parachain = { version = "2512.2.0", path = "./modules/ismp/clients/parachain/client", default-features = false }
-ismp-parachain-runtime-api = { version = "2512.0.0", path = "./modules/ismp/clients/parachain/runtime-api", default-features = false }
-pallet-ismp = { version = "2512.1.0", path = "modules/pallets/ismp", default-features = false }
-pallet-ismp-rpc = { version = "2512.0.0", path = "modules/pallets/ismp/rpc" }
-pallet-ismp-runtime-api = { version = "2512.0.0", path = "modules/pallets/ismp/runtime-api", default-features = false }
+ismp = { version = "2512.1.0", path = "./modules/ismp/core", default-features = false }
+serde-hex-utils = { version = "0.2.0", path = "modules/utils/serde", default-features = false }
+crypto-utils = { version = "0.3.0", path = "modules/utils/crypto", default-features = false }
+grandpa-verifier-primitives = { version = "2512.1.0", path = "./modules/consensus/grandpa/primitives", default-features = false }
+grandpa-verifier = { version = "2512.1.0", path = "./modules/consensus/grandpa/verifier", default-features = false }
+ismp-grandpa = { version = "2512.1.0", path = "./modules/ismp/clients/grandpa", default-features = false }
+ismp-parachain = { version = "2512.3.0", path = "./modules/ismp/clients/parachain/client", default-features = false }
+ismp-parachain-runtime-api = { version = "2512.1.0", path = "./modules/ismp/clients/parachain/runtime-api", default-features = false }
+pallet-ismp = { version = "2512.2.0", path = "modules/pallets/ismp", default-features = false }
+pallet-ismp-rpc = { version = "2512.1.0", path = "modules/pallets/ismp/rpc" }
+pallet-ismp-runtime-api = { version = "2512.1.0", path = "modules/pallets/ismp/runtime-api", default-features = false }
 pallet-bandwidth = { path = "modules/pallets/bandwidth", default-features = false }
 
 pallet-hyper-fungible-token = { version = "2512.0.0", path = "modules/pallets/hyper-fungible-token", default-features = false }
 
-substrate-state-machine = { version = "2512.0.0", path = "modules/ismp/state-machines/substrate", default-features = false }
+substrate-state-machine = { version = "2512.1.0", path = "modules/ismp/state-machines/substrate", default-features = false }
 
 # local crates
 ismp-testsuite = { path = "./modules/ismp/testsuite" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,7 +262,7 @@ pallet-ismp-rpc = { version = "2512.1.0", path = "modules/pallets/ismp/rpc" }
 pallet-ismp-runtime-api = { version = "2512.1.0", path = "modules/pallets/ismp/runtime-api", default-features = false }
 pallet-bandwidth = { path = "modules/pallets/bandwidth", default-features = false }
 
-pallet-hyper-fungible-token = { version = "2512.1.0", path = "modules/pallets/hyper-fungible-token", default-features = false }
+pallet-hyper-fungible-token = { version = "2512.0.0", path = "modules/pallets/hyper-fungible-token", default-features = false }
 
 substrate-state-machine = { version = "2512.1.0", path = "modules/ismp/state-machines/substrate", default-features = false }
 

--- a/modules/consensus/grandpa/primitives/Cargo.toml
+++ b/modules/consensus/grandpa/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grandpa-verifier-primitives"
-version = "2512.0.0"
+version = "2512.1.0"
 edition = "2021"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 license = "Apache-2.0"

--- a/modules/consensus/grandpa/verifier/Cargo.toml
+++ b/modules/consensus/grandpa/verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grandpa-verifier"
-version = "2512.0.0"
+version = "2512.1.0"
 edition = "2021"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 license = "Apache-2.0"

--- a/modules/ismp/clients/grandpa/Cargo.toml
+++ b/modules/ismp/clients/grandpa/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ismp-grandpa"
-version = "2512.0.0"
+version = "2512.1.0"
 edition = "2021"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 license = "Apache-2.0"

--- a/modules/ismp/clients/parachain/client/Cargo.toml
+++ b/modules/ismp/clients/parachain/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ismp-parachain"
-version = "2512.2.0"
+version = "2512.3.0"
 edition = "2021"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 license = "Apache-2.0"

--- a/modules/ismp/clients/parachain/runtime-api/Cargo.toml
+++ b/modules/ismp/clients/parachain/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ismp-parachain-runtime-api"
-version = "2512.0.0"
+version = "2512.1.0"
 edition = "2021"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 license = "Apache-2.0"

--- a/modules/ismp/core/Cargo.toml
+++ b/modules/ismp/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ismp"
-version = "2512.0.0"
+version = "2512.1.0"
 edition = "2021"
 description = "Rust implementation of the interoperable state machine protocol"
 authors = ["Polytope Labs <hello@polytope.technology>"]

--- a/modules/ismp/state-machines/substrate/Cargo.toml
+++ b/modules/ismp/state-machines/substrate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "substrate-state-machine"
-version = "2512.0.0"
+version = "2512.1.0"
 edition = "2021"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 license = "Apache-2.0"

--- a/modules/pallets/hyper-fungible-token/Cargo.toml
+++ b/modules/pallets/hyper-fungible-token/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-hyper-fungible-token"
-version = "2512.1.0"
+version = "2512.0.0"
 edition = "2021"
 description = "A substrate pallet for cross-chain token transfers via HyperFungibleToken contracts"
 authors = ["Polytope Labs <hello@polytope.technology>"]

--- a/modules/pallets/hyper-fungible-token/Cargo.toml
+++ b/modules/pallets/hyper-fungible-token/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-hyper-fungible-token"
-version = "2512.0.0"
+version = "2512.1.0"
 edition = "2021"
 description = "A substrate pallet for cross-chain token transfers via HyperFungibleToken contracts"
 authors = ["Polytope Labs <hello@polytope.technology>"]

--- a/modules/pallets/ismp/Cargo.toml
+++ b/modules/pallets/ismp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-ismp"
-version = "2512.1.0"
+version = "2512.2.0"
 edition = "2021"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 license = "Apache-2.0"

--- a/modules/pallets/ismp/rpc/Cargo.toml
+++ b/modules/pallets/ismp/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-ismp-rpc"
-version = "2512.0.0"
+version = "2512.1.0"
 edition = "2021"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 license = "Apache-2.0"

--- a/modules/pallets/ismp/runtime-api/Cargo.toml
+++ b/modules/pallets/ismp/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-ismp-runtime-api"
-version = "2512.0.0"
+version = "2512.1.0"
 edition = "2021"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 license = "Apache-2.0"

--- a/modules/utils/crypto/Cargo.toml
+++ b/modules/utils/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-utils"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 license = "Apache-2.0"

--- a/modules/utils/serde/Cargo.toml
+++ b/modules/utils/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde-hex-utils"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 license = "Apache-2.0"

--- a/scripts/release-crates.sh
+++ b/scripts/release-crates.sh
@@ -13,4 +13,5 @@ cargo release \
 -p grandpa-verifier \
 -p ismp-grandpa \
 -p ismp-parachain-runtime-api \
+-p pallet-hyper-fungible-token \
 --execute

--- a/scripts/release-crates.sh
+++ b/scripts/release-crates.sh
@@ -13,7 +13,4 @@ cargo release \
 -p grandpa-verifier \
 -p ismp-grandpa \
 -p ismp-parachain-runtime-api \
--p ismp-parachain-inherent \
--p token-gateway-primitives \
--p pallet-token-gateway \
 --execute


### PR DESCRIPTION
Bump the minor version of the crates released to crates.io via scripts/release-crates.sh, keeping their [workspace.dependencies] requirements and Cargo.lock in sync.