### PR TITLE
[runtime]:  replace panicking unwraps with proper error propagation across runtime pallets and modules

### DIFF
--- a/modules/ismp/clients/parachain/client/src/lib.rs
+++ b/modules/ismp/clients/parachain/client/src/lib.rs
@@ -418,8 +418,12 @@ impl<T: Config> Pallet<T> {
 			consensus_client_id: PARACHAIN_CONSENSUS_ID,
 			state_machine_commitments: vec![],
 		};
-		handlers::create_client(&host, message)
-			.expect("Failed to initialize parachain consensus client");
+		if let Err(e) = handlers::create_client(&host, message) {
+			log::error!(
+				target: "pallet-ismp-parachain",
+				"Failed to initialize parachain consensus client: {e:?}"
+			);
+		}
 	}
 }
 

--- a/modules/ismp/core/src/handlers/timeout.rs
+++ b/modules/ismp/core/src/handlers/timeout.rs
@@ -125,8 +125,8 @@ where
 						// Module callback failed; restore commitment so the request
 						// can be retried.
 						host.store_request_commitment(&request, meta)?;
-						if host.host_state_machine() != post.source && signer.is_some() {
-							host.store_request_receipt(&request, &signer.expect("Infaliible"))?;
+						if let Some(ref signer) = signer {
+							host.store_request_receipt(&request, signer)?;
 						}
 					}
 					Ok::<_, anyhow::Error>(res)

--- a/modules/ismp/core/src/handlers/timeout.rs
+++ b/modules/ismp/core/src/handlers/timeout.rs
@@ -125,8 +125,11 @@ where
 						// Module callback failed; restore commitment so the request
 						// can be retried.
 						host.store_request_commitment(&request, meta)?;
-						if let Some(ref signer) = signer {
-							host.store_request_receipt(&request, signer)?;
+						if host.host_state_machine() != post.source && signer.is_some() {
+							host.store_request_receipt(
+								&request,
+								&signer.ok_or_else(|| anyhow::anyhow!("Infallible"))?,
+							)?;
 						}
 					}
 					Ok::<_, anyhow::Error>(res)

--- a/modules/ismp/state-machines/evm/src/tendermint.rs
+++ b/modules/ismp/state-machines/evm/src/tendermint.rs
@@ -124,7 +124,7 @@ impl<H: IsmpHost + Send + Sync, T: pallet_ismp_host_executive::Config> StateMach
 			let key = storage_key_for(
 				proof.height.id.state_id,
 				&contract_address.0,
-				slot.clone().try_into().expect("32 bytes"),
+				slot.clone().try_into().map_err(|_| TendermintEvmError::UnsupportedKeyLength)?,
 			);
 
 			let commitment_proof = CommitmentProofBytes::try_from(ev.proof.clone())
