### PR TITLE
[chore]: Add apt-get update before install in CI workflows

### DIFF
--- a/.github/workflows/publish-tesseract-messaging.yml
+++ b/.github/workflows/publish-tesseract-messaging.yml
@@ -52,6 +52,7 @@ jobs:
 
             - name: Build
               run: |
+                  sudo apt-get update -y
                   sudo apt-get install -y clang netcat wget curl libssl-dev llvm libudev-dev make protobuf-compiler pkg-config
                   cargo build --release -p tesseract
 


### PR DESCRIPTION
The Build step ran apt-get install without a preceding apt-get update, causing a 404 when the cached package index referenced a superseded libudev-dev version. Mirrors the consensus and admin-relayer workflows.