### PR TITLE
 [tesseract]: periodic outbound consensus claim task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28033,6 +28033,7 @@ dependencies = [
  "futures",
  "hex",
  "ismp",
+ "ismp-parachain",
  "log",
  "messaging",
  "pallet-beefy-consensus-proofs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15352,6 +15352,7 @@ dependencies = [
  "pallet-ismp",
  "pallet-ismp-host-executive",
  "parity-scale-codec",
+ "pharos-primitives",
  "polkadot-sdk",
  "scale-info",
  "substrate-state-machine",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28025,7 +28025,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tesseract"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/modules/ismp/core/src/host.rs
+++ b/modules/ismp/core/src/host.rs
@@ -308,6 +308,12 @@ impl StateMachine {
 			_ => false,
 		}
 	}
+
+	/// Returns true if this is a Pharos state machine. Pharos stores trie values as raw
+	/// ABI-encoded bytes rather than RLP, so it needs its own decode path.
+	pub fn is_pharos(&self) -> bool {
+		matches!(self, StateMachine::Evm(688600 | 688689))
+	}
 }
 
 impl Display for StateMachine {

--- a/modules/ismp/core/src/host.rs
+++ b/modules/ismp/core/src/host.rs
@@ -308,12 +308,6 @@ impl StateMachine {
 			_ => false,
 		}
 	}
