### PR TITLE
[tesseract]: fix BEEFY session-boundary proof verification failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28539,7 +28539,7 @@ dependencies = [
 
 [[package]]
 name = "tesseract-prover"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/modules/consensus/beefy/prover/src/util.rs
+++ b/modules/consensus/beefy/prover/src/util.rs
@@ -108,6 +108,10 @@ pub async fn fetch_timestamp_extrinsic_with_proof<T: Config>(
 	Ok(TimeStampExtWithProof { ext, proof })
 }
 
+/// Sentinel leaf for a BEEFY key that fails `to_eth_address`, matching the latest
+/// `pallet_beefy_mmr::BeefyEcdsaToEthereum` (`FAILED_BEEFY_TO_ETH_ADDRESS`).
+const FAILED_BEEFY_TO_ETH_ADDRESS: [u8; 20] = [0u8; 20];
+
 /// Hash encoded authority public keys
 pub fn hash_authority_addresses(
 	encoded_public_keys: Vec<Vec<u8>>,
@@ -115,8 +119,21 @@ pub fn hash_authority_addresses(
 	let authority_address_hashes = encoded_public_keys
 		.into_iter()
 		.map(|x| {
-			sp_consensus_beefy::ecdsa_crypto::AuthorityId::decode(&mut &*x)
-				.map(|id| keccak_256(&pallet_beefy_mmr::BeefyEcdsaToEthereum::convert(id)))
+			sp_consensus_beefy::ecdsa_crypto::AuthorityId::decode(&mut &*x).map(|id| {
+				// Mirror the latest `BeefyEcdsaToEthereum`: a key that fails `to_eth_address` is
+				// committed as `FAILED_BEEFY_TO_ETH_ADDRESS = [0u8; 20]`, not an empty Vec. The
+				// pinned pallet-beefy-mmr (46.0.0, from the polkadot-sdk umbrella) still returns
+				// `Vec::default()`, hashing `keccak([])` and so producing the wrong authority-set
+				// root for any set containing an unconvertible key (Polkadot mainnet from set 5066
+				// on). `convert` returns empty iff the conversion failed, so substituting the
+				// sentinel on empty reproduces the new crate's root exactly (verified against the
+				// on-chain keyset commitments d47f121c / 1c9dedf8).
+				let mut address = pallet_beefy_mmr::BeefyEcdsaToEthereum::convert(id);
+				if address.is_empty() {
+					address = FAILED_BEEFY_TO_ETH_ADDRESS.to_vec();
+				}
+				keccak_256(&address)
+			})
 		})
 		.collect::<Result<Vec<_>, codec::Error>>()?;
 	Ok(authority_address_hashes)

--- a/tesseract/consensus/beefy/zk/src/lib.rs
+++ b/tesseract/consensus/beefy/zk/src/lib.rs
@@ -72,15 +72,6 @@ where
 		// Use the raw bytes at each commit site so the conversion is agnostic to the exact
 		// `H256`/`FixedBytes` type each consumer expects.
 		let account: [u8; 32] = self.account.0;
-		let authority = match signed_commitment.commitment.validator_set_id {
-			id if id == consensus_state.current_authorities.id =>
-				consensus_state.current_authorities,
-			id if id == consensus_state.next_authorities.id => consensus_state.next_authorities,
-			_ => Err(anyhow::anyhow!(
-				"Unknown validator set {}",
-				signed_commitment.commitment.validator_set_id
-			))?,
-		};
 
 		let message = self.inner.consensus_proof(signed_commitment.clone()).await?;
 
@@ -93,10 +84,34 @@ where
 			.await?
 			.ok_or_else(|| anyhow!("Failed to query blockhash for blocknumber"))?;
 
+		// Build the authority-set merkle tree from the ACTUAL authorities at this block and use its
+		// computed root. Select the matching set id by *root*, not the commitment's
+		// `validator_set_id`: at a session boundary the first block of a new session is still signed
+		// by the outgoing set, so trusting `validator_set_id` selects the wrong set (and root), the
+		// proof's authority-membership check fails, and the guest commits a non-zero exit code that
+		// the on-chain verifier rejects as `InvalidExitCode`.
+		let authorities = self.inner.beefy_authorities(Some(block_hash)).await?;
+		let leaf_hashes =
+			hash_authority_addresses(authorities.into_iter().map(|x| x.encode()).collect())?;
+		let tree = MerkleTree::<KeccakHasher>::from_leaves(&leaf_hashes);
+		let computed_root: [u8; 32] =
+			tree.root().ok_or_else(|| anyhow!("empty authority set, cannot compute root"))?;
+
+		let authority = if computed_root == consensus_state.current_authorities.keyset_commitment.0 {
+			consensus_state.current_authorities
+		} else if computed_root == consensus_state.next_authorities.keyset_commitment.0 {
+			consensus_state.next_authorities
+		} else {
+			Err(anyhow!(
+				"computed authority root 0x{} matches neither current ({}) nor next ({}) set",
+				hex::encode(computed_root),
+				consensus_state.current_authorities.id,
+				consensus_state.next_authorities.id,
+			))?
+		};
+		let validator_set_id = authority.id;
+
 		let authorities_witness = {
-			let authorities = self.inner.beefy_authorities(Some(block_hash)).await?;
-			let leaf_hashes =
-				hash_authority_addresses(authorities.into_iter().map(|x| x.encode()).collect())?;
 			let indices = message
 				.mmr
 				.signed_commitment
@@ -104,8 +119,6 @@ where
 				.iter()
 				.map(|s| s.index as usize)
 				.collect::<Vec<_>>();
-
-			let tree = MerkleTree::<KeccakHasher>::from_leaves(&leaf_hashes);
 			let proof = tree.proof(&indices);
 			proof.proof_hashes().iter().map(|item| item.clone().into()).collect()
 		};
@@ -136,7 +149,7 @@ where
 			authorities: AuthoritiesProof {
 				len: authority.len,
 				proof: authorities_witness,
-				root: authority.keyset_commitment.0.into(),
+				root: computed_root.into(),
 				votes: message
 					.mmr
 					.signed_commitment
@@ -193,8 +206,15 @@ where
 		tracing::trace!(target: "zk_beefy", "Plonk Proof: {:#?}", hex::encode(proof.bytes()));
 		tracing::trace!(target: "zk_beefy", "Public Inputs: {:#?}", proof.public_values.raw());
 
+		// Carry the root-selected `validator_set_id` (not the commitment's, which is off-by-one at
+		// session boundaries) so the on-chain verifier picks the authority set the proof was built
+		// against. Only this verifier-side selector changes; the signed commitment bytes the guest
+		// hashes for signature verification are untouched.
+		let mut mini_commitment = signed_commitment.commitment.clone();
+		mini_commitment.validator_set_id = validator_set_id;
+
 		Ok(SP1BeefyProof {
-			commitment: signed_commitment.commitment.into(),
+			commitment: mini_commitment.into(),
 			mmrLeaf: message.mmr.latest_mmr_leaf.into(),
 			proof: proof.bytes().into(),
 			headers: message.parachain.parachains.into_iter().map(|i| i.into()).collect(),

--- a/tesseract/prover/Cargo.toml
+++ b/tesseract/prover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tesseract-prover"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 description = "Standalone BEEFY consensus prover daemon"
 authors = ["Polytope Labs <hello@polytope.technology>"]


### PR DESCRIPTION
## Problem

Mainnet BEEFY consensus proofs were rejected on-chain (`BeefyConsensusProofs::VerificationFailed` / `InvalidExitCode`). Two distinct bugs at session boundaries:

1. **Wrong authority set selected.** The first block of a new session is still signed by the *outgoing* set, so trusting the commitment's `validator_set_id` selects the wrong set (and root), the guest's authority-membership check fails, and the verifier rejects the non-zero exit code.

2. **Wrong authority-set root for sets with unconvertible keys.** Polkadot's `pallet-beefy::Authorities` contains BEEFY keys that fail `to_eth_address` (2 of them from set 5066 onward). The latest `pallet-beefy-mmr` commits such a key as `FAILED_BEEFY_TO_ETH_ADDRESS = [0u8; 20]`, but the pinned `pallet-beefy-mmr` 46.0.0 (via the polkadot-sdk umbrella) returns an empty `Vec`, so our root hashed `keccak([])` instead of `keccak([0u8;20])` — diverging from the chain's `keyset_commitment` for every set containing a failing key.

## Fix

- Select the authority set by the *computed* merkle root rather than the commitment's `validator_set_id`.
- In `hash_authority_addresses`, substitute `[0u8; 20]` when `BeefyEcdsaToEthereum::convert` returns empty — byte-identical to the latest `BeefyEcdsaToEthereum`, without the dependency conflict that pulling 49.0.1 directly causes (sp-consensus-beefy 28↔30, sp-runtime 45↔47).

## Verification

Recomputing the authority-set root with the fix reproduces the on-chain keyset commitments exactly: `d47f121c` for set 5066 and `1c9dedf8` for set 5067 (vs. the unfixed `9c01ea1b` / `320a98ab`). Signature recovery confirms all 401/401 signers of the set-5067 boundary commitment are index-aligned members of the corrected tree.

Bumps `tesseract-prover` 2.1.0 → 2.1.1.