### PR TITLE
[simplex]: add solver allowlist for order user addresses

### DIFF
--- a/sdk/packages/simplex/filler-config-example.toml
+++ b/sdk/packages/simplex/filler-config-example.toml
@@ -93,6 +93,24 @@ triggerPercentage = 0.5
 "137" = "10000"    # Polygon: $10k USDT base
 "130" = "10000"    # Unichain: $10k USDT base
 
+# Allowlist configuration (optional)
+# Restricts which order `user` addresses the filler will process.
+# - Omit the entire [allowlist] section to accept orders from all users (default).
+# - When present, only listed users are accepted. A source chain whose merged set
+#   (global `users` + its bySource override) is empty rejects every order.
+# - Address comparisons are case-insensitive.
+#
+# [allowlist]
+# Users eligible across all source chains:
+# users = [
+#     "0x1111111111111111111111111111111111111111",
+# ]
+#
+# Per-source-chain overrides, keyed by state machine id. Merged with the global list.
+# [allowlist.bySource]
+# "EVM-1"     = ["0x2222222222222222222222222222222222222222"]  # Ethereum-only partner
+# "EVM-42161" = ["0x3333333333333333333333333333333333333333"]  # Arbitrum-only partner
+
 # Strategy configuration
 # You can configure multiple strategies
 # All strategies use the configured simplex signer (privateKey or mpcVault)

--- a/sdk/packages/simplex/src/bin/simplex.ts
+++ b/sdk/packages/simplex/src/bin/simplex.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "fs"
 import { resolve, dirname } from "path"
 import { fileURLToPath } from "url"
 import { parse } from "toml"
+import { isAddress } from "viem"
 import { IntentFiller } from "@/core/filler"
 import { BasicFiller } from "@/strategies/basic"
 import { FXFiller } from "@/strategies/fx"
@@ -15,6 +16,7 @@ import {
 	FillerConfigService,
 	type UserProvidedChainConfig,
 	type ResolvedChainConfig,
+	type AllowlistConfig,
 	FillerConfig as FillerServiceConfig,
 	resolveChainConfigs,
 } from "@/services/FillerConfigService"
@@ -191,6 +193,8 @@ interface FillerTomlConfig {
 	chains: UserProvidedChainConfig[]
 	rebalancing?: RebalancingConfig
 	binance?: BinanceConfig
+	/** Restricts order processing to listed user addresses. Omit to accept all users. */
+	allowlist?: AllowlistConfig
 }
 
 const program = new Command()
@@ -250,6 +254,7 @@ program
 				targetGasUnits: config.simplex.targetGasUnits,
 				gasFeeBump: config.simplex.gasFeeBump,
 				overfillProtection: config.simplex.overfillProtection,
+				allowlist: config.allowlist,
 			}
 
 			const configService = new FillerConfigService(resolvedChains, fillerConfigForService)
@@ -532,6 +537,25 @@ function validateConfig(config: FillerTomlConfig): void {
 		}
 		if (!chain.bundlerUrl) {
 			throw new Error("Each chain configuration must have bundlerUrl")
+		}
+	}
+
+	// Validate allowlist addresses (when present)
+	if (config.allowlist) {
+		for (const user of config.allowlist.users ?? []) {
+			if (!isAddress(user)) {
+				throw new Error(`allowlist.users contains an invalid address: ${user}`)
+			}
+		}
+		for (const [chain, users] of Object.entries(config.allowlist.bySource ?? {})) {
+			if (!Array.isArray(users)) {
+				throw new Error(`allowlist.bySource."${chain}" must be an array of addresses`)
+			}
+			for (const user of users) {
+				if (!isAddress(user)) {
+					throw new Error(`allowlist.bySource."${chain}" contains an invalid address: ${user}`)
+				}
+			}
 		}
 	}
 

--- a/sdk/packages/simplex/src/core/filler.ts
+++ b/sdk/packages/simplex/src/core/filler.ts
@@ -366,6 +366,14 @@ export class IntentFiller {
 					return
 				}
 
