### PR TITLE
[simplex]: fix double-decoded OrderPlaced state-machine ids

### DIFF
--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/simplex",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"license": "Apache-2.0",
 	"description": "IntentGateway simplex package for hyperbridge",
 	"main": "dist/index.js",

--- a/sdk/packages/simplex/src/core/event-monitor.ts
+++ b/sdk/packages/simplex/src/core/event-monitor.ts
@@ -6,7 +6,7 @@ import {
 	Order,
 	TronChain,
 	orderCommitment,
-	hexToString,
+	normalizeStateMachineId,
 	retryPromise,
 	DecodedOrderPlacedLog,
 	HexString,
@@ -50,8 +50,8 @@ export async function reconstructOrdersFromLogs(
 			try {
 				let order: Order = {
 					user: decodedLog.args.user,
-					source: hexToString(decodedLog.args.source) as HexString,
-					destination: hexToString(decodedLog.args.destination) as HexString,
+					source: normalizeStateMachineId(decodedLog.args.source) as HexString,
+					destination: normalizeStateMachineId(decodedLog.args.destination) as HexString,
 					deadline: decodedLog.args.deadline,
 					nonce: decodedLog.args.nonce,
 					fees: decodedLog.args.fees,
@@ -234,10 +234,7 @@ export class EventMonitor extends EventEmitter {
 		const maxBlockRange = 1000n
 		const toBlock = fromBlock + maxBlockRange > currentBlock ? currentBlock : fromBlock + maxBlockRange
 
-		this.logger.debug(
-			{ chainId, fromBlock, toBlock, gap: Number(toBlock - fromBlock) },
-			"Scanning blocks",
-		)
+		this.logger.debug({ chainId, fromBlock, toBlock, gap: Number(toBlock - fromBlock) }, "Scanning blocks")
 
 		let logs: any[]
 		try {
@@ -263,9 +260,7 @@ export class EventMonitor extends EventEmitter {
 		}
 
 		const placedLogs = logs.filter((l: any) => l.eventName === "OrderPlaced")
-		const filledLogs = logs.filter(
-			(l: any) => l.eventName === "OrderFilled" || l.eventName === "PartialFill",
-		)
+		const filledLogs = logs.filter((l: any) => l.eventName === "OrderFilled" || l.eventName === "PartialFill")
 
 		if (placedLogs.length > 0) {
 			this.logger.info(
@@ -289,11 +284,9 @@ export class EventMonitor extends EventEmitter {
 	private async processOrderPlacedLogs(chainId: number, chain: IEvmChain, logs: any[]): Promise<void> {
 		const results = await reconstructOrdersFromLogs(logs as DecodedOrderPlacedLog[], {
 			getPlaceOrderCalldata: (txHash, occurrenceIndex) => {
-				const sourceFromTxHash = (logs as DecodedOrderPlacedLog[]).find(
-					(l) => l.transactionHash === txHash,
-				)
+				const sourceFromTxHash = (logs as DecodedOrderPlacedLog[]).find((l) => l.transactionHash === txHash)
 				const source = sourceFromTxHash
-					? (hexToString(sourceFromTxHash.args.source) as HexString)
+					? (normalizeStateMachineId(sourceFromTxHash.args.source) as HexString)
 					: undefined
 				const intentGatewayAddress = this.configService.getIntentGatewayAddress(source!)
 				return chain.getPlaceOrderCalldata!(txHash, intentGatewayAddress, occurrenceIndex)


### PR DESCRIPTION
viem decodes `bytes source`/`destination` from `OrderPlaced` as UTF-8 strings (e.g. `"EVM-8453"`). The event monitor was running them through `hexToString` again, producing garbage that resolved the gateway address to `0x` and made every reconstruction throw `Failed to extract placeOrder calldata from trace`. Switched to `normalizeStateMachineId`, which handles both hex and string forms.