-
-	/// Returns true if this is a Pharos state machine. Pharos stores trie values as raw
-	/// ABI-encoded bytes rather than RLP, so it needs its own decode path.
-	pub fn is_pharos(&self) -> bool {
-		matches!(self, StateMachine::Evm(688600 | 688689))
-	}
 }
 
 impl Display for StateMachine {

--- a/modules/pallets/relayer/Cargo.toml
+++ b/modules/pallets/relayer/Cargo.toml
@@ -13,6 +13,7 @@ evm-state-machine = { workspace = true }
 pallet-ismp-host-executive = { workspace = true }
 ismp = { workspace = true }
 crypto-utils = { workspace = true }
+pharos-primitives = { workspace = true }
 
 # crates.io
 log = { workspace = true, default-features = false }
@@ -58,6 +59,7 @@ std = [
     "evm-state-machine/std",
     "pallet-ismp-host-executive/std",
     "anyhow/std",
-    "crypto-utils/std"
+    "crypto-utils/std",
+    "pharos-primitives/std"
 ]
 try-runtime = ["polkadot-sdk/try-runtime"]

--- a/modules/pallets/relayer/src/accumulate.rs
+++ b/modules/pallets/relayer/src/accumulate.rs
@@ -258,16 +258,17 @@ where
 				};
 
 			let fee = match proof.source_proof.height.id.state_id {
-				s if s.is_evm() => {
-					use alloy_rlp::Decodable;
-					if let Ok(fee) = alloy_primitives::U256::decode(&mut &*encoded_metadata) {
-						U256::from_big_endian(&fee.to_be_bytes::<32>())
-					} else if encoded_metadata.len() == 32 {
-						// Flat-trie chains (e.g. Pharos) store values as raw 32-byte ABI encoding
+				s if s.is_pharos() =>
+					if encoded_metadata.len() == 32 {
 						U256::from_big_endian(&encoded_metadata)
 					} else {
 						return Err(Error::<T>::ProofValidationError);
-					}
+					},
+				s if s.is_evm() => {
+					use alloy_rlp::Decodable;
+					let fee = alloy_primitives::U256::decode(&mut &*encoded_metadata)
+						.map_err(|_| Error::<T>::ProofValidationError)?;
+					U256::from_big_endian(&fee.to_be_bytes::<32>())
 				},
 				s if s.is_substrate() => {
 					use codec::Decode;
@@ -320,16 +321,18 @@ impl<T: Config> Pallet<T> {
 	/// accumulation and the outbound request delivery claim.
 	pub fn decode_receipt_relayer(state_id: StateMachine, raw: &[u8]) -> Result<Vec<u8>, Error<T>> {
 		match state_id {
+			s if s.is_pharos() =>
+				if raw.len() == 32 {
+					Ok(Address::from_slice(&raw[12..]).0.to_vec())
+				} else {
+					Err(Error::<T>::ProofValidationError)
+				},
 			s if s.is_evm() => {
 				use alloy_rlp::Decodable;
-				if let Ok(addr) = Address::decode(&mut &*raw) {
-					return Ok(addr.0.to_vec());
-				}
-				// Flat-trie chains (e.g. Pharos) store address as raw 32-byte ABI encoding
-				if raw.len() == 32 {
-					return Ok(Address::from_slice(&raw[12..]).0.to_vec());
-				}
-				Err(Error::<T>::ProofValidationError)
+				Ok(Address::decode(&mut &*raw)
+					.map_err(|_| Error::<T>::ProofValidationError)?
+					.0
+					.to_vec())
 			},
 			s if s.is_substrate() => {
 				use codec::Decode;

--- a/modules/pallets/relayer/src/accumulate.rs
+++ b/modules/pallets/relayer/src/accumulate.rs
@@ -260,9 +260,14 @@ where
 			let fee = match proof.source_proof.height.id.state_id {
 				s if s.is_evm() => {
 					use alloy_rlp::Decodable;
-					let fee = alloy_primitives::U256::decode(&mut &*encoded_metadata)
-						.map_err(|_| Error::<T>::ProofValidationError)?;
-					U256::from_big_endian(&fee.to_be_bytes::<32>())
+					if let Ok(fee) = alloy_primitives::U256::decode(&mut &*encoded_metadata) {
+						U256::from_big_endian(&fee.to_be_bytes::<32>())
+					} else if encoded_metadata.len() == 32 {
+						// Flat-trie chains (e.g. Pharos) store values as raw 32-byte ABI encoding
+						U256::from_big_endian(&encoded_metadata)
+					} else {
+						return Err(Error::<T>::ProofValidationError);
+					}
 				},
 				s if s.is_substrate() => {
 					use codec::Decode;
@@ -317,10 +322,14 @@ impl<T: Config> Pallet<T> {
 		match state_id {
 			s if s.is_evm() => {
 				use alloy_rlp::Decodable;
-				Ok(Address::decode(&mut &*raw)
-					.map_err(|_| Error::<T>::ProofValidationError)?
-					.0
-					.to_vec())
+				if let Ok(addr) = Address::decode(&mut &*raw) {
+					return Ok(addr.0.to_vec());
+				}
+				// Flat-trie chains (e.g. Pharos) store address as raw 32-byte ABI encoding
+				if raw.len() == 32 {
+					return Ok(Address::from_slice(&raw[12..]).0.to_vec());
+				}
+				Err(Error::<T>::ProofValidationError)
 			},
 			s if s.is_substrate() => {
 				use codec::Decode;

--- a/modules/pallets/relayer/src/accumulate.rs
+++ b/modules/pallets/relayer/src/accumulate.rs
@@ -258,7 +258,7 @@ where
 				};
 
 			let fee = match proof.source_proof.height.id.state_id {
-				s if s.is_pharos() =>
+				s if crate::is_pharos(&s) =>
 					if encoded_metadata.len() == 32 {
 						U256::from_big_endian(&encoded_metadata)
 					} else {
@@ -321,7 +321,7 @@ impl<T: Config> Pallet<T> {
 	/// accumulation and the outbound request delivery claim.
 	pub fn decode_receipt_relayer(state_id: StateMachine, raw: &[u8]) -> Result<Vec<u8>, Error<T>> {
 		match state_id {
-			s if s.is_pharos() =>
+			s if crate::is_pharos(&s) =>
 				if raw.len() == 32 {
 					Ok(Address::from_slice(&raw[12..]).0.to_vec())
 				} else {

--- a/modules/pallets/relayer/src/lib.rs
+++ b/modules/pallets/relayer/src/lib.rs
@@ -64,6 +64,17 @@ pub type ModuleIdBound = sp_core::ConstU32<64>;
 /// of truth.
 pub use evm_state_machine::presets::REQUEST_RECEIPTS_SLOT;
 
+/// Returns true if `state_id` is a Pharos state machine. Pharos stores trie
+/// values as raw ABI-encoded bytes rather than RLP, so the proof-decoding
+/// paths in this pallet branch on it.
+pub fn is_pharos(state_id: &StateMachine) -> bool {
+	use pharos_primitives::{PHAROS_ATLANTIC_CHAIN_ID, PHAROS_MAINNET_CHAIN_ID};
+	matches!(
+		state_id,
+		StateMachine::Evm(id) if *id == PHAROS_MAINNET_CHAIN_ID || *id == PHAROS_ATLANTIC_CHAIN_ID
+	)
+}
+
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;

--- a/modules/pallets/relayer/src/outbound_consensus.rs
+++ b/modules/pallets/relayer/src/outbound_consensus.rs
@@ -161,8 +161,8 @@ where
 		// Ethereum trie stores. Returns `None` for an unset / zero-address
 		// slot, which we surface as `OutboundDeliveryNotProven` (logically
 		// equivalent to "no delivery proven yet").
-		let evm_address =
-			Self::decode_epochs_slot_address(&raw).ok_or(Error::<T>::OutboundDeliveryNotProven)?;
+		let evm_address = Self::decode_epochs_slot_address(destination, &raw)
+			.ok_or(Error::<T>::OutboundDeliveryNotProven)?;
 
 		// Replay protection comes from the `OutboundConsensusRotationsClaimed`
 		let msg = outbound_consensus_delivery_message(set_id, destination, payee);
@@ -197,20 +197,18 @@ where
 		Ok(())
 	}
 
-	/// Decode the EVM `address` value stored at
-	/// `EvmHost._epochs[set_id]`, as returned by
-	/// `EvmStateMachine::verify_state_proof`.
-	///
-	/// Standard EVM MPT trie returns RLP-encoded values; Pharos flat trie
-	/// returns the raw 32-byte zero-padded ABI value. We try RLP first and
-	/// fall back to extracting the last 20 bytes of a 32-byte padded value.
-	pub fn decode_epochs_slot_address(raw: &[u8]) -> Option<Address> {
+	/// Decode the `address` value from `EvmHost._epochs[set_id]` as returned
+	/// by `EvmStateMachine::verify_state_proof`. Standard EVM chains RLP-encode
+	/// the value; Pharos stores it as a raw 32-byte ABI-padded word.
+	pub fn decode_epochs_slot_address(
+		state_id: ismp::host::StateMachine,
+		raw: &[u8],
+	) -> Option<Address> {
 		use alloy_rlp::Decodable;
 		if let Ok(addr) = Address::decode(&mut &*raw) {
 			return if addr == Address::ZERO { None } else { Some(addr) };
 		}
-		// Pharos flat trie: raw 32-byte zero-padded ABI encoding
-		if raw.len() == 32 {
+		if state_id.is_pharos() && raw.len() == 32 {
 			let addr = Address::from_slice(&raw[12..]);
 			return if addr == Address::ZERO { None } else { Some(addr) };
 		}

--- a/modules/pallets/relayer/src/outbound_consensus.rs
+++ b/modules/pallets/relayer/src/outbound_consensus.rs
@@ -200,14 +200,21 @@ where
 	/// Decode the EVM `address` value stored at
 	/// `EvmHost._epochs[set_id]`, as returned by
 	/// `EvmStateMachine::verify_state_proof`.
+	///
+	/// Standard EVM MPT trie returns RLP-encoded values; Pharos flat trie
+	/// returns the raw 32-byte zero-padded ABI value. We try RLP first and
+	/// fall back to extracting the last 20 bytes of a 32-byte padded value.
 	pub fn decode_epochs_slot_address(raw: &[u8]) -> Option<Address> {
 		use alloy_rlp::Decodable;
-		let addr = Address::decode(&mut &*raw).ok()?;
-		if addr == Address::ZERO {
-			None
-		} else {
-			Some(addr)
+		if let Ok(addr) = Address::decode(&mut &*raw) {
+			return if addr == Address::ZERO { None } else { Some(addr) };
 		}
+		// Pharos flat trie: raw 32-byte zero-padded ABI encoding
+		if raw.len() == 32 {
+			let addr = Address::from_slice(&raw[12..]);
+			return if addr == Address::ZERO { None } else { Some(addr) };
+		}
+		None
 	}
 }
 

--- a/modules/pallets/relayer/src/outbound_consensus.rs
+++ b/modules/pallets/relayer/src/outbound_consensus.rs
@@ -208,7 +208,7 @@ where
 		if let Ok(addr) = Address::decode(&mut &*raw) {
 			return if addr == Address::ZERO { None } else { Some(addr) };
 		}
-		if state_id.is_pharos() && raw.len() == 32 {
+		if crate::is_pharos(&state_id) && raw.len() == 32 {
 			let addr = Address::from_slice(&raw[12..]);
 			return if addr == Address::ZERO { None } else { Some(addr) };
 		}

--- a/modules/pallets/testsuite/src/tests/pallet_ismp_relayer.rs
+++ b/modules/pallets/testsuite/src/tests/pallet_ismp_relayer.rs
@@ -1125,7 +1125,7 @@ mod outbound_consensus_delivery {
 			raw.extend_from_slice(&RELAYER_ADDR);
 			assert_eq!(raw.len(), 21);
 
-			let decoded = pallet_ismp_relayer::Pallet::<Test>::decode_epochs_slot_address(&raw)
+			let decoded = pallet_ismp_relayer::Pallet::<Test>::decode_epochs_slot_address(ismp::host::StateMachine::Evm(1), &raw)
 				.expect("21-byte RLP-encoded address should decode");
 			assert_eq!(decoded, AlloyAddress::from_slice(&RELAYER_ADDR));
 		}
@@ -1149,7 +1149,7 @@ mod outbound_consensus_delivery {
 			raw.extend_from_slice(stripped);
 
 			assert!(
-				pallet_ismp_relayer::Pallet::<Test>::decode_epochs_slot_address(&raw).is_none(),
+				pallet_ismp_relayer::Pallet::<Test>::decode_epochs_slot_address(ismp::host::StateMachine::Evm(1), &raw).is_none(),
 			);
 		}
 
@@ -1160,7 +1160,7 @@ mod outbound_consensus_delivery {
 		#[test]
 		fn rejects_rlp_empty_string() {
 			assert!(
-				pallet_ismp_relayer::Pallet::<Test>::decode_epochs_slot_address(&[0x80,]).is_none()
+				pallet_ismp_relayer::Pallet::<Test>::decode_epochs_slot_address(ismp::host::StateMachine::Evm(1), &[0x80,]).is_none()
 			);
 		}
 
@@ -1176,7 +1176,7 @@ mod outbound_consensus_delivery {
 			// 1-byte string `0x00` (which is invalid per RLP) or as
 			// trailing garbage; either way we expect None.
 			assert!(
-				pallet_ismp_relayer::Pallet::<Test>::decode_epochs_slot_address(&raw).is_none(),
+				pallet_ismp_relayer::Pallet::<Test>::decode_epochs_slot_address(ismp::host::StateMachine::Evm(1), &raw).is_none(),
 				"raw 32-byte word must not decode — that was the broken legacy shape",
 			);
 		}
@@ -1184,9 +1184,10 @@ mod outbound_consensus_delivery {
 		/// Garbage bytes that aren't a valid RLP byte string at all.
 		#[test]
 		fn rejects_garbage() {
-			assert!(pallet_ismp_relayer::Pallet::<Test>::decode_epochs_slot_address(&[
-				0xff, 0xff, 0xff,
-			])
+			assert!(pallet_ismp_relayer::Pallet::<Test>::decode_epochs_slot_address(
+				ismp::host::StateMachine::Evm(1),
+				&[0xff, 0xff, 0xff],
+			)
 			.is_none());
 		}
 
@@ -1199,7 +1200,7 @@ mod outbound_consensus_delivery {
 		fn rejects_explicit_zero_address() {
 			let mut raw = vec![0x94];
 			raw.extend_from_slice(&[0u8; 20]);
-			assert!(pallet_ismp_relayer::Pallet::<Test>::decode_epochs_slot_address(&raw).is_none());
+			assert!(pallet_ismp_relayer::Pallet::<Test>::decode_epochs_slot_address(ismp::host::StateMachine::Evm(1), &raw).is_none());
 		}
 
 		/// Anything longer than 20 bytes (after stripping the RLP
@@ -1209,7 +1210,7 @@ mod outbound_consensus_delivery {
 			let big = vec![0xab; 32];
 			let mut raw = vec![0x80 + big.len() as u8];
 			raw.extend_from_slice(&big);
-			assert!(pallet_ismp_relayer::Pallet::<Test>::decode_epochs_slot_address(&raw).is_none());
+			assert!(pallet_ismp_relayer::Pallet::<Test>::decode_epochs_slot_address(ismp::host::StateMachine::Evm(1), &raw).is_none());
 		}
 	}
 

--- a/parachain/runtimes/gargantua/src/lib.rs
+++ b/parachain/runtimes/gargantua/src/lib.rs
@@ -251,7 +251,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("gargantua"),
 	impl_name: Cow::Borrowed("gargantua"),
 	authoring_version: 1,
-	spec_version: 7_400,
+	spec_version: 7_500,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/parachain/runtimes/nexus/src/lib.rs
+++ b/parachain/runtimes/nexus/src/lib.rs
@@ -238,7 +238,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("nexus"),
 	impl_name: Cow::Borrowed("nexus"),
 	authoring_version: 1,
-	spec_version: 7_600,
+	spec_version: 7_700,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -610,16 +610,17 @@ parameter_types! {
 	pub const MaxTxPauseNameLen: u32 = 256;
 }
 
-/// Calls that [`pallet_tx_pause`] is never allowed to pause. Empty by default —
-/// the pallet already exempts its own `unpause` extrinsic so the admin origin
-/// can always recover, and inherents (timestamp, parachain system, etc.) are
-/// not subject to the `BaseCallFilter` so block production is unaffected.
+/// Calls that [`pallet_tx_pause`] is never allowed to pause.
+///
+/// Governance pallets are exempt so that on-chain democracy and voting remain
+/// available even during an emergency pause — users must always be able to
+/// participate in referenda and cast conviction votes.
 pub struct TxPauseWhitelistedCalls;
 impl frame_support::traits::Contains<pallet_tx_pause::RuntimeCallNameOf<Runtime>>
 	for TxPauseWhitelistedCalls
 {
-	fn contains(_full_name: &pallet_tx_pause::RuntimeCallNameOf<Runtime>) -> bool {
-		false
+	fn contains(full_name: &pallet_tx_pause::RuntimeCallNameOf<Runtime>) -> bool {
+		matches!(full_name.0.as_slice(), b"Referenda" | b"ConvictionVoting")
 	}
 }
 

--- a/tesseract/consensus/parachain/src/host.rs
+++ b/tesseract/consensus/parachain/src/host.rs
@@ -128,6 +128,14 @@ where
 	fn provider(&self) -> Arc<dyn IsmpProvider> {
 		self.provider.clone()
 	}
+
+	async fn advance_counterparty_to(
+		&self,
+		counterparty: Arc<dyn IsmpProvider>,
+		target_height: u64,
+	) -> anyhow::Result<()> {
+		self.submit_consensus_for_height(counterparty, target_height).await
+	}
 }
 
 /// Outcome of one consensus tick: updated cursors, plus an optional consensus
@@ -143,6 +151,84 @@ where
 	R: subxt::Config + Send + Sync + Clone,
 	HashFor<R>: From<H256>,
 {
+	/// Builds and submits a parachain consensus proof to `counterparty` covering
+	/// at least `target_height` on this chain. Used by the manual claim command
+	/// to unblock Hyperbridge's state machine height for Polkadot Hub when
+	/// parachain inherents are not advancing it automatically.
+	pub async fn submit_consensus_for_height(
+		&self,
+		counterparty: Arc<dyn IsmpProvider>,
+		target_height: u64,
+	) -> anyhow::Result<()> {
+		let counterparty_finalized = counterparty.query_finalized_height().await?;
+		let latest_relay_height =
+			query_latest_known_relay_height(&*counterparty, counterparty_finalized)
+				.await?
+				.ok_or_else(|| anyhow!("counterparty has no KnownRelayHeights entries"))?;
+
+		let relay_block_hash = self
+			.relay_rpc
+			.chain_get_block_hash(Some((latest_relay_height as u64).into()))
+			.await?
+			.ok_or_else(|| anyhow!("relay chain has no block for height {latest_relay_height}"))?;
+
+		let head_key = parachain_header_storage_key(self.para_id());
+		let raw_head = self
+			.relay_client
+			.storage()
+			.at(relay_block_hash)
+			.fetch_raw(head_key.0.clone())
+			.await?
+			.ok_or_else(|| {
+				anyhow!(
+					"Paras::Heads[{}] missing at relay height {latest_relay_height}",
+					self.para_id()
+				)
+			})?;
+
+		let intermediate = Vec::<u8>::decode(&mut &raw_head[..])?;
+		let header = SpHeader::<u32, BlakeTwo256>::decode(&mut &intermediate[..])?;
+		let self_height = *header.number() as u64;
+
+		if self_height < target_height {
+			return Err(anyhow!(
+				"latest known relay height {latest_relay_height} gives para head at {self_height}, \
+				 need {target_height}; ensure Hyperbridge's relay chain consensus is current",
+			));
+		}
+
+		let read_proof = self
+			.relay_rpc
+			.state_get_read_proof(vec![&head_key.0[..]], Some(relay_block_hash))
+			.await?;
+		let storage_proof: Vec<Vec<u8>> = read_proof.proof.into_iter().map(|b| b.0).collect();
+
+		let consensus_proof =
+			ParachainConsensusProof { relay_height: latest_relay_height, storage_proof };
+		let message = ConsensusMessage {
+			consensus_state_id: self.consensus_state_id,
+			consensus_proof: consensus_proof.encode(),
+			signer: H256::random().0.to_vec(),
+		};
+
+		tracing::info!(
+			target: crate::LOG_TARGET,
+			host = %self.state_machine,
+			counterparty = %counterparty.name(),
+			relay_height = latest_relay_height,
+			para_height = self_height,
+			target = target_height,
+			"submitting parachain consensus proof to advance counterparty state",
+		);
+
+		counterparty
+			.submit(vec![Message::Consensus(message)], self.state_machine)
+			.await
+			.map_err(|e| anyhow!("submit consensus message: {e:?}"))?;
+
+		Ok(())
+	}
+
 	/// Executes one iteration of the consensus loop: fetch the counterparty's
 	/// latest known relay height at its *finalized* head, resolve it to a
 	/// parachain head, and (if that head surfaces new ISMP requests on self)

--- a/tesseract/consensus/parachain/src/lib.rs
+++ b/tesseract/consensus/parachain/src/lib.rs
@@ -33,7 +33,10 @@ use subxt::{
 use std::sync::Arc;
 
 use ismp::{consensus::ConsensusStateId, host::StateMachine};
-use ismp_parachain::parachain_consensus_state_id;
+use ismp_parachain::{
+	consensus::{ASSET_HUB_MAINNET_CHAIN_ID, ASSET_HUB_PARA_ID, PASSET_HUB_TESTNET_CHAIN_ID},
+	parachain_consensus_state_id,
+};
 use tesseract_primitives::{IsmpHost, IsmpProvider};
 use tesseract_substrate::{SubstrateClient, SubstrateConfig};
 use tesseract_substrate_evm::{SubstrateEvmClient, SubstrateEvmClientConfig};
@@ -224,7 +227,9 @@ where
 	pub fn para_id(&self) -> u32 {
 		match self.state_machine {
 			StateMachine::Polkadot(id) | StateMachine::Kusama(id) => id,
-			StateMachine::Evm(id) if id == 420420417 || id == 420420419 => 1000,
+			StateMachine::Evm(id)
+				if id == PASSET_HUB_TESTNET_CHAIN_ID || id == ASSET_HUB_MAINNET_CHAIN_ID =>
+				ASSET_HUB_PARA_ID,
 			// checked in `new`
 			_ => unreachable!("ParachainHost checked state machine at construction"),
 		}

--- a/tesseract/messaging/evm/src/gas_oracle.rs
+++ b/tesseract/messaging/evm/src/gas_oracle.rs
@@ -158,8 +158,9 @@ pub async fn get_current_gas_cost_in_usd(
 	// price for native gas in that case, which is fine for delivery — the
 	// raw `gas_price` we just fetched from the node still flows through to
 	// the actual transaction submission.
-	let token_usd =
-		get_price_from_uniswap_router(ismp_host_address, client).await.unwrap_or_default();
+	let token_usd = get_price_from_uniswap_router(ismp_host_address, client)
+		.await
+		.unwrap_or_default();
 
 	let unit_wei = get_cost_of_one_wei(token_usd);
 	let gas_price_cost = convert_27_decimals_to_18_decimals(unit_wei * gas_price)?;

--- a/tesseract/messaging/evm/src/lib.rs
+++ b/tesseract/messaging/evm/src/lib.rs
@@ -216,8 +216,20 @@ impl EvmConfig {
 	/// Fill in `state_machine`, `ismp_host`, and `consensus_state_id`
 	/// from the chain RPC + [`crate::registry`] when the operator left
 	/// them unset. Returns a new config with all three guaranteed
-	/// `Some(...)`;
+	/// `Some(...)`.
+	///
+	/// If all three are already explicitly set in the config, the RPC call
+	/// to `eth_chainId` is skipped entirely — useful for chains whose HTTP
+	/// endpoint has TLS or protocol quirks that the internal HTTP client
+	/// can't negotiate (e.g. Polkadot Hub's Cloudflare-fronted RPC under
+	/// HTTP/2).
 	pub async fn resolve(self) -> anyhow::Result<Self> {
+		if let (Some(_), Some(_), Some(_)) =
+			(&self.state_machine, &self.ismp_host, &self.consensus_state_id)
+		{
+			return Ok(self);
+		}
+
 		let chain_id = {
 			let url = self.rpc_urls.first().ok_or_else(|| {
 				anyhow::anyhow!("evm config requires at least one rpc_urls entry to resolve")
@@ -225,17 +237,26 @@ impl EvmConfig {
 			crate::registry::fetch_chain_id(url).await?
 		};
 
-		let state_machine = StateMachine::Evm(chain_id as u32);
+		let state_machine = self
+			.state_machine
+			.unwrap_or(StateMachine::Evm(chain_id as u32));
 
-		let ismp_host = crate::registry::ismp_host_for_chain_id(chain_id).ok_or_else(|| {
-			anyhow::anyhow!(
-				"no IsmpHost configured for chain_id={chain_id}; set ismp_host explicitly \
-				 or add the chain to tesseract_evm::registry"
-			)
-		})?;
+		let ismp_host = self
+			.ismp_host
+			.or_else(|| crate::registry::ismp_host_for_chain_id(chain_id))
+			.ok_or_else(|| {
+				anyhow::anyhow!(
+					"no IsmpHost configured for chain_id={chain_id}; set ismp_host explicitly \
+					 or add the chain to tesseract_evm::registry"
+				)
+			})?;
 
-		let consensus_state_id = crate::registry::consensus_state_id_for_chain_id(chain_id)
-			.map(|s| s.to_string())
+		let consensus_state_id = self
+			.consensus_state_id
+			.or_else(|| {
+				crate::registry::consensus_state_id_for_chain_id(chain_id)
+					.map(|s| s.to_string())
+			})
 			.ok_or_else(|| {
 				anyhow::anyhow!(
 					"no consensus_state_id configured for chain_id={chain_id}; set it \
@@ -348,6 +369,10 @@ impl EvmClient {
 
 		let http_client = alloy::transports::http::reqwest::Client::builder()
 			.timeout(Duration::from_secs(180))
+			// Some cloud-fronted endpoints (e.g. Polkadot Hub's Cloudflare RPC)
+			// reject the ALPN h2 handshake. HTTP/1.1 works everywhere and is
+			// fine for JSON-RPC (single request/response, no server push needed).
+			.http1_only()
 			.build()?;
 
 		let root_provider = if config.rpc_urls.len() == 1 {

--- a/tesseract/messaging/evm/src/lib.rs
+++ b/tesseract/messaging/evm/src/lib.rs
@@ -1,10 +1,7 @@
 /// Log/tracing target for this crate.
 pub const LOG_TARGET: &str = "messaging-evm";
 
-use crate::{
-	abi::EvmHostInstance,
-	transport::RpcTransport,
-};
+use crate::{abi::EvmHostInstance, transport::RpcTransport};
 
 use alloy::{
 	eips::BlockId,
@@ -89,9 +86,7 @@ pub fn create_providers_per_url(urls: &[String]) -> Result<Vec<Arc<RootProvider>
 	if urls.is_empty() {
 		return Err(anyhow::anyhow!("At least one RPC URL must be provided"));
 	}
-	urls.iter()
-		.map(|u| Ok(Arc::new(RootProvider::new_http(u.parse()?))))
-		.collect()
+	urls.iter().map(|u| Ok(Arc::new(RootProvider::new_http(u.parse()?)))).collect()
 }
 
 #[cfg(test)]
@@ -219,10 +214,7 @@ impl EvmConfig {
 	/// `Some(...)`.
 	///
 	/// If all three are already explicitly set in the config, the RPC call
-	/// to `eth_chainId` is skipped entirely — useful for chains whose HTTP
-	/// endpoint has TLS or protocol quirks that the internal HTTP client
-	/// can't negotiate (e.g. Polkadot Hub's Cloudflare-fronted RPC under
-	/// HTTP/2).
+	/// to `eth_chainId` is skipped entirely.
 	pub async fn resolve(self) -> anyhow::Result<Self> {
 		if let (Some(_), Some(_), Some(_)) =
 			(&self.state_machine, &self.ismp_host, &self.consensus_state_id)
@@ -237,9 +229,7 @@ impl EvmConfig {
 			crate::registry::fetch_chain_id(url).await?
 		};
 
-		let state_machine = self
-			.state_machine
-			.unwrap_or(StateMachine::Evm(chain_id as u32));
+		let state_machine = self.state_machine.unwrap_or(StateMachine::Evm(chain_id as u32));
 
 		let ismp_host = self
 			.ismp_host
@@ -254,8 +244,7 @@ impl EvmConfig {
 		let consensus_state_id = self
 			.consensus_state_id
 			.or_else(|| {
-				crate::registry::consensus_state_id_for_chain_id(chain_id)
-					.map(|s| s.to_string())
+				crate::registry::consensus_state_id_for_chain_id(chain_id).map(|s| s.to_string())
 			})
 			.ok_or_else(|| {
 				anyhow::anyhow!(
@@ -369,10 +358,6 @@ impl EvmClient {
 
 		let http_client = alloy::transports::http::reqwest::Client::builder()
 			.timeout(Duration::from_secs(180))
-			// Some cloud-fronted endpoints (e.g. Polkadot Hub's Cloudflare RPC)
-			// reject the ALPN h2 handshake. HTTP/1.1 works everywhere and is
-			// fine for JSON-RPC (single request/response, no server push needed).
-			.http1_only()
 			.build()?;
 
 		let root_provider = if config.rpc_urls.len() == 1 {

--- a/tesseract/messaging/messaging/src/lib.rs
+++ b/tesseract/messaging/messaging/src/lib.rs
@@ -17,6 +17,9 @@
 /// Log/tracing target for this crate.
 pub const LOG_TARGET: &str = concat!("messaging", "-inbound");
 
+/// How often both outbound claim tasks wake to process pending rows.
+pub(crate) const CLAIM_INTERVAL_SECS: u64 = 600;
+
 pub mod events;
 pub mod fees;
 mod get_requests;

--- a/tesseract/messaging/messaging/src/outbound.rs
+++ b/tesseract/messaging/messaging/src/outbound.rs
@@ -31,8 +31,8 @@ use ismp::{
 use primitive_types::H256;
 use tesseract_primitives::{
 	config::RelayerConfig, ConsensusProofSource, Hasher, IsmpProvider, NewEpochEvent,
-	PendingConsensusDeliveryClaim, PendingRequestDeliveryClaim, ProofAccepted, RotationProof,
-	StateMachineUpdated, TxReceipt, BEEFY_CONSENSUS_STATE_ID,
+	PendingRequestDeliveryClaim, ProofAccepted, RotationProof, StateMachineUpdated, TxReceipt,
+	BEEFY_CONSENSUS_STATE_ID,
 };
 use tesseract_substrate::{config::KeccakSubstrateChain, SubstrateClient};
 use tokio::sync::mpsc::Sender;
@@ -58,7 +58,6 @@ pub async fn run(
 	relayer_config: RelayerConfig,
 	client_map: HashMap<StateMachine, Arc<dyn IsmpProvider>>,
 	fee_senders: HashMap<StateMachine, Sender<Vec<TxReceipt>>>,
-	claim_sender: Option<Sender<Vec<PendingConsensusDeliveryClaim>>>,
 	claim_tx_payment: Option<Arc<TransactionPayment>>,
 	request_claim_sender: Option<Sender<Vec<PendingRequestDeliveryClaim>>>,
 ) -> Result<(), anyhow::Error> {
@@ -93,19 +92,18 @@ pub async fn run(
 			let hb = hyperbridge.clone();
 			let dest = dest.clone();
 			let proof_source = proof_source.clone();
-			let claim_sender = claim_sender.clone();
 			let claim_tx_payment = claim_tx_payment.clone();
 			let dest_name = dest.name();
 			let dest_state_machine = dest.state_machine_id().state_id;
 			startup_tasks.push(
 				async move {
 					let result = catch_up_rotations(&hb, &dest, &proof_source, None).await;
-					(dest_name, dest_state_machine, result, claim_sender, claim_tx_payment)
+					(dest_name, dest_state_machine, result, claim_tx_payment)
 				}
 				.boxed(),
 			);
 		}
-		while let Some((dest_name, dest_state_machine, result, claim_sender, claim_tx_payment)) =
+		while let Some((dest_name, dest_state_machine, result, claim_tx_payment)) =
 			startup_tasks.next().await
 		{
 			match result {
@@ -118,16 +116,10 @@ pub async fn run(
 							rotations = new_epochs.len(),
 							"startup rotation catch-up landed rotations",
 						);
-						// Forward the earned `NewEpoch` events so the
-						// outbound-claim task can collect their
-						// `OutboundConsensusDeliveryReward`. Same
-						// channel and DB persistence the per-proof
-						// path uses.
 						forward_consensus_delivery_claims(
 							&dest_name,
 							dest_state_machine,
 							new_epochs,
-							&claim_sender,
 							&claim_tx_payment,
 						)
 						.await;
@@ -246,7 +238,6 @@ pub async fn run(
 			let dest_ctx = DestinationContext {
 				dest: dest.clone(),
 				fee_sender,
-				claim_sender: claim_sender.clone(),
 				claim_tx_payment: claim_tx_payment.clone(),
 				request_claim_sender: request_claim_sender.clone(),
 			};
@@ -301,7 +292,6 @@ struct OutboundEventContext {
 struct DestinationContext {
 	dest: Arc<dyn IsmpProvider>,
 	fee_sender: Option<Sender<Vec<TxReceipt>>>,
-	claim_sender: Option<Sender<Vec<PendingConsensusDeliveryClaim>>>,
 	claim_tx_payment: Option<Arc<TransactionPayment>>,
 	request_claim_sender: Option<Sender<Vec<PendingRequestDeliveryClaim>>>,
 }
@@ -324,13 +314,7 @@ async fn submit_for_dest(
 		new_set_id,
 		incentivized,
 	} = event_ctx;
-	let DestinationContext {
-		dest,
-		fee_sender,
-		claim_sender,
-		claim_tx_payment,
-		request_claim_sender,
-	} = dest_ctx;
+	let DestinationContext { dest, fee_sender, claim_tx_payment, request_claim_sender } = dest_ctx;
 	let dest_state_machine = dest.state_machine_id().state_id;
 	let dest_name = dest.name();
 	// Bring the destination's BEEFY light client up to HB's current
@@ -380,13 +364,12 @@ async fn submit_for_dest(
 		tracing::trace!(target: LOG_TARGET, dest = %dest_name, "skipping — no events for this chain, not mandatory");
 		// Even though we're not submitting anything else, the catch-up
 		// loop above may already have landed rotation proofs on this dest
-		// — forward those new_epochs so the claim task can collect their
+		// — persist those new_epochs so the claim task can collect their
 		// `OutboundConsensusDeliveryReward`.
 		forward_consensus_delivery_claims(
 			&dest_name,
 			dest_state_machine,
 			catchup_new_epochs,
-			&claim_sender,
 			&claim_tx_payment,
 		)
 		.await;
@@ -436,12 +419,11 @@ async fn submit_for_dest(
 	if batch.len() == 1 && !is_mandatory {
 		tracing::trace!(target: LOG_TARGET,dest = %dest_name, "skipping — consensus-only batch, not mandatory");
 		// As above: catch-up rotations already landed on the dest carry
-		// claim-eligible new_epochs; forward them before bailing out.
+		// claim-eligible new_epochs; persist them before bailing out.
 		forward_consensus_delivery_claims(
 			&dest_name,
 			dest_state_machine,
 			catchup_new_epochs,
-			&claim_sender,
 			&claim_tx_payment,
 		)
 		.await;
@@ -544,7 +526,6 @@ async fn submit_for_dest(
 		&dest_name,
 		dest_state_machine,
 		combined_new_epochs,
-		&claim_sender,
 		&claim_tx_payment,
 	)
 	.await;
@@ -568,98 +549,30 @@ fn retain_incentivized_requests(
 	});
 }
 
-/// Forward a vec of just-landed `NewEpoch` events to the outbound-claim
-/// task, persisting them to the local DB first so a crash between this
-/// call and the channel push doesn't lose the reward (the claim task
-/// reads the DB on every trigger and replays anything pending).
-///
-/// `delivery_height` for each claim is the receipt block in which the
-/// `NewEpoch(set_id, self)` log was emitted. That block is guaranteed to
-/// have `_epochs[set_id]` populated, so the storage proof the claim task
-/// later builds verifies on first try — no race against the destination
-/// chain mining the outbound tx, and no race against HB's view of the
-/// destination catching up to a guessed-at "finalized" head.
-///
-/// No-op if `new_epochs` is empty or there's no `claim_sender` configured
-/// (e.g. tests, or any wiring that disables the claim pipeline). Each
-/// failure path warns and continues — claim forwarding is best-effort.
 async fn forward_consensus_delivery_claims(
 	dest_name: &str,
 	dest_state_machine: StateMachine,
 	new_epochs: Vec<NewEpochEvent>,
-	claim_sender: &Option<Sender<Vec<PendingConsensusDeliveryClaim>>>,
 	claim_tx_payment: &Option<Arc<TransactionPayment>>,
 ) {
 	if new_epochs.is_empty() {
 		return;
 	}
-	let Some(sender) = claim_sender else {
-		return;
-	};
+
+	let Some(tx_payment) = claim_tx_payment else { return };
 
 	let dest_str = dest_state_machine.to_string();
 	let claim_rows: Vec<(u64, u64)> =
 		new_epochs.iter().map(|ev| (ev.set_id, ev.block_number)).collect();
 
-	if let Some(tx_payment) = claim_tx_payment {
-		if let Err(err) = tx_payment.insert_pending_rotation_claims(&dest_str, &claim_rows).await {
-			tracing::warn!(
-				target: LOG_TARGET,
-				?err,
-				dest = %dest_name,
-				?claim_rows,
-				"failed to persist outbound-consensus claims; the channel send may \
-				 still succeed but the claims will not survive a restart",
-			);
-		}
-	}
-
-	// One trigger per call: the claim task merges with the DB, dedupes,
-	// then filters against `OutboundConsensusRotationsClaimed` on
-	// Hyperbridge before submitting. Bounding the channel that way keeps
-	// it sane even when a catch-up + main batch land several rotations in
-	// the same outbound cycle.
-	let claims: Vec<PendingConsensusDeliveryClaim> = new_epochs
-		.iter()
-		.map(|ev| PendingConsensusDeliveryClaim {
-			destination: dest_state_machine,
-			delivery_height: ev.block_number,
-			set_id: ev.set_id,
-		})
-		.collect();
-	let summary: Vec<(u64, u64)> = claim_rows.clone();
-	// `try_send` instead of `send().await`: the outbound task must never
-	// block on a downstream consumer. If `outbound_claim::run` gets stuck
-	// (e.g. inside `wait_for_state_machine_update` waiting on a stream
-	// that silently stalled) the channel fills up; a blocking `send` here
-	// would pin `submit_for_dest`, which pins `tasks.next().await` in the
-	// outbound run loop, which kills the outer heartbeat and stops new
-	// `ProofAccepted` events being polled. We've seen this in production
-	// (claim task wedged ~8 h before outbound silently froze on the next
-	// proof).
-	//
-	// On `Full`: the persisted DB row written above will be picked up on
-	// the next outbound trigger via `outbound_claim::merge_pending`, so
-	// dropping the in-memory trigger is safe; on `Closed`: the receiver
-	// is gone, nothing more to do — log and move on.
-	match sender.try_send(claims) {
-		Ok(()) => {},
-		Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-			tracing::warn!(
-				target: LOG_TARGET,
-				dest = %dest_name,
-				?summary,
-				"outbound-consensus claim channel full; trigger dropped — DB row will replay on next outbound cycle",
-			);
-		},
-		Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-			tracing::warn!(
-				target: LOG_TARGET,
-				dest = %dest_name,
-				?summary,
-				"outbound-consensus claim channel closed; receiver gone",
-			);
-		},
+	if let Err(err) = tx_payment.insert_pending_rotation_claims(&dest_str, &claim_rows).await {
+		tracing::warn!(
+			target: LOG_TARGET,
+			?err,
+			dest = %dest_name,
+			?claim_rows,
+			"failed to persist outbound-consensus claims to DB; will retry on next delivery",
+		);
 	}
 }
 
@@ -956,11 +869,7 @@ pub async fn initialize(
 		}
 	}
 
-	// Outbound consensus delivery reward claim task. Reads pending rows
-	// from the DB on every trigger and processes them, so no startup
-	// replay is needed in the caller.
-	let (claim_sender, claim_receiver) =
-		tokio::sync::mpsc::channel::<Vec<PendingConsensusDeliveryClaim>>(512);
+	// Periodic task that claims outbound consensus delivery rewards from the DB.
 	let claim_hb = SubstrateClient::<KeccakSubstrateChain>::new(hyperbridge_config.clone()).await?;
 	let claim_destinations: HashMap<StateMachine, Arc<dyn IsmpProvider>> =
 		destinations.iter().map(|(sm, p)| (*sm, p.clone())).collect();
@@ -972,13 +881,9 @@ pub async fn initialize(
 		"outbound",
 		async move {
 			tracing::trace!(target: LOG_TARGET, "task started");
-			let res = crate::outbound_claim::run(
-				claim_hb,
-				claim_destinations,
-				claim_receiver,
-				Some(claim_tx_payment),
-			)
-			.await;
+			let res =
+				crate::outbound_claim::run(claim_hb, claim_destinations, Some(claim_tx_payment))
+					.await;
 			tracing::error!(target: LOG_TARGET, ?res, "task terminated");
 		}
 		.instrument(claim_span)
@@ -1040,7 +945,6 @@ pub async fn initialize(
 				relayer_config,
 				provider_clients,
 				fee_senders,
-				Some(claim_sender),
 				Some(outbound_tx_payment),
 				Some(request_claim_sender),
 			)
@@ -1143,7 +1047,6 @@ mod tests {
 			DestinationContext {
 				dest,
 				fee_sender: None,
-				claim_sender: None,
 				claim_tx_payment: None,
 				request_claim_sender: None,
 			},
@@ -1183,7 +1086,6 @@ mod tests {
 			DestinationContext {
 				dest,
 				fee_sender: None,
-				claim_sender: None,
 				claim_tx_payment: None,
 				request_claim_sender: None,
 			},
@@ -1226,7 +1128,6 @@ mod tests {
 			DestinationContext {
 				dest,
 				fee_sender: None,
-				claim_sender: None,
 				claim_tx_payment: None,
 				request_claim_sender: None,
 			},

--- a/tesseract/messaging/messaging/src/outbound.rs
+++ b/tesseract/messaging/messaging/src/outbound.rs
@@ -30,7 +30,7 @@ use ismp::{
 };
 use primitive_types::H256;
 use tesseract_primitives::{
-	config::RelayerConfig, ConsensusProofSource, Hasher, IsmpProvider, NewEpochEvent,
+	config::RelayerConfig, ConsensusProofSource, Hasher, IsmpHost, IsmpProvider, NewEpochEvent,
 	PendingRequestDeliveryClaim, ProofAccepted, RotationProof, StateMachineUpdated, TxReceipt,
 	BEEFY_CONSENSUS_STATE_ID,
 };
@@ -785,6 +785,9 @@ pub struct OutboundInitParams {
 	/// When `true`, no fee-accumulation tasks are spawned and the
 	/// outbound loop runs without forwarding receipts.
 	pub fees_disabled: bool,
+	/// Consensus hosts for substrate-backed destinations like Polkadot Hub that need an
+	/// explicit consensus proof before their claim heights advance on Hyperbridge.
+	pub consensus_hosts: HashMap<StateMachine, Arc<dyn IsmpHost>>,
 }
 
 /// Spawn the full outbound pipeline:
@@ -809,6 +812,7 @@ pub async fn initialize(
 		relayer_config,
 		tx_payment,
 		fees_disabled,
+		consensus_hosts,
 	} = params;
 
 	if destinations.is_empty() {
@@ -861,6 +865,7 @@ pub async fn initialize(
 	let claim_destinations: HashMap<StateMachine, Arc<dyn IsmpProvider>> =
 		destinations.iter().map(|(sm, p)| (*sm, p.clone())).collect();
 	let claim_tx_payment = tx_payment.clone();
+	let claim_consensus_hosts = consensus_hosts.clone();
 	let claim_name = format!("outbound-claim-{}", hyperbridge_provider.name());
 	let claim_span = tracing::info_span!("outbound_claim", hb = %hyperbridge_provider.name());
 	task_manager.spawn_essential_handle().spawn_blocking(
@@ -868,9 +873,13 @@ pub async fn initialize(
 		"outbound",
 		async move {
 			tracing::trace!(target: LOG_TARGET, "task started");
-			let res =
-				crate::outbound_claim::run(claim_hb, claim_destinations, Some(claim_tx_payment))
-					.await;
+			let res = crate::outbound_claim::run(
+				claim_hb,
+				claim_destinations,
+				claim_consensus_hosts,
+				Some(claim_tx_payment),
+			)
+			.await;
 			tracing::error!(target: LOG_TARGET, ?res, "task terminated");
 		}
 		.instrument(claim_span)
@@ -884,6 +893,7 @@ pub async fn initialize(
 	let request_claim_destinations: HashMap<StateMachine, Arc<dyn IsmpProvider>> =
 		destinations.iter().map(|(sm, p)| (*sm, p.clone())).collect();
 	let request_claim_tx_payment = tx_payment.clone();
+	let request_claim_consensus_hosts = consensus_hosts.clone();
 	let request_claim_name = format!("outbound-request-claim-{}", hyperbridge_provider.name());
 	let request_claim_span =
 		tracing::info_span!("outbound_request_claim", hb = %hyperbridge_provider.name());
@@ -895,6 +905,7 @@ pub async fn initialize(
 			let res = crate::outbound_request_claim::run(
 				request_claim_hb,
 				request_claim_destinations,
+				request_claim_consensus_hosts,
 				Some(request_claim_tx_payment),
 			)
 			.await;

--- a/tesseract/messaging/messaging/src/outbound.rs
+++ b/tesseract/messaging/messaging/src/outbound.rs
@@ -59,7 +59,6 @@ pub async fn run(
 	client_map: HashMap<StateMachine, Arc<dyn IsmpProvider>>,
 	fee_senders: HashMap<StateMachine, Sender<Vec<TxReceipt>>>,
 	claim_tx_payment: Option<Arc<TransactionPayment>>,
-	request_claim_sender: Option<Sender<Vec<PendingRequestDeliveryClaim>>>,
 ) -> Result<(), anyhow::Error> {
 	let hb_state_machine_id = hyperbridge.state_machine_id();
 	let coprocessor = hb_state_machine_id.state_id;
@@ -239,7 +238,6 @@ pub async fn run(
 				dest: dest.clone(),
 				fee_sender,
 				claim_tx_payment: claim_tx_payment.clone(),
-				request_claim_sender: request_claim_sender.clone(),
 			};
 			tasks.push(
 				submit_for_dest(event_ctx, dest_ctx)
@@ -293,7 +291,6 @@ struct DestinationContext {
 	dest: Arc<dyn IsmpProvider>,
 	fee_sender: Option<Sender<Vec<TxReceipt>>>,
 	claim_tx_payment: Option<Arc<TransactionPayment>>,
-	request_claim_sender: Option<Sender<Vec<PendingRequestDeliveryClaim>>>,
 }
 
 async fn submit_for_dest(
@@ -314,7 +311,7 @@ async fn submit_for_dest(
 		new_set_id,
 		incentivized,
 	} = event_ctx;
-	let DestinationContext { dest, fee_sender, claim_tx_payment, request_claim_sender } = dest_ctx;
+	let DestinationContext { dest, fee_sender, claim_tx_payment } = dest_ctx;
 	let dest_state_machine = dest.state_machine_id().state_id;
 	let dest_name = dest.name();
 	// Bring the destination's BEEFY light client up to HB's current
@@ -457,7 +454,6 @@ async fn submit_for_dest(
 		coprocessor,
 		&batch_requests,
 		&result.receipts,
-		&request_claim_sender,
 		&claim_tx_payment,
 	)
 	.await;
@@ -579,36 +575,61 @@ async fn forward_consensus_delivery_claims(
 /// Sibling of [`forward_consensus_delivery_claims`] for the request reward.
 /// Indexes the batch's `PostRequest`s by commitment, then for every
 /// [`TxReceipt`] whose `source_chain` is the hyperbridge coprocessor,
-/// recovers the original request from the batch and forwards a
-/// [`PendingRequestDeliveryClaim`] carrying that request. The pallet hashes
-/// it on chain and looks up the reward by `(request.dest, request.from)`,
-/// so without the request we cannot key the allowlist. `TxReceipt` only
-/// carries requests since `PostResponse` was removed in #840.
-///
-/// Uses `try_send` so a full channel drops the claim immediately; the DB
-/// row persisted just above will be replayed on the next trigger.
+/// recovers the original request from the batch and persists a
+/// [`PendingRequestDeliveryClaim`] row to the local DB. The periodic claim
+/// task picks these up on its next tick.
 async fn forward_request_delivery_claims(
 	dest_name: &str,
 	dest_state_machine: StateMachine,
 	coprocessor: StateMachine,
 	batch_requests: &[PostRequest],
 	receipts: &[TxReceipt],
-	claim_sender: &Option<Sender<Vec<PendingRequestDeliveryClaim>>>,
 	claim_tx_payment: &Option<Arc<TransactionPayment>>,
 ) {
-	let Some(sender) = claim_sender else {
+	let Some(tx_payment) = claim_tx_payment else {
 		return;
 	};
 
+	let claims = collect_hyperbridge_request_claims(coprocessor, batch_requests, receipts);
+	if claims.is_empty() {
+		return;
+	}
+
+	let rows: Vec<(String, Vec<u8>, u64)> = claims
+		.iter()
+		.map(|c| (hex::encode(c.commitment().0), c.request.encode(), c.delivery_height))
+		.collect();
+	if let Err(err) = tx_payment
+		.insert_pending_request_claims(&dest_state_machine.to_string(), &rows)
+		.await
+	{
+		tracing::warn!(
+			target: LOG_TARGET,
+			?err,
+			dest = %dest_name,
+			count = rows.len(),
+			"failed to persist outbound-request claims; will retry on next delivery",
+		);
+	}
+}
+
+/// Filters receipts to those originating from the hyperbridge coprocessor and
+/// pairs each one with its source request. Returns an empty vec when nothing
+/// in the batch is hyperbridge-originated.
+fn collect_hyperbridge_request_claims(
+	coprocessor: StateMachine,
+	batch_requests: &[PostRequest],
+	receipts: &[TxReceipt],
+) -> Vec<PendingRequestDeliveryClaim> {
 	// Index every PostRequest in the batch by its commitment so receipts
 	// can be paired back to their source request. BTreeMap keeps iteration
-	// deterministic when building the claim list below.
+	// deterministic when building the claim list.
 	let by_commitment: BTreeMap<H256, PostRequest> = batch_requests
 		.iter()
 		.map(|req| (hash_request::<Hasher>(&Request::Post(req.clone())), req.clone()))
 		.collect();
 
-	let claims: Vec<PendingRequestDeliveryClaim> = receipts
+	receipts
 		.iter()
 		.filter_map(|TxReceipt { query, height }| {
 			(query.source_chain == coprocessor)
@@ -616,41 +637,7 @@ async fn forward_request_delivery_claims(
 				.flatten()
 				.map(|request| PendingRequestDeliveryClaim { request, delivery_height: *height })
 		})
-		.collect();
-
-	if claims.is_empty() {
-		return;
-	}
-
-	if let Some(tx_payment) = claim_tx_payment {
-		let rows: Vec<(String, Vec<u8>, u64)> = claims
-			.iter()
-			.map(|c| (hex::encode(c.commitment().0), c.request.encode(), c.delivery_height))
-			.collect();
-		if let Err(err) = tx_payment
-			.insert_pending_request_claims(&dest_state_machine.to_string(), &rows)
-			.await
-		{
-			tracing::warn!(
-				target: LOG_TARGET,
-				?err,
-				dest = %dest_name,
-				count = rows.len(),
-				"failed to persist outbound-request claims; claims will not survive a restart",
-			);
-		}
-	}
-
-	let summary: Vec<String> = claims.iter().map(|c| hex::encode(c.commitment().0)).collect();
-	if let Err(err) = sender.try_send(claims) {
-		tracing::warn!(
-			target: LOG_TARGET,
-			?err,
-			dest = %dest_name,
-			?summary,
-			"outbound-request claim channel try_send failed; DB row will be replayed",
-		);
-	}
+		.collect()
 }
 
 /// Read the BEEFY `current_authorities.id` out of a SCALE-encoded
@@ -891,10 +878,7 @@ pub async fn initialize(
 	);
 
 	// Outbound request delivery reward claim task. Sibling of the consensus
-	// claim task; same DB-backed merge/dedupe/replay shape, keyed by request
-	// commitment instead of (dest, set_id).
-	let (request_claim_sender, request_claim_receiver) =
-		tokio::sync::mpsc::channel::<Vec<PendingRequestDeliveryClaim>>(512);
+	// claim task; periodic 600s timer, DB-backed, keyed by request commitment.
 	let request_claim_hb =
 		SubstrateClient::<KeccakSubstrateChain>::new(hyperbridge_config.clone()).await?;
 	let request_claim_destinations: HashMap<StateMachine, Arc<dyn IsmpProvider>> =
@@ -911,7 +895,6 @@ pub async fn initialize(
 			let res = crate::outbound_request_claim::run(
 				request_claim_hb,
 				request_claim_destinations,
-				request_claim_receiver,
 				Some(request_claim_tx_payment),
 			)
 			.await;
@@ -946,7 +929,6 @@ pub async fn initialize(
 				provider_clients,
 				fee_senders,
 				Some(outbound_tx_payment),
-				Some(request_claim_sender),
 			)
 			.await;
 			tracing::error!(target: LOG_TARGET, ?res, "task terminated");
@@ -1044,12 +1026,7 @@ mod tests {
 				new_set_id: None,
 				incentivized: None,
 			},
-			DestinationContext {
-				dest,
-				fee_sender: None,
-				claim_tx_payment: None,
-				request_claim_sender: None,
-			},
+			DestinationContext { dest, fee_sender: None, claim_tx_payment: None },
 		)
 		.await
 		.unwrap();
@@ -1083,12 +1060,7 @@ mod tests {
 				new_set_id: Some(1),
 				incentivized: None,
 			},
-			DestinationContext {
-				dest,
-				fee_sender: None,
-				claim_tx_payment: None,
-				request_claim_sender: None,
-			},
+			DestinationContext { dest, fee_sender: None, claim_tx_payment: None },
 		)
 		.await
 		.unwrap();
@@ -1125,12 +1097,7 @@ mod tests {
 				new_set_id: None,
 				incentivized: None,
 			},
-			DestinationContext {
-				dest,
-				fee_sender: None,
-				claim_tx_payment: None,
-				request_claim_sender: None,
-			},
+			DestinationContext { dest, fee_sender: None, claim_tx_payment: None },
 		)
 		.await
 		.unwrap();
@@ -1169,9 +1136,8 @@ mod tests {
 		}
 	}
 
-	#[tokio::test]
-	async fn forwards_only_hyperbridge_originated_requests() {
-		let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+	#[test]
+	fn collect_claims_only_hyperbridge_originated() {
 		let hb_req_a = build_post(HB, 0x11);
 		let user_req = build_post(DEST_B, 0x22);
 		let hb_req_b = build_post(HB, 0x33);
@@ -1181,41 +1147,29 @@ mod tests {
 			request_receipt_for(&user_req, 101),
 			request_receipt_for(&hb_req_b, 102),
 		];
-		forward_request_delivery_claims(
-			"dest_a",
-			DEST_A,
-			HB,
-			&batch_requests,
-			&receipts,
-			&Some(tx),
-			&None,
-		)
-		.await;
 
-		let claims = rx.recv().await.expect("channel should receive claims");
+		let claims = collect_hyperbridge_request_claims(HB, &batch_requests, &receipts);
+
 		assert_eq!(claims.len(), 2, "only hyperbridge-originated requests forwarded");
-		let sources: Vec<StateMachine> = claims.iter().map(|c| c.request.source).collect();
-		assert!(sources.iter().all(|s| *s == HB));
-		let heights: Vec<u64> = claims.iter().map(|c| c.delivery_height).collect();
-		assert_eq!(
-			heights.iter().copied().collect::<std::collections::BTreeSet<_>>(),
-			[100u64, 102u64].into_iter().collect()
-		);
+		assert!(claims.iter().all(|c| c.request.source == HB));
+		let heights: std::collections::BTreeSet<u64> =
+			claims.iter().map(|c| c.delivery_height).collect();
+		assert_eq!(heights, [100u64, 102u64].into_iter().collect());
 	}
 
-	#[tokio::test]
-	async fn forwards_no_sender_is_noop() {
+	#[test]
+	fn collect_claims_empty_receipts_is_empty() {
 		let hb_req = build_post(HB, 0x11);
-		let receipts = vec![request_receipt_for(&hb_req, 100)];
-		forward_request_delivery_claims("dest_a", DEST_A, HB, &[hb_req], &receipts, &None, &None)
-			.await;
+		let claims = collect_hyperbridge_request_claims(HB, &[hb_req], &[]);
+		assert!(claims.is_empty());
 	}
 
-	#[tokio::test]
-	async fn forwards_empty_receipts_is_noop() {
-		let (tx, mut rx) = tokio::sync::mpsc::channel(8);
-		forward_request_delivery_claims("dest_a", DEST_A, HB, &[], &[], &Some(tx), &None).await;
-		assert!(rx.try_recv().is_err());
+	#[test]
+	fn collect_claims_no_hyperbridge_requests_is_empty() {
+		let user_req = build_post(DEST_B, 0x11);
+		let receipts = vec![request_receipt_for(&user_req, 100)];
+		let claims = collect_hyperbridge_request_claims(HB, &[user_req], &receipts);
+		assert!(claims.is_empty());
 	}
 
 	#[test]
@@ -1272,18 +1226,14 @@ mod tests {
 		assert_eq!(events.len(), 1);
 	}
 
-	#[tokio::test]
-	async fn forwards_drops_receipts_with_no_matching_batch_request() {
-		// Defensive case: a receipt's commitment is HB-sourced but the batch
-		// didn't actually contain a matching request (shouldn't happen in
-		// practice; tests document the guard).
-		let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+	#[test]
+	fn collect_claims_drops_receipts_with_no_matching_batch_request() {
+		// A receipt whose commitment is HB-sourced but whose request wasn't in
+		// the batch produces no claim (shouldn't happen in practice).
 		let orphan = build_post(HB, 0x11);
 		let receipts = vec![request_receipt_for(&orphan, 100)];
-		// Note: orphan is NOT in batch_requests.
-		forward_request_delivery_claims("dest_a", DEST_A, HB, &[], &receipts, &Some(tx), &None)
-			.await;
-
-		assert!(rx.try_recv().is_err());
+		// orphan is NOT in batch_requests.
+		let claims = collect_hyperbridge_request_claims(HB, &[], &receipts);
+		assert!(claims.is_empty());
 	}
 }

--- a/tesseract/messaging/messaging/src/outbound_claim.rs
+++ b/tesseract/messaging/messaging/src/outbound_claim.rs
@@ -36,10 +36,11 @@
 //!      Hyperbridge.
 //!    - Delete the persisted claim row.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use anyhow::{anyhow, Context as _};
 use codec::Decode;
+use futures::{stream::FuturesUnordered, StreamExt};
 use ismp::{consensus::StateMachineHeight, host::StateMachine, messaging::Proof};
 use pallet_ismp_relayer::{
 	outbound_consensus_delivery_message, OutboundConsensusDeliveryClaim, EVM_HOST_EPOCHS_SLOT,
@@ -52,7 +53,7 @@ use tesseract_primitives::{
 	wait_for_state_machine_update, IsmpProvider, PendingConsensusDeliveryClaim, StateProofQueryType,
 };
 use tesseract_substrate::{config::KeccakSubstrateChain, SubstrateClient};
-use tokio::sync::mpsc::Receiver;
+use tokio::{sync::mpsc::Receiver, time::MissedTickBehavior};
 use tracing::Instrument;
 use transaction_fees::TransactionPayment;
 
@@ -77,22 +78,31 @@ pub async fn run(
 	let hb_provider: Arc<dyn IsmpProvider> = Arc::new(hyperbridge.clone());
 	let payee_bytes: [u8; 32] = hyperbridge.signer.public().0;
 
-	while let Some(trigger) = receiver.recv().await {
+	// Periodic scan so stuck rows in the DB are retried even when deliveries
+	// stop (no new trigger would otherwise wake the loop).
+	let mut retry_interval = tokio::time::interval(Duration::from_secs(600));
+	retry_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+	loop {
+		let trigger = tokio::select! {
+			maybe = receiver.recv() => match maybe {
+				Some(t) => t,
+				None => return Err(anyhow!("outbound-claim channel closed")),
+			},
+			_ = retry_interval.tick() => vec![],
+		};
+
 		// Merge the live trigger with everything still pending in the DB,
-		// deduped on `(destination, set_id)`. The DB is the source of
-		// truth for surviving a crash; the trigger vec covers the
-		// just-delivered rotations that may not have round-tripped
-		// through the DB yet (e.g. if the persist write failed).
+		// deduped on `(destination, set_id)`. The DB is the source of truth
+		// for surviving a crash; the trigger vec covers freshly-delivered
+		// rotations that may not have round-tripped through the DB yet.
 		let merged = merge_pending(&tx_payment, trigger).await;
 		if merged.is_empty() {
 			continue;
 		}
 
-		// Split into "already claimed by some other relayer" (skip + queue
-		// for delete) and "still claimable" (process). The former group
-		// would just revert with `OutboundRotationAlreadyClaimed` if we
-		// submitted, so short-circuiting saves a Hyperbridge round-trip
-		// per stale row.
+		// Drop anything Hyperbridge already records as claimed — resubmitting
+		// would just burn a round-trip on a guaranteed revert.
 		let (claimed, unclaimed) = match partition_claimed(&hyperbridge, &merged).await {
 			Ok(parts) => parts,
 			Err(err) => {
@@ -106,9 +116,6 @@ pub async fn run(
 			},
 		};
 
-		// Queue already-claimed rows for deletion. Best-effort: a failure
-		// here just means the row will be revisited on the next trigger,
-		// where this same partition step will catch it again.
 		if !claimed.is_empty() {
 			tracing::info!(
 				target: LOG_TARGET,
@@ -133,6 +140,9 @@ pub async fn run(
 			}
 		}
 
+		// Process all unclaimed rows in parallel so a slow state-machine-update
+		// wait on one destination cannot block claims for others.
+		let mut tasks = FuturesUnordered::new();
 		for pending in unclaimed {
 			let span = tracing::info_span!(
 				"outbound_claim",
@@ -144,38 +154,39 @@ pub async fn run(
 			let hb = hyperbridge.clone();
 			let hb_view = hb_provider.clone();
 			let tx_payment = tx_payment.clone();
-			async move {
-				let Some(dest) = dest else {
-					tracing::warn!(target: LOG_TARGET, "no provider for destination; dropping claim");
-					return;
-				};
-				match process_claim(&hb, hb_view, dest, &pending, payee_bytes).await {
-					Ok(()) => {
-						tracing::info!(target: LOG_TARGET, "claim submitted");
-						if let Some(tx_payment) = &tx_payment {
-							let _ = tx_payment
-								.delete_rotation_claim(
-									&pending.destination.to_string(),
-									pending.set_id,
-								)
-								.await;
-						}
-					},
-					Err(err) => {
-						tracing::error!(
-							target: LOG_TARGET,
-							?err,
-							"claim submission failed; row left in DB for next trigger",
-						);
-					},
+			tasks.push(
+				async move {
+					let Some(dest) = dest else {
+						tracing::warn!(target: LOG_TARGET, "no provider for destination; dropping claim");
+						return;
+					};
+					match process_claim(&hb, hb_view, dest, &pending, payee_bytes).await {
+						Ok(()) => {
+							tracing::info!(target: LOG_TARGET, "claim submitted");
+							if let Some(tp) = &tx_payment {
+								let _ = tp
+									.delete_rotation_claim(
+										&pending.destination.to_string(),
+										pending.set_id,
+									)
+									.await;
+							}
+						},
+						Err(err) => {
+							tracing::error!(
+								target: LOG_TARGET,
+								?err,
+								"claim submission failed; row left in DB for next trigger",
+							);
+						},
+					}
 				}
-			}
-			.instrument(span)
-			.await;
+				.instrument(span),
+			);
 		}
-	}
 
-	Err(anyhow!("outbound-claim channel closed"))
+		while tasks.next().await.is_some() {}
+	}
 }
 
 /// Read `list_pending_rotation_claims` and union-merge it with the
@@ -244,7 +255,7 @@ async fn merge_pending(
 /// Lookups are sequential — the surface is small (typically a handful
 /// of rows per trigger) and parallelism would just dogpile the HB RPC
 /// for no real win.
-async fn partition_claimed(
+pub async fn partition_claimed(
 	hyperbridge: &SubstrateClient<KeccakSubstrateChain>,
 	pending: &[PendingConsensusDeliveryClaim],
 ) -> anyhow::Result<(Vec<PendingConsensusDeliveryClaim>, Vec<PendingConsensusDeliveryClaim>)> {
@@ -290,22 +301,33 @@ async fn partition_claimed(
 	Ok((claimed, unclaimed))
 }
 
-async fn process_claim(
+pub async fn process_claim(
 	hyperbridge: &SubstrateClient<KeccakSubstrateChain>,
 	hb_provider: Arc<dyn IsmpProvider>,
 	dest: Arc<dyn IsmpProvider>,
 	pending: &PendingConsensusDeliveryClaim,
 	payee: [u8; 32],
 ) -> anyhow::Result<()> {
-	// Same shape fee_accumulation uses: wait for HB's view of the
-	// destination to cross the delivery block.
-	let dest_height = wait_for_state_machine_update(
-		dest.state_machine_id(),
-		hb_provider.clone(),
-		dest.clone(),
-		pending.delivery_height,
+	// Wait for HB's view of the destination to cross the delivery block,
+	// with a timeout so a permanently-stalled destination (e.g. Polkadot Hub
+	// without parachain inherents) does not block this task indefinitely.
+	let dest_height = tokio::time::timeout(
+		Duration::from_secs(300),
+		wait_for_state_machine_update(
+			dest.state_machine_id(),
+			hb_provider.clone(),
+			dest.clone(),
+			pending.delivery_height,
+		),
 	)
 	.await
+	.map_err(|_| {
+		anyhow!(
+			"timed out waiting for state machine update for {} at height {}",
+			pending.destination,
+			pending.delivery_height,
+		)
+	})?
 	.context("wait_for_state_machine_update")?;
 
 	// Build the 52-byte EIP-1186 key the EVM verifier expects:

--- a/tesseract/messaging/messaging/src/outbound_claim.rs
+++ b/tesseract/messaging/messaging/src/outbound_claim.rs
@@ -97,6 +97,18 @@ pub async fn run(
 			}
 		}
 
+		// Bring Hyperbridge's view of any lagging destination up to the highest
+		// pending delivery height before fanning out — once per destination,
+		// not per claim, so concurrent claims don't submit byte-identical
+		// consensus proofs that collide in Hyperbridge's transaction pool.
+		advance_lagging_destinations(
+			&hb_provider,
+			&destinations,
+			&consensus_hosts,
+			unclaimed.iter().map(|c| (c.destination, c.delivery_height)),
+		)
+		.await;
+
 		let mut tasks = FuturesUnordered::new();
 		for pending in unclaimed {
 			let span = tracing::info_span!(
@@ -106,7 +118,6 @@ pub async fn run(
 				set_id = pending.set_id,
 			);
 			let dest = destinations.get(&pending.destination).cloned();
-			let consensus_host = consensus_hosts.get(&pending.destination).cloned();
 			let hb = hyperbridge.clone();
 			let hb_view = hb_provider.clone();
 			let tp = tx_payment.clone();
@@ -116,9 +127,7 @@ pub async fn run(
 						tracing::warn!(target: LOG_TARGET, "no provider for destination; dropping claim");
 						return;
 					};
-					match process_claim(&hb, hb_view, dest, &pending, payee_bytes, consensus_host)
-						.await
-					{
+					match process_claim(&hb, hb_view, dest, &pending, payee_bytes).await {
 						Ok(()) => {
 							tracing::info!(target: LOG_TARGET, "claim submitted");
 							if let Some(tp) = &tp {
@@ -226,20 +235,82 @@ pub async fn partition_claimed(
 	Ok((claimed, unclaimed))
 }
 
+/// Log target for [`advance_lagging_destinations`], shared by both claim
+/// tasks. `tracing` requires a const target, so the helper can't log under
+/// each caller's own target.
+const ADVANCE_LOG_TARGET: &str = "messaging-claim-advance";
+
+/// Submit a consensus proof for every destination whose committed height on
+/// Hyperbridge is behind a pending delivery height, targeting the highest
+/// height pending for that destination.
+///
+/// Called once per tick before the per-claim fan-out. Advancing inside each
+/// claim future would submit byte-identical consensus proofs concurrently,
+/// which collide in Hyperbridge's transaction pool (the unsigned extrinsic's
+/// `provides` tag hashes the proof content) and fail all but one of the
+/// claims for that tick; it would also submit a redundant proof even when
+/// Hyperbridge is already past the delivery height.
+///
+/// Destinations whose consensus host can't advance the counterparty are
+/// covered by the default no-op `advance_counterparty_to`. Failures here are
+/// logged and left for the per-claim height check to retry on the next tick.
+pub(crate) async fn advance_lagging_destinations(
+	hb_provider: &Arc<dyn IsmpProvider>,
+	destinations: &HashMap<StateMachine, Arc<dyn IsmpProvider>>,
+	consensus_hosts: &HashMap<StateMachine, Arc<dyn IsmpHost>>,
+	pending: impl Iterator<Item = (StateMachine, u64)>,
+) {
+	let mut max_heights: HashMap<StateMachine, u64> = HashMap::new();
+	for (destination, delivery_height) in pending {
+		let entry = max_heights.entry(destination).or_default();
+		*entry = (*entry).max(delivery_height);
+	}
+
+	for (destination, target_height) in max_heights {
+		let Some(host) = consensus_hosts.get(&destination) else { continue };
+		let Some(dest) = destinations.get(&destination) else { continue };
+
+		let committed = match hb_provider.query_latest_height(dest.state_machine_id()).await {
+			Ok(height) => height as u64,
+			Err(err) => {
+				tracing::warn!(
+					target: ADVANCE_LOG_TARGET,
+					%destination,
+					?err,
+					"could not query committed height; skipping advance this tick",
+				);
+				continue;
+			},
+		};
+		if committed >= target_height {
+			continue;
+		}
+
+		tracing::info!(
+			target: ADVANCE_LOG_TARGET,
+			%destination,
+			committed,
+			target_height,
+			"advancing Hyperbridge's view of destination for pending claims",
+		);
+		if let Err(err) = host.advance_counterparty_to(hb_provider.clone(), target_height).await {
+			tracing::warn!(
+				target: ADVANCE_LOG_TARGET,
+				%destination,
+				?err,
+				"failed to advance destination height; claims will retry on next tick",
+			);
+		}
+	}
+}
+
 pub async fn process_claim(
 	hyperbridge: &SubstrateClient<KeccakSubstrateChain>,
 	hb_provider: Arc<dyn IsmpProvider>,
 	dest: Arc<dyn IsmpProvider>,
 	pending: &PendingConsensusDeliveryClaim,
 	payee: [u8; 32],
-	consensus_host: Option<Arc<dyn IsmpHost>>,
 ) -> anyhow::Result<()> {
-	if let Some(host) = consensus_host {
-		host.advance_counterparty_to(hb_provider.clone(), pending.delivery_height)
-			.await
-			.context("advance_counterparty_to")?;
-	}
-
 	let committed = hb_provider
 		.query_latest_height(dest.state_machine_id())
 		.await

--- a/tesseract/messaging/messaging/src/outbound_claim.rs
+++ b/tesseract/messaging/messaging/src/outbound_claim.rs
@@ -13,30 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Outbound consensus delivery reward claim task.
+//! Periodic task that claims outbound consensus delivery rewards.
 //!
-//! Modeled on the fee accumulation task. For every batch of
-//! [`PendingConsensusDeliveryClaim`]s pushed by the outbound delivery task:
-//!
-//! 1. Pull every persisted row from the local DB (`list_pending_rotation_claims`) and merge it with
-//!    the incoming trigger vec, deduplicated on `(destination, set_id)`. The DB is the source of
-//!    truth for surviving a crash; the trigger vec carries the freshly-delivered rotations that may
-//!    not yet have been queried back from the DB.
-//! 2. Filter against `pallet_ismp_relayer::OutboundConsensusRotationsClaimed` on Hyperbridge: any
-//!    `(destination, set_id)` already present there has been claimed by some other relayer. Those
-//!    rows are queued for deletion from the local DB and skipped — there is no reward left to
-//!    collect, and resubmitting would just waste a Hyperbridge extrinsic on a guaranteed revert.
-//! 3. For each surviving (still-unclaimed) row:
-//!    - Wait for Hyperbridge's consensus client for the destination to verify a height >=
-//!      `delivery_height`.
-//!    - Build an EIP-1186 storage proof of `EvmHost._epochs[set_id]` at that height.
-//!    - Sign `outbound_consensus_delivery_message(set_id, destination, payee)` with the
-//!      destination's EVM key.
-//!    - Submit `pallet_ismp_relayer::claim_outbound_consensus_delivery_reward` (unsigned) on
-//!      Hyperbridge.
-//!    - Delete the persisted claim row.
+//! Each time the relayer delivers a mandatory BEEFY rotation to an EVM destination, the delivery
+//! path writes a row to the local DB. This task wakes on a fixed interval, reads those rows,
+//! skips anything already claimed on Hyperbridge, and submits the remaining claims in parallel.
 
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
 
 use anyhow::{anyhow, Context as _};
 use codec::Decode;
@@ -53,66 +36,40 @@ use tesseract_primitives::{
 	wait_for_state_machine_update, IsmpProvider, PendingConsensusDeliveryClaim, StateProofQueryType,
 };
 use tesseract_substrate::{config::KeccakSubstrateChain, SubstrateClient};
-use tokio::{sync::mpsc::Receiver, time::MissedTickBehavior};
+use tokio::time::MissedTickBehavior;
 use tracing::Instrument;
 use transaction_fees::TransactionPayment;
 
 const LOG_TARGET: &str = "messaging-outbound-claim";
 
-/// Drive a single relayer's outbound consensus delivery claims. Mirrors
-/// [`fee_accumulation`](crate::fee_accumulation) shape: receive a trigger
-/// (now a vector of newly-delivered rotations), pull every pending row
-/// from the DB, merge both, drop anything Hyperbridge already records as
-/// claimed, then process whatever's left.
-///
-/// The payee is always the relayer's own Hyperbridge sr25519 account
-/// (`hyperbridge.signer.public()`) — the same account that already
-/// receives messaging incentives, so all relayer earnings on HB land in one
-/// place.
 pub async fn run(
 	hyperbridge: SubstrateClient<KeccakSubstrateChain>,
 	destinations: HashMap<StateMachine, Arc<dyn IsmpProvider>>,
-	mut receiver: Receiver<Vec<PendingConsensusDeliveryClaim>>,
 	tx_payment: Option<Arc<TransactionPayment>>,
 ) -> Result<(), anyhow::Error> {
 	let hb_provider: Arc<dyn IsmpProvider> = Arc::new(hyperbridge.clone());
 	let payee_bytes: [u8; 32] = hyperbridge.signer.public().0;
 
-	// Periodic scan so stuck rows in the DB are retried even when deliveries
-	// stop (no new trigger would otherwise wake the loop).
-	let mut retry_interval = tokio::time::interval(Duration::from_secs(600));
-	retry_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+	let mut interval = tokio::time::interval(Duration::from_secs(600));
+	interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
 	loop {
-		let trigger = tokio::select! {
-			maybe = receiver.recv() => match maybe {
-				Some(t) => t,
-				None => return Err(anyhow!("outbound-claim channel closed")),
-			},
-			_ = retry_interval.tick() => vec![],
-		};
+		interval.tick().await;
 
-		// Merge the live trigger with everything still pending in the DB,
-		// deduped on `(destination, set_id)`. The DB is the source of truth
-		// for surviving a crash; the trigger vec covers freshly-delivered
-		// rotations that may not have round-tripped through the DB yet.
-		let merged = merge_pending(&tx_payment, trigger).await;
-		if merged.is_empty() {
+		let pending = read_pending_claims(&tx_payment).await;
+		if pending.is_empty() {
 			continue;
 		}
 
-		// Drop anything Hyperbridge already records as claimed — resubmitting
-		// would just burn a round-trip on a guaranteed revert.
-		let (claimed, unclaimed) = match partition_claimed(&hyperbridge, &merged).await {
+		let (claimed, unclaimed) = match partition_claimed(&hyperbridge, &pending).await {
 			Ok(parts) => parts,
 			Err(err) => {
 				tracing::warn!(
 					target: LOG_TARGET,
 					?err,
-					"OutboundConsensusRotationsClaimed lookup failed; processing all rows \
-					 without filtering — duplicates will revert on Hyperbridge",
+					"could not check claimed status on Hyperbridge; processing all rows without filtering",
 				);
-				(Vec::new(), merged)
+				(Vec::new(), pending)
 			},
 		};
 
@@ -123,25 +80,22 @@ pub async fn run(
 				"dropping claims already redeemed on Hyperbridge",
 			);
 			if let Some(tp) = &tx_payment {
-				for pending in &claimed {
-					if let Err(err) = tp
-						.delete_rotation_claim(&pending.destination.to_string(), pending.set_id)
-						.await
+				for row in &claimed {
+					if let Err(err) =
+						tp.delete_rotation_claim(&row.destination.to_string(), row.set_id).await
 					{
 						tracing::warn!(
 							target: LOG_TARGET,
 							?err,
-							destination = %pending.destination,
-							set_id = pending.set_id,
-							"failed to delete already-claimed row; will retry next trigger",
+							destination = %row.destination,
+							set_id = row.set_id,
+							"failed to delete already-claimed row",
 						);
 					}
 				}
 			}
 		}
 
-		// Process all unclaimed rows in parallel so a slow state-machine-update
-		// wait on one destination cannot block claims for others.
 		let mut tasks = FuturesUnordered::new();
 		for pending in unclaimed {
 			let span = tracing::info_span!(
@@ -153,7 +107,7 @@ pub async fn run(
 			let dest = destinations.get(&pending.destination).cloned();
 			let hb = hyperbridge.clone();
 			let hb_view = hb_provider.clone();
-			let tx_payment = tx_payment.clone();
+			let tp = tx_payment.clone();
 			tasks.push(
 				async move {
 					let Some(dest) = dest else {
@@ -163,7 +117,7 @@ pub async fn run(
 					match process_claim(&hb, hb_view, dest, &pending, payee_bytes).await {
 						Ok(()) => {
 							tracing::info!(target: LOG_TARGET, "claim submitted");
-							if let Some(tp) = &tx_payment {
+							if let Some(tp) = &tp {
 								let _ = tp
 									.delete_rotation_claim(
 										&pending.destination.to_string(),
@@ -176,7 +130,7 @@ pub async fn run(
 							tracing::error!(
 								target: LOG_TARGET,
 								?err,
-								"claim submission failed; row left in DB for next trigger",
+								"claim failed; will retry on next tick",
 							);
 						},
 					}
@@ -189,22 +143,15 @@ pub async fn run(
 	}
 }
 
-/// Read `list_pending_rotation_claims` and union-merge it with the
-/// trigger vec. The merged vec is deduplicated on `(destination, set_id)`
-/// so each pair is processed at most once per wake-up. DB rows take
-/// precedence on conflict — they carry the persisted `delivery_height`
-/// in the same `rotation_height` column the writer used.
-async fn merge_pending(
+async fn read_pending_claims(
 	tx_payment: &Option<Arc<TransactionPayment>>,
-	trigger: Vec<PendingConsensusDeliveryClaim>,
 ) -> Vec<PendingConsensusDeliveryClaim> {
-	let mut merged: HashMap<(StateMachine, u64), PendingConsensusDeliveryClaim> = HashMap::new();
-
-	if let Some(tp) = tx_payment {
-		match tp.list_pending_rotation_claims().await {
-			Ok(rows) =>
-				for row in rows {
-					use std::str::FromStr;
+	let Some(tp) = tx_payment else { return Vec::new() };
+	match tp.list_pending_rotation_claims().await {
+		Ok(rows) => {
+			let mut claims: Vec<PendingConsensusDeliveryClaim> = rows
+				.into_iter()
+				.filter_map(|row| {
 					let destination = match StateMachine::from_str(&row.dest) {
 						Ok(sm) => sm,
 						Err(err) => {
@@ -212,49 +159,28 @@ async fn merge_pending(
 								target: LOG_TARGET,
 								dest = %row.dest,
 								?err,
-								"unparseable state machine in DB; skipping row",
+								"unparseable state machine in DB row; skipping",
 							);
-							continue;
+							return None;
 						},
 					};
-					let set_id = row.set_id as u64;
-					merged.insert(
-						(destination, set_id),
-						PendingConsensusDeliveryClaim {
-							destination,
-							delivery_height: row.rotation_height as u64,
-							set_id,
-						},
-					);
-				},
-			Err(err) => {
-				tracing::warn!(
-					target: LOG_TARGET,
-					?err,
-					"list_pending_rotation_claims failed; trigger-only this cycle",
-				);
-			},
-		}
+					Some(PendingConsensusDeliveryClaim {
+						destination,
+						delivery_height: row.rotation_height as u64,
+						set_id: row.set_id as u64,
+					})
+				})
+				.collect();
+			claims.sort_by_key(|c| (c.delivery_height, c.set_id));
+			claims
+		},
+		Err(err) => {
+			tracing::warn!(target: LOG_TARGET, ?err, "could not read pending claims; skipping tick");
+			Vec::new()
+		},
 	}
-
-	for pending in trigger {
-		merged.entry((pending.destination, pending.set_id)).or_insert(pending);
-	}
-
-	let mut result: Vec<_> = merged.into_values().collect();
-	result.sort_by_key(|c| (c.delivery_height, c.set_id));
-	result
 }
 
-/// Split `pending` into `(already_claimed, still_unclaimed)` by reading
-/// `pallet_ismp_relayer::OutboundConsensusRotationsClaimed[(destination,
-/// set_id)]` on Hyperbridge. The storage value is `()` so a non-empty
-/// raw fetch (i.e. `Some(_)`) means the `(destination, set_id)` is
-/// closed.
-///
-/// Lookups are sequential — the surface is small (typically a handful
-/// of rows per trigger) and parallelism would just dogpile the HB RPC
-/// for no real win.
 pub async fn partition_claimed(
 	hyperbridge: &SubstrateClient<KeccakSubstrateChain>,
 	pending: &[PendingConsensusDeliveryClaim],
@@ -263,38 +189,33 @@ pub async fn partition_claimed(
 		.rpc
 		.chain_get_block_hash(None)
 		.await?
-		.ok_or_else(|| anyhow!("Failed to query latest hyperbridge block hash"))?;
+		.ok_or_else(|| anyhow!("failed to fetch latest Hyperbridge block hash"))?;
 
 	let mut claimed = Vec::new();
 	let mut unclaimed = Vec::new();
 
-	for pending in pending {
-		let key =
-			outbound_consensus_rotations_claimed_storage_key(pending.destination, pending.set_id);
+	for item in pending {
+		let key = outbound_consensus_rotations_claimed_storage_key(item.destination, item.set_id);
 		let raw = hyperbridge.client.storage().at(block_hash).fetch_raw(key).await.with_context(
 			|| {
 				format!(
 					"OutboundConsensusRotationsClaimed lookup ({:?}, {})",
-					pending.destination, pending.set_id,
+					item.destination, item.set_id,
 				)
 			},
 		)?;
 
-		// Stored value is `()`, so any presence — even an empty `Vec` —
-		// means the entry exists. `OptionQuery` ensures absence is
-		// `None`. `Decode` against `()` is the strict version of this
-		// check; we keep it cheap with the `is_some` shortcut and only
-		// fall through to decode if some chain encoded the unit value
-		// explicitly.
+		// The stored value is `()` — any presence (including empty bytes from OptionQuery)
+		// means the slot is taken.
 		let is_claimed = match raw {
 			Some(bytes) => <()>::decode(&mut &*bytes).is_ok() || bytes.is_empty(),
 			None => false,
 		};
 
 		if is_claimed {
-			claimed.push(pending.clone());
+			claimed.push(item.clone());
 		} else {
-			unclaimed.push(pending.clone());
+			unclaimed.push(item.clone());
 		}
 	}
 
@@ -308,9 +229,6 @@ pub async fn process_claim(
 	pending: &PendingConsensusDeliveryClaim,
 	payee: [u8; 32],
 ) -> anyhow::Result<()> {
-	// Wait for HB's view of the destination to cross the delivery block,
-	// with a timeout so a permanently-stalled destination (e.g. Polkadot Hub
-	// without parachain inherents) does not block this task indefinitely.
 	let dest_height = tokio::time::timeout(
 		Duration::from_secs(300),
 		wait_for_state_machine_update(
@@ -323,33 +241,26 @@ pub async fn process_claim(
 	.await
 	.map_err(|_| {
 		anyhow!(
-			"timed out waiting for state machine update for {} at height {}",
+			"timed out waiting for Hyperbridge to see {} at height {}",
 			pending.destination,
 			pending.delivery_height,
 		)
 	})?
 	.context("wait_for_state_machine_update")?;
 
-	// Build the 52-byte EIP-1186 key the EVM verifier expects:
-	// `evm_host (20) || keccak256(set_id || EVM_HOST_EPOCHS_SLOT) (32)`.
-	// Substrate destinations report `None` and are skipped — the claim
-	// flow is EVM-only.
-	let evm_host = dest.ismp_host_contract().ok_or_else(|| {
-		anyhow!(
-			"destination has no EvmHost address (non-EVM); \
-			 cannot derive _epochs[set_id] key",
-		)
-	})?;
-	let key = epochs_slot_key(evm_host, pending.set_id);
+	let evm_host = dest
+		.ismp_host_contract()
+		.ok_or_else(|| anyhow!("destination {} has no EvmHost address", pending.destination))?;
 
 	let proof_bytes = dest
-		.query_state_proof(dest_height, StateProofQueryType::Arbitrary(vec![key]))
+		.query_state_proof(
+			dest_height,
+			StateProofQueryType::Arbitrary(vec![epochs_slot_key(evm_host, pending.set_id)]),
+		)
 		.await
-		.context("query_state_proof on destination")?;
+		.context("query_state_proof")?;
 
 	let msg = outbound_consensus_delivery_message(pending.set_id, pending.destination, payee);
-	let signature = dest.sign(&msg);
-
 	let claim = OutboundConsensusDeliveryClaim {
 		state_proof: Proof {
 			height: StateMachineHeight { id: dest.state_machine_id(), height: dest_height },
@@ -357,7 +268,7 @@ pub async fn process_claim(
 		},
 		set_id: pending.set_id,
 		payee,
-		signature,
+		signature: dest.sign(&msg),
 	};
 
 	tracing::info!(
@@ -365,22 +276,16 @@ pub async fn process_claim(
 		destination = %pending.destination,
 		set_id = pending.set_id,
 		dest_height,
-		"submitting outbound consensus delivery claim to hyperbridge",
+		"submitting outbound consensus delivery claim",
 	);
+
 	hyperbridge
 		.submit_outbound_consensus_delivery_claim(claim)
 		.await
-		.context("submit_outbound_consensus_delivery_claim")?;
-	Ok(())
+		.context("submit_outbound_consensus_delivery_claim")
 }
 
-/// 52-byte EIP-1186 storage key for `EvmHost._epochs[set_id]`:
-/// `evm_host (20) || keccak256(set_id_be32 || EVM_HOST_EPOCHS_SLOT_be32) (32)`.
-/// Matches the pallet-side derivation in
-/// `process_outbound_consensus_delivery_claim` (which goes through
-/// `evm_state_machine::utils::derive_unhashed_map_key`); we use the
-/// equivalent off-chain helper from `tesseract-evm` so the hashing
-/// logic lives in one place instead of being re-implemented here.
+/// Builds the 52-byte EIP-1186 storage key for `EvmHost._epochs[set_id]`.
 fn epochs_slot_key(evm_host: H160, set_id: u64) -> Vec<u8> {
 	let slot_hash =
 		derive_map_key(U256::from(set_id).to_big_endian().to_vec(), EVM_HOST_EPOCHS_SLOT);

--- a/tesseract/messaging/messaging/src/outbound_claim.rs
+++ b/tesseract/messaging/messaging/src/outbound_claim.rs
@@ -19,12 +19,7 @@
 //! path writes a row to the local DB. This task wakes on a fixed interval, reads those rows,
 //! skips anything already claimed on Hyperbridge, and submits the remaining claims in parallel.
 
-use std::{
-	collections::{BTreeMap, HashMap},
-	str::FromStr,
-	sync::Arc,
-	time::Duration,
-};
+use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
 
 use anyhow::{anyhow, Context as _};
 use codec::Decode;
@@ -102,8 +97,6 @@ pub async fn run(
 			}
 		}
 
-		advance_hub_heights(&unclaimed, &destinations, &consensus_hosts, &hb_provider).await;
-
 		let mut tasks = FuturesUnordered::new();
 		for pending in unclaimed {
 			let span = tracing::info_span!(
@@ -113,6 +106,7 @@ pub async fn run(
 				set_id = pending.set_id,
 			);
 			let dest = destinations.get(&pending.destination).cloned();
+			let consensus_host = consensus_hosts.get(&pending.destination).cloned();
 			let hb = hyperbridge.clone();
 			let hb_view = hb_provider.clone();
 			let tp = tx_payment.clone();
@@ -122,7 +116,9 @@ pub async fn run(
 						tracing::warn!(target: LOG_TARGET, "no provider for destination; dropping claim");
 						return;
 					};
-					match process_claim(&hb, hb_view, dest, &pending, payee_bytes).await {
+					match process_claim(&hb, hb_view, dest, &pending, payee_bytes, consensus_host)
+						.await
+					{
 						Ok(()) => {
 							tracing::info!(target: LOG_TARGET, "claim submitted");
 							if let Some(tp) = &tp {
@@ -236,7 +232,14 @@ pub async fn process_claim(
 	dest: Arc<dyn IsmpProvider>,
 	pending: &PendingConsensusDeliveryClaim,
 	payee: [u8; 32],
+	consensus_host: Option<Arc<dyn IsmpHost>>,
 ) -> anyhow::Result<()> {
+	if let Some(host) = consensus_host {
+		host.advance_counterparty_to(hb_provider.clone(), pending.delivery_height)
+			.await
+			.context("advance_counterparty_to")?;
+	}
+
 	let committed = hb_provider
 		.query_latest_height(dest.state_machine_id())
 		.await
@@ -288,63 +291,6 @@ pub async fn process_claim(
 		.submit_outbound_consensus_delivery_claim(claim)
 		.await
 		.context("submit_outbound_consensus_delivery_claim")
-}
-
-/// Advances Hyperbridge's committed height for any destination that has a consensus host
-/// and is lagging behind the max pending delivery height. Parachain-backed chains handle
-/// the advance; all other hosts are a no-op by default.
-pub(crate) async fn advance_hub_heights<T>(
-	pending: &[T],
-	destinations: &HashMap<StateMachine, Arc<dyn IsmpProvider>>,
-	consensus_hosts: &HashMap<StateMachine, Arc<dyn IsmpHost>>,
-	hb_provider: &Arc<dyn IsmpProvider>,
-) where
-	T: HasDestination,
-{
-	let mut max_heights: BTreeMap<StateMachine, u64> = BTreeMap::new();
-	for item in pending {
-		let entry = max_heights.entry(item.destination()).or_insert(0);
-		*entry = (*entry).max(item.delivery_height());
-	}
-
-	for (sm, max_height) in max_heights {
-		let Some(host) = consensus_hosts.get(&sm) else { continue };
-		let Some(dest) = destinations.get(&sm) else { continue };
-		let hb_height =
-			hb_provider.query_latest_height(dest.state_machine_id()).await.unwrap_or(0) as u64;
-		if hb_height < max_height {
-			tracing::info!(
-				target: LOG_TARGET,
-				%sm,
-				hb_height,
-				max_height,
-				"advancing Hyperbridge state machine height",
-			);
-			if let Err(err) = host.advance_counterparty_to(hb_provider.clone(), max_height).await {
-				tracing::warn!(
-					target: LOG_TARGET,
-					%sm,
-					?err,
-					"advance_counterparty_to failed; claims may fail this tick",
-				);
-			}
-		}
-	}
-}
-
-pub(crate) trait HasDestination {
-	fn destination(&self) -> StateMachine;
-	fn delivery_height(&self) -> u64;
-}
-
-impl HasDestination for PendingConsensusDeliveryClaim {
-	fn destination(&self) -> StateMachine {
-		self.destination
-	}
-
-	fn delivery_height(&self) -> u64 {
-		self.delivery_height
-	}
 }
 
 /// Builds the 52-byte EIP-1186 storage key for `EvmHost._epochs[set_id]`.

--- a/tesseract/messaging/messaging/src/outbound_claim.rs
+++ b/tesseract/messaging/messaging/src/outbound_claim.rs
@@ -19,7 +19,12 @@
 //! path writes a row to the local DB. This task wakes on a fixed interval, reads those rows,
 //! skips anything already claimed on Hyperbridge, and submits the remaining claims in parallel.
 
-use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
+use std::{
+	collections::{BTreeMap, HashMap},
+	str::FromStr,
+	sync::Arc,
+	time::Duration,
+};
 
 use anyhow::{anyhow, Context as _};
 use codec::Decode;
@@ -33,7 +38,7 @@ use sp_core::Pair;
 use subxt_utils::outbound_consensus_rotations_claimed_storage_key;
 use tesseract_evm::derive_map_key;
 use tesseract_primitives::{
-	wait_for_state_machine_update, IsmpProvider, PendingConsensusDeliveryClaim, StateProofQueryType,
+	IsmpHost, IsmpProvider, PendingConsensusDeliveryClaim, StateProofQueryType,
 };
 use tesseract_substrate::{config::KeccakSubstrateChain, SubstrateClient};
 use tokio::time::MissedTickBehavior;
@@ -45,12 +50,13 @@ const LOG_TARGET: &str = "messaging-outbound-claim";
 pub async fn run(
 	hyperbridge: SubstrateClient<KeccakSubstrateChain>,
 	destinations: HashMap<StateMachine, Arc<dyn IsmpProvider>>,
+	consensus_hosts: HashMap<StateMachine, Arc<dyn IsmpHost>>,
 	tx_payment: Option<Arc<TransactionPayment>>,
 ) -> Result<(), anyhow::Error> {
 	let hb_provider: Arc<dyn IsmpProvider> = Arc::new(hyperbridge.clone());
 	let payee_bytes: [u8; 32] = hyperbridge.signer.public().0;
 
-	let mut interval = tokio::time::interval(Duration::from_secs(600));
+	let mut interval = tokio::time::interval(Duration::from_secs(crate::CLAIM_INTERVAL_SECS));
 	interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
 	loop {
@@ -95,6 +101,8 @@ pub async fn run(
 				}
 			}
 		}
+
+		advance_hub_heights(&unclaimed, &destinations, &consensus_hosts, &hb_provider).await;
 
 		let mut tasks = FuturesUnordered::new();
 		for pending in unclaimed {
@@ -243,24 +251,7 @@ pub async fn process_claim(
 		));
 	}
 
-	let dest_height = tokio::time::timeout(
-		Duration::from_secs(300),
-		wait_for_state_machine_update(
-			dest.state_machine_id(),
-			hb_provider.clone(),
-			dest.clone(),
-			pending.delivery_height,
-		),
-	)
-	.await
-	.map_err(|_| {
-		anyhow!(
-			"timed out waiting for Hyperbridge to see {} at height {}",
-			pending.destination,
-			pending.delivery_height,
-		)
-	})?
-	.context("wait_for_state_machine_update")?;
+	let dest_height = committed as u64;
 
 	let evm_host = dest
 		.ismp_host_contract()
@@ -297,6 +288,63 @@ pub async fn process_claim(
 		.submit_outbound_consensus_delivery_claim(claim)
 		.await
 		.context("submit_outbound_consensus_delivery_claim")
+}
+
+/// Advances Hyperbridge's committed height for any destination that has a consensus host
+/// and is lagging behind the max pending delivery height. Parachain-backed chains handle
+/// the advance; all other hosts are a no-op by default.
+pub(crate) async fn advance_hub_heights<T>(
+	pending: &[T],
+	destinations: &HashMap<StateMachine, Arc<dyn IsmpProvider>>,
+	consensus_hosts: &HashMap<StateMachine, Arc<dyn IsmpHost>>,
+	hb_provider: &Arc<dyn IsmpProvider>,
+) where
+	T: HasDestination,
+{
+	let mut max_heights: BTreeMap<StateMachine, u64> = BTreeMap::new();
+	for item in pending {
+		let entry = max_heights.entry(item.destination()).or_insert(0);
+		*entry = (*entry).max(item.delivery_height());
+	}
+
+	for (sm, max_height) in max_heights {
+		let Some(host) = consensus_hosts.get(&sm) else { continue };
+		let Some(dest) = destinations.get(&sm) else { continue };
+		let hb_height =
+			hb_provider.query_latest_height(dest.state_machine_id()).await.unwrap_or(0) as u64;
+		if hb_height < max_height {
+			tracing::info!(
+				target: LOG_TARGET,
+				%sm,
+				hb_height,
+				max_height,
+				"advancing Hyperbridge state machine height",
+			);
+			if let Err(err) = host.advance_counterparty_to(hb_provider.clone(), max_height).await {
+				tracing::warn!(
+					target: LOG_TARGET,
+					%sm,
+					?err,
+					"advance_counterparty_to failed; claims may fail this tick",
+				);
+			}
+		}
+	}
+}
+
+pub(crate) trait HasDestination {
+	fn destination(&self) -> StateMachine;
+	fn delivery_height(&self) -> u64;
+}
+
+impl HasDestination for PendingConsensusDeliveryClaim {
+	fn destination(&self) -> StateMachine {
+		self.destination
+	}
+
+	fn delivery_height(&self) -> u64 {
+		self.delivery_height
+	}
 }
 
 /// Builds the 52-byte EIP-1186 storage key for `EvmHost._epochs[set_id]`.

--- a/tesseract/messaging/messaging/src/outbound_claim.rs
+++ b/tesseract/messaging/messaging/src/outbound_claim.rs
@@ -229,6 +229,20 @@ pub async fn process_claim(
 	pending: &PendingConsensusDeliveryClaim,
 	payee: [u8; 32],
 ) -> anyhow::Result<()> {
+	let committed = hb_provider
+		.query_latest_height(dest.state_machine_id())
+		.await
+		.context("query_latest_height")?;
+
+	if (committed as u64) < pending.delivery_height {
+		return Err(anyhow!(
+			"Hyperbridge has only committed {} for {}, delivery block {} not yet reachable",
+			committed,
+			pending.destination,
+			pending.delivery_height,
+		));
+	}
+
 	let dest_height = tokio::time::timeout(
 		Duration::from_secs(300),
 		wait_for_state_machine_update(

--- a/tesseract/messaging/messaging/src/outbound_request_claim.rs
+++ b/tesseract/messaging/messaging/src/outbound_request_claim.rs
@@ -36,7 +36,7 @@ use sp_core::Pair;
 use subxt_utils::outbound_requests_claimed_storage_key;
 use tesseract_evm::derive_map_key;
 use tesseract_primitives::{
-	wait_for_state_machine_update, IsmpProvider, PendingRequestDeliveryClaim, StateProofQueryType,
+	IsmpHost, IsmpProvider, PendingRequestDeliveryClaim, StateProofQueryType,
 };
 use tesseract_substrate::{config::KeccakSubstrateChain, SubstrateClient};
 use tokio::time::MissedTickBehavior;
@@ -48,12 +48,13 @@ const LOG_TARGET: &str = "messaging-outbound-request-claim";
 pub async fn run(
 	hyperbridge: SubstrateClient<KeccakSubstrateChain>,
 	destinations: HashMap<StateMachine, Arc<dyn IsmpProvider>>,
+	consensus_hosts: HashMap<StateMachine, Arc<dyn IsmpHost>>,
 	tx_payment: Option<Arc<TransactionPayment>>,
 ) -> Result<(), anyhow::Error> {
 	let hb_provider: Arc<dyn IsmpProvider> = Arc::new(hyperbridge.clone());
 	let payee_bytes: [u8; 32] = hyperbridge.signer.public().0;
 
-	let mut interval = tokio::time::interval(Duration::from_secs(600));
+	let mut interval = tokio::time::interval(Duration::from_secs(crate::CLAIM_INTERVAL_SECS));
 	interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
 	loop {
@@ -96,6 +97,14 @@ pub async fn run(
 				}
 			}
 		}
+
+		crate::outbound_claim::advance_hub_heights(
+			&unclaimed,
+			&destinations,
+			&consensus_hosts,
+			&hb_provider,
+		)
+		.await;
 
 		let mut tasks = FuturesUnordered::new();
 		for pending in unclaimed {
@@ -184,7 +193,7 @@ async fn read_pending_claims(
 	}
 }
 
-async fn partition_claimed(
+pub async fn partition_claimed(
 	hyperbridge: &SubstrateClient<KeccakSubstrateChain>,
 	pending: &[PendingRequestDeliveryClaim],
 ) -> anyhow::Result<(Vec<PendingRequestDeliveryClaim>, Vec<PendingRequestDeliveryClaim>)> {
@@ -218,7 +227,7 @@ async fn partition_claimed(
 	Ok((claimed, unclaimed))
 }
 
-async fn process_claim(
+pub async fn process_claim(
 	hyperbridge: &SubstrateClient<KeccakSubstrateChain>,
 	hb_provider: Arc<dyn IsmpProvider>,
 	dest: Arc<dyn IsmpProvider>,
@@ -242,24 +251,7 @@ async fn process_claim(
 		));
 	}
 
-	let dest_height = tokio::time::timeout(
-		Duration::from_secs(300),
-		wait_for_state_machine_update(
-			dest.state_machine_id(),
-			hb_provider.clone(),
-			dest.clone(),
-			pending.delivery_height,
-		),
-	)
-	.await
-	.map_err(|_| {
-		anyhow!(
-			"timed out waiting for Hyperbridge to see {} at height {}",
-			destination,
-			pending.delivery_height,
-		)
-	})?
-	.context("wait_for_state_machine_update")?;
+	let dest_height = committed as u64;
 
 	let key = receipt_key_for(destination, commitment, dest.ismp_host_contract())?;
 
@@ -314,5 +306,15 @@ fn receipt_key_for(
 		Ok(request_receipt_storage_key(commitment))
 	} else {
 		Err(anyhow!("unsupported destination state machine: {destination}"))
+	}
+}
+
+impl crate::outbound_claim::HasDestination for PendingRequestDeliveryClaim {
+	fn destination(&self) -> StateMachine {
+		PendingRequestDeliveryClaim::destination(self)
+	}
+
+	fn delivery_height(&self) -> u64 {
+		self.delivery_height
 	}
 }

--- a/tesseract/messaging/messaging/src/outbound_request_claim.rs
+++ b/tesseract/messaging/messaging/src/outbound_request_claim.rs
@@ -98,6 +98,18 @@ pub async fn run(
 			}
 		}
 
+		// Bring Hyperbridge's view of any lagging destination up to the highest
+		// pending delivery height before fanning out — once per destination,
+		// not per claim, so concurrent claims don't submit byte-identical
+		// consensus proofs that collide in Hyperbridge's transaction pool.
+		crate::outbound_claim::advance_lagging_destinations(
+			&hb_provider,
+			&destinations,
+			&consensus_hosts,
+			unclaimed.iter().map(|c| (c.destination(), c.delivery_height)),
+		)
+		.await;
+
 		let mut tasks = FuturesUnordered::new();
 		for pending in unclaimed {
 			let span = tracing::info_span!(
@@ -107,7 +119,6 @@ pub async fn run(
 				commitment = %pending.commitment(),
 			);
 			let dest = destinations.get(&pending.destination()).cloned();
-			let consensus_host = consensus_hosts.get(&pending.destination()).cloned();
 			let hb = hyperbridge.clone();
 			let hb_view = hb_provider.clone();
 			let tp = tx_payment.clone();
@@ -121,9 +132,7 @@ pub async fn run(
 						return;
 					};
 					let commitment = pending.commitment();
-					match process_claim(&hb, hb_view, dest, &pending, payee_bytes, consensus_host)
-						.await
-					{
+					match process_claim(&hb, hb_view, dest, &pending, payee_bytes).await {
 						Ok(()) => {
 							tracing::info!(target: LOG_TARGET, "claim submitted");
 							if let Some(tp) = &tp {
@@ -228,16 +237,9 @@ pub async fn process_claim(
 	dest: Arc<dyn IsmpProvider>,
 	pending: &PendingRequestDeliveryClaim,
 	payee: [u8; 32],
-	consensus_host: Option<Arc<dyn IsmpHost>>,
 ) -> anyhow::Result<()> {
 	let destination = pending.destination();
 	let commitment = pending.commitment();
-
-	if let Some(host) = consensus_host {
-		host.advance_counterparty_to(hb_provider.clone(), pending.delivery_height)
-			.await
-			.context("advance_counterparty_to")?;
-	}
 
 	let committed = hb_provider
 		.query_latest_height(dest.state_machine_id())

--- a/tesseract/messaging/messaging/src/outbound_request_claim.rs
+++ b/tesseract/messaging/messaging/src/outbound_request_claim.rs
@@ -98,14 +98,6 @@ pub async fn run(
 			}
 		}
 
-		crate::outbound_claim::advance_hub_heights(
-			&unclaimed,
-			&destinations,
-			&consensus_hosts,
-			&hb_provider,
-		)
-		.await;
-
 		let mut tasks = FuturesUnordered::new();
 		for pending in unclaimed {
 			let span = tracing::info_span!(
@@ -115,6 +107,7 @@ pub async fn run(
 				commitment = %pending.commitment(),
 			);
 			let dest = destinations.get(&pending.destination()).cloned();
+			let consensus_host = consensus_hosts.get(&pending.destination()).cloned();
 			let hb = hyperbridge.clone();
 			let hb_view = hb_provider.clone();
 			let tp = tx_payment.clone();
@@ -128,7 +121,9 @@ pub async fn run(
 						return;
 					};
 					let commitment = pending.commitment();
-					match process_claim(&hb, hb_view, dest, &pending, payee_bytes).await {
+					match process_claim(&hb, hb_view, dest, &pending, payee_bytes, consensus_host)
+						.await
+					{
 						Ok(()) => {
 							tracing::info!(target: LOG_TARGET, "claim submitted");
 							if let Some(tp) = &tp {
@@ -233,9 +228,16 @@ pub async fn process_claim(
 	dest: Arc<dyn IsmpProvider>,
 	pending: &PendingRequestDeliveryClaim,
 	payee: [u8; 32],
+	consensus_host: Option<Arc<dyn IsmpHost>>,
 ) -> anyhow::Result<()> {
 	let destination = pending.destination();
 	let commitment = pending.commitment();
+
+	if let Some(host) = consensus_host {
+		host.advance_counterparty_to(hb_provider.clone(), pending.delivery_height)
+			.await
+			.context("advance_counterparty_to")?;
+	}
 
 	let committed = hb_provider
 		.query_latest_height(dest.state_machine_id())
@@ -306,15 +308,5 @@ fn receipt_key_for(
 		Ok(request_receipt_storage_key(commitment))
 	} else {
 		Err(anyhow!("unsupported destination state machine: {destination}"))
-	}
-}
-
-impl crate::outbound_claim::HasDestination for PendingRequestDeliveryClaim {
-	fn destination(&self) -> StateMachine {
-		PendingRequestDeliveryClaim::destination(self)
-	}
-
-	fn delivery_height(&self) -> u64 {
-		self.delivery_height
 	}
 }

--- a/tesseract/messaging/messaging/src/outbound_request_claim.rs
+++ b/tesseract/messaging/messaging/src/outbound_request_claim.rs
@@ -15,14 +15,9 @@
 
 //! Periodic task that claims outbound request delivery rewards.
 //!
-//! Sibling to [`outbound_claim`](crate::outbound_claim). Where that task claims rewards for
-//! delivering BEEFY rotations, this one claims rewards for delivering hyperbridge-originated
-//! requests (system messages from host-executive, intents-coprocessor, token-governor, etc.).
-//! Supports both EVM and substrate destinations.
-//!
-//! Each delivery writes a row to the local DB. This task wakes on a fixed interval, reads those
-//! rows, skips anything already claimed on Hyperbridge, and submits the remaining claims in
-//! parallel.
+//! Each time the relayer delivers a hyperbridge-originated request, the delivery path writes a
+//! row to the local DB. This task wakes on a fixed interval, reads those rows, skips anything
+//! already claimed on Hyperbridge, and submits the remaining claims in parallel.
 
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
@@ -302,7 +297,6 @@ async fn process_claim(
 	Ok(())
 }
 
-/// Destination-side storage key for `RequestReceipts[commitment]`.
 fn receipt_key_for(
 	destination: StateMachine,
 	commitment: H256,

--- a/tesseract/messaging/messaging/src/outbound_request_claim.rs
+++ b/tesseract/messaging/messaging/src/outbound_request_claim.rs
@@ -13,38 +13,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Outbound request delivery reward claim task.
+//! Periodic task that claims outbound request delivery rewards.
 //!
-//! Sibling to [`outbound_claim`](crate::outbound_claim). Where that task
-//! claims rewards for delivering BEEFY rotations, this one claims rewards
-//! for delivering hyperbridge-originated requests (system messages from
-//! host-executive, intents-coprocessor, token-governor, etc.). Supports
-//! both EVM and substrate destinations.
+//! Sibling to [`outbound_claim`](crate::outbound_claim). Where that task claims rewards for
+//! delivering BEEFY rotations, this one claims rewards for delivering hyperbridge-originated
+//! requests (system messages from host-executive, intents-coprocessor, token-governor, etc.).
+//! Supports both EVM and substrate destinations.
 //!
-//! For every batch of [`PendingRequestDeliveryClaim`]s pushed by the
-//! outbound delivery task:
-//!
-//! 1. Merge with whatever is still pending in the local DB, deduplicated on `commitment`.
-//! 2. Filter against `pallet_ismp_relayer::OutboundRequestsClaimed` on Hyperbridge: anything
-//!    already present has been claimed by some other relayer; queue for delete and skip.
-//! 3. For each surviving row:
-//!    - Wait for Hyperbridge's consensus client for the destination to verify a height >=
-//!      `delivery_height`.
-//!    - Build a state proof of `RequestReceipts[commitment]` at that height (32-byte EVM slot
-//!      routed to the ISMP host contract, or substrate child-trie key).
-//!    - Sign `outbound_request_delivery_message(commitment, destination, payee)` with the
-//!      destination's signing key.
-//!    - Submit `pallet_ismp_relayer::claim_outbound_request_delivery_reward` (unsigned) on
-//!      Hyperbridge.
-//!    - Delete the persisted row.
+//! Each delivery writes a row to the local DB. This task wakes on a fixed interval, reads those
+//! rows, skips anything already claimed on Hyperbridge, and submits the remaining claims in
+//! parallel.
 
-use std::{
-	collections::{BTreeMap, HashMap},
-	sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use anyhow::{anyhow, Context as _};
 use codec::Decode;
+use futures::{stream::FuturesUnordered, StreamExt};
 use ismp::{
 	consensus::StateMachineHeight, host::StateMachine, messaging::Proof, router::PostRequest,
 };
@@ -60,44 +44,40 @@ use tesseract_primitives::{
 	wait_for_state_machine_update, IsmpProvider, PendingRequestDeliveryClaim, StateProofQueryType,
 };
 use tesseract_substrate::{config::KeccakSubstrateChain, SubstrateClient};
-use tokio::sync::mpsc::Receiver;
+use tokio::time::MissedTickBehavior;
 use tracing::Instrument;
 use transaction_fees::TransactionPayment;
 
 const LOG_TARGET: &str = "messaging-outbound-request-claim";
 
-/// Drive a single relayer's outbound request delivery claims. Same shape
-/// as [`outbound_claim::run`](crate::outbound_claim::run); see that module
-/// for the high-level pipeline.
-///
-/// The payee is the relayer's Hyperbridge sr25519 account, so all relayer
-/// earnings on HB (messaging fees, consensus-delivery rewards, request-
-/// delivery rewards) land in the same place.
 pub async fn run(
 	hyperbridge: SubstrateClient<KeccakSubstrateChain>,
 	destinations: HashMap<StateMachine, Arc<dyn IsmpProvider>>,
-	mut receiver: Receiver<Vec<PendingRequestDeliveryClaim>>,
 	tx_payment: Option<Arc<TransactionPayment>>,
 ) -> Result<(), anyhow::Error> {
 	let hb_provider: Arc<dyn IsmpProvider> = Arc::new(hyperbridge.clone());
 	let payee_bytes: [u8; 32] = hyperbridge.signer.public().0;
 
-	while let Some(trigger) = receiver.recv().await {
-		let merged = merge_pending(&tx_payment, trigger).await;
-		if merged.is_empty() {
+	let mut interval = tokio::time::interval(Duration::from_secs(600));
+	interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+	loop {
+		interval.tick().await;
+
+		let pending = read_pending_claims(&tx_payment).await;
+		if pending.is_empty() {
 			continue;
 		}
 
-		let (claimed, unclaimed) = match partition_claimed(&hyperbridge, &merged).await {
+		let (claimed, unclaimed) = match partition_claimed(&hyperbridge, &pending).await {
 			Ok(parts) => parts,
 			Err(err) => {
 				tracing::warn!(
 					target: LOG_TARGET,
 					?err,
-					"OutboundRequestsClaimed lookup failed; processing all rows without \
-					 filtering. Duplicates will revert on Hyperbridge",
+					"could not check claimed status on Hyperbridge; processing all rows without filtering",
 				);
-				(Vec::new(), merged)
+				(Vec::new(), pending)
 			},
 		};
 
@@ -108,77 +88,75 @@ pub async fn run(
 				"dropping claims already redeemed on Hyperbridge",
 			);
 			if let Some(tp) = &tx_payment {
-				for pending in &claimed {
-					let commitment = pending.commitment();
-					let key = hex::encode(commitment.0);
+				for row in &claimed {
+					let key = hex::encode(row.commitment().0);
 					if let Err(err) = tp.delete_request_claim(&key).await {
 						tracing::warn!(
 							target: LOG_TARGET,
 							?err,
-							commitment = %commitment,
-							"failed to delete already-claimed row; will retry next trigger",
+							commitment = %row.commitment(),
+							"failed to delete already-claimed row",
 						);
 					}
 				}
 			}
 		}
 
+		let mut tasks = FuturesUnordered::new();
 		for pending in unclaimed {
-			let destination = pending.destination();
-			let commitment = pending.commitment();
 			let span = tracing::info_span!(
 				"outbound_request_claim",
-				destination = %destination,
+				destination = %pending.destination(),
 				delivery_height = pending.delivery_height,
-				commitment = %commitment,
+				commitment = %pending.commitment(),
 			);
-			let dest = destinations.get(&destination).cloned();
+			let dest = destinations.get(&pending.destination()).cloned();
 			let hb = hyperbridge.clone();
 			let hb_view = hb_provider.clone();
-			let tx_payment = tx_payment.clone();
-			async move {
-				let Some(dest) = dest else {
-					tracing::warn!(target: LOG_TARGET, "no provider for destination; dropping claim");
-					return;
-				};
-				match process_claim(&hb, hb_view, dest, &pending, payee_bytes).await {
-					Ok(()) => {
-						tracing::info!(target: LOG_TARGET, "claim submitted");
-						if let Some(tx_payment) = &tx_payment {
-							let _ =
-								tx_payment.delete_request_claim(&hex::encode(commitment.0)).await;
-						}
-					},
-					Err(err) => {
-						tracing::error!(
+			let tp = tx_payment.clone();
+			tasks.push(
+				async move {
+					let Some(dest) = dest else {
+						tracing::warn!(
 							target: LOG_TARGET,
-							?err,
-							"claim submission failed; row left in DB for next trigger",
+							"no provider for destination; dropping claim"
 						);
-					},
+						return;
+					};
+					let commitment = pending.commitment();
+					match process_claim(&hb, hb_view, dest, &pending, payee_bytes).await {
+						Ok(()) => {
+							tracing::info!(target: LOG_TARGET, "claim submitted");
+							if let Some(tp) = &tp {
+								let _ = tp.delete_request_claim(&hex::encode(commitment.0)).await;
+							}
+						},
+						Err(err) => {
+							tracing::error!(
+								target: LOG_TARGET,
+								?err,
+								"claim failed; will retry on next tick",
+							);
+						},
+					}
 				}
-			}
-			.instrument(span)
-			.await;
+				.instrument(span),
+			);
 		}
-	}
 
-	Err(anyhow!("outbound-request-claim channel closed"))
+		while tasks.next().await.is_some() {}
+	}
 }
 
-/// Read `list_pending_request_claims` and union-merge it with the trigger
-/// vec, deduplicated on the request commitment. DB rows take precedence on
-/// conflict. BTreeMap gives deterministic iteration over the result.
-async fn merge_pending(
+async fn read_pending_claims(
 	tx_payment: &Option<Arc<TransactionPayment>>,
-	trigger: Vec<PendingRequestDeliveryClaim>,
 ) -> Vec<PendingRequestDeliveryClaim> {
-	let mut merged: BTreeMap<H256, PendingRequestDeliveryClaim> = BTreeMap::new();
-
-	if let Some(tp) = tx_payment {
-		match tp.list_pending_request_claims().await {
-			Ok(rows) =>
-				for row in rows {
+	let Some(tp) = tx_payment else { return Vec::new() };
+	match tp.list_pending_request_claims().await {
+		Ok(rows) => {
+			let mut claims: Vec<PendingRequestDeliveryClaim> = rows
+				.into_iter()
+				.filter_map(|row| {
 					let request = match PostRequest::decode(&mut &*row.encoded_request) {
 						Ok(r) => r,
 						Err(err) => {
@@ -188,36 +166,29 @@ async fn merge_pending(
 								?err,
 								"undecodable encoded_request in DB; skipping row",
 							);
-							continue;
+							return None;
 						},
 					};
-					let claim = PendingRequestDeliveryClaim {
+					Some(PendingRequestDeliveryClaim {
 						request,
 						delivery_height: row.delivery_height as u64,
-					};
-					merged.insert(claim.commitment(), claim);
-				},
-			Err(err) => {
-				tracing::warn!(
-					target: LOG_TARGET,
-					?err,
-					"list_pending_request_claims failed; trigger-only this cycle",
-				);
-			},
-		}
+					})
+				})
+				.collect();
+			claims.sort_by_key(|c| c.delivery_height);
+			claims
+		},
+		Err(err) => {
+			tracing::warn!(
+				target: LOG_TARGET,
+				?err,
+				"could not read pending claims; skipping tick"
+			);
+			Vec::new()
+		},
 	}
-
-	for pending in trigger {
-		merged.entry(pending.commitment()).or_insert(pending);
-	}
-
-	let mut result: Vec<_> = merged.into_values().collect();
-	result.sort_by_key(|c| c.delivery_height);
-	result
 }
 
-/// Split `pending` into `(already_claimed, still_unclaimed)` by reading
-/// `pallet_ismp_relayer::OutboundRequestsClaimed[commitment]` on Hyperbridge.
 async fn partition_claimed(
 	hyperbridge: &SubstrateClient<KeccakSubstrateChain>,
 	pending: &[PendingRequestDeliveryClaim],
@@ -226,13 +197,13 @@ async fn partition_claimed(
 		.rpc
 		.chain_get_block_hash(None)
 		.await?
-		.ok_or_else(|| anyhow!("Failed to query latest hyperbridge block hash"))?;
+		.ok_or_else(|| anyhow!("failed to fetch latest Hyperbridge block hash"))?;
 
 	let mut claimed = Vec::new();
 	let mut unclaimed = Vec::new();
 
-	for pending in pending {
-		let commitment = pending.commitment();
+	for item in pending {
+		let commitment = item.commitment();
 		let key = outbound_requests_claimed_storage_key(commitment);
 		let raw = hyperbridge
 			.client
@@ -242,13 +213,10 @@ async fn partition_claimed(
 			.await
 			.with_context(|| format!("OutboundRequestsClaimed lookup ({})", commitment))?;
 
-		// `OutboundRequestsClaimed` stores a unit value, so key presence is the signal.
-		let is_claimed = raw.is_some();
-
-		if is_claimed {
-			claimed.push(pending.clone());
+		if raw.is_some() {
+			claimed.push(item.clone());
 		} else {
-			unclaimed.push(pending.clone());
+			unclaimed.push(item.clone());
 		}
 	}
 
@@ -265,13 +233,37 @@ async fn process_claim(
 	let destination = pending.destination();
 	let commitment = pending.commitment();
 
-	let dest_height = wait_for_state_machine_update(
-		dest.state_machine_id(),
-		hb_provider.clone(),
-		dest.clone(),
-		pending.delivery_height,
+	let committed = hb_provider
+		.query_latest_height(dest.state_machine_id())
+		.await
+		.context("query_latest_height")?;
+
+	if (committed as u64) < pending.delivery_height {
+		return Err(anyhow!(
+			"Hyperbridge has only committed {} for {}, delivery block {} not yet reachable",
+			committed,
+			destination,
+			pending.delivery_height,
+		));
+	}
+
+	let dest_height = tokio::time::timeout(
+		Duration::from_secs(300),
+		wait_for_state_machine_update(
+			dest.state_machine_id(),
+			hb_provider.clone(),
+			dest.clone(),
+			pending.delivery_height,
+		),
 	)
 	.await
+	.map_err(|_| {
+		anyhow!(
+			"timed out waiting for Hyperbridge to see {} at height {}",
+			destination,
+			pending.delivery_height,
+		)
+	})?
 	.context("wait_for_state_machine_update")?;
 
 	let key = receipt_key_for(destination, commitment, dest.ismp_host_contract())?;
@@ -299,27 +291,24 @@ async fn process_claim(
 		destination = %destination,
 		commitment = %commitment,
 		dest_height,
-		"submitting outbound request delivery claim to hyperbridge",
+		"submitting outbound request delivery claim",
 	);
+
 	hyperbridge
 		.submit_outbound_request_delivery_claim(claim)
 		.await
 		.context("submit_outbound_request_delivery_claim")?;
+
 	Ok(())
 }
 
-/// Destination-side storage key for `RequestReceipts[commitment]`. Matches
-/// the pallet-side derivation via `StateMachineClient::receipts_state_trie_key`.
+/// Destination-side storage key for `RequestReceipts[commitment]`.
 fn receipt_key_for(
 	destination: StateMachine,
 	commitment: H256,
 	ismp_host: Option<H160>,
 ) -> anyhow::Result<Vec<u8>> {
 	if destination.is_evm() {
-		// EVM `query_state_proof` expects a 52-byte arbitrary key: the 20-byte
-		// host contract address followed by the 32-byte storage slot hash.
-		// `RequestReceipts` lives in the
-		// destination's IsmpHost contract, so prefix the host address here.
 		let host = ismp_host.ok_or_else(|| {
 			anyhow!("no IsmpHost contract address for EVM destination {destination}")
 		})?;

--- a/tesseract/messaging/primitives/src/lib.rs
+++ b/tesseract/messaging/primitives/src/lib.rs
@@ -601,6 +601,20 @@ pub trait IsmpHost: Send + Sync {
 
 	/// Return the instance of the [`IsmpProvider`] associated with this host
 	fn provider(&self) -> Arc<dyn IsmpProvider>;
+
+	/// Advance the counterparty's state machine height for this host's chain
+	/// to at least `target_height` by submitting a consensus proof. Used by
+	/// the manual claim command when the counterparty has fallen behind a
+	/// delivery height and cannot update on its own (e.g. Polkadot Hub when
+	/// parachain inherents are absent). The default is a no-op; only parachain
+	/// hosts override this.
+	async fn advance_counterparty_to(
+		&self,
+		_counterparty: Arc<dyn IsmpProvider>,
+		_target_height: u64,
+	) -> anyhow::Result<()> {
+		Ok(())
+	}
 }
 
 #[async_trait::async_trait]

--- a/tesseract/relayer/Cargo.toml
+++ b/tesseract/relayer/Cargo.toml
@@ -17,6 +17,7 @@ clap = { version = "4.3.5", features = ["derive"] }
 codec = { workspace = true, default-features = true, features = ["derive"] }
 futures = "0.3.28"
 ismp = { workspace = true, default-features = true }
+ismp-parachain = { workspace = true, default-features = true }
 log = "0.4.19"
 primitive-types = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/tesseract/relayer/Cargo.toml
+++ b/tesseract/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tesseract"
-version = "2.4.2"
+version = "2.4.3"
 edition = "2021"
 description = "Consolidated Hyperbridge relayer — inbound and outbound consensus + messaging"
 authors = ["Polytope Labs <hello@polytope.technology>"]

--- a/tesseract/relayer/src/claim_rewards.rs
+++ b/tesseract/relayer/src/claim_rewards.rs
@@ -198,7 +198,7 @@ impl ClaimRewards {
 						);
 						return;
 					};
-					match process_claim(&hb, hb_view, dest, &pending, payee_bytes, None).await {
+					match process_claim(&hb, hb_view, dest, &pending, payee_bytes).await {
 						Ok(()) => {
 							tracing::info!(
 								target: LOG_TARGET,
@@ -360,7 +360,6 @@ impl ClaimRewards {
 						dest,
 						&pending,
 						payee_bytes,
-						None,
 					)
 					.await
 					{

--- a/tesseract/relayer/src/claim_rewards.rs
+++ b/tesseract/relayer/src/claim_rewards.rs
@@ -14,12 +14,19 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use anyhow::Context;
+use codec::Decode;
 use futures::{stream::FuturesUnordered, StreamExt};
 use ismp::host::StateMachine;
-use messaging::outbound_claim::{partition_claimed, process_claim};
+use ismp_parachain::consensus::{ASSET_HUB_MAINNET_CHAIN_ID, PASSET_HUB_TESTNET_CHAIN_ID};
+use messaging::{
+	outbound_claim::{partition_claimed, process_claim},
+	outbound_request_claim,
+};
 use sp_core::Pair;
 use tesseract_consensus_config::create_client_map;
-use tesseract_primitives::{IsmpProvider, PendingConsensusDeliveryClaim};
+use tesseract_primitives::{
+	IsmpProvider, PendingConsensusDeliveryClaim, PendingRequestDeliveryClaim,
+};
 use tesseract_substrate::{config::KeccakSubstrateChain, SubstrateClient};
 use tracing::Instrument;
 use transaction_fees::TransactionPayment;
@@ -70,7 +77,6 @@ impl ClaimRewards {
 
 		if all_rows.is_empty() {
 			tracing::info!(target: LOG_TARGET, "no pending rotation claims in DB");
-			return Ok(());
 		}
 
 		let all_claims: Vec<PendingConsensusDeliveryClaim> = all_rows
@@ -117,11 +123,6 @@ impl ClaimRewards {
 			if let Err(err) = cleanup_claimed(&tx_payment, &already_claimed).await {
 				tracing::warn!(target: LOG_TARGET, ?err, "failed to clean up already-claimed rows");
 			}
-		}
-
-		if unclaimed.is_empty() {
-			tracing::info!(target: LOG_TARGET, "all pending claims already redeemed");
-			return Ok(());
 		}
 
 		// For Polkadot Hub, Hyperbridge's state machine height may not advance
@@ -229,6 +230,164 @@ impl ClaimRewards {
 
 		while tasks.next().await.is_some() {}
 
+		// --- request delivery claims ---
+		let request_rows = tx_payment
+			.list_pending_request_claims()
+			.await
+			.context("list_pending_request_claims")?;
+
+		if request_rows.is_empty() {
+			tracing::info!(target: LOG_TARGET, "no pending request claims in DB");
+		}
+
+		let all_request_claims: Vec<PendingRequestDeliveryClaim> = request_rows
+			.into_iter()
+			.filter_map(|row| {
+				use ismp::router::PostRequest;
+				let request = PostRequest::decode(&mut &*row.encoded_request)
+					.map_err(|e| {
+						tracing::warn!(
+							target: LOG_TARGET,
+							commitment = %row.commitment,
+							?e,
+							"undecodable request in DB; skipping row",
+						)
+					})
+					.ok()?;
+				Some(PendingRequestDeliveryClaim {
+					request,
+					delivery_height: row.delivery_height as u64,
+				})
+			})
+			.collect();
+
+		let hub_request_claims = group_request_claims_by_polkadot_hub(&all_request_claims);
+		for (sm, claims) in &hub_request_claims {
+			let Some(host) = consensus_hosts.get(sm) else {
+				tracing::warn!(
+					target: LOG_TARGET,
+					%sm,
+					"no consensus host configured for Polkadot Hub; request claim may fail",
+				);
+				continue;
+			};
+
+			let max_delivery_height =
+				claims.iter().map(|c| c.delivery_height).max().unwrap_or_default();
+
+			let hb_height = hyperbridge_provider
+				.query_latest_height(
+					clients
+						.get(sm)
+						.map(|p| p.state_machine_id())
+						.unwrap_or_else(|| host.provider().state_machine_id()),
+				)
+				.await
+				.unwrap_or(0) as u64;
+
+			if hb_height < max_delivery_height {
+				tracing::info!(
+					target: LOG_TARGET,
+					%sm,
+					hb_height,
+					max_delivery_height,
+					"advancing Hyperbridge's state machine height for Polkadot Hub request claims",
+				);
+				if let Err(err) = host
+					.advance_counterparty_to(hyperbridge_provider.clone(), max_delivery_height)
+					.await
+				{
+					tracing::warn!(
+						target: LOG_TARGET,
+						%sm,
+						?err,
+						"failed to advance state machine height; request claims may fail",
+					);
+				}
+			}
+		}
+
+		let (already_claimed_reqs, unclaimed_reqs) =
+			match outbound_request_claim::partition_claimed(&hyperbridge, &all_request_claims).await
+			{
+				Ok(parts) => parts,
+				Err(err) => {
+					tracing::warn!(
+						target: LOG_TARGET,
+						?err,
+						"OutboundRequestsClaimed lookup failed; processing all rows",
+					);
+					(Vec::new(), all_request_claims)
+				},
+			};
+
+		if !already_claimed_reqs.is_empty() {
+			tracing::info!(
+				target: LOG_TARGET,
+				count = already_claimed_reqs.len(),
+				"skipping request claims already redeemed on Hyperbridge",
+			);
+			for row in &already_claimed_reqs {
+				let _ = tx_payment.delete_request_claim(&hex::encode(row.commitment().0)).await;
+			}
+		}
+
+		let mut req_tasks = FuturesUnordered::new();
+		for pending in unclaimed_reqs {
+			let span = tracing::info_span!(
+				"claim_request_rewards",
+				destination = %pending.destination(),
+				delivery_height = pending.delivery_height,
+				commitment = %pending.commitment(),
+			);
+			let dest = clients.get(&pending.destination()).cloned();
+			let hb = hyperbridge.clone();
+			let hb_view = hyperbridge_provider.clone();
+			let tp = tx_payment.clone();
+			req_tasks.push(
+				async move {
+					let Some(dest) = dest else {
+						tracing::warn!(
+							target: LOG_TARGET,
+							destination = %pending.destination(),
+							"no messaging client for destination; skipping request claim",
+						);
+						return;
+					};
+					match outbound_request_claim::process_claim(
+						&hb,
+						hb_view,
+						dest,
+						&pending,
+						payee_bytes,
+					)
+					.await
+					{
+						Ok(()) => {
+							tracing::info!(
+								target: LOG_TARGET,
+								commitment = %pending.commitment(),
+								"request claim submitted",
+							);
+							let _ =
+								tp.delete_request_claim(&hex::encode(pending.commitment().0)).await;
+						},
+						Err(err) => {
+							tracing::error!(
+								target: LOG_TARGET,
+								commitment = %pending.commitment(),
+								?err,
+								"request claim failed",
+							);
+						},
+					}
+				}
+				.instrument(span),
+			);
+		}
+
+		while req_tasks.next().await.is_some() {}
+
 		tracing::info!(target: LOG_TARGET, "claim-rewards complete");
 		Ok(())
 	}
@@ -248,7 +407,19 @@ fn group_by_polkadot_hub(
 }
 
 fn is_polkadot_hub(sm: StateMachine) -> bool {
-	matches!(sm, StateMachine::Evm(id) if id == 420420417 || id == 420420419)
+	matches!(sm, StateMachine::Evm(id) if id == PASSET_HUB_TESTNET_CHAIN_ID || id == ASSET_HUB_MAINNET_CHAIN_ID)
+}
+
+fn group_request_claims_by_polkadot_hub(
+	claims: &[PendingRequestDeliveryClaim],
+) -> BTreeMap<StateMachine, Vec<PendingRequestDeliveryClaim>> {
+	let mut out: BTreeMap<StateMachine, Vec<PendingRequestDeliveryClaim>> = BTreeMap::new();
+	for claim in claims {
+		if is_polkadot_hub(claim.destination()) {
+			out.entry(claim.destination()).or_default().push(claim.clone());
+		}
+	}
+	out
 }
 
 async fn cleanup_claimed(

--- a/tesseract/relayer/src/claim_rewards.rs
+++ b/tesseract/relayer/src/claim_rewards.rs
@@ -1,0 +1,264 @@
+// Copyright (C) Polytope Labs Ltd.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0.
+
+//! `claim-rewards` subcommand.
+//!
+//! One-shot pass over every pending outbound consensus delivery claim in the
+//! local DB. For Polkadot Hub deliveries — where Hyperbridge's state machine
+//! height for the destination may not advance on its own (no parachain
+//! inherents) — a parachain consensus proof is submitted to Hyperbridge first
+//! before the claim proof is built.
+
+use std::{collections::BTreeMap, sync::Arc};
+
+use anyhow::Context;
+use futures::{stream::FuturesUnordered, StreamExt};
+use ismp::host::StateMachine;
+use messaging::outbound_claim::{partition_claimed, process_claim};
+use sp_core::Pair;
+use tesseract_consensus_config::create_client_map;
+use tesseract_primitives::{IsmpProvider, PendingConsensusDeliveryClaim};
+use tesseract_substrate::{config::KeccakSubstrateChain, SubstrateClient};
+use tracing::Instrument;
+use transaction_fees::TransactionPayment;
+
+use crate::config::{setup_logging, HyperbridgeConfig};
+
+const LOG_TARGET: &str = "tesseract-claim-rewards";
+
+#[derive(Debug, clap::Args)]
+#[command(about = "Manually claim outbound consensus delivery rewards for all pending rotations.")]
+pub struct ClaimRewards {}
+
+impl ClaimRewards {
+	pub async fn run(&self, config_path: &str, db: &str) -> anyhow::Result<()> {
+		let _ = setup_logging();
+		let config = HyperbridgeConfig::parse_conf(config_path).await?;
+
+		let hyperbridge =
+			SubstrateClient::<KeccakSubstrateChain>::new(config.hyperbridge.substrate.clone())
+				.await?;
+		let hyperbridge_provider: Arc<dyn IsmpProvider> = Arc::new(hyperbridge.clone());
+
+		let mut clients = std::collections::HashMap::new();
+		for (sm, pc) in &config.chains {
+			let provider = pc
+				.messaging
+				.clone()
+				.into_client(hyperbridge_provider.clone())
+				.await
+				.with_context(|| format!("failed to build messaging client for {sm}"))?;
+			clients.insert(*sm, provider);
+		}
+
+		let consensus_hosts = create_client_map(config.consensus_chains()).await?;
+
+		let tx_payment = Arc::new(
+			TransactionPayment::initialize(db)
+				.await
+				.context("error initializing fee database")?,
+		);
+
+		let payee_bytes: [u8; 32] = hyperbridge.signer.public().0;
+
+		let all_rows = tx_payment
+			.list_pending_rotation_claims()
+			.await
+			.context("list_pending_rotation_claims")?;
+
+		if all_rows.is_empty() {
+			tracing::info!(target: LOG_TARGET, "no pending rotation claims in DB");
+			return Ok(());
+		}
+
+		let all_claims: Vec<PendingConsensusDeliveryClaim> = all_rows
+			.into_iter()
+			.filter_map(|row| {
+				use std::str::FromStr;
+				let destination = StateMachine::from_str(&row.dest)
+					.map_err(|e| {
+						tracing::warn!(
+							target: LOG_TARGET,
+							dest = %row.dest,
+							?e,
+							"unparseable state machine in DB; skipping row",
+						)
+					})
+					.ok()?;
+				Some(PendingConsensusDeliveryClaim {
+					destination,
+					delivery_height: row.rotation_height as u64,
+					set_id: row.set_id as u64,
+				})
+			})
+			.collect();
+
+		let (already_claimed, unclaimed) = match partition_claimed(&hyperbridge, &all_claims).await
+		{
+			Ok(parts) => parts,
+			Err(err) => {
+				tracing::warn!(
+					target: LOG_TARGET,
+					?err,
+					"OutboundConsensusRotationsClaimed lookup failed; processing all rows",
+				);
+				(Vec::new(), all_claims)
+			},
+		};
+
+		if !already_claimed.is_empty() {
+			tracing::info!(
+				target: LOG_TARGET,
+				count = already_claimed.len(),
+				"skipping claims already redeemed on Hyperbridge",
+			);
+			if let Err(err) = cleanup_claimed(&tx_payment, &already_claimed).await {
+				tracing::warn!(target: LOG_TARGET, ?err, "failed to clean up already-claimed rows");
+			}
+		}
+
+		if unclaimed.is_empty() {
+			tracing::info!(target: LOG_TARGET, "all pending claims already redeemed");
+			return Ok(());
+		}
+
+		// For Polkadot Hub, Hyperbridge's state machine height may not advance
+		// automatically without parachain inherents. Submit a consensus proof to
+		// Hyperbridge first so the claim proof can be anchored against a known
+		// state commitment.
+		let polkadot_hub_claims = group_by_polkadot_hub(&unclaimed);
+		for (sm, claims) in &polkadot_hub_claims {
+			let Some(host) = consensus_hosts.get(sm) else {
+				tracing::warn!(
+					target: LOG_TARGET,
+					%sm,
+					"no consensus host configured for Polkadot Hub; claim may fail if \
+					 Hyperbridge has not seen the delivery height",
+				);
+				continue;
+			};
+
+			let max_delivery_height =
+				claims.iter().map(|c| c.delivery_height).max().unwrap_or_default();
+
+			let hb_height = hyperbridge_provider
+				.query_latest_height(
+					clients
+						.get(sm)
+						.map(|p| p.state_machine_id())
+						.unwrap_or_else(|| host.provider().state_machine_id()),
+				)
+				.await
+				.unwrap_or(0) as u64;
+
+			if hb_height < max_delivery_height {
+				tracing::info!(
+					target: LOG_TARGET,
+					%sm,
+					hb_height,
+					max_delivery_height,
+					"advancing Hyperbridge's state machine height for Polkadot Hub",
+				);
+				if let Err(err) = host
+					.advance_counterparty_to(hyperbridge_provider.clone(), max_delivery_height)
+					.await
+				{
+					tracing::warn!(
+						target: LOG_TARGET,
+						%sm,
+						?err,
+						"failed to advance state machine height; claims may fail",
+					);
+				}
+			}
+		}
+
+		let mut tasks = FuturesUnordered::new();
+		for pending in unclaimed {
+			let span = tracing::info_span!(
+				"claim_rewards",
+				destination = %pending.destination,
+				delivery_height = pending.delivery_height,
+				set_id = pending.set_id,
+			);
+			let dest = clients.get(&pending.destination).cloned();
+			let hb = hyperbridge.clone();
+			let hb_view = hyperbridge_provider.clone();
+			let tp = tx_payment.clone();
+			tasks.push(
+				async move {
+					let Some(dest) = dest else {
+						tracing::warn!(
+							target: LOG_TARGET,
+							destination = %pending.destination,
+							"no messaging client for destination; skipping claim",
+						);
+						return;
+					};
+					match process_claim(&hb, hb_view, dest, &pending, payee_bytes).await {
+						Ok(()) => {
+							tracing::info!(
+								target: LOG_TARGET,
+								destination = %pending.destination,
+								set_id = pending.set_id,
+								"claim submitted",
+							);
+							let _ = tp
+								.delete_rotation_claim(
+									&pending.destination.to_string(),
+									pending.set_id,
+								)
+								.await;
+						},
+						Err(err) => {
+							tracing::error!(
+								target: LOG_TARGET,
+								destination = %pending.destination,
+								set_id = pending.set_id,
+								?err,
+								"claim failed",
+							);
+						},
+					}
+				}
+				.instrument(span),
+			);
+		}
+
+		while tasks.next().await.is_some() {}
+
+		tracing::info!(target: LOG_TARGET, "claim-rewards complete");
+		Ok(())
+	}
+}
+
+/// Group unclaimed rows that target Polkadot Hub, keyed by state machine.
+fn group_by_polkadot_hub(
+	claims: &[PendingConsensusDeliveryClaim],
+) -> BTreeMap<StateMachine, Vec<PendingConsensusDeliveryClaim>> {
+	let mut out: BTreeMap<StateMachine, Vec<PendingConsensusDeliveryClaim>> = BTreeMap::new();
+	for claim in claims {
+		if is_polkadot_hub(claim.destination) {
+			out.entry(claim.destination).or_default().push(claim.clone());
+		}
+	}
+	out
+}
+
+fn is_polkadot_hub(sm: StateMachine) -> bool {
+	matches!(sm, StateMachine::Evm(id) if id == 420420417 || id == 420420419)
+}
+
+async fn cleanup_claimed(
+	tx_payment: &TransactionPayment,
+	claimed: &[PendingConsensusDeliveryClaim],
+) -> anyhow::Result<()> {
+	for pending in claimed {
+		tx_payment
+			.delete_rotation_claim(&pending.destination.to_string(), pending.set_id)
+			.await?;
+	}
+	Ok(())
+}

--- a/tesseract/relayer/src/claim_rewards.rs
+++ b/tesseract/relayer/src/claim_rewards.rs
@@ -198,7 +198,7 @@ impl ClaimRewards {
 						);
 						return;
 					};
-					match process_claim(&hb, hb_view, dest, &pending, payee_bytes).await {
+					match process_claim(&hb, hb_view, dest, &pending, payee_bytes, None).await {
 						Ok(()) => {
 							tracing::info!(
 								target: LOG_TARGET,
@@ -360,6 +360,7 @@ impl ClaimRewards {
 						dest,
 						&pending,
 						payee_bytes,
+						None,
 					)
 					.await
 					{

--- a/tesseract/relayer/src/cli.rs
+++ b/tesseract/relayer/src/cli.rs
@@ -30,6 +30,7 @@ use tracing::Instrument;
 use transaction_fees::TransactionPayment;
 
 use crate::{
+	claim_rewards::ClaimRewards,
 	config::{setup_logging, HyperbridgeConfig},
 	fees::AccumulateFees,
 	provider::{ConsensusProofSource, OffchainProofSource},
@@ -89,6 +90,11 @@ pub enum Subcommand {
 	/// directions, and (optionally) withdraw the resulting hyperbridge
 	/// balance to each destination.
 	AccumulateFees(AccumulateFees),
+	/// Manually claim outbound consensus delivery rewards for all pending
+	/// rotation claims in the local DB. For Polkadot Hub deliveries, submits
+	/// a parachain consensus proof to Hyperbridge first so the claim proof can
+	/// be anchored against a known state commitment.
+	ClaimRewards(ClaimRewards),
 }
 
 const BANNER: &str = r"

--- a/tesseract/relayer/src/cli.rs
+++ b/tesseract/relayer/src/cli.rs
@@ -311,6 +311,7 @@ impl Cli {
 				relayer_config: messaging_config.clone(),
 				tx_payment: tx_payment.clone(),
 				fees_disabled,
+				consensus_hosts: consensus_hosts.clone(),
 			},
 			&task_manager,
 		)

--- a/tesseract/relayer/src/lib.rs
+++ b/tesseract/relayer/src/lib.rs
@@ -23,6 +23,7 @@
 /// Log/tracing target for this crate.
 pub const LOG_TARGET: &str = "tesseract";
 
+pub mod claim_rewards;
 pub mod cli;
 pub mod config;
 pub mod fees;

--- a/tesseract/relayer/src/main.rs
+++ b/tesseract/relayer/src/main.rs
@@ -28,6 +28,7 @@ async fn main() -> Result<(), anyhow::Error> {
 			return cli.log_consensus_state(state_machine.clone()).await,
 		Some(Subcommand::Withdraw) => return cli.withdraw_once().await,
 		Some(Subcommand::AccumulateFees(cmd)) => return cmd.run(&cli.config, &cli.db).await,
+		Some(Subcommand::ClaimRewards(cmd)) => return cmd.run(&cli.config, &cli.db).await,
 		None => {},
 	}
 


### PR DESCRIPTION
The outbound consensus claim task has been refactored to work like the fee withdrawal mechanism. Instead of forwarding claims through a channel on each delivery, the delivery path now writes a row to the database and a separate periodic task wakes every 600 seconds, checks which claims have already been redeemed on Hyperbridge, and submits the rest in parallel. A fast-fail height check was also added so claims on chains where Hyperbridge has not yet committed to the delivery block are skipped immediately rather than burning the full 300 second wait on every cycle.