+				if (!this.configService.isUserAllowed(order.user, order.source)) {
+					this.logger.debug(
+						{ orderId: order.id, user: order.user, source: order.source },
+						"Order user not in allowlist, skipping",
+					)
+					return
+				}
+
 				// Guard against phantom commitments: the off-chain order reconstruction
 				// can mis-pair OrderPlaced logs with placeOrder calldata when a single tx
 				// contains multiple placeOrder calls, yielding a commitment that has no

--- a/sdk/packages/simplex/src/services/FillerConfigService.ts
+++ b/sdk/packages/simplex/src/services/FillerConfigService.ts
@@ -108,6 +108,13 @@ export interface OverfillProtectionConfig {
 	maxConsecutiveClamps?: number
 }
 
+export interface AllowlistConfig {
+	/** Hex addresses eligible across all chains. */
+	users?: string[]
+	/** Per-source-chain overrides, keyed by state machine id (e.g. "EVM-1"). Merged with the global list. */
+	bySource?: Record<string, string[]>
+}
+
 export interface FillerConfig {
 	maxConcurrentOrders: number
 	logging?: LogLevel
@@ -131,6 +138,12 @@ export interface FillerConfig {
 	 * (maxOverfillBps=100, maxConsecutiveClamps=3).
 	 */
 	overfillProtection?: OverfillProtectionConfig
+	/**
+	 * Restricts which order `user` addresses the filler processes. When omitted, all
+	 * users are accepted. When present, only listed users (global ∪ per-source) are
+	 * accepted; a chain whose merged set is empty rejects every order.
+	 */
+	allowlist?: AllowlistConfig
 }
 
 /**
@@ -142,6 +155,10 @@ export class FillerConfigService {
 	private rpcOverrides: Map<number, string[]> = new Map()
 	private bundlerUrls: Map<number, string> = new Map()
 	private fillerConfig?: FillerConfig
+	/** Lowercased global allowlist users, or undefined when no allowlist is configured. */
+	private allowlistGlobal?: Set<string>
+	/** Lowercased per-source allowlist users, keyed by state machine id. */
+	private allowlistBySource: Map<string, Set<string>> = new Map()
 
 	constructor(chainConfigs: ResolvedChainConfig[], fillerConfig?: FillerConfig) {
 		chainConfigs.forEach((config) => {
@@ -157,6 +174,31 @@ export class FillerConfigService {
 
 		this.chainConfigService = new ChainConfigService({})
 		this.fillerConfig = fillerConfig
+
+		const allowlist = fillerConfig?.allowlist
+		if (allowlist) {
+			this.allowlistGlobal = new Set((allowlist.users ?? []).map((u) => u.toLowerCase()))
+			for (const [chain, users] of Object.entries(allowlist.bySource ?? {})) {
+				this.allowlistBySource.set(chain, new Set(users.map((u) => u.toLowerCase())))
+			}
+		}
+	}
+
+	getAllowlist(): AllowlistConfig | undefined {
+		return this.fillerConfig?.allowlist
+	}
+
+	/**
+	 * Whether an order from `user` on `chain` (a source state machine id, e.g. "EVM-1")
+	 * may be processed. Returns true when no allowlist is configured. Otherwise the user
+	 * must appear in the global list or the per-source override for that chain; an empty
+	 * merged set rejects every order on that chain.
+	 */
+	isUserAllowed(user: string, chain: string): boolean {
+		if (!this.allowlistGlobal) return true
+		const normalized = user.toLowerCase()
+		if (this.allowlistGlobal.has(normalized)) return true
+		return this.allowlistBySource.get(chain)?.has(normalized) ?? false
 	}
 
 	getChainConfig(chain: string): ChainConfig {

--- a/sdk/packages/simplex/src/services/FillerConfigService.ts
+++ b/sdk/packages/simplex/src/services/FillerConfigService.ts
@@ -155,10 +155,10 @@ export class FillerConfigService {
 	private rpcOverrides: Map<number, string[]> = new Map()
 	private bundlerUrls: Map<number, string> = new Map()
 	private fillerConfig?: FillerConfig
-	/** Lowercased global allowlist users, or undefined when no allowlist is configured. */
+	/** Lowercased global allowlist users, or undefined when no global list is configured. */
 	private allowlistGlobal?: Set<string>
-	/** Lowercased per-source allowlist users, keyed by state machine id. */
-	private allowlistBySource: Map<string, Set<string>> = new Map()
+	/** Lowercased per-source allowlist users keyed by state machine id, or undefined when no per-source list is configured. */
+	private allowlistBySource?: Map<string, Set<string>>
 
 	constructor(chainConfigs: ResolvedChainConfig[], fillerConfig?: FillerConfig) {
 		chainConfigs.forEach((config) => {
@@ -176,11 +176,16 @@ export class FillerConfigService {
 		this.fillerConfig = fillerConfig
 
 		const allowlist = fillerConfig?.allowlist
-		if (allowlist) {
-			this.allowlistGlobal = new Set((allowlist.users ?? []).map((u) => u.toLowerCase()))
-			for (const [chain, users] of Object.entries(allowlist.bySource ?? {})) {
-				this.allowlistBySource.set(chain, new Set(users.map((u) => u.toLowerCase())))
-			}
+		if (allowlist?.users) {
+			this.allowlistGlobal = new Set(allowlist.users.map((u) => u.toLowerCase()))
+		}
+		if (allowlist?.bySource) {
+			this.allowlistBySource = new Map(
+				Object.entries(allowlist.bySource).map(([chain, users]) => [
+					chain,
+					new Set(users.map((u) => u.toLowerCase())),
+				]),
+			)
 		}
 	}
 
@@ -195,10 +200,10 @@ export class FillerConfigService {
 	 * merged set rejects every order on that chain.
 	 */
 	isUserAllowed(user: string, chain: string): boolean {
-		if (!this.allowlistGlobal) return true
+		if (!this.allowlistGlobal && !this.allowlistBySource) return true
 		const normalized = user.toLowerCase()
-		if (this.allowlistGlobal.has(normalized)) return true
-		return this.allowlistBySource.get(chain)?.has(normalized) ?? false
+		if (this.allowlistGlobal?.has(normalized)) return true
+		return this.allowlistBySource?.get(chain)?.has(normalized) ?? false
 	}
 
 	getChainConfig(chain: string): ChainConfig {

--- a/sdk/packages/simplex/src/services/FillerConfigService.ts
+++ b/sdk/packages/simplex/src/services/FillerConfigService.ts
@@ -1,5 +1,5 @@
 import type { ChainConfig, HexString } from "@hyperbridge/sdk"
-import { ChainConfigService } from "@hyperbridge/sdk"
+import { ChainConfigService, bytes32ToBytes20 } from "@hyperbridge/sdk"
 import { LogLevel } from "./Logger"
 
 export interface UserProvidedChainConfig {
@@ -177,13 +177,13 @@ export class FillerConfigService {
 
 		const allowlist = fillerConfig?.allowlist
 		if (allowlist?.users) {
-			this.allowlistGlobal = new Set(allowlist.users.map((u) => u.toLowerCase()))
+			this.allowlistGlobal = new Set(allowlist.users.map((u) => bytes32ToBytes20(u).toLowerCase()))
 		}
 		if (allowlist?.bySource) {
 			this.allowlistBySource = new Map(
 				Object.entries(allowlist.bySource).map(([chain, users]) => [
 					chain,
-					new Set(users.map((u) => u.toLowerCase())),
+					new Set(users.map((u) => bytes32ToBytes20(u).toLowerCase())),
 				]),
 			)
 		}
@@ -201,7 +201,9 @@ export class FillerConfigService {
 	 */
 	isUserAllowed(user: string, chain: string): boolean {
 		if (!this.allowlistGlobal && !this.allowlistBySource) return true
-		const normalized = user.toLowerCase()
+		// order.user arrives as the bytes32 (left-padded) form from OrderPlaced; the
+		// allowlist is configured with 20-byte addresses. Canonicalize both to compare.
+		const normalized = bytes32ToBytes20(user).toLowerCase()
 		if (this.allowlistGlobal?.has(normalized)) return true
 		return this.allowlistBySource?.get(chain)?.has(normalized) ?? false
 	}

--- a/sdk/packages/simplex/src/tests/services/FillerConfigService.allowlist.test.ts
+++ b/sdk/packages/simplex/src/tests/services/FillerConfigService.allowlist.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect } from "vitest"
+import { bytes20ToBytes32 } from "@hyperbridge/sdk"
 import { FillerConfigService, type AllowlistConfig } from "@/services/FillerConfigService"
 
 const USER_A = "0x1111111111111111111111111111111111111111"
 const USER_B = "0x2222222222222222222222222222222222222222"
 const USER_C = "0x3333333333333333333333333333333333333333"
+
+// Orders surface `user` as the bytes32 (left-padded) form; isUserAllowed is called with that.
+const asOrderUser = (addr: string) => bytes20ToBytes32(addr)
 
 function service(allowlist?: AllowlistConfig): FillerConfigService {
 	return new FillerConfigService([], { maxConcurrentOrders: 5, allowlist })
@@ -12,50 +16,57 @@ function service(allowlist?: AllowlistConfig): FillerConfigService {
 describe("FillerConfigService allowlist", () => {
 	it("accepts every user when no allowlist is configured", () => {
 		const svc = service()
-		expect(svc.isUserAllowed(USER_A, "EVM-1")).toBe(true)
-		expect(svc.isUserAllowed(USER_B, "EVM-42161")).toBe(true)
+		expect(svc.isUserAllowed(asOrderUser(USER_A), "EVM-1")).toBe(true)
+		expect(svc.isUserAllowed(asOrderUser(USER_B), "EVM-42161")).toBe(true)
+	})
+
+	it("matches a bytes32 order user against a 20-byte config address", () => {
+		const svc = service({ users: [USER_A] })
+		// The runtime bytes32 form must match the 20-byte configured address.
+		expect(svc.isUserAllowed(asOrderUser(USER_A), "EVM-1")).toBe(true)
+		expect(svc.isUserAllowed(asOrderUser(USER_B), "EVM-1")).toBe(false)
 	})
 
 	it("matches global users case-insensitively", () => {
 		const svc = service({ users: [USER_A.toUpperCase()] })
-		expect(svc.isUserAllowed(USER_A.toLowerCase(), "EVM-1")).toBe(true)
-		expect(svc.isUserAllowed(USER_A.toUpperCase(), "EVM-1")).toBe(true)
-		expect(svc.isUserAllowed(USER_B, "EVM-1")).toBe(false)
+		expect(svc.isUserAllowed(asOrderUser(USER_A).toLowerCase(), "EVM-1")).toBe(true)
+		expect(svc.isUserAllowed(asOrderUser(USER_A).toUpperCase(), "EVM-1")).toBe(true)
+		expect(svc.isUserAllowed(asOrderUser(USER_B), "EVM-1")).toBe(false)
 	})
 
 	it("merges per-source overrides with the global list", () => {
 		const svc = service({ users: [USER_A], bySource: { "EVM-1": [USER_B] } })
 		// Global user is allowed everywhere.
-		expect(svc.isUserAllowed(USER_A, "EVM-1")).toBe(true)
-		expect(svc.isUserAllowed(USER_A, "EVM-42161")).toBe(true)
+		expect(svc.isUserAllowed(asOrderUser(USER_A), "EVM-1")).toBe(true)
+		expect(svc.isUserAllowed(asOrderUser(USER_A), "EVM-42161")).toBe(true)
 		// Per-source user is allowed only on its chain.
-		expect(svc.isUserAllowed(USER_B, "EVM-1")).toBe(true)
-		expect(svc.isUserAllowed(USER_B, "EVM-42161")).toBe(false)
+		expect(svc.isUserAllowed(asOrderUser(USER_B), "EVM-1")).toBe(true)
+		expect(svc.isUserAllowed(asOrderUser(USER_B), "EVM-42161")).toBe(false)
 	})
 
 	it("isolates per-source overrides between chains", () => {
 		const svc = service({ bySource: { "EVM-1": [USER_B], "EVM-42161": [USER_C] } })
-		expect(svc.isUserAllowed(USER_B, "EVM-1")).toBe(true)
-		expect(svc.isUserAllowed(USER_B, "EVM-42161")).toBe(false)
-		expect(svc.isUserAllowed(USER_C, "EVM-42161")).toBe(true)
-		expect(svc.isUserAllowed(USER_C, "EVM-1")).toBe(false)
+		expect(svc.isUserAllowed(asOrderUser(USER_B), "EVM-1")).toBe(true)
+		expect(svc.isUserAllowed(asOrderUser(USER_B), "EVM-42161")).toBe(false)
+		expect(svc.isUserAllowed(asOrderUser(USER_C), "EVM-42161")).toBe(true)
+		expect(svc.isUserAllowed(asOrderUser(USER_C), "EVM-1")).toBe(false)
 	})
 
 	it("enforces per-source overrides when no global users list is configured", () => {
 		const svc = service({ bySource: { "EVM-1": [USER_B] } })
-		expect(svc.isUserAllowed(USER_B, "EVM-1")).toBe(true)
+		expect(svc.isUserAllowed(asOrderUser(USER_B), "EVM-1")).toBe(true)
 		// No global list and no override for this chain rejects all.
-		expect(svc.isUserAllowed(USER_B, "EVM-42161")).toBe(false)
-		expect(svc.isUserAllowed(USER_A, "EVM-1")).toBe(false)
+		expect(svc.isUserAllowed(asOrderUser(USER_B), "EVM-42161")).toBe(false)
+		expect(svc.isUserAllowed(asOrderUser(USER_A), "EVM-1")).toBe(false)
 	})
 
 	it("rejects every user when the allowlist is present but empty for a chain", () => {
 		const svc = service({ users: [], bySource: { "EVM-1": [USER_B] } })
 		// Chain with no override and an empty global list rejects all.
-		expect(svc.isUserAllowed(USER_B, "EVM-42161")).toBe(false)
-		expect(svc.isUserAllowed(USER_A, "EVM-42161")).toBe(false)
+		expect(svc.isUserAllowed(asOrderUser(USER_B), "EVM-42161")).toBe(false)
+		expect(svc.isUserAllowed(asOrderUser(USER_A), "EVM-42161")).toBe(false)
 		// Chain with an override still admits its listed user.
-		expect(svc.isUserAllowed(USER_B, "EVM-1")).toBe(true)
+		expect(svc.isUserAllowed(asOrderUser(USER_B), "EVM-1")).toBe(true)
 	})
 
 	it("exposes the raw allowlist via getAllowlist", () => {

--- a/sdk/packages/simplex/src/tests/services/FillerConfigService.allowlist.test.ts
+++ b/sdk/packages/simplex/src/tests/services/FillerConfigService.allowlist.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest"
+import { FillerConfigService, type AllowlistConfig } from "@/services/FillerConfigService"
+
+const USER_A = "0x1111111111111111111111111111111111111111"
+const USER_B = "0x2222222222222222222222222222222222222222"
+const USER_C = "0x3333333333333333333333333333333333333333"
+
+function service(allowlist?: AllowlistConfig): FillerConfigService {
+	return new FillerConfigService([], { maxConcurrentOrders: 5, allowlist })
+}
+
+describe("FillerConfigService allowlist", () => {
+	it("accepts every user when no allowlist is configured", () => {
+		const svc = service()
+		expect(svc.isUserAllowed(USER_A, "EVM-1")).toBe(true)
+		expect(svc.isUserAllowed(USER_B, "EVM-42161")).toBe(true)
+	})
+
+	it("matches global users case-insensitively", () => {
+		const svc = service({ users: [USER_A.toUpperCase()] })
+		expect(svc.isUserAllowed(USER_A.toLowerCase(), "EVM-1")).toBe(true)
+		expect(svc.isUserAllowed(USER_A.toUpperCase(), "EVM-1")).toBe(true)
+		expect(svc.isUserAllowed(USER_B, "EVM-1")).toBe(false)
+	})
+
+	it("merges per-source overrides with the global list", () => {
+		const svc = service({ users: [USER_A], bySource: { "EVM-1": [USER_B] } })
+		// Global user is allowed everywhere.
+		expect(svc.isUserAllowed(USER_A, "EVM-1")).toBe(true)
+		expect(svc.isUserAllowed(USER_A, "EVM-42161")).toBe(true)
+		// Per-source user is allowed only on its chain.
+		expect(svc.isUserAllowed(USER_B, "EVM-1")).toBe(true)
+		expect(svc.isUserAllowed(USER_B, "EVM-42161")).toBe(false)
+	})
+
+	it("isolates per-source overrides between chains", () => {
+		const svc = service({ bySource: { "EVM-1": [USER_B], "EVM-42161": [USER_C] } })
+		expect(svc.isUserAllowed(USER_B, "EVM-1")).toBe(true)
+		expect(svc.isUserAllowed(USER_B, "EVM-42161")).toBe(false)
+		expect(svc.isUserAllowed(USER_C, "EVM-42161")).toBe(true)
+		expect(svc.isUserAllowed(USER_C, "EVM-1")).toBe(false)
+	})
+
+	it("rejects every user when the allowlist is present but empty for a chain", () => {
+		const svc = service({ users: [], bySource: { "EVM-1": [USER_B] } })
+		// Chain with no override and an empty global list rejects all.
+		expect(svc.isUserAllowed(USER_B, "EVM-42161")).toBe(false)
+		expect(svc.isUserAllowed(USER_A, "EVM-42161")).toBe(false)
+		// Chain with an override still admits its listed user.
+		expect(svc.isUserAllowed(USER_B, "EVM-1")).toBe(true)
+	})
+
+	it("exposes the raw allowlist via getAllowlist", () => {
+		const allowlist: AllowlistConfig = { users: [USER_A] }
+		expect(service(allowlist).getAllowlist()).toBe(allowlist)
+		expect(service().getAllowlist()).toBeUndefined()
+	})
+})

--- a/sdk/packages/simplex/src/tests/services/FillerConfigService.allowlist.test.ts
+++ b/sdk/packages/simplex/src/tests/services/FillerConfigService.allowlist.test.ts
@@ -41,6 +41,14 @@ describe("FillerConfigService allowlist", () => {
 		expect(svc.isUserAllowed(USER_C, "EVM-1")).toBe(false)
 	})
 
+	it("enforces per-source overrides when no global users list is configured", () => {
+		const svc = service({ bySource: { "EVM-1": [USER_B] } })
+		expect(svc.isUserAllowed(USER_B, "EVM-1")).toBe(true)
+		// No global list and no override for this chain rejects all.
+		expect(svc.isUserAllowed(USER_B, "EVM-42161")).toBe(false)
+		expect(svc.isUserAllowed(USER_A, "EVM-1")).toBe(false)
+	})
+
 	it("rejects every user when the allowlist is present but empty for a chain", () => {
 		const svc = service({ users: [], bySource: { "EVM-1": [USER_B] } })
 		// Chain with no override and an empty global list rejects all.


### PR DESCRIPTION
Restricts which order `user` addresses the filler processes, configured via a new optional `[allowlist]` section. Omitting it preserves accept-all behavior.

- Global `users` list merged with per-source overrides in `[allowlist.bySource]` (keyed by state machine id, e.g. `EVM-1`); case-insensitive.
- A present-but-empty merged set for a chain rejects every order; a fully-absent `[allowlist]` accepts all.
- Early rejection in `IntentFiller.handleNewOrder` before `verifyOrderOnSource`.

Closes #947