### PR TITLE
[runtime]: Enforce BSC vote adjacency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28025,7 +28025,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tesseract"
-version = "2.4.1"
+version = "2.4.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/modules/consensus/bsc/prover/src/lib.rs
+++ b/modules/consensus/bsc/prover/src/lib.rs
@@ -120,6 +120,25 @@ impl<C: Config> BscPosProver<C> {
 			.await?
 			.ok_or_else(|| anyhow!("header block could not be fetched {target_hash}"))?;
 
+		// BEP-126 fast finality only finalizes `source_header` once the justified
+		// `target_header` is its direct child (two consecutive justified blocks).
+		// A non-adjacent vote leaves `source_header` merely justified and still
+		// reorg-able, so never emit such an update: the on-chain verifier rejects
+		// it (`NonConsecutiveFinalization`) and committing a reorg-able source as
+		// finalized would be unsound.
+		if target_header.number.low_u64() != source_header.number.low_u64().saturating_add(1) ||
+			target_header.parent_hash.0 != source_hash.0
+		{
+			trace!(
+				target: "bsc-prover",
+				"skipping non-adjacent vote: source #{} target #{} (target parent {:?} != source {source_hash:?})",
+				source_header.number.low_u64(),
+				target_header.number.low_u64(),
+				target_header.parent_hash,
+			);
+			return Ok(None);
+		}
+
 		let mut epoch_header_ancestry = vec![];
 		let epoch_header_number = params.epoch * params.epoch_length;
 		// If we are still in authority rotation period get the epoch header ancestry alongside

--- a/modules/consensus/bsc/verifier/src/error.rs
+++ b/modules/consensus/bsc/verifier/src/error.rs
@@ -37,6 +37,12 @@ pub enum Error {
 	/// The hashed source/target headers don't match the vote data.
 	#[error("Target and source headers do not match vote data")]
 	HeaderVoteDataMismatch,
+	/// The justified `target_header` is not the direct child of the finalized
+	/// `source_header`. BEP-126 fast finality only finalizes a block once it and
+	/// its direct child are both justified, so a non-adjacent vote attestation
+	/// must not be accepted as finalizing `source_header`.
+	#[error("Target header is not the direct child of the source header")]
+	NonConsecutiveFinalization,
 	/// One or more participant public keys failed to decompress.
 	#[error("Failed to aggregate participant public keys: {0}")]
 	AggregatePublicKeys(String),

--- a/modules/consensus/bsc/verifier/src/lib.rs
+++ b/modules/consensus/bsc/verifier/src/lib.rs
@@ -22,7 +22,7 @@ use alloc::vec::Vec;
 use bls_utils::aggregate_public_keys;
 use geth_primitives::{CodecHeader, Header};
 use ismp::messaging::Keccak256;
-use primitives::{BscClientUpdate, Config, VALIDATOR_BIT_SET_SIZE, parse_extra};
+use primitives::{parse_extra, BscClientUpdate, Config, VALIDATOR_BIT_SET_SIZE};
 use sp_core::H256;
 use ssz_rs::{Bitvector, Deserialize};
 use sync_committee_primitives::constants::BlsPublicKey;
@@ -96,6 +96,18 @@ pub fn verify_bsc_header<H: Keccak256, C: Config>(
 		target_header_hash.0 != extra_data.vote_data.target_hash.0
 	{
 		Err(Error::HeaderVoteDataMismatch)?
+	}
+
+	// BEP-126 fast finality only *finalizes* `source_header` once the justified
+	// `target_header` is its direct child (two consecutive justified blocks). A
+	// supermajority-signed but non-adjacent vote justifies `target_header` yet
+	// leaves `source_header` merely justified and still reorg-able, so committing
+	// its state root as a finalized BSC state commitment would be unsound.
+	if update.target_header.number.low_u64() !=
+		update.source_header.number.low_u64().saturating_add(1) ||
+		update.target_header.parent_hash.0 != source_header_hash.0
+	{
+		Err(Error::NonConsecutiveFinalization)?
 	}
 
 	let participants: Vec<BlsPublicKey> = current_validators
@@ -202,7 +214,7 @@ pub fn verify_bsc_header<H: Keccak256, C: Config>(
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use alloy_primitives::{B256, Bytes, FixedBytes};
+	use alloy_primitives::{Bytes, FixedBytes, B256};
 	use alloy_rlp::Encodable;
 	use geth_primitives::CodecHeader;
 	use primitive_types::{H160, H256, U256};
@@ -335,5 +347,44 @@ mod tests {
 		let err = verify_bsc_header::<TestHost, Testnet>(&validators, update_with(header), 1000)
 			.expect_err("under-threshold update must be rejected");
 		assert!(format!("{err}").contains("Not enough participants"), "unexpected error: {err:?}");
+	}
+
+	/// Minimal header at a given block number (no vote attestation).
+	fn plain_header(number: u64, parent_hash: H256) -> CodecHeader {
+		let mut header = header_with_vote_set(0, B256::ZERO, B256::ZERO);
+		header.extra_data = Vec::new();
+		header.number = U256::from(number);
+		header.parent_hash = parent_hash;
+		header
+	}
+
+	/// A supermajority-signed vote whose `target` is NOT the direct child of
+	/// `source` must be rejected: committing a merely-justified (reorg-able)
+	/// `source` as finalized violates BEP-126's two-consecutive-justified rule.
+	#[test]
+	fn rejects_non_adjacent_source_target() {
+		let validators = dummy_validators(21);
+		let mask: u64 = (1u64 << 21) - 1;
+
+		// source #10 and target #15 — not consecutive, and target.parent != source.
+		let source_header = plain_header(10, H256::repeat_byte(0x11));
+		let source_hash = Header::from(&source_header).hash::<TestHost>();
+		let target_header = plain_header(15, H256::repeat_byte(0x22));
+		let target_hash = Header::from(&target_header).hash::<TestHost>();
+
+		// The attestation carries the genuine source/target header hashes, so the
+		// header<->vote binding check passes and we reach the adjacency check.
+		let attested_header =
+			header_with_vote_set(mask, B256::from(source_hash.0), B256::from(target_hash.0));
+		let update = BscClientUpdate {
+			source_header,
+			target_header,
+			attested_header,
+			epoch_header_ancestry: Default::default(),
+		};
+
+		let err = verify_bsc_header::<TestHost, Testnet>(&validators, update, 1000)
+			.expect_err("non-adjacent vote must be rejected");
+		assert!(format!("{err}").contains("not the direct child"), "unexpected error: {err:?}");
 	}
 }

--- a/modules/ismp/core/src/host.rs
+++ b/modules/ismp/core/src/host.rs
@@ -397,8 +397,12 @@ impl FromStr for StateMachine {
 					.split('-')
 					.last()
 					.ok_or_else(|| format!("invalid state machine: {name}"))?;
+				let bytes = name.as_bytes();
+				if bytes.len() != 4 {
+					Err(format!("invalid state machine: {name}"))?
+				}
 				let mut id = [0u8; 4];
-				id.copy_from_slice(name.as_bytes());
+				id.copy_from_slice(bytes);
 				StateMachine::Substrate(id)
 			},
 			name if name.starts_with("TNDRMINT-") => {
@@ -406,8 +410,12 @@ impl FromStr for StateMachine {
 					.split('-')
 					.last()
 					.ok_or_else(|| format!("invalid state machine: {name}"))?;
+				let bytes = name.as_bytes();
+				if bytes.len() != 4 {
+					Err(format!("invalid state machine: {name}"))?
+				}
 				let mut id = [0u8; 4];
-				id.copy_from_slice(name.as_bytes());
+				id.copy_from_slice(bytes);
 				StateMachine::Tendermint(id)
 			},
 			name => Err(format!("Unknown state machine: {name}"))?,
@@ -457,5 +465,26 @@ mod tests {
 		assert_eq!(grandpa_string, "SUBSTRATE-XXXX".to_string());
 		assert_eq!(beefy_string, "TNDRMINT-XXXX".to_string());
 		assert_eq!(solo_string, "RELAY-XXXX-1000".to_string());
+	}
+
+	// A malformed `SUBSTRATE-`/`TNDRMINT-` id whose byte length is not exactly 4
+	// must return an error rather than panic. The id is copied into a `[u8; 4]`,
+	// and `copy_from_slice` traps on a length mismatch — in the runtime this is a
+	// wasm trap reachable from untrusted input (e.g. `BandwidthManager.purchase`),
+	// so the length is now checked up-front (matching the `RELAY-` arm).
+	#[test]
+	fn from_str_rejects_non_four_byte_consensus_ids() {
+		for s in ["SUBSTRATE-", "SUBSTRATE-AB", "SUBSTRATE-ABCDE", "TNDRMINT-XYZ"] {
+			assert!(StateMachine::from_str(s).is_err(), "expected error for {s:?}");
+		}
+		// Exactly-4-byte ids still parse.
+		assert_eq!(
+			StateMachine::from_str("SUBSTRATE-ABCD").unwrap(),
+			StateMachine::Substrate(*b"ABCD")
+		);
+		assert_eq!(
+			StateMachine::from_str("TNDRMINT-ABCD").unwrap(),
+			StateMachine::Tendermint(*b"ABCD")
+		);
 	}
 }

--- a/modules/pallets/call-decompressor/src/lib.rs
+++ b/modules/pallets/call-decompressor/src/lib.rs
@@ -221,6 +221,15 @@ where
 		compressed_bytes: Vec<u8>,
 		encoded_call_size: u32,
 	) -> Result<Vec<u8>, DispatchError> {
+		// Bound the claimed decompressed size against the configured maximum here,
+		// at the single choke point every caller flows through. Previously this
+		// gate lived only in `decompress_call` (the dispatch path); the unsigned
+		// `validate_unsigned` mempool path called `decompress` directly with no
+		// bound, so a fee-less attacker could claim `encoded_call_size = u32::MAX`
+		// and have a tiny zstd "bomb" expanded to gigabytes during transaction-pool
+		// validation, before any size check. Enforcing it here protects both paths.
+		ensure!(encoded_call_size < T::MaxCallSize::get() * ONE_MB, Error::<T>::CallSizeOutOfBound);
+
 		let mut decoder = StreamingDecoder::new(compressed_bytes.as_slice())
 			.map_err(|_| Error::<T>::DecompressionFailed)?;
 

--- a/modules/pallets/testsuite/src/tests/pallet_call_decompressor.rs
+++ b/modules/pallets/testsuite/src/tests/pallet_call_decompressor.rs
@@ -271,6 +271,46 @@ fn should_reject_decompression_when_actual_size_diverges_from_claim() {
 }
 
 #[test]
+fn decompress_rejects_oversize_claim_before_decompressing() {
+	use frame_support::pallet_prelude::{InvalidTransaction, TransactionSource, ValidateUnsigned};
+
+	let mut ext = new_test_ext();
+	ext.execute_with(|| {
+		// A tiny, perfectly valid zstd frame; the inflated *claim* is the attack.
+		let payload = b"a small decompressible payload".to_vec();
+		let mut buffer = vec![0u8; 1_000];
+		let compressed = zstd_safe::compress(&mut buffer[..], &payload, 3).unwrap();
+		let compressed = buffer[..compressed].to_vec();
+
+		// `u32::MAX` is far above `MaxCallSize * ONE_MB`. The gate inside
+		// `decompress` must reject it up-front (`CallSizeOutOfBound`) before the
+		// decompression loop expands anything — this is the mempool zstd-bomb guard.
+		let res =
+			pallet_call_decompressor::Pallet::<Test>::decompress(compressed.clone(), u32::MAX);
+		assert!(
+			matches!(
+				res,
+				Err(DispatchError::Module(ModuleError { message: Some("CallSizeOutOfBound"), .. }))
+			),
+			"oversize claim must be rejected by the size gate, got {res:?}",
+		);
+
+		// And the unsigned mempool path (`validate_unsigned`) must reject it too,
+		// without performing the decompression first.
+		let call = pallet_call_decompressor::Call::<Test>::decompress_call {
+			compressed,
+			encoded_call_size: u32::MAX,
+		};
+		let validity =
+			<pallet_call_decompressor::Pallet<Test> as ValidateUnsigned>::validate_unsigned(
+				TransactionSource::External,
+				&call,
+			);
+		assert_eq!(validity, Err(InvalidTransaction::Call.into()));
+	});
+}
+
+#[test]
 fn decompress_stack_exhaustion_poc() {
 	let mut ext = new_test_ext();
 	ext.execute_with(|| {

--- a/tesseract/relayer/Cargo.toml
+++ b/tesseract/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tesseract"
-version = "2.4.1"
+version = "2.4.2"
 edition = "2021"
 description = "Consolidated Hyperbridge relayer — inbound and outbound consensus + messaging"
 authors = ["Polytope Labs <hello@polytope.technology>"]


### PR DESCRIPTION
BSC fast-finality adjacency 
- `verify_bsc_header` committed `source_header` as finalized from a supermajority-signed vote attestation without checking that the justified `target_header` is the direct child of `source_header`. Per BEP-126, a block is finalized only when it and its direct child are both justified; a non-adjacent (but genuinely signed) vote leaves `source_header` merely justified and still reorg-able, so its state root must not be committed as final. Add `target.number == source.number + 1 && target.parent_hash == source_hash` (new `Error::NonConsecutiveFinalization`). The `ismp-bsc` client performed no adjacency check either.
- The BSC prover now performs the same adjacency check and skips emitting a non-adjacent update.

StateMachine::from_str wasm trap 
- The `SUBSTRATE-`/`TNDRMINT-` arms did an unguarded `copy_from_slice` into a `[u8; 4]`, which traps on a non-4-byte id. This is reachable from untrusted input (e.g. `BandwidthManager.purchase`). Add a length check up-front, matching the existing `RELAY-` arm.

Adds unit tests for both: a non-adjacent vote is rejected, and malformed consensus-id strings return an error instead of panicking.