### PR TITLE
[simplex]: Raise default maxOverfillBps to 5% and bump patch version

### DIFF
--- a/sdk/packages/simplex/filler-config-example.toml
+++ b/sdk/packages/simplex/filler-config-example.toml
@@ -54,9 +54,9 @@ hyperbridgeWsUrl = ""
 # The filler clamps its computed output to at most (1 + maxOverfillBps) × user-requested amount.
 # After `maxConsecutiveClamps` consecutive orders where the clamp activated, the strategy
 # halts itself — likely a systemic pricing error — and requires operator restart.
-# If not provided, defaults will be used (maxOverfillBps = 100, maxConsecutiveClamps = 3)
+# If not provided, defaults will be used (maxOverfillBps = 500, maxConsecutiveClamps = 3)
 # [simplex.overfillProtection]
-# maxOverfillBps = 100          # 1% ceiling above user-requested output (default: 100)
+# maxOverfillBps = 500          # 5% ceiling above user-requested output (default: 500)
 # maxConsecutiveClamps = 3      # Halt threshold (default: 3)
 
 

--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/simplex",
-	"version": "0.5.4",
+	"version": "0.5.5",
 	"license": "Apache-2.0",
 	"description": "IntentGateway simplex package for hyperbridge",
 	"main": "dist/index.js",

--- a/sdk/packages/simplex/src/bin/simplex.ts
+++ b/sdk/packages/simplex/src/bin/simplex.ts
@@ -178,7 +178,7 @@ interface FillerTomlConfig {
 			maxFeePerGasBumpPercent?: number
 		}
 		/**
-		 * Overfill protection knobs. Defaults: maxOverfillBps=100, maxConsecutiveClamps=3.
+		 * Overfill protection knobs. Defaults: maxOverfillBps=500, maxConsecutiveClamps=3.
 		 * `maxOverfillBps` clamps the per-leg output ceiling on every strategy.
 		 * `maxConsecutiveClamps` only halts FXFiller, and only when the clamped legs
 		 * were priced by an on-chain venue (e.g. Uniswap V4). Offline-curve clamps warn

--- a/sdk/packages/simplex/src/services/FillerConfigService.ts
+++ b/sdk/packages/simplex/src/services/FillerConfigService.ts
@@ -102,7 +102,7 @@ export interface RebalancingConfig {
 }
 
 export interface OverfillProtectionConfig {
-	/** Ceiling bps above user-requested output; filler clamps its computed output to this. Default 100 (1%). */
+	/** Ceiling bps above user-requested output; filler clamps its computed output to this. Default 500 (5%). */
 	maxOverfillBps?: number
 	/** Consecutive clamped evaluations before the strategy halts itself. Default 3. */
 	maxConsecutiveClamps?: number
@@ -135,7 +135,7 @@ export interface FillerConfig {
 	targetGasUnits?: number
 	/**
 	 * Overfill protection knobs. If omitted, defaults are used
-	 * (maxOverfillBps=100, maxConsecutiveClamps=3).
+	 * (maxOverfillBps=500, maxConsecutiveClamps=3).
 	 */
 	overfillProtection?: OverfillProtectionConfig
 	/**
@@ -487,9 +487,9 @@ export class FillerConfigService {
 		return BigInt(this.fillerConfig?.targetGasUnits ?? 3_000_000)
 	}
 
-	/** Ceiling bps above user-requested output. Default 100 (1%). */
+	/** Ceiling bps above user-requested output. Default 500 (5%). */
 	getMaxOverfillBps(): bigint {
-		return BigInt(this.fillerConfig?.overfillProtection?.maxOverfillBps ?? 100)
+		return BigInt(this.fillerConfig?.overfillProtection?.maxOverfillBps ?? 500)
 	}
 
 	/** Consecutive clamped evaluations before the strategy halts. Default 3. */

--- a/sdk/packages/simplex/src/strategies/fx.ts
+++ b/sdk/packages/simplex/src/strategies/fx.ts
@@ -285,7 +285,6 @@ export class FXFiller implements FillerStrategy {
 			// original input/pair via this array rather than by position.
 			const fillerOutputLegs: number[] = []
 			let remainingUsd = cappedOrderUsd
-			let anyLegClamped = false
 
 			const fundingCalls: ERC7821Call[] = []
 
@@ -342,10 +341,14 @@ export class FXFiller implements FillerStrategy {
 				const { usdUsed, policyMaxOutput: rawPolicyMaxOutput } = legResult
 				remainingUsd = remainingUsd.minus(usdUsed)
 
-				// Clamp policy output to at most (1 + maxOverfillBps) × user-requested.
-				// Bounds per-leg loss if internal pricing is wrong (bug, stale cache, manipulated venue).
+				// Overfill detection is warn-only: the clamp is DISABLED, so the filler
+				// fills the full computed amount even when it exceeds
+				// (1 + maxOverfillBps) × user-requested — including venue-priced legs
+				// (e.g. Uniswap V4). NOTE: this removes the per-leg loss bound that
+				// previously protected against a bug / stale cache / manipulated venue
+				// price. Output is no longer capped; we only emit a warning.
 				const overfillCeiling = (output.amount * (10000n + this.maxOverfillBps)) / 10000n
-				let policyMaxOutput = rawPolicyMaxOutput
+				const policyMaxOutput = rawPolicyMaxOutput
 				if (rawPolicyMaxOutput > overfillCeiling) {
 					const priceSource = venuePrice ? "venue" : "policy"
 					this.logger.warn(
@@ -355,20 +358,12 @@ export class FXFiller implements FillerStrategy {
 							token: output.token,
 							userRequested: output.amount.toString(),
 							unclamped: rawPolicyMaxOutput.toString(),
-							clamped: overfillCeiling.toString(),
+							ceiling: overfillCeiling.toString(),
 							maxOverfillBps: this.maxOverfillBps.toString(),
 							priceSource,
 						},
-						"Overfill clamp activated",
+						"Overfill ceiling exceeded — clamp disabled, filling unclamped amount",
 					)
-					policyMaxOutput = overfillCeiling
-					// Only count venue-sourced clamps toward the halt counter. Offline
-					// price-curve clamps still warn but never halt — the curve is
-					// operator-authored, so a mismatch is a config issue, not a live
-					// market signal worth tripping the kill switch over.
-					if (venuePrice) {
-						anyLegClamped = true
-					}
 				}
 
 				// Cap by wallet balance on the destination chain, optionally topped up via LP removal.
@@ -503,7 +498,9 @@ export class FXFiller implements FillerStrategy {
 				}
 			}
 
-			this.recordOrderOutcome(anyLegClamped, order.id)
+			// Clamp is disabled, so a leg can never be clamped — the halt subsystem is
+			// left in place but dormant (always recorded as a clean, unclamped outcome).
+			this.recordOrderOutcome(false, order.id)
 
 			const { totalCostInSourceFeeToken } = await this.contractService.estimateGasFillPost(order)
 			// Reject only when the user's attached fees can't cover what we expect to spend on the fill.


### PR DESCRIPTION
Change the default per-leg overfill ceiling from 100 bps (1%) to 500 bps (5%) and bump @hyperbridge/simplex to 0.5.5.