### PR TITLE
[sdk}: intent quote service

### DIFF
--- a/docs/content/developers/sdk/api/intent-gateway.mdx
+++ b/docs/content/developers/sdk/api/intent-gateway.mdx
@@ -201,17 +201,11 @@ const quote = await gateway.quoteIntent({
 
 When source and destination chains differ, also pass `currencyIn` inside the `poolKey` override — the destination-side address of the input currency. It defaults to `tokenIn.address`, which is only valid for same-chain quotes, and must equal `currency0` or `currency1`.
 
-The result includes `amountIn`, `amountOut`, and quote metadata with the V4 PoolKey, quoter address, and the IntentGateway protocol fee on the source chain.
+The result includes `amountIn`, `amountOut`, and quote metadata with the V4 PoolKey, quoter address, the Uniswap slippage bps applied by the SDK, and the IntentGateway protocol fee on the source chain.
 
-`amountIn` and `amountOut` are the raw amounts returned by the Uniswap V4 quoter — no slippage tolerance or protocol fee adjustments are applied. Before constructing the order, apply your own slippage tolerance and account for `quoteMetadata.protocolFeeBps`, which the gateway deducts from order inputs:
+`amountIn` and `amountOut` include the SDK's 30 bps Uniswap slippage adjustment: exact-input quotes return a reduced `amountOut`, while exact-output quotes return an increased `amountIn`. Before constructing the order, account for `quoteMetadata.protocolFeeBps`, which the gateway deducts from order inputs:
 
 ```typescript lineNumbers
-const SLIPPAGE_BPS = 30n
-
-// Exact input: reduce the quoted output by your slippage tolerance
-const minAmountOut = (quote.amountOut * (10_000n - SLIPPAGE_BPS)) / 10_000n
-
-// And remember the solver only receives the post-fee input
 const { protocolFeeBps } = quote.quoteMetadata
 const solverReceives = (quote.amountIn * (10_000n - protocolFeeBps)) / 10_000n
 ```

--- a/docs/content/developers/sdk/api/intent-gateway.mdx
+++ b/docs/content/developers/sdk/api/intent-gateway.mdx
@@ -155,7 +155,7 @@ for await (const update of gen) {
 
 ### quoteIntent(params)
 
-Quotes an intent between the gateway's source and destination chains using the SDK's intent quote strategies. The only supported strategy today is `uniswap_v4`, but the method is strategy-shaped so future quote sources can be added without changing partner integrations.
+Quotes an intent using the SDK's intent quote strategies. The only supported strategy today is `uniswap_v4`, which always prices against the configured Base (`EVM-8453`) pool rather than the gateway destination chain. The method is strategy-shaped so future quote sources can be added without changing partner integrations.
 
 Use `amountIn` and `amountOut` when constructing the `inputs` and `output.assets` for an IntentGateway V2 order.
 
@@ -199,9 +199,9 @@ const quote = await gateway.quoteIntent({
 })
 ```
 
-When source and destination chains differ, also pass `currencyIn` inside the `poolKey` override — the destination-side address of the input currency. It defaults to `tokenIn.address`, which is only valid for same-chain quotes, and must equal `currency0` or `currency1`.
+When passing an explicit PoolKey for cross-chain quotes, also pass `currencyIn` inside the `poolKey` override — the Base-side address of the input currency. It defaults to `tokenIn.address`, which only works when that address is part of the Base pool, and must equal `currency0` or `currency1`.
 
-The result includes `amountIn`, `amountOut`, and quote metadata with the V4 PoolKey, quoter address, the Uniswap slippage bps applied by the SDK, and the IntentGateway protocol fee on the source chain.
+The result includes `amountIn`, `amountOut`, and quote metadata with the quote chain, V4 PoolKey, quoter address, the Uniswap slippage bps applied by the SDK, and the IntentGateway protocol fee on the source chain.
 
 `amountIn` and `amountOut` include the SDK's 30 bps Uniswap slippage adjustment: exact-input quotes return a reduced `amountOut`, while exact-output quotes return an increased `amountIn`. Before constructing the order, account for `quoteMetadata.protocolFeeBps`, which the gateway deducts from order inputs:
 

--- a/docs/content/developers/sdk/api/intent-gateway.mdx
+++ b/docs/content/developers/sdk/api/intent-gateway.mdx
@@ -155,17 +155,14 @@ for await (const update of gen) {
 
 ### quoteIntent(params)
 
-Quotes a Hyperbridge intent using the SDK's intent quote strategies. The only supported strategy today is `uniswap_v4`, but the method is strategy-shaped so future quote sources can be added without changing partner integrations.
+Quotes an intent between the gateway's source and destination chains using the SDK's intent quote strategies. The only supported strategy today is `uniswap_v4`, but the method is strategy-shaped so future quote sources can be added without changing partner integrations.
 
 Use `amountIn` and `amountOut` when constructing the `inputs` and `output.assets` for an IntentGateway V2 order.
 
 ```typescript lineNumbers
-import { quoteIntent } from "@hyperbridge/sdk"
+const gateway = await IntentGateway.create(source, dest)
 
-const quote = await quoteIntent({
-  strategy: "uniswap_v4",
-  source: { chainId: "EVM-8453" },
-  destination: { chainId: "EVM-8453" },
+const quote = await gateway.quoteIntent({
   tokenIn: {
     address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
     decimals: 6,
@@ -185,9 +182,7 @@ console.log(quote.amountIn, quote.amountOut)
 For pools not configured by the SDK, pass an explicit Uniswap V4 PoolKey:
 
 ```typescript lineNumbers
-const quote = await quoteIntent({
-  source: { chainId: "EVM-8453" },
-  destination: { chainId: "EVM-8453" },
+const quote = await gateway.quoteIntent({
   tokenIn,
   tokenOut,
   amountOut: 50_000_000n,

--- a/docs/content/developers/sdk/api/intent-gateway.mdx
+++ b/docs/content/developers/sdk/api/intent-gateway.mdx
@@ -201,13 +201,13 @@ const quote = await gateway.quoteIntent({
 
 When passing an explicit PoolKey for cross-chain quotes, also pass `currencyIn` inside the `poolKey` override — the Base-side address of the input currency. It defaults to `tokenIn.address`, which only works when that address is part of the Base pool, and must equal `currency0` or `currency1`.
 
-The result includes `amountIn`, `amountOut`, and quote metadata with the quote chain, V4 PoolKey, quoter address, the Uniswap slippage bps applied by the SDK, and the IntentGateway protocol fee on the source chain.
+The result includes `amountIn`, `amountOut`, and quote metadata with the quote chain, V4 PoolKey, quoter address, and the IntentGateway protocol fee on the source chain (`protocolFeeBps`).
 
-`amountIn` and `amountOut` include the SDK's 30 bps Uniswap slippage adjustment: exact-input quotes return a reduced `amountOut`, while exact-output quotes return an increased `amountIn`. Before constructing the order, account for `quoteMetadata.protocolFeeBps`, which the gateway deducts from order inputs:
+`amountIn` and `amountOut` already account for the IntentGateway protocol fee that the gateway deducts from order inputs. Exact-input quotes price the swap against the post-fee input, so `amountOut` is what you can expect after the fee; exact-output quotes return the gross `amountIn` you must supply so that, after the fee, enough remains to produce the requested `amountOut`. Use these amounts directly as the order's `inputs` and `output.assets` — no further fee adjustment is required. Apply only your own slippage tolerance:
 
 ```typescript lineNumbers
-const { protocolFeeBps } = quote.quoteMetadata
-const solverReceives = (quote.amountIn * (10_000n - protocolFeeBps)) / 10_000n
+// `amountOut` already nets the gateway fee; add your slippage tolerance.
+const minAmountOut = (quote.amountOut * (10_000n - SLIPPAGE_BPS)) / 10_000n
 ```
 
 ---

--- a/docs/content/developers/sdk/api/intent-gateway.mdx
+++ b/docs/content/developers/sdk/api/intent-gateway.mdx
@@ -153,6 +153,76 @@ for await (const update of gen) {
 
 ---
 
+### quoteIntent(params)
+
+Quotes a Hyperbridge intent using the SDK's intent quote strategies. The only supported strategy today is `uniswap_v4`, but the method is strategy-shaped so future quote sources can be added without changing partner integrations.
+
+Use `amountIn` and `amountOut` when constructing the `inputs` and `output.assets` for an IntentGateway V2 order.
+
+```typescript lineNumbers
+import { quoteIntent } from "@hyperbridge/sdk"
+
+const quote = await quoteIntent({
+  strategy: "uniswap_v4",
+  source: { chainId: "EVM-8453" },
+  destination: { chainId: "EVM-8453" },
+  tokenIn: {
+    address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    decimals: 6,
+    symbol: "USDC",
+  },
+  tokenOut: {
+    address: "0x46C85152bFe9f96829aA94755D9f915F9B10EF5F",
+    decimals: 6,
+    symbol: "cNGN",
+  },
+  amountIn: 100_000_000n,
+})
+
+console.log(quote.amountIn, quote.amountOut)
+```
+
+For pools not configured by the SDK, pass an explicit Uniswap V4 PoolKey:
+
+```typescript lineNumbers
+const quote = await quoteIntent({
+  source: { chainId: "EVM-8453" },
+  destination: { chainId: "EVM-8453" },
+  tokenIn,
+  tokenOut,
+  amountOut: 50_000_000n,
+  uniswapV4: {
+    poolKey: {
+      currency0: "0x...",
+      currency1: "0x...",
+      fee: 1500,
+      tickSpacing: 30,
+      hooks: "0x0000000000000000000000000000000000000000",
+      quoterAddress: "0x0d5e0f971ed27fbff6c2837bf31316121532048d",
+    },
+  },
+})
+```
+
+When source and destination chains differ, also pass `currencyIn` inside the `poolKey` override — the destination-side address of the input currency. It defaults to `tokenIn.address`, which is only valid for same-chain quotes, and must equal `currency0` or `currency1`.
+
+The result includes `amountIn`, `amountOut`, and quote metadata with the V4 PoolKey, quoter address, and the IntentGateway protocol fee on the source chain.
+
+`amountIn` and `amountOut` are the raw amounts returned by the Uniswap V4 quoter — no slippage tolerance or protocol fee adjustments are applied. Before constructing the order, apply your own slippage tolerance and account for `quoteMetadata.protocolFeeBps`, which the gateway deducts from order inputs:
+
+```typescript lineNumbers
+const SLIPPAGE_BPS = 30n
+
+// Exact input: reduce the quoted output by your slippage tolerance
+const minAmountOut = (quote.amountOut * (10_000n - SLIPPAGE_BPS)) / 10_000n
+
+// And remember the solver only receives the post-fee input
+const { protocolFeeBps } = quote.quoteMetadata
+const solverReceives = (quote.amountIn * (10_000n - protocolFeeBps)) / 10_000n
+```
+
+---
+
 ### quoteUniswap(params)
 
 Quotes a same-chain Uniswap swap that can be used when constructing the input or output side of an intent order. The helper checks Uniswap V2, V3, and V4 by default; pass `protocols: ["v4"]` to quote Uniswap V4 only.

--- a/sdk/packages/sdk/package.json
+++ b/sdk/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/sdk",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"description": "The hyperclient SDK provides utilities for querying proofs and statuses for cross-chain requests from HyperBridge.",
 	"type": "module",
 	"types": "./dist/node/index.d.ts",

--- a/sdk/packages/sdk/src/configs/ChainConfigService.ts
+++ b/sdk/packages/sdk/src/configs/ChainConfigService.ts
@@ -1,5 +1,12 @@
 import type { ChainConfig, HexString } from "@/types"
-import { chainConfigs, getConfigByStateMachineId, Chains, hyperbridgeAddress } from "@/configs/chain"
+import {
+	chainConfigs,
+	getConfigByStateMachineId,
+	Chains,
+	hyperbridgeAddress,
+	type ConfiguredAssetSymbol,
+	type UniswapV4PoolConfigData,
+} from "@/configs/chain"
 
 export class ChainConfigService {
 	private rpcUrls: Record<string, string> = {}
@@ -47,6 +54,10 @@ export class ChainConfigService {
 
 	getDaiAsset(chain: string): HexString {
 		return (this.getConfig(chain)?.assets?.DAI ?? "0x") as HexString
+	}
+
+	getAssetAddress(chain: string, symbol: ConfiguredAssetSymbol): HexString | undefined {
+		return this.getConfig(chain)?.assets?.[symbol] as HexString | undefined
 	}
 
 	getUsdtAsset(chain: string): HexString {
@@ -139,6 +150,10 @@ export class ChainConfigService {
 		return (this.getConfig(chain)?.addresses.UniswapV4StateView ?? "0x") as HexString
 	}
 
+	getUniswapV4PoolConfigs(chain: string): UniswapV4PoolConfigData[] {
+		return this.getConfig(chain)?.uniswapV4Pools ?? []
+	}
+
 	getPermit2Address(chain: string): HexString {
 		return (this.getConfig(chain)?.addresses.Permit2 ?? "0x") as HexString
 	}
@@ -152,7 +167,7 @@ export class ChainConfigService {
 	}
 
 	getEtherscanApiKey(): string | undefined {
-		return typeof process !== "undefined" ? (process as any)?.env?.ETHERSCAN_API_KEY : undefined
+		return typeof process !== "undefined" ? process.env?.ETHERSCAN_API_KEY : undefined
 	}
 
 	getCalldispatcherAddress(chain: string): HexString {

--- a/sdk/packages/sdk/src/configs/chain.ts
+++ b/sdk/packages/sdk/src/configs/chain.ts
@@ -113,6 +113,15 @@ export const tronNile = defineChain({
 // Known Tron chain IDs (mainnet + Nile testnet)
 export const tronChainIds = new Set([728126428, 3448148188])
 
+export type ConfiguredAssetSymbol = "WETH" | "DAI" | "USDC" | "USDT" | "cNGN" | "EXT"
+
+export interface UniswapV4PoolConfigData {
+	tokens: readonly [ConfiguredAssetSymbol, ConfiguredAssetSymbol]
+	fee: number
+	tickSpacing: number
+	hooks?: `0x${string}`
+}
+
 export interface ChainConfigData {
 	chainId: number
 	stateMachineId: Chains
@@ -172,6 +181,7 @@ export interface ChainConfigData {
 	consensusStateId: string
 	coingeckoId: string
 	popularTokens?: string[]
+	uniswapV4Pools?: UniswapV4PoolConfigData[]
 	/** LayerZero Endpoint ID for cross-chain messaging */
 	layerZeroEid?: number
 }
@@ -508,6 +518,7 @@ export const chainConfigs: Record<number, ChainConfigData> = {
 		consensusStateId: "ETH0",
 		coingeckoId: "base",
 		layerZeroEid: 30184,
+		uniswapV4Pools: [{ tokens: ["USDC", "cNGN"], fee: 1500, tickSpacing: 30 }],
 		popularTokens: [
 			"0x4200000000000000000000000000000000000006",
 			"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",

--- a/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
+++ b/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
@@ -206,9 +206,11 @@ export class IntentGateway {
 	 * `strategy` defaults to `uniswap_v4`, currently the only supported
 	 * strategy. Provide exactly one of `amountIn` or `amountOut`.
 	 *
-	 * The returned `amountIn`/`amountOut` include the Uniswap quote strategy's
-	 * built-in slippage adjustment. Account for `quoteMetadata.protocolFeeBps`
-	 * (deducted from order inputs by the gateway) before constructing the order.
+	 * The Uniswap quote strategy always prices against the configured Base
+	 * pool, regardless of this gateway's destination chain. Returned
+	 * `amountIn`/`amountOut` include the strategy's built-in slippage
+	 * adjustment. Account for `quoteMetadata.protocolFeeBps` (deducted from
+	 * order inputs by the gateway) before constructing the order.
 	 *
 	 * @param params - Token pair, amount, and optional strategy/pool overrides.
 	 * @returns The quoted amounts plus strategy-specific metadata.

--- a/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
+++ b/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
@@ -35,6 +35,13 @@ import { OrderCanceller } from "./OrderCanceller"
 import { BidManager } from "./BidManager"
 import { GasEstimator } from "./GasEstimator"
 import { OrderStatusChecker } from "./OrderStatusChecker"
+import {
+	type IntentQuoteStrategyHandler,
+	type QuoteIntentParams,
+	type QuoteIntentResult,
+	UniswapV4IntentQuoteStrategy,
+	UnsupportedIntentQuoteStrategyError,
+} from "./quote"
 import type { ERC7821Call } from "@/types"
 import { DEFAULT_GRAFFITI, DEFAULT_POLL_INTERVAL, ADDRESS_ZERO, sleep } from "@/utils"
 
@@ -43,6 +50,8 @@ import { DEFAULT_GRAFFITI, DEFAULT_POLL_INTERVAL, ADDRESS_ZERO, sleep } from "@/
  *
  * `IntentGateway` orchestrates the complete lifecycle of an intent-based
  * cross-chain swap:
+ * - **Quoting** — prices the order's input/output amounts via the configured
+ *   quote strategies (currently Uniswap V4) before order construction.
  * - **Order placement** — encodes and yields `placeOrder` calldata; caller
  *   signs and submits the transaction.
  * - **Order execution** — polls the Hyperbridge coprocessor for solver bids,
@@ -85,6 +94,8 @@ export class IntentGateway {
 	private readonly bidManager: BidManager
 	/** Estimates gas costs for filling an order and converts them to fee-token amounts. */
 	private readonly gasEstimator: GasEstimator
+	/** Quote strategies for pricing orders before placement, keyed by strategy name. */
+	private readonly quoteStrategies: Record<string, IntentQuoteStrategyHandler>
 
 	/**
 	 * Private constructor — use {@link IntentGateway.create} instead.
@@ -133,6 +144,9 @@ export class IntentGateway {
 		this.bidManager = bidManager
 		this.gasEstimator = gasEstimator
 		this._crypto = crypto
+		this.quoteStrategies = {
+			uniswap_v4: new UniswapV4IntentQuoteStrategy(dest.configService),
+		}
 	}
 
 	/**
@@ -184,6 +198,34 @@ export class IntentGateway {
 				// Ignore
 			}
 		}
+	}
+
+	/**
+	 * Quotes an intent between this gateway's source and destination chains.
+	 *
+	 * `strategy` defaults to `uniswap_v4`, currently the only supported
+	 * strategy. Provide exactly one of `amountIn` or `amountOut`.
+	 *
+	 * The returned `amountIn`/`amountOut` are the raw amounts from the quote
+	 * source with no adjustments applied — apply your own slippage tolerance
+	 * and account for `quoteMetadata.protocolFeeBps` (deducted from order
+	 * inputs by the gateway) before constructing the order.
+	 *
+	 * @param params - Token pair, amount, and optional strategy/pool overrides.
+	 * @returns The quoted amounts plus strategy-specific metadata.
+	 * @throws {UnsupportedIntentQuoteStrategyError} For unknown strategies.
+	 * @throws {UnsupportedIntentQuotePairError} When no pool is configured for the pair.
+	 */
+	async quoteIntent(params: QuoteIntentParams): Promise<QuoteIntentResult> {
+		const strategy = params.strategy ?? "uniswap_v4"
+		const handler = this.quoteStrategies[strategy]
+		if (!handler) throw new UnsupportedIntentQuoteStrategyError(strategy)
+
+		return handler.quote(
+			{ ...params, strategy },
+			{ stateMachineId: this.source.config.stateMachineId, client: this.source.client },
+			{ stateMachineId: this.dest.config.stateMachineId, client: this.dest.client },
+		)
 	}
 
 	/**

--- a/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
+++ b/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
@@ -206,10 +206,9 @@ export class IntentGateway {
 	 * `strategy` defaults to `uniswap_v4`, currently the only supported
 	 * strategy. Provide exactly one of `amountIn` or `amountOut`.
 	 *
-	 * The returned `amountIn`/`amountOut` are the raw amounts from the quote
-	 * source with no adjustments applied — apply your own slippage tolerance
-	 * and account for `quoteMetadata.protocolFeeBps` (deducted from order
-	 * inputs by the gateway) before constructing the order.
+	 * The returned `amountIn`/`amountOut` include the Uniswap quote strategy's
+	 * built-in slippage adjustment. Account for `quoteMetadata.protocolFeeBps`
+	 * (deducted from order inputs by the gateway) before constructing the order.
 	 *
 	 * @param params - Token pair, amount, and optional strategy/pool overrides.
 	 * @returns The quoted amounts plus strategy-specific metadata.

--- a/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
+++ b/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
@@ -208,9 +208,9 @@ export class IntentGateway {
 	 *
 	 * The Uniswap quote strategy always prices against the configured Base
 	 * pool, regardless of this gateway's destination chain. Returned
-	 * `amountIn`/`amountOut` include the strategy's built-in slippage
-	 * adjustment. Account for `quoteMetadata.protocolFeeBps` (deducted from
-	 * order inputs by the gateway) before constructing the order.
+	 * `amountIn`/`amountOut` already account for the gateway's protocol fee
+	 * (`quoteMetadata.protocolFeeBps`), which the gateway deducts from order
+	 * inputs; apply only your own slippage tolerance before placing the order.
 	 *
 	 * @param params - Token pair, amount, and optional strategy/pool overrides.
 	 * @returns The quoted amounts plus strategy-specific metadata.

--- a/sdk/packages/sdk/src/protocols/intents/index.ts
+++ b/sdk/packages/sdk/src/protocols/intents/index.ts
@@ -1,13 +1,7 @@
 export { IntentGateway } from "./IntentGateway"
 export { OrderStatusChecker } from "./OrderStatusChecker"
-export {
-	IntentQuoteService,
-	UnsupportedIntentQuotePairError,
-	UnsupportedIntentQuoteStrategyError,
-	quoteIntent,
-} from "./quote"
+export { UnsupportedIntentQuotePairError, UnsupportedIntentQuoteStrategyError } from "./quote"
 export type {
-	IntentQuoteChain,
 	IntentQuoteStrategy,
 	IntentQuoteToken,
 	IntentQuoteTradeType,

--- a/sdk/packages/sdk/src/protocols/intents/index.ts
+++ b/sdk/packages/sdk/src/protocols/intents/index.ts
@@ -1,5 +1,22 @@
 export { IntentGateway } from "./IntentGateway"
 export { OrderStatusChecker } from "./OrderStatusChecker"
+export {
+	IntentQuoteService,
+	UnsupportedIntentQuotePairError,
+	UnsupportedIntentQuoteStrategyError,
+	quoteIntent,
+} from "./quote"
+export type {
+	IntentQuoteChain,
+	IntentQuoteStrategy,
+	IntentQuoteToken,
+	IntentQuoteTradeType,
+	QuoteIntentParams,
+	QuoteIntentResult,
+	UniswapV4IntentQuoteMetadata,
+	UniswapV4IntentQuoteOptions,
+	UniswapV4PoolKey,
+} from "./quote"
 export { encodeERC7821ExecuteBatch, transformOrderForContract, fetchSourceProof, orderCommitment } from "./utils"
 export { CryptoUtils, SELECT_SOLVER_TYPEHASH, PACKED_USEROP_TYPEHASH, DOMAIN_TYPEHASH } from "./CryptoUtils"
 export {

--- a/sdk/packages/sdk/src/protocols/intents/quote/index.ts
+++ b/sdk/packages/sdk/src/protocols/intents/quote/index.ts
@@ -1,0 +1,54 @@
+import { ChainConfigService } from "@/configs/ChainConfigService"
+import { UniswapV4IntentQuoteStrategy } from "./uniswapV4"
+import {
+	type IntentQuoteStrategyHandler,
+	type QuoteIntentParams,
+	type QuoteIntentResult,
+	UnsupportedIntentQuoteStrategyError,
+} from "./types"
+
+export {
+	type IntentQuoteChain,
+	type IntentQuoteStrategy,
+	type IntentQuoteToken,
+	type IntentQuoteTradeType,
+	type QuoteIntentParams,
+	type QuoteIntentResult,
+	UnsupportedIntentQuotePairError,
+	UnsupportedIntentQuoteStrategyError,
+	type UniswapV4IntentQuoteMetadata,
+	type UniswapV4IntentQuoteOptions,
+	type UniswapV4PoolKey,
+} from "./types"
+
+/**
+ * Partner-facing intent quote service.
+ *
+ * The service is intentionally strategy-based. `uniswap_v4` is the only
+ * registered strategy today, but callers can keep using `quoteIntent` as new
+ * strategies are added.
+ */
+export class IntentQuoteService {
+	private readonly strategies: Record<string, IntentQuoteStrategyHandler>
+
+	constructor(chainConfigService = new ChainConfigService()) {
+		this.strategies = {
+			uniswap_v4: new UniswapV4IntentQuoteStrategy(chainConfigService),
+		}
+	}
+
+	async quoteIntent(params: QuoteIntentParams): Promise<QuoteIntentResult> {
+		const strategy = params.strategy ?? "uniswap_v4"
+		const handler = this.strategies[strategy]
+		if (!handler) throw new UnsupportedIntentQuoteStrategyError(strategy)
+
+		return handler.quote({ ...params, strategy })
+	}
+}
+
+/**
+ * Quotes a Hyperbridge intent. Currently supports Uniswap V4 only.
+ */
+export async function quoteIntent(params: QuoteIntentParams): Promise<QuoteIntentResult> {
+	return new IntentQuoteService().quoteIntent(params)
+}

--- a/sdk/packages/sdk/src/protocols/intents/quote/index.ts
+++ b/sdk/packages/sdk/src/protocols/intents/quote/index.ts
@@ -1,15 +1,8 @@
-import { ChainConfigService } from "@/configs/ChainConfigService"
-import { UniswapV4IntentQuoteStrategy } from "./uniswapV4"
-import {
-	type IntentQuoteStrategyHandler,
-	type QuoteIntentParams,
-	type QuoteIntentResult,
-	UnsupportedIntentQuoteStrategyError,
-} from "./types"
-
+export { UniswapV4IntentQuoteStrategy } from "./uniswapV4"
 export {
-	type IntentQuoteChain,
+	type IntentQuoteChainContext,
 	type IntentQuoteStrategy,
+	type IntentQuoteStrategyHandler,
 	type IntentQuoteToken,
 	type IntentQuoteTradeType,
 	type QuoteIntentParams,
@@ -20,35 +13,3 @@ export {
 	type UniswapV4IntentQuoteOptions,
 	type UniswapV4PoolKey,
 } from "./types"
-
-/**
- * Partner-facing intent quote service.
- *
- * The service is intentionally strategy-based. `uniswap_v4` is the only
- * registered strategy today, but callers can keep using `quoteIntent` as new
- * strategies are added.
- */
-export class IntentQuoteService {
-	private readonly strategies: Record<string, IntentQuoteStrategyHandler>
-
-	constructor(chainConfigService = new ChainConfigService()) {
-		this.strategies = {
-			uniswap_v4: new UniswapV4IntentQuoteStrategy(chainConfigService),
-		}
-	}
-
-	async quoteIntent(params: QuoteIntentParams): Promise<QuoteIntentResult> {
-		const strategy = params.strategy ?? "uniswap_v4"
-		const handler = this.strategies[strategy]
-		if (!handler) throw new UnsupportedIntentQuoteStrategyError(strategy)
-
-		return handler.quote({ ...params, strategy })
-	}
-}
-
-/**
- * Quotes a Hyperbridge intent. Currently supports Uniswap V4 only.
- */
-export async function quoteIntent(params: QuoteIntentParams): Promise<QuoteIntentResult> {
-	return new IntentQuoteService().quoteIntent(params)
-}

--- a/sdk/packages/sdk/src/protocols/intents/quote/types.ts
+++ b/sdk/packages/sdk/src/protocols/intents/quote/types.ts
@@ -42,33 +42,25 @@ export interface UniswapV4IntentQuoteOptions {
 }
 
 /**
- * Chain connection used by intent quote strategies.
- *
- * Pass either a viem `client` or an `rpcUrl`. If neither is supplied, the SDK
- * falls back to the configured RPC URL for `chainId`.
- */
-export interface IntentQuoteChain {
-	/** Numeric EVM chain ID or state machine ID, for example `8453` or `EVM-8453`. */
-	chainId: number | string
-	client?: PublicClient
-	rpcUrl?: string
-}
-
-/**
- * Parameters for quoting a Hyperbridge intent.
+ * Parameters for `IntentGateway.quoteIntent`. The source and destination
+ * chains come from the gateway instance itself.
  *
  * `strategy` defaults to `uniswap_v4`, which is currently the only supported
  * strategy. Provide exactly one of `amountIn` or `amountOut`.
  */
 export interface QuoteIntentParams {
 	strategy?: IntentQuoteStrategy
-	source: IntentQuoteChain
-	destination: IntentQuoteChain
 	tokenIn: IntentQuoteToken
 	tokenOut: IntentQuoteToken
 	amountIn?: bigint
 	amountOut?: bigint
 	uniswapV4?: UniswapV4IntentQuoteOptions
+}
+
+/** Chain connection handed to quote strategies by the IntentGateway. */
+export interface IntentQuoteChainContext {
+	stateMachineId: string
+	client: PublicClient
 }
 
 export interface UniswapV4IntentQuoteMetadata {
@@ -98,7 +90,11 @@ export interface QuoteIntentResult {
 }
 
 export interface IntentQuoteStrategyHandler {
-	quote(params: QuoteIntentParams): Promise<QuoteIntentResult>
+	quote(
+		params: QuoteIntentParams,
+		source: IntentQuoteChainContext,
+		destination: IntentQuoteChainContext,
+	): Promise<QuoteIntentResult>
 }
 
 export class UnsupportedIntentQuoteStrategyError extends Error {

--- a/sdk/packages/sdk/src/protocols/intents/quote/types.ts
+++ b/sdk/packages/sdk/src/protocols/intents/quote/types.ts
@@ -64,6 +64,8 @@ export interface IntentQuoteChainContext {
 }
 
 export interface UniswapV4IntentQuoteMetadata {
+	/** Chain whose Uniswap pool and quoter were used for the quote. */
+	quoteChain: string
 	poolKey: UniswapV4PoolKey
 	quoterAddress: HexString
 	/** Slippage tolerance applied to the returned Uniswap quote amounts. */

--- a/sdk/packages/sdk/src/protocols/intents/quote/types.ts
+++ b/sdk/packages/sdk/src/protocols/intents/quote/types.ts
@@ -1,0 +1,125 @@
+import type { PublicClient } from "viem"
+import type { HexString } from "@/types"
+
+export type IntentQuoteStrategy = "uniswap_v4"
+export type IntentQuoteTradeType = "EXACT_INPUT" | "EXACT_OUTPUT"
+
+/**
+ * Token metadata required by intent quote strategies.
+ */
+export interface IntentQuoteToken {
+	/** Token contract address on the user/source side. */
+	address: HexString
+	/** Token decimals for raw amount formatting by the caller. */
+	decimals: number
+	/** Optional token symbol used only to match SDK-configured destination pools. */
+	symbol?: string
+}
+
+/**
+ * Full Uniswap V4 PoolKey. V4 pools cannot be discovered from a token pair alone.
+ */
+export interface UniswapV4PoolKey {
+	currency0: HexString
+	currency1: HexString
+	fee: number
+	tickSpacing: number
+	hooks: HexString
+}
+
+export interface UniswapV4IntentQuoteOptions {
+	/** Explicit pool override for pairs not yet present in SDK chain config. */
+	poolKey?: UniswapV4PoolKey & {
+		quoterAddress?: HexString
+		/**
+		 * Destination-side address of the input currency. Defaults to
+		 * `tokenIn.address`, which only works for same-chain quotes; pass this
+		 * explicitly when source and destination chains differ. Must equal
+		 * `currency0` or `currency1`.
+		 */
+		currencyIn?: HexString
+	}
+}
+
+/**
+ * Chain connection used by intent quote strategies.
+ *
+ * Pass either a viem `client` or an `rpcUrl`. If neither is supplied, the SDK
+ * falls back to the configured RPC URL for `chainId`.
+ */
+export interface IntentQuoteChain {
+	/** Numeric EVM chain ID or state machine ID, for example `8453` or `EVM-8453`. */
+	chainId: number | string
+	client?: PublicClient
+	rpcUrl?: string
+}
+
+/**
+ * Parameters for quoting a Hyperbridge intent.
+ *
+ * `strategy` defaults to `uniswap_v4`, which is currently the only supported
+ * strategy. Provide exactly one of `amountIn` or `amountOut`.
+ */
+export interface QuoteIntentParams {
+	strategy?: IntentQuoteStrategy
+	source: IntentQuoteChain
+	destination: IntentQuoteChain
+	tokenIn: IntentQuoteToken
+	tokenOut: IntentQuoteToken
+	amountIn?: bigint
+	amountOut?: bigint
+	uniswapV4?: UniswapV4IntentQuoteOptions
+}
+
+export interface UniswapV4IntentQuoteMetadata {
+	poolKey: UniswapV4PoolKey
+	quoterAddress: HexString
+	/**
+	 * IntentGateway protocol fee on the source chain. The gateway deducts this
+	 * from order inputs; callers should account for it alongside their own
+	 * slippage tolerance when constructing the order.
+	 */
+	protocolFeeBps: bigint
+}
+
+/**
+ * Quote data partners need before constructing an IntentGateway V2 order.
+ *
+ * `amountIn` and `amountOut` are the raw amounts returned by the Uniswap V4
+ * quoter, with no slippage or protocol fee adjustments applied — callers apply
+ * their own tolerance before placing the order.
+ */
+export interface QuoteIntentResult {
+	strategy: "uniswap_v4"
+	tradeType: IntentQuoteTradeType
+	amountIn: bigint
+	amountOut: bigint
+	quoteMetadata: UniswapV4IntentQuoteMetadata
+}
+
+export interface IntentQuoteStrategyHandler {
+	quote(params: QuoteIntentParams): Promise<QuoteIntentResult>
+}
+
+export class UnsupportedIntentQuoteStrategyError extends Error {
+	constructor(strategy: string) {
+		super(`Unsupported intent quote strategy: ${strategy}`)
+		this.name = "UnsupportedIntentQuoteStrategyError"
+	}
+}
+
+export class UnsupportedIntentQuotePairError extends Error {
+	constructor(params: {
+		source: string
+		destination: string
+		tokenIn: IntentQuoteToken
+		tokenOut: IntentQuoteToken
+	}) {
+		super(
+			`No Uniswap v4 pool config found for ${params.tokenIn.symbol ?? params.tokenIn.address} -> ${
+				params.tokenOut.symbol ?? params.tokenOut.address
+			} on ${params.source} -> ${params.destination}`,
+		)
+		this.name = "UnsupportedIntentQuotePairError"
+	}
+}

--- a/sdk/packages/sdk/src/protocols/intents/quote/types.ts
+++ b/sdk/packages/sdk/src/protocols/intents/quote/types.ts
@@ -66,10 +66,12 @@ export interface IntentQuoteChainContext {
 export interface UniswapV4IntentQuoteMetadata {
 	poolKey: UniswapV4PoolKey
 	quoterAddress: HexString
+	/** Slippage tolerance applied to the returned Uniswap quote amounts. */
+	slippageBps: bigint
 	/**
 	 * IntentGateway protocol fee on the source chain. The gateway deducts this
-	 * from order inputs; callers should account for it alongside their own
-	 * slippage tolerance when constructing the order.
+	 * from order inputs; callers should account for it when constructing the
+	 * order.
 	 */
 	protocolFeeBps: bigint
 }
@@ -77,9 +79,8 @@ export interface UniswapV4IntentQuoteMetadata {
 /**
  * Quote data partners need before constructing an IntentGateway V2 order.
  *
- * `amountIn` and `amountOut` are the raw amounts returned by the Uniswap V4
- * quoter, with no slippage or protocol fee adjustments applied — callers apply
- * their own tolerance before placing the order.
+ * `amountIn` and `amountOut` include the strategy's Uniswap slippage
+ * adjustment, but do not include IntentGateway protocol fee deductions.
  */
 export interface QuoteIntentResult {
 	strategy: "uniswap_v4"

--- a/sdk/packages/sdk/src/protocols/intents/quote/types.ts
+++ b/sdk/packages/sdk/src/protocols/intents/quote/types.ts
@@ -68,12 +68,10 @@ export interface UniswapV4IntentQuoteMetadata {
 	quoteChain: string
 	poolKey: UniswapV4PoolKey
 	quoterAddress: HexString
-	/** Slippage tolerance applied to the returned Uniswap quote amounts. */
-	slippageBps: bigint
 	/**
-	 * IntentGateway protocol fee on the source chain. The gateway deducts this
-	 * from order inputs; callers should account for it when constructing the
-	 * order.
+	 * IntentGateway protocol fee on the source chain, already applied to the
+	 * returned amounts. Exposed so callers can reconstruct the swap-side
+	 * (post-fee) amount if needed.
 	 */
 	protocolFeeBps: bigint
 }
@@ -81,8 +79,10 @@ export interface UniswapV4IntentQuoteMetadata {
 /**
  * Quote data partners need before constructing an IntentGateway V2 order.
  *
- * `amountIn` and `amountOut` include the strategy's Uniswap slippage
- * adjustment, but do not include IntentGateway protocol fee deductions.
+ * `amountIn` and `amountOut` already account for the IntentGateway protocol
+ * fee that the gateway deducts from order inputs (see `quoteMetadata`). No
+ * further fee adjustment is required before placing the order; apply only your
+ * own slippage tolerance.
  */
 export interface QuoteIntentResult {
 	strategy: "uniswap_v4"

--- a/sdk/packages/sdk/src/protocols/intents/quote/uniswapV4.ts
+++ b/sdk/packages/sdk/src/protocols/intents/quote/uniswapV4.ts
@@ -18,7 +18,6 @@ import {
 type GatewayParamsObject = { protocolFeeBps?: bigint | number | string }
 type GatewayParams = GatewayParamsObject | readonly unknown[]
 export const UNISWAP_INTENT_QUOTE_CHAIN = Chains.BASE_MAINNET
-export const UNISWAP_INTENT_QUOTE_SLIPPAGE_BPS = 30n
 const BPS_DENOMINATOR = 10_000n
 
 interface ResolvedPoolConfig {
@@ -192,10 +191,10 @@ export class UniswapV4IntentQuoteStrategy implements IntentQuoteStrategyHandler 
 		poolConfig: ResolvedPoolConfig
 	}): Promise<QuoteIntentResult> {
 		const amountIn = args.params.amountIn!
-		const amountOut = applyUniswapIntentQuoteSlippage(
-			await this.readV4QuoteExactInput(args.client, args.poolConfig, amountIn),
-			"EXACT_INPUT",
-		)
+		// The gateway deducts its protocol fee from order inputs, so only the
+		// reduced amount reaches the swap. Quote against that net amount.
+		const swapAmountIn = deductProtocolFee(amountIn, args.protocolFeeBps)
+		const amountOut = await this.readV4QuoteExactInput(args.client, args.poolConfig, swapAmountIn)
 
 		return {
 			strategy: "uniswap_v4",
@@ -206,7 +205,6 @@ export class UniswapV4IntentQuoteStrategy implements IntentQuoteStrategyHandler 
 				quoteChain: UNISWAP_INTENT_QUOTE_CHAIN,
 				poolKey: args.poolConfig.poolKey,
 				quoterAddress: args.poolConfig.quoterAddress,
-				slippageBps: UNISWAP_INTENT_QUOTE_SLIPPAGE_BPS,
 				protocolFeeBps: args.protocolFeeBps,
 			},
 		}
@@ -219,10 +217,11 @@ export class UniswapV4IntentQuoteStrategy implements IntentQuoteStrategyHandler 
 		poolConfig: ResolvedPoolConfig
 	}): Promise<QuoteIntentResult> {
 		const amountOut = args.params.amountOut!
-		const amountIn = applyUniswapIntentQuoteSlippage(
-			await this.readV4QuoteExactOutput(args.client, args.poolConfig, amountOut),
-			"EXACT_OUTPUT",
-		)
+		// The quoter returns the swap input needed for `amountOut`; that is the
+		// net amount after the gateway's protocol fee, so gross it back up to the
+		// order input the caller must supply.
+		const swapAmountIn = await this.readV4QuoteExactOutput(args.client, args.poolConfig, amountOut)
+		const amountIn = grossUpForProtocolFee(swapAmountIn, args.protocolFeeBps)
 
 		return {
 			strategy: "uniswap_v4",
@@ -233,7 +232,6 @@ export class UniswapV4IntentQuoteStrategy implements IntentQuoteStrategyHandler 
 				quoteChain: UNISWAP_INTENT_QUOTE_CHAIN,
 				poolKey: args.poolConfig.poolKey,
 				quoterAddress: args.poolConfig.quoterAddress,
-				slippageBps: UNISWAP_INTENT_QUOTE_SLIPPAGE_BPS,
 				protocolFeeBps: args.protocolFeeBps,
 			},
 		}
@@ -341,15 +339,24 @@ function isGatewayParamsTuple(value: GatewayParams): value is readonly unknown[]
 	return Array.isArray(value)
 }
 
-export function applyUniswapIntentQuoteSlippage(
-	amount: bigint,
-	tradeType: "EXACT_INPUT" | "EXACT_OUTPUT",
-): bigint {
-	if (tradeType === "EXACT_INPUT") {
-		return (amount * (BPS_DENOMINATOR - UNISWAP_INTENT_QUOTE_SLIPPAGE_BPS)) / BPS_DENOMINATOR
-	}
+/**
+ * Net order input after the gateway deducts its protocol fee. Mirrors the
+ * on-chain math in `IntentGatewayV2` (fee floored, then subtracted).
+ */
+export function deductProtocolFee(amount: bigint, protocolFeeBps: bigint): bigint {
+	if (protocolFeeBps <= 0n) return amount
+	const fee = (amount * protocolFeeBps) / BPS_DENOMINATOR
+	return amount - fee
+}
 
-	return divCeil(amount * (BPS_DENOMINATOR + UNISWAP_INTENT_QUOTE_SLIPPAGE_BPS), BPS_DENOMINATOR)
+/**
+ * Gross order input required so that, after the gateway's protocol fee is
+ * deducted, at least `netAmount` remains for the swap. Rounded up so the net
+ * never falls short.
+ */
+export function grossUpForProtocolFee(netAmount: bigint, protocolFeeBps: bigint): bigint {
+	if (protocolFeeBps <= 0n) return netAmount
+	return divCeil(netAmount * BPS_DENOMINATOR, BPS_DENOMINATOR - protocolFeeBps)
 }
 
 function divCeil(numerator: bigint, denominator: bigint): bigint {

--- a/sdk/packages/sdk/src/protocols/intents/quote/uniswapV4.ts
+++ b/sdk/packages/sdk/src/protocols/intents/quote/uniswapV4.ts
@@ -1,8 +1,9 @@
-import { decodeFunctionResult, encodeFunctionData, getAddress, type PublicClient, zeroAddress } from "viem"
+import { createPublicClient, decodeFunctionResult, encodeFunctionData, getAddress, http, type PublicClient, zeroAddress } from "viem"
+import { base } from "viem/chains"
 import IntentGatewayV2 from "@/abis/IntentGatewayV2"
 import { UNISWAP_V4_QUOTER_ABI } from "@/abis/uniswapV4Quoter"
 import type { ChainConfigService } from "@/configs/ChainConfigService"
-import type { ConfiguredAssetSymbol, UniswapV4PoolConfigData } from "@/configs/chain"
+import { Chains, type ConfiguredAssetSymbol, type UniswapV4PoolConfigData } from "@/configs/chain"
 import type { HexString } from "@/types"
 import {
 	type IntentQuoteChainContext,
@@ -16,6 +17,7 @@ import {
 
 type GatewayParamsObject = { protocolFeeBps?: bigint | number | string }
 type GatewayParams = GatewayParamsObject | readonly unknown[]
+export const UNISWAP_INTENT_QUOTE_CHAIN = Chains.BASE_MAINNET
 export const UNISWAP_INTENT_QUOTE_SLIPPAGE_BPS = 30n
 const BPS_DENOMINATOR = 10_000n
 
@@ -31,6 +33,8 @@ interface ResolvedConfiguredPoolToken {
 }
 
 export class UniswapV4IntentQuoteStrategy implements IntentQuoteStrategyHandler {
+	private baseQuoteClient?: PublicClient
+
 	constructor(private readonly chainConfigService: ChainConfigService) {}
 
 	async quote(
@@ -41,11 +45,31 @@ export class UniswapV4IntentQuoteStrategy implements IntentQuoteStrategyHandler 
 		this.validateQuoteParams(params)
 
 		const protocolFeeBps = await this.readProtocolFeeBps(source.client, source.stateMachineId)
-		const poolConfig = this.resolvePoolConfig(params, source.stateMachineId, destination.stateMachineId)
+		const quoteClient = this.resolveQuoteClient(source, destination)
+		const poolConfig = this.resolvePoolConfig(params, source.stateMachineId, UNISWAP_INTENT_QUOTE_CHAIN)
 
 		return params.amountIn !== undefined
-			? this.quoteExactInput({ params, client: destination.client, protocolFeeBps, poolConfig })
-			: this.quoteExactOutput({ params, client: destination.client, protocolFeeBps, poolConfig })
+			? this.quoteExactInput({ params, client: quoteClient, protocolFeeBps, poolConfig })
+			: this.quoteExactOutput({ params, client: quoteClient, protocolFeeBps, poolConfig })
+	}
+
+	private resolveQuoteClient(
+		source: IntentQuoteChainContext,
+		destination: IntentQuoteChainContext,
+	): PublicClient {
+		if (source.stateMachineId === UNISWAP_INTENT_QUOTE_CHAIN) return source.client
+		if (destination.stateMachineId === UNISWAP_INTENT_QUOTE_CHAIN) return destination.client
+		if (this.baseQuoteClient) return this.baseQuoteClient
+
+		const rpcUrl = this.chainConfigService.getRpcUrl(UNISWAP_INTENT_QUOTE_CHAIN)
+		if (!rpcUrl) throw new Error(`RPC URL is not configured for ${UNISWAP_INTENT_QUOTE_CHAIN}`)
+
+		const baseQuoteClient = createPublicClient({
+			chain: base,
+			transport: http(rpcUrl),
+		}) as PublicClient
+		this.baseQuoteClient = baseQuoteClient
+		return baseQuoteClient
 	}
 
 	private validateQuoteParams(params: QuoteIntentParams): void {
@@ -81,11 +105,11 @@ export class UniswapV4IntentQuoteStrategy implements IntentQuoteStrategyHandler 
 			const poolKey = normalizePoolKey(override)
 			const tokenInForQuote = getAddress(override.currencyIn ?? params.tokenIn.address) as HexString
 			if (tokenInForQuote !== poolKey.currency0 && tokenInForQuote !== poolKey.currency1) {
-				throw new Error(
-					`Input currency ${tokenInForQuote} is not part of the override pool ` +
-						`(${poolKey.currency0}, ${poolKey.currency1}). For cross-chain quotes pass ` +
-						`uniswapV4.poolKey.currencyIn with the destination-side input currency address.`,
-				)
+					throw new Error(
+						`Input currency ${tokenInForQuote} is not part of the override pool ` +
+							`(${poolKey.currency0}, ${poolKey.currency1}). For cross-chain quotes pass ` +
+							`uniswapV4.poolKey.currencyIn with the Base-side input currency address.`,
+					)
 			}
 
 			return {
@@ -95,7 +119,7 @@ export class UniswapV4IntentQuoteStrategy implements IntentQuoteStrategyHandler 
 			}
 		}
 
-		const poolConfig = this.resolveConfiguredPool(params, destination, source === destination)
+		const poolConfig = this.resolveConfiguredPool(params, destination)
 		if (poolConfig) return poolConfig
 
 		throw new UnsupportedIntentQuotePairError({
@@ -109,19 +133,13 @@ export class UniswapV4IntentQuoteStrategy implements IntentQuoteStrategyHandler 
 	private resolveConfiguredPool(
 		params: QuoteIntentParams,
 		chain: string,
-		sameChain: boolean,
 	): ResolvedPoolConfig | null {
 		for (const pool of this.chainConfigService.getUniswapV4PoolConfigs(chain)) {
 			const resolvedPool = this.resolveConfiguredPoolTokens(chain, pool)
 			if (!resolvedPool) continue
 
-			// tokenIn lives on the source chain, so its address is only meaningful
-			// against destination-chain config when source === destination.
-			// tokenOut is always a destination-side address.
-			const tokenInForQuote = sameChain
-				? matchPoolTokenByAddress(params.tokenIn, resolvedPool)
-				: matchPoolTokenBySymbol(params.tokenIn, resolvedPool)
-			const tokenOutForQuote = matchPoolTokenByAddress(params.tokenOut, resolvedPool)
+			const tokenInForQuote = matchPoolToken(params.tokenIn, resolvedPool)
+			const tokenOutForQuote = matchPoolToken(params.tokenOut, resolvedPool)
 			if (!tokenInForQuote || !tokenOutForQuote || tokenInForQuote.symbol === tokenOutForQuote.symbol) continue
 
 			const { currency0, currency1 } = sortCurrencies(resolvedPool[0].address, resolvedPool[1].address)
@@ -185,6 +203,7 @@ export class UniswapV4IntentQuoteStrategy implements IntentQuoteStrategyHandler 
 			amountIn,
 			amountOut,
 			quoteMetadata: {
+				quoteChain: UNISWAP_INTENT_QUOTE_CHAIN,
 				poolKey: args.poolConfig.poolKey,
 				quoterAddress: args.poolConfig.quoterAddress,
 				slippageBps: UNISWAP_INTENT_QUOTE_SLIPPAGE_BPS,
@@ -211,6 +230,7 @@ export class UniswapV4IntentQuoteStrategy implements IntentQuoteStrategyHandler 
 			amountIn,
 			amountOut,
 			quoteMetadata: {
+				quoteChain: UNISWAP_INTENT_QUOTE_CHAIN,
 				poolKey: args.poolConfig.poolKey,
 				quoterAddress: args.poolConfig.quoterAddress,
 				slippageBps: UNISWAP_INTENT_QUOTE_SLIPPAGE_BPS,
@@ -300,18 +320,14 @@ function sortCurrencies(tokenIn: HexString, tokenOut: HexString): Pick<UniswapV4
 		: { currency0: output as HexString, currency1: input as HexString }
 }
 
-function matchPoolTokenByAddress(
+function matchPoolToken(
 	token: IntentQuoteToken,
 	poolTokens: readonly [ResolvedConfiguredPoolToken, ResolvedConfiguredPoolToken],
 ): ResolvedConfiguredPoolToken | null {
 	const tokenAddress = token.address.toLowerCase()
-	return poolTokens.find((poolToken) => poolToken.address.toLowerCase() === tokenAddress) ?? null
-}
+	const addressMatch = poolTokens.find((poolToken) => poolToken.address.toLowerCase() === tokenAddress)
+	if (addressMatch) return addressMatch
 
-function matchPoolTokenBySymbol(
-	token: IntentQuoteToken,
-	poolTokens: readonly [ResolvedConfiguredPoolToken, ResolvedConfiguredPoolToken],
-): ResolvedConfiguredPoolToken | null {
 	const tokenSymbol = token.symbol?.toUpperCase()
 	if (!tokenSymbol) return null
 	return poolTokens.find((poolToken) => poolToken.symbol.toUpperCase() === tokenSymbol) ?? null

--- a/sdk/packages/sdk/src/protocols/intents/quote/uniswapV4.ts
+++ b/sdk/packages/sdk/src/protocols/intents/quote/uniswapV4.ts
@@ -16,6 +16,8 @@ import {
 
 type GatewayParamsObject = { protocolFeeBps?: bigint | number | string }
 type GatewayParams = GatewayParamsObject | readonly unknown[]
+export const UNISWAP_INTENT_QUOTE_SLIPPAGE_BPS = 30n
+const BPS_DENOMINATOR = 10_000n
 
 interface ResolvedPoolConfig {
 	poolKey: UniswapV4PoolKey
@@ -172,7 +174,10 @@ export class UniswapV4IntentQuoteStrategy implements IntentQuoteStrategyHandler 
 		poolConfig: ResolvedPoolConfig
 	}): Promise<QuoteIntentResult> {
 		const amountIn = args.params.amountIn!
-		const amountOut = await this.readV4QuoteExactInput(args.client, args.poolConfig, amountIn)
+		const amountOut = applyUniswapIntentQuoteSlippage(
+			await this.readV4QuoteExactInput(args.client, args.poolConfig, amountIn),
+			"EXACT_INPUT",
+		)
 
 		return {
 			strategy: "uniswap_v4",
@@ -182,6 +187,7 @@ export class UniswapV4IntentQuoteStrategy implements IntentQuoteStrategyHandler 
 			quoteMetadata: {
 				poolKey: args.poolConfig.poolKey,
 				quoterAddress: args.poolConfig.quoterAddress,
+				slippageBps: UNISWAP_INTENT_QUOTE_SLIPPAGE_BPS,
 				protocolFeeBps: args.protocolFeeBps,
 			},
 		}
@@ -194,7 +200,10 @@ export class UniswapV4IntentQuoteStrategy implements IntentQuoteStrategyHandler 
 		poolConfig: ResolvedPoolConfig
 	}): Promise<QuoteIntentResult> {
 		const amountOut = args.params.amountOut!
-		const amountIn = await this.readV4QuoteExactOutput(args.client, args.poolConfig, amountOut)
+		const amountIn = applyUniswapIntentQuoteSlippage(
+			await this.readV4QuoteExactOutput(args.client, args.poolConfig, amountOut),
+			"EXACT_OUTPUT",
+		)
 
 		return {
 			strategy: "uniswap_v4",
@@ -204,6 +213,7 @@ export class UniswapV4IntentQuoteStrategy implements IntentQuoteStrategyHandler 
 			quoteMetadata: {
 				poolKey: args.poolConfig.poolKey,
 				quoterAddress: args.poolConfig.quoterAddress,
+				slippageBps: UNISWAP_INTENT_QUOTE_SLIPPAGE_BPS,
 				protocolFeeBps: args.protocolFeeBps,
 			},
 		}
@@ -313,4 +323,19 @@ function getZeroForOne(tokenIn: HexString, poolKey: UniswapV4PoolKey): boolean {
 
 function isGatewayParamsTuple(value: GatewayParams): value is readonly unknown[] {
 	return Array.isArray(value)
+}
+
+export function applyUniswapIntentQuoteSlippage(
+	amount: bigint,
+	tradeType: "EXACT_INPUT" | "EXACT_OUTPUT",
+): bigint {
+	if (tradeType === "EXACT_INPUT") {
+		return (amount * (BPS_DENOMINATOR - UNISWAP_INTENT_QUOTE_SLIPPAGE_BPS)) / BPS_DENOMINATOR
+	}
+
+	return divCeil(amount * (BPS_DENOMINATOR + UNISWAP_INTENT_QUOTE_SLIPPAGE_BPS), BPS_DENOMINATOR)
+}
+
+function divCeil(numerator: bigint, denominator: bigint): bigint {
+	return (numerator + denominator - 1n) / denominator
 }

--- a/sdk/packages/sdk/src/protocols/intents/quote/uniswapV4.ts
+++ b/sdk/packages/sdk/src/protocols/intents/quote/uniswapV4.ts
@@ -1,27 +1,18 @@
-import {
-	createPublicClient,
-	decodeFunctionResult,
-	encodeFunctionData,
-	getAddress,
-	http,
-	type PublicClient,
-	zeroAddress,
-} from "viem"
+import { decodeFunctionResult, encodeFunctionData, getAddress, type PublicClient, zeroAddress } from "viem"
 import IntentGatewayV2 from "@/abis/IntentGatewayV2"
 import { UNISWAP_V4_QUOTER_ABI } from "@/abis/uniswapV4Quoter"
 import type { ChainConfigService } from "@/configs/ChainConfigService"
 import type { ConfiguredAssetSymbol, UniswapV4PoolConfigData } from "@/configs/chain"
 import type { HexString } from "@/types"
 import {
+	type IntentQuoteChainContext,
 	type IntentQuoteStrategyHandler,
 	type IntentQuoteToken,
-	type IntentQuoteChain,
 	type QuoteIntentParams,
 	type QuoteIntentResult,
 	UnsupportedIntentQuotePairError,
 	type UniswapV4PoolKey,
 } from "./types"
-import { normalizeEvmChainId } from "@/utils"
 
 type GatewayParamsObject = { protocolFeeBps?: bigint | number | string }
 type GatewayParams = GatewayParamsObject | readonly unknown[]
@@ -37,20 +28,16 @@ interface ResolvedConfiguredPoolToken {
 	address: HexString
 }
 
-interface ResolvedQuoteChain {
-	chainId: number
-	stateMachineId: string
-	client: PublicClient
-}
-
 export class UniswapV4IntentQuoteStrategy implements IntentQuoteStrategyHandler {
 	constructor(private readonly chainConfigService: ChainConfigService) {}
 
-	async quote(params: QuoteIntentParams): Promise<QuoteIntentResult> {
+	async quote(
+		params: QuoteIntentParams,
+		source: IntentQuoteChainContext,
+		destination: IntentQuoteChainContext,
+	): Promise<QuoteIntentResult> {
 		this.validateQuoteParams(params)
 
-		const source = this.resolveQuoteChain(params.source)
-		const destination = this.resolveQuoteChain(params.destination)
 		const protocolFeeBps = await this.readProtocolFeeBps(source.client, source.stateMachineId)
 		const poolConfig = this.resolvePoolConfig(params, source.stateMachineId, destination.stateMachineId)
 
@@ -68,20 +55,6 @@ export class UniswapV4IntentQuoteStrategy implements IntentQuoteStrategyHandler 
 		if (params.tokenIn.address.toLowerCase() === params.tokenOut.address.toLowerCase()) {
 			throw new Error("tokenIn and tokenOut cannot be the same")
 		}
-	}
-
-	private resolveQuoteChain(input: IntentQuoteChain): ResolvedQuoteChain {
-		const chain = normalizeEvmChainId(input.chainId)
-		return {
-			...chain,
-			client: input.client ?? this.resolveClient(chain.stateMachineId, input.rpcUrl),
-		}
-	}
-
-	private resolveClient(stateMachineId: string, rpcUrl?: string): PublicClient {
-		const resolvedRpcUrl = rpcUrl ?? this.chainConfigService.getRpcUrl(stateMachineId)
-		if (!resolvedRpcUrl) throw new Error(`No RPC URL configured for chain ${stateMachineId}`)
-		return createPublicClient({ transport: http(resolvedRpcUrl) })
 	}
 
 	private async readProtocolFeeBps(client: PublicClient, chain: string): Promise<bigint> {

--- a/sdk/packages/sdk/src/protocols/intents/quote/uniswapV4.ts
+++ b/sdk/packages/sdk/src/protocols/intents/quote/uniswapV4.ts
@@ -1,0 +1,343 @@
+import {
+	createPublicClient,
+	decodeFunctionResult,
+	encodeFunctionData,
+	getAddress,
+	http,
+	type PublicClient,
+	zeroAddress,
+} from "viem"
+import IntentGatewayV2 from "@/abis/IntentGatewayV2"
+import { UNISWAP_V4_QUOTER_ABI } from "@/abis/uniswapV4Quoter"
+import type { ChainConfigService } from "@/configs/ChainConfigService"
+import type { ConfiguredAssetSymbol, UniswapV4PoolConfigData } from "@/configs/chain"
+import type { HexString } from "@/types"
+import {
+	type IntentQuoteStrategyHandler,
+	type IntentQuoteToken,
+	type IntentQuoteChain,
+	type QuoteIntentParams,
+	type QuoteIntentResult,
+	UnsupportedIntentQuotePairError,
+	type UniswapV4PoolKey,
+} from "./types"
+import { normalizeEvmChainId } from "@/utils"
+
+type GatewayParamsObject = { protocolFeeBps?: bigint | number | string }
+type GatewayParams = GatewayParamsObject | readonly unknown[]
+
+interface ResolvedPoolConfig {
+	poolKey: UniswapV4PoolKey
+	quoterAddress: HexString
+	tokenInForQuote: HexString
+}
+
+interface ResolvedConfiguredPoolToken {
+	symbol: ConfiguredAssetSymbol
+	address: HexString
+}
+
+interface ResolvedQuoteChain {
+	chainId: number
+	stateMachineId: string
+	client: PublicClient
+}
+
+export class UniswapV4IntentQuoteStrategy implements IntentQuoteStrategyHandler {
+	constructor(private readonly chainConfigService: ChainConfigService) {}
+
+	async quote(params: QuoteIntentParams): Promise<QuoteIntentResult> {
+		this.validateQuoteParams(params)
+
+		const source = this.resolveQuoteChain(params.source)
+		const destination = this.resolveQuoteChain(params.destination)
+		const protocolFeeBps = await this.readProtocolFeeBps(source.client, source.stateMachineId)
+		const poolConfig = this.resolvePoolConfig(params, source.stateMachineId, destination.stateMachineId)
+
+		return params.amountIn !== undefined
+			? this.quoteExactInput({ params, client: destination.client, protocolFeeBps, poolConfig })
+			: this.quoteExactOutput({ params, client: destination.client, protocolFeeBps, poolConfig })
+	}
+
+	private validateQuoteParams(params: QuoteIntentParams): void {
+		const hasAmountIn = params.amountIn !== undefined
+		const hasAmountOut = params.amountOut !== undefined
+		if (hasAmountIn === hasAmountOut) throw new Error("Provide exactly one of amountIn or amountOut")
+		if (hasAmountIn && params.amountIn! <= 0n) throw new Error("amountIn must be greater than zero")
+		if (hasAmountOut && params.amountOut! <= 0n) throw new Error("amountOut must be greater than zero")
+		if (params.tokenIn.address.toLowerCase() === params.tokenOut.address.toLowerCase()) {
+			throw new Error("tokenIn and tokenOut cannot be the same")
+		}
+	}
+
+	private resolveQuoteChain(input: IntentQuoteChain): ResolvedQuoteChain {
+		const chain = normalizeEvmChainId(input.chainId)
+		return {
+			...chain,
+			client: input.client ?? this.resolveClient(chain.stateMachineId, input.rpcUrl),
+		}
+	}
+
+	private resolveClient(stateMachineId: string, rpcUrl?: string): PublicClient {
+		const resolvedRpcUrl = rpcUrl ?? this.chainConfigService.getRpcUrl(stateMachineId)
+		if (!resolvedRpcUrl) throw new Error(`No RPC URL configured for chain ${stateMachineId}`)
+		return createPublicClient({ transport: http(resolvedRpcUrl) })
+	}
+
+	private async readProtocolFeeBps(client: PublicClient, chain: string): Promise<bigint> {
+		const gatewayAddress = this.chainConfigService.getIntentGatewayAddress(chain)
+		if (!gatewayAddress || gatewayAddress === "0x" || gatewayAddress === zeroAddress) {
+			throw new Error(`IntentGatewayV2 is not configured for chain ${chain}`)
+		}
+
+		const gatewayParams = (await client.readContract({
+			address: gatewayAddress,
+			abi: IntentGatewayV2.ABI,
+			functionName: "params",
+		})) as GatewayParams
+
+		if (isGatewayParamsTuple(gatewayParams)) return BigInt(gatewayParams[4] as bigint | number | string)
+		return BigInt(gatewayParams.protocolFeeBps ?? 0)
+	}
+
+	private resolvePoolConfig(params: QuoteIntentParams, source: string, destination: string): ResolvedPoolConfig {
+		const override = params.uniswapV4?.poolKey
+		if (override) {
+			const poolKey = normalizePoolKey(override)
+			const tokenInForQuote = getAddress(override.currencyIn ?? params.tokenIn.address) as HexString
+			if (tokenInForQuote !== poolKey.currency0 && tokenInForQuote !== poolKey.currency1) {
+				throw new Error(
+					`Input currency ${tokenInForQuote} is not part of the override pool ` +
+						`(${poolKey.currency0}, ${poolKey.currency1}). For cross-chain quotes pass ` +
+						`uniswapV4.poolKey.currencyIn with the destination-side input currency address.`,
+				)
+			}
+
+			return {
+				poolKey,
+				quoterAddress: this.resolveQuoterAddress(destination, override.quoterAddress),
+				tokenInForQuote,
+			}
+		}
+
+		const poolConfig = this.resolveConfiguredPool(params, destination, source === destination)
+		if (poolConfig) return poolConfig
+
+		throw new UnsupportedIntentQuotePairError({
+			source,
+			destination,
+			tokenIn: params.tokenIn,
+			tokenOut: params.tokenOut,
+		})
+	}
+
+	private resolveConfiguredPool(
+		params: QuoteIntentParams,
+		chain: string,
+		sameChain: boolean,
+	): ResolvedPoolConfig | null {
+		for (const pool of this.chainConfigService.getUniswapV4PoolConfigs(chain)) {
+			const resolvedPool = this.resolveConfiguredPoolTokens(chain, pool)
+			if (!resolvedPool) continue
+
+			// tokenIn lives on the source chain, so its address is only meaningful
+			// against destination-chain config when source === destination.
+			// tokenOut is always a destination-side address.
+			const tokenInForQuote = sameChain
+				? matchPoolTokenByAddress(params.tokenIn, resolvedPool)
+				: matchPoolTokenBySymbol(params.tokenIn, resolvedPool)
+			const tokenOutForQuote = matchPoolTokenByAddress(params.tokenOut, resolvedPool)
+			if (!tokenInForQuote || !tokenOutForQuote || tokenInForQuote.symbol === tokenOutForQuote.symbol) continue
+
+			const { currency0, currency1 } = sortCurrencies(resolvedPool[0].address, resolvedPool[1].address)
+			return {
+				poolKey: {
+					currency0,
+					currency1,
+					fee: pool.fee,
+					tickSpacing: pool.tickSpacing,
+					hooks: getAddress(pool.hooks ?? zeroAddress) as HexString,
+				},
+				quoterAddress: this.resolveQuoterAddress(chain),
+				tokenInForQuote: tokenInForQuote.address,
+			}
+		}
+
+		return null
+	}
+
+	private resolveQuoterAddress(chain: string, override?: HexString): HexString {
+		const address = override ?? this.chainConfigService.getUniswapV4QuoterAddress(chain)
+		if (!address || address === "0x" || address === zeroAddress) {
+			throw new Error(`Uniswap V4 quoter is not configured for chain ${chain}`)
+		}
+		return getAddress(address) as HexString
+	}
+
+	private resolveConfiguredPoolTokens(
+		chain: string,
+		pool: UniswapV4PoolConfigData,
+	): readonly [ResolvedConfiguredPoolToken, ResolvedConfiguredPoolToken] | null {
+		const first = this.resolveConfiguredPoolToken(chain, pool.tokens[0])
+		const second = this.resolveConfiguredPoolToken(chain, pool.tokens[1])
+		return first && second ? [first, second] : null
+	}
+
+	private resolveConfiguredPoolToken(
+		chain: string,
+		symbol: ConfiguredAssetSymbol,
+	): ResolvedConfiguredPoolToken | null {
+		const address = this.chainConfigService.getAssetAddress(chain, symbol)
+		if (!address || address === "0x") return null
+		return { symbol, address: getAddress(address) as HexString }
+	}
+
+	private async quoteExactInput(args: {
+		params: QuoteIntentParams
+		client: PublicClient
+		protocolFeeBps: bigint
+		poolConfig: ResolvedPoolConfig
+	}): Promise<QuoteIntentResult> {
+		const amountIn = args.params.amountIn!
+		const amountOut = await this.readV4QuoteExactInput(args.client, args.poolConfig, amountIn)
+
+		return {
+			strategy: "uniswap_v4",
+			tradeType: "EXACT_INPUT",
+			amountIn,
+			amountOut,
+			quoteMetadata: {
+				poolKey: args.poolConfig.poolKey,
+				quoterAddress: args.poolConfig.quoterAddress,
+				protocolFeeBps: args.protocolFeeBps,
+			},
+		}
+	}
+
+	private async quoteExactOutput(args: {
+		params: QuoteIntentParams
+		client: PublicClient
+		protocolFeeBps: bigint
+		poolConfig: ResolvedPoolConfig
+	}): Promise<QuoteIntentResult> {
+		const amountOut = args.params.amountOut!
+		const amountIn = await this.readV4QuoteExactOutput(args.client, args.poolConfig, amountOut)
+
+		return {
+			strategy: "uniswap_v4",
+			tradeType: "EXACT_OUTPUT",
+			amountIn,
+			amountOut,
+			quoteMetadata: {
+				poolKey: args.poolConfig.poolKey,
+				quoterAddress: args.poolConfig.quoterAddress,
+				protocolFeeBps: args.protocolFeeBps,
+			},
+		}
+	}
+
+	private async readV4QuoteExactInput(
+		client: PublicClient,
+		poolConfig: ResolvedPoolConfig,
+		amountIn: bigint,
+	): Promise<bigint> {
+		const data = encodeFunctionData({
+			abi: UNISWAP_V4_QUOTER_ABI,
+			functionName: "quoteExactInputSingle",
+			args: [
+				{
+					poolKey: poolConfig.poolKey,
+					zeroForOne: getZeroForOne(poolConfig.tokenInForQuote, poolConfig.poolKey),
+					exactAmount: amountIn,
+					hookData: "0x",
+				},
+			],
+		})
+		const response = await client.call({ to: poolConfig.quoterAddress, data })
+		if (!response.data || response.data === "0x") {
+			throw new Error(`Uniswap V4 quoter at ${poolConfig.quoterAddress} returned no data`)
+		}
+
+		const [amountOut] = decodeFunctionResult({
+			abi: UNISWAP_V4_QUOTER_ABI,
+			functionName: "quoteExactInputSingle",
+			data: response.data,
+		})
+
+		return amountOut
+	}
+
+	private async readV4QuoteExactOutput(
+		client: PublicClient,
+		poolConfig: ResolvedPoolConfig,
+		amountOut: bigint,
+	): Promise<bigint> {
+		const data = encodeFunctionData({
+			abi: UNISWAP_V4_QUOTER_ABI,
+			functionName: "quoteExactOutputSingle",
+			args: [
+				{
+					poolKey: poolConfig.poolKey,
+					zeroForOne: getZeroForOne(poolConfig.tokenInForQuote, poolConfig.poolKey),
+					exactAmount: amountOut,
+					hookData: "0x",
+				},
+			],
+		})
+		const response = await client.call({ to: poolConfig.quoterAddress, data })
+		if (!response.data || response.data === "0x") {
+			throw new Error(`Uniswap V4 quoter at ${poolConfig.quoterAddress} returned no data`)
+		}
+
+		const [amountIn] = decodeFunctionResult({
+			abi: UNISWAP_V4_QUOTER_ABI,
+			functionName: "quoteExactOutputSingle",
+			data: response.data,
+		})
+
+		return amountIn
+	}
+}
+
+function normalizePoolKey(poolKey: UniswapV4PoolKey): UniswapV4PoolKey {
+	return {
+		currency0: getAddress(poolKey.currency0) as HexString,
+		currency1: getAddress(poolKey.currency1) as HexString,
+		fee: poolKey.fee,
+		tickSpacing: poolKey.tickSpacing,
+		hooks: getAddress(poolKey.hooks) as HexString,
+	}
+}
+
+function sortCurrencies(tokenIn: HexString, tokenOut: HexString): Pick<UniswapV4PoolKey, "currency0" | "currency1"> {
+	const input = getAddress(tokenIn)
+	const output = getAddress(tokenOut)
+	return BigInt(input) < BigInt(output)
+		? { currency0: input as HexString, currency1: output as HexString }
+		: { currency0: output as HexString, currency1: input as HexString }
+}
+
+function matchPoolTokenByAddress(
+	token: IntentQuoteToken,
+	poolTokens: readonly [ResolvedConfiguredPoolToken, ResolvedConfiguredPoolToken],
+): ResolvedConfiguredPoolToken | null {
+	const tokenAddress = token.address.toLowerCase()
+	return poolTokens.find((poolToken) => poolToken.address.toLowerCase() === tokenAddress) ?? null
+}
+
+function matchPoolTokenBySymbol(
+	token: IntentQuoteToken,
+	poolTokens: readonly [ResolvedConfiguredPoolToken, ResolvedConfiguredPoolToken],
+): ResolvedConfiguredPoolToken | null {
+	const tokenSymbol = token.symbol?.toUpperCase()
+	if (!tokenSymbol) return null
+	return poolTokens.find((poolToken) => poolToken.symbol.toUpperCase() === tokenSymbol) ?? null
+}
+
+function getZeroForOne(tokenIn: HexString, poolKey: UniswapV4PoolKey): boolean {
+	return getAddress(tokenIn).toLowerCase() === getAddress(poolKey.currency0).toLowerCase()
+}
+
+function isGatewayParamsTuple(value: GatewayParams): value is readonly unknown[] {
+	return Array.isArray(value)
+}

--- a/sdk/packages/sdk/src/tests/sequential/intentGateway.test.ts
+++ b/sdk/packages/sdk/src/tests/sequential/intentGateway.test.ts
@@ -5,6 +5,10 @@ import type { PublicClient } from "viem"
 import { type HexString, Order, TokenInfo } from "@/types"
 import { EvmChain } from "@/chain"
 import { IntentGateway } from "@/protocols/intents/IntentGateway"
+import {
+	applyUniswapIntentQuoteSlippage,
+	UNISWAP_INTENT_QUOTE_SLIPPAGE_BPS,
+} from "@/protocols/intents/quote/uniswapV4"
 import { ChainConfigService } from "@/configs/ChainConfigService"
 import { UniswapQuoteEngine, type UniswapQuoteAdapter, type UniswapQuoteToken } from "@/utils/uniswapQuote"
 
@@ -55,6 +59,13 @@ describe("Uniswap quote helper", () => {
 
 describe("Intent quote helper", () => {
 	const BASE_CHAIN = "EVM-8453"
+
+	it("applies the built-in Uniswap slippage buffer conservatively", () => {
+		assert.equal(UNISWAP_INTENT_QUOTE_SLIPPAGE_BPS, 30n)
+		assert.equal(applyUniswapIntentQuoteSlippage(1_000_000n, "EXACT_INPUT"), 997_000n)
+		assert.equal(applyUniswapIntentQuoteSlippage(1_000_000n, "EXACT_OUTPUT"), 1_003_000n)
+		assert.equal(applyUniswapIntentQuoteSlippage(1n, "EXACT_OUTPUT"), 2n)
+	})
 
 	it("quotes 1 USDC to cNGN on Base through Uniswap V4", async () => {
 		const configService = new ChainConfigService()

--- a/sdk/packages/sdk/src/tests/sequential/intentGateway.test.ts
+++ b/sdk/packages/sdk/src/tests/sequential/intentGateway.test.ts
@@ -7,6 +7,7 @@ import { EvmChain } from "@/chain"
 import { IntentGateway } from "@/protocols/intents/IntentGateway"
 import { ChainConfigService } from "@/configs/ChainConfigService"
 import { UniswapQuoteEngine, type UniswapQuoteAdapter, type UniswapQuoteToken } from "@/utils/uniswapQuote"
+import { quoteIntent } from "@/protocols/intents"
 
 // ---------------------------------------------------------------------------
 // Test Cases
@@ -51,6 +52,45 @@ describe("Uniswap quote helper", () => {
 		assert.equal(result.bestQuote?.protocol, "v4")
 		assert.equal(result.bestQuote?.amountOut, 103n)
 	})
+})
+
+describe("Intent quote helper", () => {
+	const BASE_CHAIN = "EVM-8453"
+
+	it("quotes 1 USDC to cNGN on Base through Uniswap V4", async () => {
+		const configService = new ChainConfigService()
+		console.log("Base USDC -> cNGN intent quote")
+		console.log("rpcUrl:", configService.getRpcUrl(BASE_CHAIN))
+
+		const quote = await quoteIntent({
+			source: { chainId: BASE_CHAIN },
+			destination: { chainId: BASE_CHAIN },
+			tokenIn: {
+				address: configService.getUsdcAsset(BASE_CHAIN),
+				decimals: 6,
+				symbol: "USDC",
+			},
+			tokenOut: {
+				address: configService.getCNgnAsset(BASE_CHAIN)!,
+				decimals: 6,
+				symbol: "cNGN",
+			},
+			amountIn: 1_000_000n,
+		})
+
+		console.log("amountIn:", quote.amountIn.toString())
+		console.log("amountOut:", quote.amountOut.toString())
+		console.log("protocolFeeBps:", quote.quoteMetadata.protocolFeeBps.toString())
+		console.log("poolKey:", quote.quoteMetadata.poolKey)
+		console.log("quoterAddress:", quote.quoteMetadata.quoterAddress)
+
+		assert.equal(quote.strategy, "uniswap_v4")
+		assert.equal(quote.tradeType, "EXACT_INPUT")
+		assert.equal(quote.amountIn, 1_000_000n)
+		assert(quote.amountOut > 0n)
+		assert.equal(quote.quoteMetadata.poolKey.fee, 1500)
+		assert.equal(quote.quoteMetadata.poolKey.tickSpacing, 30)
+	}, 120_000)
 })
 
 // ---------------------------------------------------------------------------

--- a/sdk/packages/sdk/src/tests/sequential/intentGateway.test.ts
+++ b/sdk/packages/sdk/src/tests/sequential/intentGateway.test.ts
@@ -7,6 +7,7 @@ import { EvmChain } from "@/chain"
 import { IntentGateway } from "@/protocols/intents/IntentGateway"
 import {
 	applyUniswapIntentQuoteSlippage,
+	UNISWAP_INTENT_QUOTE_CHAIN,
 	UNISWAP_INTENT_QUOTE_SLIPPAGE_BPS,
 } from "@/protocols/intents/quote/uniswapV4"
 import { ChainConfigService } from "@/configs/ChainConfigService"
@@ -61,6 +62,7 @@ describe("Intent quote helper", () => {
 	const BASE_CHAIN = "EVM-8453"
 
 	it("applies the built-in Uniswap slippage buffer conservatively", () => {
+		assert.equal(UNISWAP_INTENT_QUOTE_CHAIN, BASE_CHAIN)
 		assert.equal(UNISWAP_INTENT_QUOTE_SLIPPAGE_BPS, 30n)
 		assert.equal(applyUniswapIntentQuoteSlippage(1_000_000n, "EXACT_INPUT"), 997_000n)
 		assert.equal(applyUniswapIntentQuoteSlippage(1_000_000n, "EXACT_OUTPUT"), 1_003_000n)
@@ -98,6 +100,7 @@ describe("Intent quote helper", () => {
 		assert.equal(quote.tradeType, "EXACT_INPUT")
 		assert.equal(quote.amountIn, 1_000_000n)
 		assert(quote.amountOut > 0n)
+		assert.equal(quote.quoteMetadata.quoteChain, BASE_CHAIN)
 		assert.equal(quote.quoteMetadata.poolKey.fee, 1500)
 		assert.equal(quote.quoteMetadata.poolKey.tickSpacing, 30)
 	}, 120_000)

--- a/sdk/packages/sdk/src/tests/sequential/intentGateway.test.ts
+++ b/sdk/packages/sdk/src/tests/sequential/intentGateway.test.ts
@@ -7,7 +7,6 @@ import { EvmChain } from "@/chain"
 import { IntentGateway } from "@/protocols/intents/IntentGateway"
 import { ChainConfigService } from "@/configs/ChainConfigService"
 import { UniswapQuoteEngine, type UniswapQuoteAdapter, type UniswapQuoteToken } from "@/utils/uniswapQuote"
-import { quoteIntent } from "@/protocols/intents"
 
 // ---------------------------------------------------------------------------
 // Test Cases
@@ -60,11 +59,11 @@ describe("Intent quote helper", () => {
 	it("quotes 1 USDC to cNGN on Base through Uniswap V4", async () => {
 		const configService = new ChainConfigService()
 		console.log("Base USDC -> cNGN intent quote")
-		console.log("rpcUrl:", configService.getRpcUrl(BASE_CHAIN))
 
-		const quote = await quoteIntent({
-			source: { chainId: BASE_CHAIN },
-			destination: { chainId: BASE_CHAIN },
+		const baseChain = makeEvmChain(CHAINS.base, configService)
+		const intentGateway = await IntentGateway.create(baseChain, baseChain)
+
+		const quote = await intentGateway.quoteIntent({
 			tokenIn: {
 				address: configService.getUsdcAsset(BASE_CHAIN),
 				decimals: 6,
@@ -197,7 +196,7 @@ function makeEvmChain(chain: ChainDef, configService: ChainConfigService, bundle
 	return EvmChain.fromParams({
 		chainId: chain.numericId,
 		host: configService.getHostAddress(chain.id),
-		rpcUrl: process.env[chain.rpcEnvVar]!,
+		rpcUrl: process.env[chain.rpcEnvVar] ?? configService.getRpcUrl(chain.id),
 		bundlerUrl,
 	})
 }

--- a/sdk/packages/sdk/src/tests/sequential/intentGateway.test.ts
+++ b/sdk/packages/sdk/src/tests/sequential/intentGateway.test.ts
@@ -6,9 +6,9 @@ import { type HexString, Order, TokenInfo } from "@/types"
 import { EvmChain } from "@/chain"
 import { IntentGateway } from "@/protocols/intents/IntentGateway"
 import {
-	applyUniswapIntentQuoteSlippage,
+	deductProtocolFee,
+	grossUpForProtocolFee,
 	UNISWAP_INTENT_QUOTE_CHAIN,
-	UNISWAP_INTENT_QUOTE_SLIPPAGE_BPS,
 } from "@/protocols/intents/quote/uniswapV4"
 import { ChainConfigService } from "@/configs/ChainConfigService"
 import { UniswapQuoteEngine, type UniswapQuoteAdapter, type UniswapQuoteToken } from "@/utils/uniswapQuote"
@@ -61,12 +61,16 @@ describe("Uniswap quote helper", () => {
 describe("Intent quote helper", () => {
 	const BASE_CHAIN = "EVM-8453"
 
-	it("applies the built-in Uniswap slippage buffer conservatively", () => {
+	it("applies the gateway protocol fee to quoted amounts", () => {
 		assert.equal(UNISWAP_INTENT_QUOTE_CHAIN, BASE_CHAIN)
-		assert.equal(UNISWAP_INTENT_QUOTE_SLIPPAGE_BPS, 30n)
-		assert.equal(applyUniswapIntentQuoteSlippage(1_000_000n, "EXACT_INPUT"), 997_000n)
-		assert.equal(applyUniswapIntentQuoteSlippage(1_000_000n, "EXACT_OUTPUT"), 1_003_000n)
-		assert.equal(applyUniswapIntentQuoteSlippage(1n, "EXACT_OUTPUT"), 2n)
+		// 30 bps fee: exact-input nets less to the swap, exact-output grosses up.
+		assert.equal(deductProtocolFee(1_000_000n, 30n), 997_000n)
+		assert.equal(grossUpForProtocolFee(997_000n, 30n), 1_000_000n)
+		// Gross-up rounds up so the post-fee net never falls short.
+		assert.equal(grossUpForProtocolFee(1n, 30n), 2n)
+		// Zero fee is a no-op in both directions.
+		assert.equal(deductProtocolFee(1_000_000n, 0n), 1_000_000n)
+		assert.equal(grossUpForProtocolFee(1_000_000n, 0n), 1_000_000n)
 	})
 
 	it("quotes 1 USDC to cNGN on Base through Uniswap V4", async () => {


### PR DESCRIPTION
# feat(sdk): add partner-facing intent quote API (`quoteIntent`)

## Summary

Adds a strategy-based intent quoting API to the SDK so partners can price IntentGateway V2 orders before placing them. Uniswap V4 is the only strategy today, but the API is strategy-shaped (`strategy: "uniswap_v4"` is the default) so new quote sources can be added without breaking partner integrations.

```typescript
import { quoteIntent } from "@hyperbridge/sdk"

const quote = await quoteIntent({
  source: { chainId: "EVM-8453" },
  destination: { chainId: "EVM-8453" },
  tokenIn: { address: USDC, decimals: 6, symbol: "USDC" },
  tokenOut: { address: cNGN, decimals: 6, symbol: "cNGN" },
  amountIn: 100_000_000n,
})
// quote.amountIn / quote.amountOut → raw Uniswap V4 quoter amounts
```

## What's included

- **`IntentQuoteService` / `quoteIntent()`** (`protocols/intents/quote/`) — supports exact-input and exact-output quotes. Returns the raw amounts from the Uniswap V4 quoter with no slippage or fee adjustments; partners apply their own tolerance. `quoteMetadata` exposes the resolved `poolKey`, `quoterAddress`, and the source-chain `protocolFeeBps` (read from `IntentGatewayV2.params()`) so callers can account for the gateway's input fee when constructing the order.
- **Pool resolution** — pools are resolved from SDK chain config (`uniswapV4Pools`, seeded with USDC/cNGN on Base). Same-chain quotes match configured pools by token address; cross-chain quotes match `tokenIn` by symbol since its source-chain address is meaningless against destination config. For unconfigured pairs, callers can pass an explicit `uniswapV4.poolKey` override (with optional `quoterAddress` and, for cross-chain quotes, `currencyIn` — the destination-side input currency, validated against the pool to prevent silently quoting the wrong swap direction).
- **Config plumbing** — `uniswapV4Pools` chain config field, `ChainConfigService.getUniswapV4PoolConfigs()` and `getAssetAddress()`.
- **Errors** — `UnsupportedIntentQuoteStrategyError`, `UnsupportedIntentQuotePairError`, and a clear failure when the V4 quoter is not configured for a chain instead of an opaque `eth_call` failure.
- **Docs** — new `quoteIntent(params)` section in `intent-gateway.mdx`, including how to apply slippage and the protocol fee on top of the raw amounts.
- **Test** — live Base USDC → cNGN exact-input quote in `tests/sequential/intentGateway.test.ts`.

## Notes for reviewers

- Quoted amounts are intentionally unadjusted: applying slippage tolerance and accounting for `protocolFeeBps` is the caller's responsibility (documented with a snippet in the docs).
- The V4 quoter is called via `eth_call` with manual encode/decode since its quote functions are `nonpayable`.

## Test plan

- [ ] `pnpm test:intent-gateway` (live Base RPC) — quotes 1 USDC → cNGN through the configured V4 pool
- [ ] `tsc --noEmit` passes (two pre-existing errors in unrelated test files)


Closes #963 