### PR TITLE
[tesseract]: claim oldest rewards first in outbound claims task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28041,7 +28041,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tesseract"
-version = "2.5.0"
+version = "2.4.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28041,7 +28041,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tesseract"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/tesseract/messaging/messaging/src/outbound_claim.rs
+++ b/tesseract/messaging/messaging/src/outbound_claim.rs
@@ -230,7 +230,9 @@ async fn merge_pending(
 		merged.entry((pending.destination, pending.set_id)).or_insert(pending);
 	}
 
-	merged.into_values().collect()
+	let mut result: Vec<_> = merged.into_values().collect();
+	result.sort_by_key(|c| (c.delivery_height, c.set_id));
+	result
 }
 
 /// Split `pending` into `(already_claimed, still_unclaimed)` by reading

--- a/tesseract/messaging/messaging/src/outbound_request_claim.rs
+++ b/tesseract/messaging/messaging/src/outbound_request_claim.rs
@@ -211,7 +211,9 @@ async fn merge_pending(
 		merged.entry(pending.commitment()).or_insert(pending);
 	}
 
-	merged.into_values().collect()
+	let mut result: Vec<_> = merged.into_values().collect();
+	result.sort_by_key(|c| c.delivery_height);
+	result
 }
 
 /// Split `pending` into `(already_claimed, still_unclaimed)` by reading

--- a/tesseract/relayer/Cargo.toml
+++ b/tesseract/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tesseract"
-version = "2.4.0"
+version = "2.5.0"
 edition = "2021"
 description = "Consolidated Hyperbridge relayer — inbound and outbound consensus + messaging"
 authors = ["Polytope Labs <hello@polytope.technology>"]

--- a/tesseract/relayer/Cargo.toml
+++ b/tesseract/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tesseract"
-version = "2.5.0"
+version = "2.4.1"
 edition = "2021"
 description = "Consolidated Hyperbridge relayer — inbound and outbound consensus + messaging"
 authors = ["Polytope Labs <hello@polytope.technology>"]


### PR DESCRIPTION
Merged result is now sorted by `delivery_height` ascending before processing, so the relayer always works through its oldest pending rewards first rather than in an arbitrary hash or commitment-key order.
