### PR TITLE
[simplex]: delegation balance checks + fx pricing fixes

### DIFF
--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/simplex",
-	"version": "0.5.2",
+	"version": "0.5.3",
 	"license": "Apache-2.0",
 	"description": "IntentGateway simplex package for hyperbridge",
 	"main": "dist/index.js",

--- a/sdk/packages/simplex/src/bin/simplex.ts
+++ b/sdk/packages/simplex/src/bin/simplex.ts
@@ -587,12 +587,13 @@ function validateConfig(config: FillerTomlConfig): void {
 				)
 			}
 
-			const hasStaticCurves = bidLen >= 2 && askLen >= 2
+			// A single point is a valid flat curve — FillerPricePolicy returns that price at every size.
+			const hasStaticCurves = bidLen >= 1 && askLen >= 1
 			const hasUniswapV4Positions = (strategy.vault?.uniswapV4?.positions?.length ?? 0) > 0
 
 			if (!hasStaticCurves && !hasUniswapV4Positions) {
 				throw new Error(
-					"hyperfx: provide bid+ask price curves (≥2 points each) or configure [strategies.vault.uniswapV4].positions for pool-based pricing",
+					"hyperfx: provide bid+ask price curves (≥1 point each) or configure [strategies.vault.uniswapV4].positions for pool-based pricing",
 				)
 			}
 