@@ -191,7 +191,13 @@ impl<H: IsmpHost + Send + Sync, T: pallet_ismp_host_executive::Config> StateMach
 		for (key_bytes, ev) in keys.into_iter().zip(proofs.into_iter()) {
 			// Determine contract address and 32-byte slot based on key length
 			let (addr, slot): (H160, [u8; 32]) = if key_bytes.len() == 32 {
-				(default_contract_address, key_bytes.clone().try_into().expect("32 bytes"))
+				(
+					default_contract_address,
+					key_bytes
+						.clone()
+						.try_into()
+						.map_err(|_| TendermintEvmError::UnsupportedKeyLength)?,
+				)
 			} else {
 				// 52 bytes: first 20 bytes are contract address, last 32 bytes are the slot
 				let addr = H160::from_slice(&key_bytes[..20]);
@@ -277,7 +283,13 @@ pub fn verify_evm_kv_proofs(
 	for (key_bytes, ev) in keys.drain(..).zip(proofs.into_iter()) {
 		// Determine contract address and 32-byte slot based on key length
 		let (addr, slot): (H160, [u8; 32]) = if key_bytes.len() == 32 {
-			(default_contract_address, key_bytes.clone().try_into().expect("32 bytes"))
+			(
+				default_contract_address,
+				key_bytes
+					.clone()
+					.try_into()
+					.map_err(|_| TendermintEvmError::UnsupportedKeyLength)?,
+			)
 		} else {
 			// 52 bytes: first 20 bytes are contract address, last 32 bytes are the slot
 			let addr = H160::from_slice(&key_bytes[..20]);

--- a/modules/pallets/beefy-consensus-proofs/src/benchmarking.rs
+++ b/modules/pallets/beefy-consensus-proofs/src/benchmarking.rs
@@ -92,7 +92,8 @@ mod benchmarks {
 		// The committed nonce in the fixture is Bob's account, so the signer must be Bob for
 		// the `nonce == signer` check to pass.
 		let submitter: T::AccountId =
-			hex_literal::hex!("8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48").into();
+			hex_literal::hex!("8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48")
+				.into();
 
 		let proof =
 			frame_support::BoundedVec::<u8, T::MaxProofSize>::truncate_from(WIRE_PROOF.to_vec());

--- a/modules/pallets/beefy-consensus-proofs/src/lib.rs
+++ b/modules/pallets/beefy-consensus-proofs/src/lib.rs
@@ -820,8 +820,8 @@ pub mod pallet {
 				Err(Error::<T>::StaleProof)?
 			};
 
-			let coprocessor = T::Coprocessor::get().unwrap();
-			let latest_height = Self::latest_height();
+			let coprocessor = T::Coprocessor::get().ok_or(Error::<T>::NotInitialized)?;
+			let latest_height = Self::latest_height()?;
 
 			if latest_height <= prev_height {
 				Err(Error::<T>::StaleProof)?

--- a/modules/pallets/beefy-consensus-proofs/src/lib.rs
+++ b/modules/pallets/beefy-consensus-proofs/src/lib.rs
@@ -430,14 +430,13 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		/// Returns the latest proven parachain height from `pallet-ismp` for the
 		/// coprocessor state machine.
-		fn latest_height() -> u64 {
+		fn latest_height() -> Result<u64, Error<T>> {
 			let host = pallet_ismp::Pallet::<T>::default();
 			let id = ismp::consensus::StateMachineId {
-				state_id: T::Coprocessor::get()
-					.expect("coprocessor must be set in hyperbridge runtime; qed"),
+				state_id: T::Coprocessor::get().ok_or(Error::<T>::NotInitialized)?,
 				consensus_state_id: T::ConsensusStateId::get(),
 			};
-			host.latest_commitment_height(id).unwrap_or_default()
+			Ok(host.latest_commitment_height(id).unwrap_or_default())
 		}
 
 		/// Top-level dispatch. On success, settle as the first proof; on any failure for
@@ -590,7 +589,7 @@ pub mod pallet {
 			// `latest_height` is for the *newer* first proof; the uncle's lower
 			// `proof.block_number` will fail SP1 verification against it (StaleHeight),
 			// so a stale uncle pays the tx fee.
-			let parachain_height = Self::latest_height();
+			let parachain_height = Self::latest_height()?;
 
 			let snapshot_bytes =
 				ProofContext::<T>::get(parachain_height).ok_or(Error::<T>::NoUncleContext)?;
@@ -758,7 +757,7 @@ pub mod pallet {
 			let prev_state: beefy_verifier_primitives::ConsensusState =
 				Decode::decode(&mut &prev_state_bytes[..])
 					.map_err(|_| Error::<T>::NotInitialized)?;
-			let prev_height = Self::latest_height();
+			let prev_height = Self::latest_height()?;
 
 			let consensus_proof = match proof_type {
 				types::PROOF_TYPE_SP1 => {

--- a/modules/pallets/demo/src/lib.rs
+++ b/modules/pallets/demo/src/lib.rs
@@ -415,10 +415,10 @@ impl<T: Config> IsmpModule for IsmpModuleCallback<T> {
 		};
 		let source_chain = request.source_chain();
 
-		let payload = <Payload<T::AccountId, <T as Config>::Balance> as codec::Decode>::decode(
-			&mut &*request.body().expect("Request has been checked; qed"),
-		)
-		.map_err(|_| IsmpError::Custom("Failed to decode request data".to_string()))?;
+		let body = request.body().ok_or_else(|| anyhow::anyhow!("Request body is missing"))?;
+		let payload =
+			<Payload<T::AccountId, <T as Config>::Balance> as codec::Decode>::decode(&mut &*body)
+				.map_err(|_| IsmpError::Custom("Failed to decode request data".to_string()))?;
 		<T::NativeCurrency as Mutate<T::AccountId>>::mint_into(
 			&payload.from,
 			payload.amount.into(),

--- a/modules/pallets/host-executive/src/lib.rs
+++ b/modules/pallets/host-executive/src/lib.rs
@@ -196,9 +196,7 @@ pub mod pallet {
 				(params.clone(), update);
 			inner.update(update);
 
-			let body = inner
-				.abi_encode_with_variant()
-				.expect("u128 will always fit inside a U256; qed");
+			let body = inner.abi_encode_with_variant().map_err(|_| Error::<T>::DispatchFailed)?;
 
 			let post = DispatchPost {
 				dest: state_machine,

--- a/modules/pallets/ismp/src/utils.rs
+++ b/modules/pallets/ismp/src/utils.rs
@@ -124,7 +124,7 @@ impl ModuleId {
 			inner.copy_from_slice(bytes);
 			Ok(Self::Pallet(PalletId(inner)))
 		} else if bytes.len() == 32 {
-			Ok(Self::Contract(AccountId32::from_slice(bytes).expect("Infallible")))
+			Ok(Self::Contract(AccountId32::from_slice(bytes).map_err(|_| "slice is 32 bytes")?))
 		} else if bytes.len() == 20 {
 			Ok(Self::Evm(H160::from_slice(bytes)))
 		} else {

--- a/modules/pallets/mmr/src/lib.rs
+++ b/modules/pallets/mmr/src/lib.rs
@@ -239,8 +239,7 @@ where
 		// append new leaves to MMR
 		let range = 0u64..buffer_len;
 		for index in range {
-			let leaf = IntermediateLeaves::<T, I>::get(index)
-				.expect("Infallible: Leaf was inserted in this block");
+			let leaf = IntermediateLeaves::<T, I>::get(index).ok_or(Error::Push)?;
 			// Mmr push should never fail
 			match mmr.push(leaf) {
 				None => {

--- a/parachain/runtimes/gargantua/src/genesis_config.rs
+++ b/parachain/runtimes/gargantua/src/genesis_config.rs
@@ -18,7 +18,7 @@ use crate::{
 	RuntimeGenesisConfig, SessionConfig, SessionKeys, SudoConfig, EXISTENTIAL_DEPOSIT,
 };
 
-use alloc::{vec, vec::Vec};
+use alloc::{format, string::String, vec, vec::Vec};
 
 use polkadot_sdk::{sp_core::Pair, staging_xcm as xcm, *};
 
@@ -47,7 +47,7 @@ fn testnet_genesis(
 	endowed_accounts: Vec<AccountId>,
 	root: AccountId,
 	id: ParaId,
-) -> Value {
+) -> Result<Value, String> {
 	let genesis = RuntimeGenesisConfig {
 		balances: BalancesConfig {
 			balances: endowed_accounts
@@ -84,10 +84,10 @@ fn testnet_genesis(
 		..Default::default()
 	};
 
-	json::to_value(genesis).expect("Could not build genesis config.")
+	json::to_value(genesis).map_err(|e| format!("{e}"))
 }
 
-fn local_testnet_genesis() -> Value {
+fn local_testnet_genesis() -> Result<Value, String> {
 	testnet_genesis(
 		// initial collators.
 		vec![
@@ -113,7 +113,7 @@ fn local_testnet_genesis() -> Value {
 	)
 }
 
-fn development_config_genesis() -> Value {
+fn development_config_genesis() -> Result<Value, String> {
 	testnet_genesis(
 		// initial collators.
 		vec![
@@ -142,15 +142,11 @@ fn development_config_genesis() -> Value {
 /// Provides the JSON representation of predefined genesis config for given `id`.
 pub fn get_preset(id: &PresetId) -> Option<vec::Vec<u8>> {
 	let patch = match id.as_str().try_into() {
-		Ok(sp_genesis_builder::LOCAL_TESTNET_RUNTIME_PRESET) => local_testnet_genesis(),
-		Ok(sp_genesis_builder::DEV_RUNTIME_PRESET) => development_config_genesis(),
+		Ok(sp_genesis_builder::LOCAL_TESTNET_RUNTIME_PRESET) => local_testnet_genesis().ok()?,
+		Ok(sp_genesis_builder::DEV_RUNTIME_PRESET) => development_config_genesis().ok()?,
 		_ => return None,
 	};
-	Some(
-		json::to_string(&patch)
-			.expect("serialization to json is expected to work. qed.")
-			.into_bytes(),
-	)
+	Some(json::to_string(&patch).ok()?.into_bytes())
 }
 
 /// List of supported presets.

--- a/parachain/runtimes/nexus/src/genesis_config.rs
+++ b/parachain/runtimes/nexus/src/genesis_config.rs
@@ -18,7 +18,7 @@ use crate::{
 	RuntimeGenesisConfig, SessionConfig, SessionKeys, EXISTENTIAL_DEPOSIT,
 };
 
-use alloc::{vec, vec::Vec};
+use alloc::{format, string::String, vec, vec::Vec};
 
 use polkadot_sdk::{sp_core::Pair, staging_xcm as xcm, *};
 
@@ -47,7 +47,7 @@ fn testnet_genesis(
 	invulnerables: Vec<(AccountId, AuraId)>,
 	endowed_accounts: Vec<AccountId>,
 	id: ParaId,
-) -> Value {
+) -> Result<Value, String> {
 	let genesis = RuntimeGenesisConfig {
 		balances: BalancesConfig {
 			balances: endowed_accounts
@@ -83,10 +83,10 @@ fn testnet_genesis(
 		..Default::default()
 	};
 
-	json::to_value(genesis).expect("Could not build genesis config.")
+	json::to_value(genesis).map_err(|e| format!("{e}"))
 }
 
-fn local_testnet_genesis() -> Value {
+fn local_testnet_genesis() -> Result<Value, String> {
 	testnet_genesis(
 		// initial collators.
 		vec![
@@ -111,7 +111,7 @@ fn local_testnet_genesis() -> Value {
 	)
 }
 
-fn development_config_genesis() -> Value {
+fn development_config_genesis() -> Result<Value, String> {
 	testnet_genesis(
 		// initial collators.
 		vec![
@@ -141,15 +141,11 @@ fn development_config_genesis() -> Value {
 /// Provides the JSON representation of predefined genesis config for given `id`.
 pub fn get_preset(id: &PresetId) -> Option<vec::Vec<u8>> {
 	let patch = match id.as_str().try_into() {
-		Ok(sp_genesis_builder::LOCAL_TESTNET_RUNTIME_PRESET) => local_testnet_genesis(),
-		Ok(sp_genesis_builder::DEV_RUNTIME_PRESET) => development_config_genesis(),
+		Ok(sp_genesis_builder::LOCAL_TESTNET_RUNTIME_PRESET) => local_testnet_genesis().ok()?,
+		Ok(sp_genesis_builder::DEV_RUNTIME_PRESET) => development_config_genesis().ok()?,
 		_ => return None,
 	};
-	Some(
-		json::to_string(&patch)
-			.expect("serialization to json is expected to work. qed.")
-			.into_bytes(),
-	)
+	Some(json::to_string(&patch).ok()?.into_bytes())
 }
 
 /// List of supported presets.


### PR DESCRIPTION
Converts all .expect() calls in production pallet and ISMP module code to return Result or propagate errors via ?, using existing error variants where available.
