### PR TITLE
[sdk]: introduce ERC-4626 vault

### DIFF
--- a/docs/content/developers/evm/meta.json
+++ b/docs/content/developers/evm/meta.json
@@ -5,6 +5,7 @@
         "messaging",
         "hyper-fungible-token",
         "intent-gateway",
+        "streaming-yield-vault",
         "bandwidth",
         "lz-endpoint",
         "contract-addresses",

--- a/docs/content/developers/evm/streaming-yield-vault.mdx
+++ b/docs/content/developers/evm/streaming-yield-vault.mdx
@@ -1,0 +1,167 @@
+---
+title: StreamingYieldVault
+description: An ERC-4626 vault that distributes yield by streaming it linearly over time, neutralizing yield-sniping while keeping shares fully composable.
+---
+
+# StreamingYieldVault
+
+`StreamingYieldVault` is an [ERC-4626](https://eips.ethereum.org/EIPS/eip-4626) tokenized vault in [`@hyperbridge/core`](https://github.com/polytope-labs/hyperbridge/tree/main/sdk/packages/core). It lets an issuer turn a manual, per-user yield-distribution process into a single periodic transfer: the owner streams yield into the vault and every holder's share value rises automatically. Holders receive a standard, non-rebasing, composable share token.
+
+It is a self-contained primitive with **no Hyperbridge/ISMP dependency** — it can be used on any EVM chain on its own.
+
+<Callout type="info">
+The vault assumes a **standard ERC-20** asset: non-rebasing, non-fee-on-transfer, and without transfer callbacks (no ERC-777 hooks). Wrap exotic tokens before using them as the underlying.
+</Callout>
+
+## How it works
+
+Yield is not recognized instantly. Instead, each contribution is recognized **linearly over a fixed window** (`VEST`, 23 hours). The exchange rate is:
+
+```
+totalAssets = asset.balanceOf(vault) − lockedYield
+```
+
+where `lockedYield` is the not-yet-vested portion of the current tranche. This design gives three properties:
+
+- **No yield sniping.** Because recognition is keyed on `block.timestamp`, a deposit and withdrawal in the *same block* observe an identical share price and capture nothing. An attacker can only collect the dust that vests across blocks while bearing real exposure — so they can't sandwich a yield event.
+- **No instant jump.** Adding yield never moves `totalAssets` in the same block; it only raises the price as the tranche vests.
+- **No backlog.** `addYield` reverts until the previous tranche has fully vested, so tranches never overlap and no yield is left permanently locked.
+
+The first-depositor inflation/donation attack is mitigated with OpenZeppelin's virtual shares/assets (a non-zero decimals offset). A **seed-and-burn** at deployment is still recommended.
+
+## Deployment
+
+<Steps>
+<Step>
+### Install the package
+
+<Tabs items={['pnpm', 'yarn', 'npm']}>
+<Tab value="pnpm">
+```bash
+pnpm add @hyperbridge/core
+```
+</Tab>
+<Tab value="yarn">
+```bash
+yarn add @hyperbridge/core
+```
+</Tab>
+<Tab value="npm">
+```bash
+npm install @hyperbridge/core
+```
+</Tab>
+</Tabs>
+</Step>
+<Step>
+### Deploy the vault
+
+The constructor takes the underlying asset, the share token name/symbol, and the owner.
+
+```solidity lineNumbers
+import {StreamingYieldVault} from "@hyperbridge/core/vaults/StreamingYieldVault.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+StreamingYieldVault vault = new StreamingYieldVault(
+    IERC20(USDC),        // underlying asset (standard ERC-20)
+    "Yield USDC",        // share token name
+    "yUSDC",             // share token symbol
+    MULTISIG             // owner (controls addYield, pause/unpause)
+);
+```
+
+<Callout type="warn">
+Set the owner to a **multisig or timelock**, never an EOA. The owner can pause the vault and supply yield.
+</Callout>
+</Step>
+<Step>
+### Seed and burn
+
+Make a small first deposit and burn the shares so the vault is never empty. Together with the built-in decimals offset, this fully closes the first-depositor inflation attack.
+
+```solidity lineNumbers
+IERC20(USDC).approve(address(vault), 1e6);
+uint256 shares = vault.deposit(1e6, address(this));
+vault.transfer(address(0xdead), shares); // burn
+```
+</Step>
+<Step>
+### Schedule yield top-ups
+
+Have your treasury/keeper call `addYield` on a regular cadence (e.g. daily). Because `VEST` is 23h, scheduling daily leaves margin so the call never reverts on the vesting guard.
+
+```solidity lineNumbers
+IERC20(USDC).approve(address(vault), amount);
+vault.addYield(amount); // owner only; reverts if the prior tranche is still vesting
+```
+
+Use the `vestedAt()` view to know the earliest time the next `addYield` is allowed.
+</Step>
+</Steps>
+
+## Depositing and withdrawing
+
+The vault is a standard ERC-4626, so integrators use the usual entrypoints. Depositors first approve the underlying asset, then deposit:
+
+```solidity lineNumbers
+asset.approve(address(vault), amount);
+uint256 shares = vault.deposit(amount, receiver); // fixed asset amount in
+```
+
+Exiting uses `redeem` (clean full exit) or `withdraw` (fixed asset amount out):
+
+```solidity lineNumbers
+// burn an exact share amount — idiomatic for fully exiting a position
+uint256 assets = vault.redeem(vault.balanceOf(owner), receiver, owner);
+
+// or withdraw an exact asset amount
+uint256 burned = vault.withdraw(assets, receiver, owner);
+```
+
+`convertToAssets(shares)` reports the current value of a share balance, which climbs as yield vests.
+
+## Adding yield
+
+`addYield(uint256 amount)` is **owner-only**. It pulls `amount` of the underlying from the caller and begins streaming it over `VEST`.
+
+```solidity lineNumbers
+function addYield(uint256 amount) external onlyOwner;
+```
+
+It reverts with `YieldStillVesting(vestedAt)` if the previous tranche has not fully vested, and `ZeroAmount()` for a zero amount. Yield may be added while the vault is paused — it simply can't be withdrawn until unpaused.
+
+## Pausing
+
+The owner can freeze all share movement — transfers, deposits, and withdrawals — in an emergency. Pausing is enforced at a single `_update` chokepoint that every mint, burn, and transfer flows through.
+
+```solidity lineNumbers
+vault.pause();    // owner only — blocks transfers, deposits, withdrawals
+vault.unpause();  // owner only — restores share movement
+```
+
+<Callout type="warn">
+While paused, holders **cannot withdraw**. Treat the pause as an emergency stop and restrict it to a trusted owner.
+</Callout>
+
+## Reference
+
+| Member | Description |
+| --- | --- |
+| `VEST` | Vesting window per tranche (constant, `23 hours`). Keep `≤` your `addYield` cadence. |
+| `addYield(uint256)` | Owner-only; streams a yield tranche over `VEST`. |
+| `lockedYield()` | The not-yet-recognized portion of the active tranche. |
+| `vestedAt()` | Timestamp the active tranche finishes vesting / next `addYield` is allowed. |
+| `pause()` / `unpause()` | Owner-only emergency stop for all share movement. |
+| `totalAssets()` | `balanceOf(vault) − lockedYield`. |
+| `YieldAdded(amount, vestingStart)` | Emitted when a tranche begins vesting. |
+| `YieldStillVesting(vestedAt)` | Reverts `addYield` while the prior tranche is vesting. |
+| `ZeroAmount()` | Reverts `addYield` for a zero amount. |
+
+## Security considerations
+
+- **Standard ERC-20 only.** Fee-on-transfer and rebasing assets desync the vault's accounting; ERC-777 callbacks reintroduce reentrancy vectors the design otherwise avoids.
+- **Seed-and-burn at deploy.** Combined with the decimals offset, this removes the empty-vault inflation attack.
+- **Tune `VEST` to your cadence.** It must be `≤` the interval between `addYield` calls; otherwise the guard rejects timely top-ups. 23h suits a daily cadence.
+- **Owner is trusted.** The owner can pause withdrawals and supply yield — use a multisig/timelock.
+
+The contract is covered by an extensive Foundry suite exercising the inflation attack, yield sniping, vesting math, the `addYield` guard, the pause chokepoint, access control, and ERC-4626 rounding/preview parity.

--- a/sdk/packages/core/contracts/vaults/StreamingYieldVault.sol
+++ b/sdk/packages/core/contracts/vaults/StreamingYieldVault.sol
@@ -1,0 +1,143 @@
+// Copyright (C) Polytope Labs Ltd.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+pragma solidity ^0.8.17;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC4626} from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+
+/// @title StreamingYieldVault
+/// @author Polytope Labs (hello@polytope.technology)
+/// @notice An ERC-4626 vault whose yield is supplied by the owner via periodic transfers
+///         (`addYield`) and recognized linearly over a fixed window (`VEST`). Because yield
+///         is streamed rather than recognized instantly, no single block can be sandwiched
+///         around a yield event ("yield sniping"): a same-block deposit/withdraw sees an
+///         unchanged share price and captures nothing.
+///
+/// @dev Design notes:
+///      - The exchange rate is `(balanceOf(this) - lockedYield) / totalSupply`. Yield that has
+///        not yet vested is masked out of `totalAssets`, so it cannot be claimed early.
+///      - The owner may `pause()` to freeze all share movement (transfers, deposits, withdrawals)
+///        in an emergency. Yield may still be added while paused; it simply cannot be withdrawn.
+///      - The first-depositor inflation/donation attack is mitigated by OpenZeppelin's virtual
+///        shares/assets via a non-zero `_decimalsOffset()`. Seed-and-burn at deployment as well.
+///      - No reentrancy guard is used: the only external calls are `transfer`/`transferFrom` on
+///        the asset, and OpenZeppelin's ERC4626 orders effects before interactions. This assumes
+///        a standard, non-rebasing, non-fee-on-transfer, non-hooked (no ERC-777 callbacks) asset.
+contract StreamingYieldVault is ERC4626, Pausable, Ownable {
+    using SafeERC20 for IERC20;
+
+    /// @notice Window over which each yield tranche is linearly recognized.
+    /// @dev Keep `VEST <= the cadence at which `addYield` is called`. For ~24h cadence, 23h
+    ///      maximizes anti-snipe protection while leaving margin for keeper jitter.
+    uint256 public constant VEST = 23 hours;
+
+    /// @dev Virtual-share offset hardening the first-depositor inflation attack. Shares carry
+    ///      `assetDecimals + DECIMALS_OFFSET` decimals.
+    uint8 private constant DECIMALS_OFFSET = 6;
+
+    /// @dev The size of the yield tranche currently being recognized.
+    uint256 private _vestingAmount;
+
+    /// @dev The timestamp at which the current tranche started vesting. Zero means no tranche
+    ///      has ever been added.
+    uint256 private _vestingStart;
+
+    /// @notice Thrown when `addYield` is called before the previous tranche has fully vested.
+    error YieldStillVesting(uint256 vestedAt);
+
+    /// @notice Thrown when `addYield` is called with a zero amount.
+    error ZeroAmount();
+
+    /// @notice Emitted when a new yield tranche begins vesting.
+    event YieldAdded(uint256 amount, uint256 vestingStart);
+
+    constructor(IERC20 asset_, string memory name_, string memory symbol_, address owner_)
+        ERC20(name_, symbol_)
+        ERC4626(asset_)
+        Ownable(owner_)
+    {}
+
+    /// @inheritdoc ERC4626
+    /// @notice Total assets backing shares, net of any not-yet-vested yield.
+    function totalAssets() public view override returns (uint256) {
+        return IERC20(asset()).balanceOf(address(this)) - _lockedYield();
+    }
+
+    /// @notice The portion of the current tranche that has not yet been recognized.
+    function lockedYield() external view returns (uint256) {
+        return _lockedYield();
+    }
+
+    /// @notice The timestamp at which the current tranche finishes vesting, which is also the
+    ///         earliest time `addYield` may be called again.
+    function vestedAt() external view returns (uint256) {
+        return _vestingStart + VEST;
+    }
+
+    /// @notice Add a new yield tranche, pulled from the caller. Reverts unless the previous
+    ///         tranche has fully vested, which guarantees tranches never overlap and no yield
+    ///         is ever left permanently locked.
+    /// @param amount The amount of `asset` to stream in over `VEST`.
+    function addYield(uint256 amount) external onlyOwner {
+        if (amount == 0) revert ZeroAmount();
+
+        uint256 start = _vestingStart;
+        if (start != 0 && block.timestamp < start + VEST) {
+            revert YieldStillVesting(start + VEST);
+        }
+
+        // Pull the funds first so `balanceOf` already reflects `amount` before it is marked
+        // locked; otherwise `totalAssets` would transiently underflow when a tranche exceeds
+        // the current backing (e.g. the very first `addYield` on a near-empty vault).
+        IERC20(asset()).safeTransferFrom(msg.sender, address(this), amount);
+
+        _vestingAmount = amount;
+        _vestingStart = block.timestamp;
+
+        emit YieldAdded(amount, block.timestamp);
+    }
+
+    /// @notice Freeze all share movement (transfers, deposits, withdrawals) in an emergency.
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    /// @notice Resume share movement.
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    /// @dev Linear unlock of the current tranche, keyed on `block.timestamp` so that a deposit
+    ///      and withdrawal within the same block observe an identical, unchanged share price.
+    function _lockedYield() internal view returns (uint256) {
+        uint256 start = _vestingStart;
+        uint256 elapsed = block.timestamp - start;
+        if (elapsed >= VEST) return 0;
+        return (_vestingAmount * (VEST - elapsed)) / VEST;
+    }
+
+    /// @inheritdoc ERC4626
+    function _decimalsOffset() internal pure override returns (uint8) {
+        return DECIMALS_OFFSET;
+    }
+
+    /// @dev Single chokepoint for all share movement (mint, burn, transfer); gated by the pause.
+    function _update(address from, address to, uint256 value) internal override whenNotPaused {
+        super._update(from, to, value);
+    }
+}

--- a/sdk/packages/core/package.json
+++ b/sdk/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/core",
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"description": "Hyperbridge Solidity SDK for dispatching & receiving cross-chain messages",
 	"author": "Polytope Labs <hello@polytope.technology>",
 	"license": "Apache-2.0",

--- a/sdk/packages/core/remappings.txt
+++ b/sdk/packages/core/remappings.txt
@@ -1,2 +1,3 @@
 @openzeppelin/=node_modules/@openzeppelin
 @polytope-labs/solidity-merkle-trees/=node_modules/@polytope-labs/solidity-merkle-trees
+forge-std/=node_modules/forge-std/src/

--- a/sdk/packages/core/test/StreamingYieldVault.t.sol
+++ b/sdk/packages/core/test/StreamingYieldVault.t.sol
@@ -1,0 +1,550 @@
+// Copyright (C) Polytope Labs Ltd.
+// SPDX-License-Identifier: Apache-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+
+import {StreamingYieldVault} from "../contracts/vaults/StreamingYieldVault.sol";
+
+/// @dev Minimal mintable ERC-20 used as the vault's underlying asset. Standard behaviour:
+///      no transfer fee, no rebasing, no callbacks.
+contract MockERC20 is ERC20 {
+    constructor() ERC20("Mock", "MOCK") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+/// @notice Adversarial and invariant tests for {StreamingYieldVault}, focused on the known
+///         ERC-4626 / yield-vault vulnerability classes:
+///          - first-depositor inflation / donation attack
+///          - yield sniping (sandwiching a yield event)
+///          - vesting correctness & the no-backlog `addYield` guard
+///          - underflow safety, access control, input validation
+///          - rounding-in-the-vault's-favour and ERC-4626 preview parity
+contract StreamingYieldVaultTest is Test {
+    MockERC20 internal asset;
+    StreamingYieldVault internal vault;
+
+    address internal owner = makeAddr("owner");
+    address internal alice = makeAddr("alice"); // long-term, honest LP
+    address internal bob = makeAddr("bob");
+    address internal attacker = makeAddr("attacker");
+    address internal seeder = makeAddr("seeder");
+
+    uint256 internal constant VEST = 23 hours;
+    uint256 internal constant OFFSET = 6;
+
+    function setUp() public {
+        // Warp to a realistic, mainnet-like timestamp so vesting/guard arithmetic behaves as
+        // it would in production (and never near the chain-genesis edge).
+        vm.warp(1_700_000_000);
+
+        asset = new MockERC20();
+        vault = new StreamingYieldVault(IERC20(address(asset)), "Vault MOCK", "vMOCK", owner);
+
+        address[4] memory actors = [alice, bob, attacker, seeder];
+        for (uint256 i = 0; i < actors.length; i++) {
+            asset.mint(actors[i], 2_000_000 ether);
+            vm.prank(actors[i]);
+            asset.approve(address(vault), type(uint256).max);
+        }
+        // The owner funds yield, so it needs balance + allowance too.
+        asset.mint(owner, 2_000_000 ether);
+        vm.prank(owner);
+        asset.approve(address(vault), type(uint256).max);
+    }
+
+    // --------------------------------------------------------------------------------------
+    // helpers
+    // --------------------------------------------------------------------------------------
+
+    function _deposit(address who, uint256 amount) internal returns (uint256 shares) {
+        vm.prank(who);
+        shares = vault.deposit(amount, who);
+    }
+
+    function _redeemAll(address who) internal returns (uint256 assets) {
+        uint256 shares = vault.balanceOf(who);
+        vm.prank(who);
+        assets = vault.redeem(shares, who, who);
+    }
+
+    function _addYield(uint256 amount) internal {
+        vm.prank(owner);
+        vault.addYield(amount);
+    }
+
+    /// @dev Seed the vault with a real first deposit and burn the shares. Together with the
+    ///      decimals offset this removes the empty-vault edge for the economic tests.
+    function _seedAndBurn(uint256 amount) internal {
+        vm.prank(seeder);
+        uint256 shares = vault.deposit(amount, seeder);
+        vm.prank(seeder);
+        vault.transfer(address(0xdead), shares);
+    }
+
+    // --------------------------------------------------------------------------------------
+    // 1. first-depositor inflation / donation attack
+    // --------------------------------------------------------------------------------------
+
+    /// @notice Classic attack on an empty vault: deposit 1 wei, donate a large amount directly
+    ///         to spike the price, then let the victim deposit. The virtual-share offset must
+    ///         leave the victim with non-zero shares and make the attack unprofitable.
+    function test_InflationAttack_isUnprofitable_andVictimKeptWhole() public {
+        uint256 donation = 100 ether;
+        uint256 victimDeposit = 100 ether;
+
+        uint256 attackerSpent;
+
+        // 1 wei first deposit.
+        vm.prank(attacker);
+        vault.deposit(1, attacker);
+        attackerSpent += 1;
+
+        // Direct donation to inflate balanceOf (and thus the naive price).
+        vm.prank(attacker);
+        asset.transfer(address(vault), donation);
+        attackerSpent += donation;
+
+        // Victim deposits.
+        uint256 victimShares = _deposit(alice, victimDeposit);
+
+        // The offset prevents the victim from being rounded down to nothing.
+        assertGt(victimShares, 0, "victim minted zero shares");
+
+        // Attacker unwinds; must not profit from the manipulation.
+        uint256 attackerOut = _redeemAll(attacker);
+        assertLt(attackerOut, attackerSpent, "attack was profitable");
+
+        // Victim can recover essentially their whole deposit (>= 99%).
+        uint256 victimOut = _redeemAll(alice);
+        assertGe(victimOut, (victimDeposit * 99) / 100, "victim lost value to the attacker");
+    }
+
+    /// @notice With a seed-and-burn at deployment, the same attack is strictly weaker: the
+    ///         victim is fully made whole.
+    function test_InflationAttack_defeatedBySeed() public {
+        _seedAndBurn(10 ether);
+
+        vm.prank(attacker);
+        asset.transfer(address(vault), 100 ether);
+
+        uint256 victimShares = _deposit(alice, 100 ether);
+        assertGt(victimShares, 0);
+
+        uint256 victimOut = _redeemAll(alice);
+        assertGe(victimOut, (100 ether * 99) / 100, "victim lost value despite seed");
+    }
+
+    // --------------------------------------------------------------------------------------
+    // 2. yield sniping
+    // --------------------------------------------------------------------------------------
+
+    /// @notice Same-block sandwich: deposit -> addYield -> redeem all at one timestamp. Because
+    ///         the freshly added tranche is fully locked, the sniper captures nothing.
+    function test_Snipe_sameBlock_capturesNothing() public {
+        _seedAndBurn(1_000 ether);
+        _deposit(alice, 1_000 ether); // honest holder
+
+        uint256 snipe = 1_000_000 ether;
+        uint256 spent = snipe;
+        _deposit(attacker, snipe);
+
+        _addYield(100 ether); // same block.timestamp as the deposit & redeem
+
+        uint256 out = _redeemAll(attacker);
+        assertLe(out, spent, "same-block snipe extracted yield");
+    }
+
+    /// @notice Crossing a single block (~12s) lets the sniper capture only the dust that vested
+    ///         in that interval — far below any meaningful slice of the tranche.
+    function test_Snipe_oneBlock_capturesOnlyDust() public {
+        _seedAndBurn(1_000 ether);
+        _deposit(alice, 1_000 ether);
+
+        uint256 snipe = 1_000_000 ether;
+        _deposit(attacker, snipe);
+
+        uint256 yield = 100 ether;
+        _addYield(yield);
+
+        vm.warp(block.timestamp + 12); // one mainnet block
+        uint256 out = _redeemAll(attacker);
+
+        uint256 profit = out > snipe ? out - snipe : 0;
+        // Captured dust must be well under 1% of the tranche.
+        assertLt(profit, yield / 100, "one-block snipe captured a meaningful share");
+    }
+
+    /// @notice The yield a sniper is denied accrues to the honest long-term holder once the
+    ///         tranche has fully vested.
+    function test_Yield_accruesToLongTermHolder() public {
+        _seedAndBurn(1_000 ether);
+        _deposit(alice, 1_000 ether);
+
+        uint256 before = vault.convertToAssets(vault.balanceOf(alice));
+        _addYield(100 ether);
+        vm.warp(block.timestamp + VEST);
+
+        uint256 afterVest = vault.convertToAssets(vault.balanceOf(alice));
+        assertGt(afterVest, before, "long-term holder did not accrue yield");
+    }
+
+    // --------------------------------------------------------------------------------------
+    // 3. vesting correctness
+    // --------------------------------------------------------------------------------------
+
+    /// @notice Adding yield must not move `totalAssets` in the same block (no instant jump to
+    ///         snipe), then must unlock linearly to the full amount over `VEST`.
+    function test_Vesting_noJump_thenLinear() public {
+        _seedAndBurn(1_000 ether);
+
+        uint256 base = vault.totalAssets();
+        _addYield(100 ether);
+        assertEq(vault.totalAssets(), base, "yield recognized instantly (jump)");
+
+        vm.warp(block.timestamp + VEST / 2);
+        assertApproxEqAbs(vault.totalAssets(), base + 50 ether, 1e6, "half not recognized");
+
+        vm.warp(block.timestamp + VEST / 2);
+        assertEq(vault.totalAssets(), base + 100 ether, "full not recognized after VEST");
+        assertEq(vault.lockedYield(), 0, "locked yield remained after full vest");
+    }
+
+    /// @notice `totalAssets` is monotonically non-decreasing while a tranche vests with no other
+    ///         flows.
+    function testFuzz_Vesting_monotonic(uint256 amount, uint96 dt1, uint96 dt2) public {
+        amount = bound(amount, 1, 1_000_000 ether);
+        uint256 e1 = bound(dt1, 0, VEST);
+        uint256 e2 = bound(dt2, e1, VEST);
+
+        _seedAndBurn(1_000 ether);
+        uint256 t0 = block.timestamp;
+        _addYield(amount);
+
+        vm.warp(t0 + e1);
+        uint256 a1 = vault.totalAssets();
+        vm.warp(t0 + e2);
+        uint256 a2 = vault.totalAssets();
+
+        assertGe(a2, a1, "totalAssets decreased during vesting");
+    }
+
+    // --------------------------------------------------------------------------------------
+    // 4. addYield guard / no backlog
+    // --------------------------------------------------------------------------------------
+
+    function test_AddYield_revertsWhileVesting() public {
+        _seedAndBurn(1_000 ether);
+        _addYield(100 ether);
+
+        vm.warp(block.timestamp + VEST - 1);
+        uint256 expectedVestedAt = vault.vestedAt(); // evaluate before prank so it isn't consumed
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(StreamingYieldVault.YieldStillVesting.selector, expectedVestedAt));
+        vault.addYield(100 ether);
+    }
+
+    function test_AddYield_allowedExactlyAtVestedAt() public {
+        _seedAndBurn(1_000 ether);
+        _addYield(100 ether);
+
+        vm.warp(vault.vestedAt());
+        _addYield(50 ether); // must not revert
+    }
+
+    /// @notice A full add -> vest -> add cycle leaves no permanently locked backlog: after the
+    ///         first tranche vests, all of it is recognized and the second tranche starts clean.
+    function test_AddYield_noBacklogAcrossCycles() public {
+        _seedAndBurn(1_000 ether);
+        uint256 base = vault.totalAssets();
+
+        _addYield(100 ether);
+        vm.warp(block.timestamp + VEST);
+        assertEq(vault.totalAssets(), base + 100 ether, "first tranche not fully recognized");
+
+        _addYield(40 ether);
+        assertEq(vault.lockedYield(), 40 ether, "second tranche did not start at full lock");
+        vm.warp(block.timestamp + VEST);
+        assertEq(vault.totalAssets(), base + 140 ether, "backlog left locked after two cycles");
+    }
+
+    // --------------------------------------------------------------------------------------
+    // 5. underflow safety, access control, validation
+    // --------------------------------------------------------------------------------------
+
+    /// @notice The first `addYield` on an empty vault must not underflow `totalAssets` despite
+    ///         the tranche exceeding the (zero) backing.
+    function test_AddYield_firstTrancheExceedingBacking_noUnderflow() public {
+        _addYield(100 ether); // empty vault
+        assertEq(vault.totalAssets(), 0, "locked tranche leaked into totalAssets");
+
+        vm.warp(block.timestamp + VEST);
+        assertEq(vault.totalAssets(), 100 ether);
+    }
+
+    function test_AddYield_onlyOwner() public {
+        vm.prank(attacker);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, attacker));
+        vault.addYield(1 ether);
+    }
+
+    function test_AddYield_zeroAmountReverts() public {
+        vm.prank(owner);
+        vm.expectRevert(StreamingYieldVault.ZeroAmount.selector);
+        vault.addYield(0);
+    }
+
+    // --------------------------------------------------------------------------------------
+    // 6. rounding & ERC-4626 parity
+    // --------------------------------------------------------------------------------------
+
+    /// @notice A deposit immediately followed by a full redeem must never return more than was
+    ///         put in — rounding always favours the vault.
+    function testFuzz_depositRedeem_roundsInVaultFavour(uint256 amount) public {
+        amount = bound(amount, 1, 1_000_000 ether);
+        _seedAndBurn(1_000 ether);
+
+        uint256 shares = _deposit(alice, amount);
+        vm.prank(alice);
+        uint256 out = vault.redeem(shares, alice, alice);
+
+        assertLe(out, amount, "user extracted value via rounding");
+    }
+
+    /// @notice `previewDeposit`/`previewRedeem` must match the realized amounts.
+    function test_previewParity() public {
+        _seedAndBurn(1_000 ether);
+        _addYield(100 ether);
+        vm.warp(block.timestamp + VEST / 3);
+
+        uint256 pd = vault.previewDeposit(123 ether);
+        uint256 shares = _deposit(bob, 123 ether);
+        assertEq(shares, pd, "previewDeposit != deposit");
+
+        uint256 pr = vault.previewRedeem(shares);
+        vm.prank(bob);
+        uint256 out = vault.redeem(shares, bob, bob);
+        assertEq(out, pr, "previewRedeem != redeem");
+    }
+
+    function test_decimalsOffsetApplied() public view {
+        assertEq(vault.decimals(), asset.decimals() + OFFSET);
+    }
+
+    // --------------------------------------------------------------------------------------
+    // 7. pausing
+    // --------------------------------------------------------------------------------------
+
+    function test_Pause_blocksShareTransfer() public {
+        _seedAndBurn(1_000 ether);
+        _deposit(alice, 100 ether);
+
+        vm.prank(owner);
+        vault.pause();
+
+        vm.prank(alice);
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        vault.transfer(bob, 1);
+    }
+
+    function test_Pause_blocksDeposit() public {
+        vm.prank(owner);
+        vault.pause();
+
+        vm.prank(alice);
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        vault.deposit(100 ether, alice);
+    }
+
+    function test_Pause_blocksWithdraw() public {
+        _seedAndBurn(1_000 ether);
+        uint256 shares = _deposit(alice, 100 ether);
+
+        vm.prank(owner);
+        vault.pause();
+
+        vm.prank(alice);
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        vault.redeem(shares, alice, alice);
+    }
+
+    function test_Unpause_restoresShareMovement() public {
+        _seedAndBurn(1_000 ether);
+        _deposit(alice, 100 ether);
+
+        vm.prank(owner);
+        vault.pause();
+        vm.prank(owner);
+        vault.unpause();
+
+        vm.prank(alice);
+        vault.transfer(bob, 1); // must not revert
+        assertEq(vault.balanceOf(bob), 1);
+    }
+
+    function test_Pause_onlyOwner() public {
+        vm.prank(attacker);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, attacker));
+        vault.pause();
+    }
+
+    function test_Unpause_onlyOwner() public {
+        vm.prank(owner);
+        vault.pause();
+
+        vm.prank(attacker);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, attacker));
+        vault.unpause();
+    }
+
+    /// @notice Adding yield touches no shares, so it remains possible while paused; the funds
+    ///         simply cannot be withdrawn until the vault is unpaused.
+    function test_AddYield_worksWhilePaused() public {
+        _seedAndBurn(1_000 ether);
+
+        vm.prank(owner);
+        vault.pause();
+
+        _addYield(100 ether);
+        vm.warp(block.timestamp + VEST);
+        assertApproxEqAbs(vault.totalAssets(), 1_000 ether + 100 ether, 1e6);
+    }
+
+    // --------------------------------------------------------------------------------------
+    // 8. the `_update` chokepoint
+    //
+    // Every share movement — mint (deposit/mint), burn (withdraw/redeem) and transfer
+    // (transfer/transferFrom) — funnels through `_update`. These tests assert each distinct
+    // entry into `_update` is gated, that the gate sits at `_update` itself (so even a
+    // zero-value move reverts), and that it is a pure no-op when unpaused.
+    // --------------------------------------------------------------------------------------
+
+    /// @notice The share-denominated mint path (`mint`) hits `_update` via `_mint`.
+    function test_Pause_chokepoint_blocksMint() public {
+        _seedAndBurn(1_000 ether);
+
+        vm.prank(owner);
+        vault.pause();
+
+        vm.prank(alice);
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        vault.mint(100 ether, alice);
+    }
+
+    /// @notice The asset-denominated burn path (`withdraw`) hits `_update` via `_burn`.
+    function test_Pause_chokepoint_blocksWithdrawByAssets() public {
+        _seedAndBurn(1_000 ether);
+        _deposit(alice, 100 ether);
+
+        vm.prank(owner);
+        vault.pause();
+
+        vm.prank(alice);
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        vault.withdraw(50 ether, alice, alice);
+    }
+
+    /// @notice The delegated-transfer path (`transferFrom`) hits `_update` via `_transfer`.
+    function test_Pause_chokepoint_blocksTransferFrom() public {
+        _seedAndBurn(1_000 ether);
+        uint256 shares = _deposit(alice, 100 ether);
+
+        vm.prank(alice);
+        vault.approve(bob, shares);
+
+        vm.prank(owner);
+        vault.pause();
+
+        vm.prank(bob);
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        vault.transferFrom(alice, bob, shares);
+    }
+
+    /// @notice The gate lives in `_update`, not in any amount-specific branch: even a zero-value
+    ///         transfer (which still calls `_update`) reverts while paused.
+    function test_Pause_chokepoint_blocksZeroValueTransfer() public {
+        _seedAndBurn(1_000 ether);
+        _deposit(alice, 100 ether);
+
+        vm.prank(owner);
+        vault.pause();
+
+        vm.prank(alice);
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        vault.transfer(bob, 0);
+    }
+
+    /// @notice `paused()` tracks the toggle, and the chokepoint re-engages after a pause/unpause
+    ///         cycle (no sticky state).
+    function test_Pause_chokepoint_isRepausable() public {
+        _seedAndBurn(1_000 ether);
+        _deposit(alice, 100 ether);
+
+        assertFalse(vault.paused());
+
+        vm.prank(owner);
+        vault.pause();
+        assertTrue(vault.paused());
+
+        vm.prank(owner);
+        vault.unpause();
+        assertFalse(vault.paused());
+
+        // pause again — movement must be blocked once more
+        vm.prank(owner);
+        vault.pause();
+        assertTrue(vault.paused());
+
+        vm.prank(alice);
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        vault.transfer(bob, 1);
+    }
+
+    /// @notice When unpaused the chokepoint is a no-op: every `_update` path (mint, transferFrom,
+    ///         burn) succeeds.
+    function test_Unpause_chokepoint_allPathsFlow() public {
+        _seedAndBurn(1_000 ether);
+
+        vm.prank(owner);
+        vault.pause();
+        vm.prank(owner);
+        vault.unpause();
+
+        // mint (mint -> _mint -> _update); mint() takes a share amount and returns assets paid
+        vm.prank(alice);
+        vault.mint(100 ether, alice);
+        uint256 shares = vault.balanceOf(alice);
+        assertEq(shares, 100 ether);
+
+        // transferFrom (-> _transfer -> _update)
+        vm.prank(alice);
+        vault.approve(bob, shares);
+        vm.prank(bob);
+        vault.transferFrom(alice, bob, shares);
+        assertEq(vault.balanceOf(bob), shares);
+
+        // burn (redeem -> _burn -> _update)
+        vm.prank(bob);
+        uint256 out = vault.redeem(shares, bob, bob);
+        assertGt(out, 0);
+        assertEq(vault.balanceOf(bob), 0);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `StreamingYieldVault` — a standalone ERC-4626 vault to `@hyperbridge/core` where yield is supplied by the owner via periodic transfers (`addYield`) and recognized **linearly over a fixed window** rather than instantly. Built on OpenZeppelin's audited `ERC4626`, `Ownable`, and `Pausable`.

Motivating use case: a stablecoin issuer (e.g. cNGN) that today distributes yield to holders manually. With this vault, distribution becomes a single periodic transfer, holders get a composable yield-bearing share token, and yield is paid in the asset itself.

## Design

- **Yield streaming.** `totalAssets() = balanceOf(this) - lockedYield`, where the current tranche unlocks linearly over `VEST` (23h, tuned for a ~24h add cadence). This defeats **yield sniping**: because recognition is keyed on `block.timestamp`, a same-block deposit→withdraw sees an unchanged share price and captures nothing.
- **Owner-supplied yield + no-backlog guard.** `addYield` is `onlyOwner` and reverts (`YieldStillVesting`) until the previous tranche has fully vested, so tranches never overlap and no yield is left permanently locked.
- **Pausable.** The owner can `pause()` to freeze all share movement — transfers, deposits, and withdrawals — via a single `_update` chokepoint, for emergencies. Yield can still be added while paused; it simply can't be withdrawn until unpaused.
- **Inflation-attack hardening.** Non-zero `_decimalsOffset()` (OZ virtual shares/assets); seed-and-burn recommended at deploy.
- **Underflow-safe ordering.** `addYield` pulls funds before marking them locked, so a first tranche larger than current backing can't underflow `totalAssets`.
- **No reentrancy guard by design.** The only external calls are `transfer`/`transferFrom`; OZ orders effects before interactions. Assumes a standard, non-rebasing, non-fee-on-transfer, non-hooked ERC-20 (documented as an invariant).

## Tests

`test/StreamingYieldVault.t.sol` — 29 tests (incl. 2 fuzz), covering the known vuln classes:

- First-depositor **inflation/donation attack** — victim keeps non-zero shares, attack is unprofitable, victim made whole (with and without seed).
- **Yield sniping** — same-block sandwich captures nothing; one-block crossing captures only sub-1% dust; denied yield accrues to the long-term holder.
- **Vesting** — no instant jump, linear unlock to full over `VEST`, monotonic (fuzz).
- **`addYield` guard** — reverts while vesting, allowed at `vestedAt()`, no backlog across cycles.
- **Pausing** — pause blocks transfers / deposits / withdrawals; unpause restores them; `pause`/`unpause` are owner-only; `addYield` still works while paused.
- **`_update` chokepoint** — every path into `_update` is gated (mint, withdraw-by-assets, `transferFrom`), the gate sits at `_update` itself (even a zero-value transfer reverts while paused), `paused()` tracks state across re-pause cycles, and all paths flow as a no-op when unpaused.
- **Underflow / access control / validation** — first-tranche-exceeds-backing, `onlyOwner`, zero-amount.
- **Rounding & ERC-4626 parity** — deposit→redeem rounds in the vault's favour (fuzz), `preview*` matches realized, decimals offset applied.

```
Suite result: ok. 29 passed; 0 failed; 0 skipped
```

## Notes

- New files only: `contracts/vaults/StreamingYieldVault.sol`, `test/StreamingYieldVault.t.sol`, plus a `forge-std` remapping. No existing contracts touched.
- The vault has no Hyperbridge/ISMP dependency; it lives in `@hyperbridge/core` as a reusable Solidity primitive.


## Docs

Adds a developer guide at `docs/content/developers/evm/streaming-yield-vault.mdx` (registered in the EVM section nav) covering how streaming/vesting works, deployment with seed-and-burn, deposit/withdraw, `addYield`, pausing, a reference table, and security considerations. `pnpm types:check` passes.