@@ -603,9 +604,6 @@ function validateConfig(config: FillerTomlConfig): void {
 			}
 
 			if (bidLen > 0) {
-				if (!hasStaticCurves) {
-					throw new Error("hyperfx: bid and ask price curves must each have at least 2 points when provided")
-				}
 				for (const point of strategy.bidPriceCurve!) {
 					if (point.amount === undefined || point.price === undefined) {
 						throw new Error("Each FX bidPriceCurve point must have 'amount' and 'price'")

--- a/sdk/packages/simplex/src/bin/simplex.ts
+++ b/sdk/packages/simplex/src/bin/simplex.ts
@@ -9,7 +9,6 @@ import { BasicFiller } from "@/strategies/basic"
 import { FXFiller } from "@/strategies/fx"
 import type { FundingVenue, UniswapV4PositionConfig } from "@/funding/types"
 import { UniswapV4FundingPlanner } from "@/funding/uniswapV4/UniswapV4FundingPlanner"
-import Decimal from "decimal.js"
 import { ConfirmationPolicy, FillerBpsPolicy, FillerPricePolicy } from "@/config/interpolated-curve"
 import { ChainConfig, FillerConfig, HexString } from "@hyperbridge/sdk"
 import {
@@ -615,27 +614,6 @@ function validateConfig(config: FillerTomlConfig): void {
 				for (const point of strategy.askPriceCurve!) {
 					if (point.amount === undefined || point.price === undefined) {
 						throw new Error("Each FX askPriceCurve point must have 'amount' and 'price'")
-					}
-				}
-
-				// Prices are quoted as "exotic per USD" (an inverted price), so a profitable
-				// spread requires bid ≥ ask at every order size: the filler must hand out fewer
-				// exotic when selling (ask) than it demands when buying (bid). bid < ask is an
-				// inverted spread that loses money on every fill — reject it up front instead of
-				// silently filling at a loss. Both curves are piecewise-linear, so the bid−ask
-				// difference is minimised at a breakpoint; checking the union of points suffices.
-				const bidPolicy = new FillerPricePolicy({ points: strategy.bidPriceCurve! })
-				const askPolicy = new FillerPricePolicy({ points: strategy.askPriceCurve! })
-				const breakpoints = [...strategy.bidPriceCurve!, ...strategy.askPriceCurve!].map((p) => new Decimal(p.amount))
-				for (const amount of breakpoints) {
-					const bid = bidPolicy.getPrice(amount)
-					const ask = askPolicy.getPrice(amount)
-					if (bid.lt(ask)) {
-						throw new Error(
-							`hyperfx: inverted price spread at amount ${amount.toString()} — bidPriceCurve (${bid.toString()}) ` +
-								`must be ≥ askPriceCurve (${ask.toString()}). Prices are 'exotic per USD', so the bid (buying ` +
-								`exotic) is the higher number; a lower bid loses money on every fill.`,
-						)
 					}
 				}
 			}

--- a/sdk/packages/simplex/src/bin/simplex.ts
+++ b/sdk/packages/simplex/src/bin/simplex.ts
@@ -9,6 +9,7 @@ import { BasicFiller } from "@/strategies/basic"
 import { FXFiller } from "@/strategies/fx"
 import type { FundingVenue, UniswapV4PositionConfig } from "@/funding/types"
 import { UniswapV4FundingPlanner } from "@/funding/uniswapV4/UniswapV4FundingPlanner"
+import Decimal from "decimal.js"
 import { ConfirmationPolicy, FillerBpsPolicy, FillerPricePolicy } from "@/config/interpolated-curve"
 import { ChainConfig, FillerConfig, HexString } from "@hyperbridge/sdk"
 import {
@@ -614,6 +615,27 @@ function validateConfig(config: FillerTomlConfig): void {
 				for (const point of strategy.askPriceCurve!) {
 					if (point.amount === undefined || point.price === undefined) {
 						throw new Error("Each FX askPriceCurve point must have 'amount' and 'price'")
+					}
+				}
+
+				// Prices are quoted as "exotic per USD" (an inverted price), so a profitable
+				// spread requires bid ≥ ask at every order size: the filler must hand out fewer
+				// exotic when selling (ask) than it demands when buying (bid). bid < ask is an
+				// inverted spread that loses money on every fill — reject it up front instead of
+				// silently filling at a loss. Both curves are piecewise-linear, so the bid−ask
+				// difference is minimised at a breakpoint; checking the union of points suffices.
+				const bidPolicy = new FillerPricePolicy({ points: strategy.bidPriceCurve! })
+				const askPolicy = new FillerPricePolicy({ points: strategy.askPriceCurve! })
+				const breakpoints = [...strategy.bidPriceCurve!, ...strategy.askPriceCurve!].map((p) => new Decimal(p.amount))
+				for (const amount of breakpoints) {
+					const bid = bidPolicy.getPrice(amount)
+					const ask = askPolicy.getPrice(amount)
+					if (bid.lt(ask)) {
+						throw new Error(
+							`hyperfx: inverted price spread at amount ${amount.toString()} — bidPriceCurve (${bid.toString()}) ` +
+								`must be ≥ askPriceCurve (${ask.toString()}). Prices are 'exotic per USD', so the bid (buying ` +
+								`exotic) is the higher number; a lower bid loses money on every fill.`,
+						)
 					}
 				}
 			}

--- a/sdk/packages/simplex/src/services/DelegationService.ts
+++ b/sdk/packages/simplex/src/services/DelegationService.ts
@@ -1,11 +1,11 @@
 import type { HexString } from "@hyperbridge/sdk"
 import { CryptoUtils, BundlerMethod } from "@hyperbridge/sdk"
-import { concat, keccak256, toHex, toRlp, zeroAddress } from "viem"
+import { concat, formatEther, formatUnits, keccak256, toHex, toRlp, zeroAddress } from "viem"
 import { ChainClientManager } from "./ChainClientManager"
 import { FillerConfigService } from "./FillerConfigService"
 import { getLogger } from "./Logger"
 import type { SigningAccount } from "./wallet"
-import { buildPaymasterAndData, hasPaymaster } from "./paymaster"
+import { buildPaymasterAndData, getUsdcBalanceStatus, hasPaymaster } from "./paymaster"
 import { ENTRYPOINT_ABI } from "@/config/abis/Entrypoint"
 
 /** EIP-7702 delegation indicator prefix */
@@ -163,6 +163,29 @@ export class DelegationService {
 		const chainId = this.configService.getChainId(chain)
 
 		try {
+			// The paymaster sponsors gas in USDC; without enough USDC it can't pay and the
+			// bundler path is impossible. Check up front so we log a precise reason rather
+			// than a generic "no paymaster" further down.
+			const usdcDecimals = this.configService.getUsdcDecimals(chain)
+			const usdc = await getUsdcBalanceStatus(
+				publicClient,
+				solverAccount,
+				this.configService.getUsdcAsset(chain),
+				usdcDecimals,
+			)
+			if (!usdc.sufficient) {
+				this.logger.warn(
+					{
+						chain,
+						solverAccount,
+						usdcBalance: formatUnits(usdc.balance, usdcDecimals),
+						requiredUsdc: formatUnits(usdc.required, usdcDecimals),
+					},
+					"Insufficient USDC balance to sponsor delegation via paymaster; falling back to direct tx",
+				)
+				return false
+			}
+
 			// Build EIP-7702 authorization (bundler submits tx, so use current nonce)
 			const authorization = await this.buildAuthorization(chain, solverAccountContract, true)
 
@@ -181,7 +204,10 @@ export class DelegationService {
 				configService: this.configService,
 			})
 			if (pmResult.type === "none") {
-				this.logger.warn({ chain }, "No paymaster available for delegation")
+				this.logger.warn(
+					{ chain, solverAccount },
+					"Paymaster data unavailable despite sufficient USDC; falling back to direct tx",
+				)
 				return false
 			}
 			const paymasterAndData = pmResult.paymasterAndData
@@ -330,10 +356,31 @@ export class DelegationService {
 
 		// Fallback: direct type-0x04 transaction (requires native token)
 		const publicClient = this.clientManager.getPublicClient(chain)
+		const authority = this.signer.account.address as HexString
+
+		// The direct tx pays gas in native ETH. If the EOA can't cover it, delegation fails
+		// outright (the paymaster path already failed too) — surface the deficit explicitly.
+		const [nativeBalance, gasPrice] = await Promise.all([
+			publicClient.getBalance({ address: authority }),
+			publicClient.getGasPrice(),
+		])
+		const requiredNative = DELEGATION_TX_GAS_FLOOR * gasPrice
+		if (nativeBalance < requiredNative) {
+			this.logger.error(
+				{
+					chain,
+					authority,
+					nativeBalance: formatEther(nativeBalance),
+					requiredNative: formatEther(requiredNative),
+				},
+				"Delegation failed: insufficient native balance for direct EIP-7702 tx and paymaster path unavailable",
+			)
+			return false
+		}
 
 		try {
 			this.logger.info(
-				{ chain, authority: this.signer.account.address, solverAccountContract, mode: this.signer.mode },
+				{ chain, authority, solverAccountContract, mode: this.signer.mode },
 				"Setting up EIP-7702 delegation via direct tx",
 			)
 

--- a/sdk/packages/simplex/src/services/paymaster/index.ts
+++ b/sdk/packages/simplex/src/services/paymaster/index.ts
@@ -33,7 +33,12 @@ export async function buildPaymasterAndData(options: PaymasterOptions): Promise<
 	const usdcAddress = configService.getUsdcAsset(chain)
 	const usdcDecimals = configService.getUsdcDecimals(chain)
 
-	if (!usdcAddress || !(await hasSufficientBalance(publicClient, solverAccount, usdcAddress, usdcDecimals))) {
+	if (!usdcAddress) {
+		return { paymasterAndData: "0x" as HexString, type: "none" }
+	}
+
+	const { sufficient } = await getUsdcBalanceStatus(publicClient, solverAccount, usdcAddress, usdcDecimals)
+	if (!sufficient) {
 		return { paymasterAndData: "0x" as HexString, type: "none" }
 	}
 
@@ -47,12 +52,17 @@ export async function buildPaymasterAndData(options: PaymasterOptions): Promise<
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
-async function hasSufficientBalance(
+/**
+ * Reads `account`'s token balance and reports it against the 1-token minimum the paymaster
+ * needs to sponsor a UserOp. Returns the raw balance and required amount too, so callers can
+ * log a precise deficit rather than a bare boolean.
+ */
+export async function getUsdcBalanceStatus(
 	publicClient: PaymasterOptions["publicClient"],
 	account: HexString,
 	tokenAddress: HexString,
 	tokenDecimals: number,
-): Promise<boolean> {
+): Promise<{ balance: bigint; required: bigint; sufficient: boolean }> {
 	const balance = (await publicClient.readContract({
 		address: tokenAddress,
 		abi: erc20Abi,
@@ -60,6 +70,6 @@ async function hasSufficientBalance(
 		args: [account],
 	})) as bigint
 
-	const minBalance = 10n ** BigInt(tokenDecimals)
-	return balance >= minBalance
+	const required = 10n ** BigInt(tokenDecimals)
+	return { balance, required, sufficient: balance >= required }
 }

--- a/sdk/packages/simplex/src/services/wallet/signer.ts
+++ b/sdk/packages/simplex/src/services/wallet/signer.ts
@@ -2,21 +2,27 @@ import { SignerType, type SignerConfig, type SigningAccount } from "./types"
 import { createMpcVaultSigningAccount } from "./accounts/mpc"
 import { createPrivateKeySigningAccount } from "./accounts/privatekey"
 import { createTurnkeySigningAccount } from "./accounts/turnkey"
+import { getLogger } from "@/services/Logger"
+
+const logger = getLogger("signer")
 
 export async function createSimplexSigner(config: SignerConfig): Promise<SigningAccount> {
+	let account: SigningAccount
 	if (config.type === SignerType.PrivateKey) {
-		return createPrivateKeySigningAccount(config.key)
+		account = await createPrivateKeySigningAccount(config.key)
+	} else if (config.type === SignerType.MpcVault) {
+		account = await createMpcVaultSigningAccount(config)
+	} else if (config.type === SignerType.Turnkey) {
+		account = await createTurnkeySigningAccount(config)
+	} else {
+		throw new Error(`Unsupported signer mode: ${(config as { type?: string }).type ?? "unknown"}`)
 	}
 
-	if (config.type === SignerType.MpcVault) {
-		return createMpcVaultSigningAccount(config)
-	}
-
-	if (config.type === SignerType.Turnkey) {
-		return createTurnkeySigningAccount(config)
-	}
-
-	throw new Error(`Unsupported signer mode: ${(config as { type?: string }).type ?? "unknown"}`)
+	logger.info(
+		{ signingStrategy: account.mode, address: account.account.address },
+		`EVM signing strategy: ${account.mode}`,
+	)
+	return account
 }
 
 export function validateSignerConfig(config: SignerConfig): void {

--- a/sdk/packages/simplex/src/strategies/fx.ts
+++ b/sdk/packages/simplex/src/strategies/fx.ts
@@ -462,16 +462,13 @@ export class FXFiller implements FillerStrategy {
 				}
 			}
 
-			// Spread profit (bid/ask): value received minus cost, using opposite side of spread for valuation.
-			// - When filler sells exotic (stable→exotic): value exotic we give at acquisition cost (bid).
-			// - When filler buys exotic (exotic→stable): value exotic we receive at resale (ask).
-			// Also accumulates totalInputUsd / totalOutputUsd for the input-over-output check.
-			//
-			// `fillerOutputs[i]` is the i-th *surviving* leg; realign to its original input/pair
-			// via `fillerOutputLegs` — skipped legs would otherwise shift the indices.
-			let spreadProfitUsd = new Decimal(0)
-			let totalInputUsdValued = new Decimal(0)
-			let totalOutputUsdValued = new Decimal(0)
+			// Realized FX margin, report-only — never rejects an order. A single fill is half a
+			// round-trip, so the open leg is marked at the opposite side of the spread:
+			// - sells exotic (stable→exotic): value the exotic given at bid (rebuy cost).
+			// - buys exotic (exotic→stable): value the exotic received at ask (resale value).
+			// Positive by construction when bid ≥ ask. `fillerOutputs[i]` is the i-th *surviving*
+			// leg; realign to its original input/pair via `fillerOutputLegs`.
+			let fxMarginUsd = new Decimal(0)
 			for (let i = 0; i < fillerOutputs.length; i++) {
 				const legIndex = fillerOutputLegs[i]
 				const input = order.inputs[legIndex]
@@ -494,43 +491,37 @@ export class FXFiller implements FillerStrategy {
 				const askPrice = venuePriceProfit?.ask ?? policyAskPrice
 
 				if (pair.inputIsStable) {
-					// Filler sells exotic (stable→exotic): receives stable, gives exotic. Value exotic at bid (acquisition cost).
+					// Sells exotic: receives stable, gives exotic valued at bid (rebuy cost).
 					const inputUsd = new Decimal(formatUnits(input.amount, stableDecimals))
 					const outputExotic = new Decimal(formatUnits(output.amount, exoticDecimalsLeg))
-					const outputUsd = outputExotic.div(bidPrice)
-					spreadProfitUsd = spreadProfitUsd.plus(inputUsd.minus(outputUsd))
-					totalInputUsdValued = totalInputUsdValued.plus(inputUsd)
-					totalOutputUsdValued = totalOutputUsdValued.plus(outputUsd)
+					fxMarginUsd = fxMarginUsd.plus(inputUsd.minus(outputExotic.div(bidPrice)))
 				} else {
-					// Filler buys exotic (exotic→stable): receives exotic, gives stable. Value exotic at ask (resale value).
+					// Buys exotic: gives stable, receives exotic valued at ask (resale value).
 					const inputExotic = new Decimal(formatUnits(input.amount, exoticDecimalsLeg))
 					const outputUsd = new Decimal(formatUnits(output.amount, stableDecimals))
-					const inputUsd = inputExotic.div(askPrice)
-					spreadProfitUsd = spreadProfitUsd.plus(inputUsd.minus(outputUsd))
-					totalInputUsdValued = totalInputUsdValued.plus(inputUsd)
-					totalOutputUsdValued = totalOutputUsdValued.plus(outputUsd)
+					fxMarginUsd = fxMarginUsd.plus(inputExotic.div(askPrice).minus(outputUsd))
 				}
-			}
-
-			// Input USD must always exceed output USD — filler cannot pay more than it receives.
-			if (totalOutputUsdValued.gte(totalInputUsdValued)) {
-				this.logger.warn(
-					{
-						orderId: order.id,
-						totalInputUsd: totalInputUsdValued.toString(),
-						totalOutputUsd: totalOutputUsdValued.toString(),
-					},
-					"Rejecting order: output USD ≥ input USD",
-				)
-				return 0
 			}
 
 			this.recordOrderOutcome(anyLegClamped, order.id)
 
 			const { totalCostInSourceFeeToken } = await this.contractService.estimateGasFillPost(order)
-			const feeProfit = order.fees > totalCostInSourceFeeToken ? order.fees - totalCostInSourceFeeToken : 0n
+			// Reject only when the user's attached fees can't cover what we expect to spend on the fill.
+			// FX profitability is trusted to the bid/ask curves; fxMarginUsd is reported, never gated.
+			if (order.fees < totalCostInSourceFeeToken) {
+				this.logger.info(
+					{
+						orderId: order.id,
+						orderFees: formatUnits(order.fees, feeTokenDecimals),
+						estimatedCost: formatUnits(totalCostInSourceFeeToken, feeTokenDecimals),
+					},
+					"Skipping order: attached fees do not cover estimated execution cost",
+				)
+				return 0
+			}
+			const feeProfit = order.fees - totalCostInSourceFeeToken
 			const feeProfitParsed = parseFloat(formatUnits(feeProfit, feeTokenDecimals))
-			const totalProfit = feeProfitParsed + spreadProfitUsd.toNumber()
+			const totalProfit = feeProfitParsed + fxMarginUsd.toNumber()
 
 			this.logger.info(
 				{
@@ -546,7 +537,7 @@ export class FXFiller implements FillerStrategy {
 					orderFees: formatUnits(order.fees, feeTokenDecimals),
 					estimatedFees: formatUnits(totalCostInSourceFeeToken, feeTokenDecimals),
 					feeProfit: formatUnits(feeProfit, feeTokenDecimals),
-					spreadProfitUsd: spreadProfitUsd.toString(),
+					fxMarginUsd: fxMarginUsd.toString(),
 					totalProfit,
 					profitable: totalProfit > 0,
 				},

--- a/sdk/packages/simplex/src/strategies/fx.ts
+++ b/sdk/packages/simplex/src/strategies/fx.ts
@@ -279,6 +279,11 @@ export class FXFiller implements FillerStrategy {
 			const policyBidPrice = this.bidPricePolicy.getPrice(cappedOrderUsd)
 			const policyAskPrice = this.askPricePolicy.getPrice(cappedOrderUsd)
 			const fillerOutputs: TokenInfo[] = []
+			// Original leg index for each entry in `fillerOutputs`. Legs can be skipped
+			// (insufficient balance, exhausted budget), so `fillerOutputs[k]` is the k-th
+			// *surviving* leg, not the k-th leg. The valuation pass below realigns to the
+			// original input/pair via this array rather than by position.
+			const fillerOutputLegs: number[] = []
 			let remainingUsd = cappedOrderUsd
 			let anyLegClamped = false
 
@@ -427,6 +432,7 @@ export class FXFiller implements FillerStrategy {
 				balanceCache.set(tokenAddress, remaining > 0n ? remaining : 0n)
 
 				fillerOutputs.push({ token: output.token, amount: finalOutputAmount })
+				fillerOutputLegs.push(i)
 
 				if (remainingUsd.lte(0)) {
 					break
@@ -460,13 +466,17 @@ export class FXFiller implements FillerStrategy {
 			// - When filler sells exotic (stable→exotic): value exotic we give at acquisition cost (bid).
 			// - When filler buys exotic (exotic→stable): value exotic we receive at resale (ask).
 			// Also accumulates totalInputUsd / totalOutputUsd for the input-over-output check.
+			//
+			// `fillerOutputs[i]` is the i-th *surviving* leg; realign to its original input/pair
+			// via `fillerOutputLegs` — skipped legs would otherwise shift the indices.
 			let spreadProfitUsd = new Decimal(0)
 			let totalInputUsdValued = new Decimal(0)
 			let totalOutputUsdValued = new Decimal(0)
 			for (let i = 0; i < fillerOutputs.length; i++) {
-				const input = order.inputs[i]
+				const legIndex = fillerOutputLegs[i]
+				const input = order.inputs[legIndex]
 				const output = fillerOutputs[i]
-				const pair = pairs[i]
+				const pair = pairs[legIndex]
 
 				const inputDecimals = await this.contractService.getTokenDecimals(
 					bytes32ToBytes20(input.token) as HexString,

--- a/sdk/packages/simplex/src/strategies/fx.ts
+++ b/sdk/packages/simplex/src/strategies/fx.ts
@@ -507,7 +507,6 @@ export class FXFiller implements FillerStrategy {
 
 			const { totalCostInSourceFeeToken } = await this.contractService.estimateGasFillPost(order)
 			// Reject only when the user's attached fees can't cover what we expect to spend on the fill.
-			// FX profitability is trusted to the bid/ask curves; fxMarginUsd is reported, never gated.
 			if (order.fees < totalCostInSourceFeeToken) {
 				this.logger.info(
 					{
@@ -520,8 +519,9 @@ export class FXFiller implements FillerStrategy {
 				return 0
 			}
 			const feeProfit = order.fees - totalCostInSourceFeeToken
-			const feeProfitParsed = parseFloat(formatUnits(feeProfit, feeTokenDecimals))
-			const totalProfit = feeProfitParsed + fxMarginUsd.toNumber()
+			// FX bids are gated on fee profit only. fxMarginUsd is a theoretical mark-to-model
+			// value (open leg priced at the opposite curve) and is reported separately, never summed in.
+			const totalProfit = parseFloat(formatUnits(feeProfit, feeTokenDecimals))
 
 			this.logger.info(
 				{


### PR DESCRIPTION
Two independent simplex fixes:

**Delegation** (`DelegationService`, paymaster)
Pre-check balances before attempting EIP-7702 delegation and log the specific shortfall instead of a generic failure:
- USDC balance on the bundler/paymaster path (paymaster can't sponsor gas without it)
- Native ETH on the direct-tx fallback
- Fixed the misleading "no paymaster available" log when the paymaster *is* configured but USDC is short. Shared the balance check via `getUsdcBalanceStatus`.

**FX pricing** (`fx.ts`, `simplex.ts`)
Fixes orders being wrongly rejected during profitability evaluation:
- **Leg-index desync:** the valuation loop indexed `fillerOutputs[i]` against `order.inputs[i]`/`pairs[i]`, but skipped legs aren't pushed to `fillerOutputs` — so on a multi-leg order with a skipped leg it applied the wrong bid/ask curve. Now realigns via the original leg index.