### PR TITLE
[indexer]: add chain field to DustCollected/DustSwept entities

### DIFF
--- a/sdk/packages/indexer/src/configs/schema.graphql
+++ b/sdk/packages/indexer/src/configs/schema.graphql
@@ -1777,6 +1777,56 @@ type ProtocolDustSwept @entity {
 }
 
 """
+Cumulative dust collected per chain, denominated in USD
+"""
+type CumulativeDustCollectedPerChain @entity {
+	"""
+	Unique identifier: chain
+	"""
+	id: ID!
+
+	"""
+	Host state machine
+	"""
+	chain: String! @index
+
+	"""
+	Cumulative dust collected in USD, scaled by 1e18 (18-decimal fixed-point integer)
+	"""
+	amountUSD: BigInt!
+
+	"""
+	Last updated at
+	"""
+	lastUpdatedAt: BigInt!
+}
+
+"""
+Cumulative dust swept per chain, denominated in USD
+"""
+type CumulativeDustSweptPerChain @entity {
+	"""
+	Unique identifier: chain
+	"""
+	id: ID!
+
+	"""
+	Host state machine
+	"""
+	chain: String! @index
+
+	"""
+	Cumulative dust swept in USD, scaled by 1e18 (18-decimal fixed-point integer)
+	"""
+	amountUSD: BigInt!
+
+	"""
+	Last updated at
+	"""
+	lastUpdatedAt: BigInt!
+}
+
+"""
 Collator rewards indexed from treasury transfers to block authors
 """
 type HyperbridgeCollatorReward @entity {

--- a/sdk/packages/indexer/src/configs/schema.graphql
+++ b/sdk/packages/indexer/src/configs/schema.graphql
@@ -1719,7 +1719,7 @@ type UserActivityV2 @entity {
 """
 Represents dust collected by the protocol
 """
-type DustCollected @entity {
+type ProtocolDustCollected @entity {
 	"""
 	Unique identifier: chain-tokenAddress
 	"""
@@ -1749,7 +1749,7 @@ type DustCollected @entity {
 """
 Represents dust swept by the protocol
 """
-type DustSwept @entity {
+type ProtocolDustSwept @entity {
 	"""
 	Unique identifier: chain-tokenAddress
 	"""

--- a/sdk/packages/indexer/src/configs/schema.graphql
+++ b/sdk/packages/indexer/src/configs/schema.graphql
@@ -1721,9 +1721,14 @@ Represents dust collected by the protocol
 """
 type DustCollected @entity {
 	"""
-	Unique identifier: chainId-tokenAddress
+	Unique identifier: chain-tokenAddress
 	"""
 	id: ID!
+
+	"""
+	Host state machine that emitted the event
+	"""
+	chain: String! @index
 
 	"""
 	Token symbol
@@ -1746,9 +1751,14 @@ Represents dust swept by the protocol
 """
 type DustSwept @entity {
 	"""
-	Unique identifier: chainId-tokenAddress
+	Unique identifier: chain-tokenAddress
 	"""
 	id: ID!
+
+	"""
+	Host state machine that emitted the event
+	"""
+	chain: String! @index
 
 	"""
 	Token symbol

--- a/sdk/packages/indexer/src/handlers/events/intentGatewayV3/dustCollected.event.handler.ts
+++ b/sdk/packages/indexer/src/handlers/events/intentGatewayV3/dustCollected.event.handler.ts
@@ -24,5 +24,5 @@ export const handleDustCollectedEventV3 = wrap(async (event: DustCollectedLog): 
 		})}`,
 	)
 
-	await ProtocolRevenueService.recordDustCollected(token, BigInt(amount.toString()), timestamp)
+	await ProtocolRevenueService.recordDustCollected(chain, token, BigInt(amount.toString()), timestamp)
 })

--- a/sdk/packages/indexer/src/handlers/events/intentGatewayV3/dustSwept.event.handler.ts
+++ b/sdk/packages/indexer/src/handlers/events/intentGatewayV3/dustSwept.event.handler.ts
@@ -25,5 +25,5 @@ export const handleDustSweptEventV3 = wrap(async (event: DustSweptLog): Promise<
 		})}`,
 	)
 
-	await ProtocolRevenueService.recordDustSwept(token, BigInt(amount.toString()), timestamp)
+	await ProtocolRevenueService.recordDustSwept(chain, token, BigInt(amount.toString()), timestamp)
 })

--- a/sdk/packages/indexer/src/services/protocol-revenue.service.ts
+++ b/sdk/packages/indexer/src/services/protocol-revenue.service.ts
@@ -11,8 +11,13 @@ export class ProtocolRevenueService {
 	/**
 	 * Get or create a DustCollected record
 	 */
-	static async recordDustCollected(tokenAddress: string, amount: bigint, timestamp: bigint): Promise<DustCollected> {
-		const id = `${chainId}-${tokenAddress.toLowerCase()}`
+	static async recordDustCollected(
+		chain: string,
+		tokenAddress: string,
+		amount: bigint,
+		timestamp: bigint,
+	): Promise<DustCollected> {
+		const id = `${chain}-${tokenAddress.toLowerCase()}`
 		let symbol = "eth"
 
 		// Get token symbol if not native token
@@ -35,6 +40,7 @@ export class ProtocolRevenueService {
 		if (!dustCollected) {
 			dustCollected = await DustCollected.create({
 				id,
+				chain,
 				tokenSymbol: symbol,
 				amount,
 				lastUpdated: timestampToDate(timestamp),
@@ -60,8 +66,13 @@ export class ProtocolRevenueService {
 	/**
 	 * Get or create a DustSwept record
 	 */
-	static async recordDustSwept(tokenAddress: string, amount: bigint, timestamp: bigint): Promise<DustSwept> {
-		const id = `${chainId}-${tokenAddress.toLowerCase()}`
+	static async recordDustSwept(
+		chain: string,
+		tokenAddress: string,
+		amount: bigint,
+		timestamp: bigint,
+	): Promise<DustSwept> {
+		const id = `${chain}-${tokenAddress.toLowerCase()}`
 		let symbol = "eth"
 
 		// Get token symbol if not native token
@@ -84,6 +95,7 @@ export class ProtocolRevenueService {
 		if (!dustSwept) {
 			dustSwept = await DustSwept.create({
 				id,
+				chain,
 				tokenSymbol: symbol,
 				amount,
 				lastUpdated: timestampToDate(timestamp),

--- a/sdk/packages/indexer/src/services/protocol-revenue.service.ts
+++ b/sdk/packages/indexer/src/services/protocol-revenue.service.ts
@@ -2,10 +2,16 @@ import Decimal from "decimal.js"
 import { ERC6160Ext20Abi__factory } from "@/configs/src/types/contracts"
 import { ProtocolDustCollected } from "@/configs/src/types/models/ProtocolDustCollected"
 import { ProtocolDustSwept } from "@/configs/src/types/models/ProtocolDustSwept"
+import { CumulativeDustCollectedPerChain } from "@/configs/src/types/models/CumulativeDustCollectedPerChain"
+import { CumulativeDustSweptPerChain } from "@/configs/src/types/models/CumulativeDustSweptPerChain"
 import { timestampToDate } from "@/utils/date.helpers"
 import PriceHelper from "@/utils/price.helpers"
 import { TokenPriceService } from "./token-price.service"
 import stringify from "safe-stable-stringify"
+
+/** Decimal places used for the BigInt fixed-point representation of USD amounts. */
+const USD_SCALE = 18
+const USD_SCALE_FACTOR = new Decimal(10).pow(USD_SCALE)
 
 export class ProtocolRevenueService {
 	/**
@@ -19,12 +25,14 @@ export class ProtocolRevenueService {
 	): Promise<ProtocolDustCollected> {
 		const id = `${chain}-${tokenAddress.toLowerCase()}`
 		let symbol = "eth"
+		let decimals = 18
 
-		// Get token symbol if not native token
+		// Get token symbol and decimals if not native token
 		if (tokenAddress.toLowerCase() !== "0x0000000000000000000000000000000000000000") {
 			try {
 				const tokenContract = ERC6160Ext20Abi__factory.connect(tokenAddress, api)
 				symbol = await tokenContract.symbol()
+				decimals = await tokenContract.decimals()
 			} catch (error) {
 				logger.warn(
 					`Failed to get symbol for token ${tokenAddress}: ${stringify({
@@ -52,6 +60,23 @@ export class ProtocolRevenueService {
 
 		await dustCollected.save()
 
+		const usdDelta = await this.computeDustUsdDelta(chain, symbol, amount, decimals)
+		if (usdDelta && usdDelta > 0n) {
+			let cumulative = await CumulativeDustCollectedPerChain.get(chain)
+			if (!cumulative) {
+				cumulative = CumulativeDustCollectedPerChain.create({
+					id: chain,
+					chain,
+					amountUSD: usdDelta,
+					lastUpdatedAt: timestamp,
+				})
+			} else {
+				cumulative.amountUSD = cumulative.amountUSD + usdDelta
+				cumulative.lastUpdatedAt = timestamp
+			}
+			await cumulative.save()
+		}
+
 		logger.info(
 			`DustCollected recorded: ${stringify({
 				id,
@@ -74,12 +99,14 @@ export class ProtocolRevenueService {
 	): Promise<ProtocolDustSwept> {
 		const id = `${chain}-${tokenAddress.toLowerCase()}`
 		let symbol = "eth"
+		let decimals = 18
 
-		// Get token symbol if not native token
+		// Get token symbol and decimals if not native token
 		if (tokenAddress.toLowerCase() !== "0x0000000000000000000000000000000000000000") {
 			try {
 				const tokenContract = ERC6160Ext20Abi__factory.connect(tokenAddress, api)
 				symbol = await tokenContract.symbol()
+				decimals = await tokenContract.decimals()
 			} catch (error) {
 				logger.warn(
 					`Failed to get symbol for token ${tokenAddress}: ${stringify({
@@ -107,6 +134,23 @@ export class ProtocolRevenueService {
 
 		await dustSwept.save()
 
+		const usdDelta = await this.computeDustUsdDelta(chain, symbol, amount, decimals)
+		if (usdDelta && usdDelta > 0n) {
+			let cumulative = await CumulativeDustSweptPerChain.get(chain)
+			if (!cumulative) {
+				cumulative = CumulativeDustSweptPerChain.create({
+					id: chain,
+					chain,
+					amountUSD: usdDelta,
+					lastUpdatedAt: timestamp,
+				})
+			} else {
+				cumulative.amountUSD = cumulative.amountUSD + usdDelta
+				cumulative.lastUpdatedAt = timestamp
+			}
+			await cumulative.save()
+		}
+
 		logger.info(
 			`DustSwept recorded: ${stringify({
 				id,
@@ -116,5 +160,28 @@ export class ProtocolRevenueService {
 		)
 
 		return dustSwept
+	}
+
+	/**
+	 * Convert a newly-collected/swept token amount to a scaled-1e18 USD bigint.
+	 * Returns null when no price data is available (testnet, non-whitelisted, or
+	 * unavailable), so the caller can skip the USD rollup for that token.
+	 */
+	private static async computeDustUsdDelta(
+		chain: string,
+		symbol: string,
+		amount: bigint,
+		decimals: number,
+	): Promise<bigint | null> {
+		const price = await TokenPriceService.getPrice(symbol)
+		if (!price || new Decimal(price).isZero()) {
+			logger.warn(
+				`[ProtocolRevenueService] Skipping USD rollup for ${symbol} on ${chain}: no price data`,
+			)
+			return null
+		}
+
+		const { amountValueInUSD } = PriceHelper.getAmountValueInUSD(amount, decimals, price)
+		return BigInt(new Decimal(amountValueInUSD).mul(USD_SCALE_FACTOR).toFixed(0))
 	}
 }

--- a/sdk/packages/indexer/src/services/protocol-revenue.service.ts
+++ b/sdk/packages/indexer/src/services/protocol-revenue.service.ts
@@ -1,7 +1,7 @@
 import Decimal from "decimal.js"
 import { ERC6160Ext20Abi__factory } from "@/configs/src/types/contracts"
-import { DustCollected } from "@/configs/src/types/models/DustCollected"
-import { DustSwept } from "@/configs/src/types/models/DustSwept"
+import { ProtocolDustCollected } from "@/configs/src/types/models/ProtocolDustCollected"
+import { ProtocolDustSwept } from "@/configs/src/types/models/ProtocolDustSwept"
 import { timestampToDate } from "@/utils/date.helpers"
 import PriceHelper from "@/utils/price.helpers"
 import { TokenPriceService } from "./token-price.service"
@@ -16,7 +16,7 @@ export class ProtocolRevenueService {
 		tokenAddress: string,
 		amount: bigint,
 		timestamp: bigint,
-	): Promise<DustCollected> {
+	): Promise<ProtocolDustCollected> {
 		const id = `${chain}-${tokenAddress.toLowerCase()}`
 		let symbol = "eth"
 
@@ -35,10 +35,10 @@ export class ProtocolRevenueService {
 			}
 		}
 
-		let dustCollected = await DustCollected.get(id)
+		let dustCollected = await ProtocolDustCollected.get(id)
 
 		if (!dustCollected) {
-			dustCollected = await DustCollected.create({
+			dustCollected = await ProtocolDustCollected.create({
 				id,
 				chain,
 				tokenSymbol: symbol,
@@ -71,7 +71,7 @@ export class ProtocolRevenueService {
 		tokenAddress: string,
 		amount: bigint,
 		timestamp: bigint,
-	): Promise<DustSwept> {
+	): Promise<ProtocolDustSwept> {
 		const id = `${chain}-${tokenAddress.toLowerCase()}`
 		let symbol = "eth"
 
@@ -90,10 +90,10 @@ export class ProtocolRevenueService {
 			}
 		}
 
-		let dustSwept = await DustSwept.get(id)
+		let dustSwept = await ProtocolDustSwept.get(id)
 
 		if (!dustSwept) {
-			dustSwept = await DustSwept.create({
+			dustSwept = await ProtocolDustSwept.create({
 				id,
 				chain,
 				tokenSymbol: symbol,

--- a/sdk/packages/indexer/src/services/protocol-revenue.service.ts
+++ b/sdk/packages/indexer/src/services/protocol-revenue.service.ts
@@ -7,11 +7,8 @@ import { CumulativeDustSweptPerChain } from "@/configs/src/types/models/Cumulati
 import { timestampToDate } from "@/utils/date.helpers"
 import PriceHelper from "@/utils/price.helpers"
 import { TokenPriceService } from "./token-price.service"
+import { toScaledUsd } from "./volume.service"
 import stringify from "safe-stable-stringify"
-
-/** Decimal places used for the BigInt fixed-point representation of USD amounts. */
-const USD_SCALE = 18
-const USD_SCALE_FACTOR = new Decimal(10).pow(USD_SCALE)
 
 export class ProtocolRevenueService {
 	/**
@@ -182,6 +179,6 @@ export class ProtocolRevenueService {
 		}
 
 		const { amountValueInUSD } = PriceHelper.getAmountValueInUSD(amount, decimals, price)
-		return BigInt(new Decimal(amountValueInUSD).mul(USD_SCALE_FACTOR).toFixed(0))
+		return toScaledUsd(amountValueInUSD)
 	}
 }

--- a/sdk/packages/indexer/src/services/protocol-revenue.service.ts
+++ b/sdk/packages/indexer/src/services/protocol-revenue.service.ts
@@ -6,7 +6,6 @@ import { CumulativeDustCollectedPerChain } from "@/configs/src/types/models/Cumu
 import { CumulativeDustSweptPerChain } from "@/configs/src/types/models/CumulativeDustSweptPerChain"
 import { timestampToDate } from "@/utils/date.helpers"
 import PriceHelper from "@/utils/price.helpers"
-import { TokenPriceService } from "./token-price.service"
 import { toScaledUsd } from "./volume.service"
 import stringify from "safe-stable-stringify"
 
@@ -57,7 +56,7 @@ export class ProtocolRevenueService {
 
 		await dustCollected.save()
 
-		const usdDelta = await this.computeDustUsdDelta(chain, symbol, amount, decimals)
+		const usdDelta = await this.computeDustUsdDelta(chain, tokenAddress, amount, decimals)
 		if (usdDelta && usdDelta > 0n) {
 			let cumulative = await CumulativeDustCollectedPerChain.get(chain)
 			if (!cumulative) {
@@ -131,7 +130,7 @@ export class ProtocolRevenueService {
 
 		await dustSwept.save()
 
-		const usdDelta = await this.computeDustUsdDelta(chain, symbol, amount, decimals)
+		const usdDelta = await this.computeDustUsdDelta(chain, tokenAddress, amount, decimals)
 		if (usdDelta && usdDelta > 0n) {
 			let cumulative = await CumulativeDustSweptPerChain.get(chain)
 			if (!cumulative) {
@@ -160,25 +159,24 @@ export class ProtocolRevenueService {
 	}
 
 	/**
-	 * Convert a newly-collected/swept token amount to a scaled-1e18 USD bigint.
-	 * Returns null when no price data is available (testnet, non-whitelisted, or
-	 * unavailable), so the caller can skip the USD rollup for that token.
+	 * Convert a newly-collected/swept token amount to a scaled-1e18 USD bigint using the
+	 * on-chain DEX price. Returns null when no price is available, in which case the caller
+	 * skips the USD rollup; the raw amount is still retained on the per-token entity.
 	 */
 	private static async computeDustUsdDelta(
 		chain: string,
-		symbol: string,
+		tokenAddress: string,
 		amount: bigint,
 		decimals: number,
 	): Promise<bigint | null> {
-		const price = await TokenPriceService.getPrice(symbol)
-		if (!price || new Decimal(price).isZero()) {
+		const { amountValueInUSD } = await PriceHelper.getTokenPriceInUSDUniswap(tokenAddress, amount, decimals)
+		if (!amountValueInUSD || new Decimal(amountValueInUSD).isZero()) {
 			logger.warn(
-				`[ProtocolRevenueService] Skipping USD rollup for ${symbol} on ${chain}: no price data`,
+				`[ProtocolRevenueService] No DEX price for ${tokenAddress} on ${chain}; skipping USD rollup, raw amount retained`,
 			)
 			return null
 		}
 
-		const { amountValueInUSD } = PriceHelper.getAmountValueInUSD(amount, decimals, price)
 		return toScaledUsd(amountValueInUSD)
 	}
 }

--- a/sdk/packages/indexer/src/services/volume.service.ts
+++ b/sdk/packages/indexer/src/services/volume.service.ts
@@ -9,7 +9,7 @@ const USD_SCALE = 18
 const USD_SCALE_FACTOR = new Decimal(10).pow(USD_SCALE)
 
 /** Convert a decimal-string USD value (e.g. "1.5") to a scaled BigInt (e.g. 1_500_000_000_000_000_000n). */
-function toScaledUsd(volumeUSD: string): bigint {
+export function toScaledUsd(volumeUSD: string): bigint {
 	return BigInt(new Decimal(volumeUSD).mul(USD_SCALE_FACTOR).toFixed(0))
 }
 

--- a/sdk/packages/indexer/src/utils/price.helpers.ts
+++ b/sdk/packages/indexer/src/utils/price.helpers.ts
@@ -8,6 +8,7 @@ import { ENV_CONFIG, ITokenPriceFeedDetails } from "@/constants"
 import { ChainLinkAggregatorV3Abi__factory } from "@/configs/src/types/contracts"
 import { ethers } from "ethers"
 import { UNISWAP_ADDRESSES } from "@/addresses/uniswap.addresses"
+import { getHostStateMachine } from "@/utils/substrate.helpers"
 import uniswapV2Abi from "@/configs/abis/UniswapV2.abi.json"
 import uniswapV3FactoryAbi from "@/configs/abis/UniswapV3Factory.abi.json"
 import uniswapV3PoolAbi from "@/configs/abis/UniswapV3Pool.abi.json"
@@ -113,7 +114,7 @@ export default class PriceHelper {
 
 			let priceInUSD: string
 			if (isNativeToken) {
-				const nativePrice = await this.getNativeCurrencyPrice(chainId)
+				const nativePrice = await this.getNativeCurrencyPrice(getHostStateMachine(chainId))
 				priceInUSD = new Decimal(nativePrice.toString()).dividedBy(new Decimal(10).pow(18)).toFixed(18)
 			} else {
 				const uniswapPrice = await this.getUniswapPrice(tokenAddress, decimals)
@@ -187,7 +188,7 @@ export default class PriceHelper {
 
 								if (liquidity > BigInt(0)) {
 									const quoter = new ethers.Contract(V3_QUOTER, uniswapV3QuoterV2Abi, api)
-									const quoteResult = await quoter.quoteExactInputSingle({
+									const quoteResult = await quoter.callStatic.quoteExactInputSingle({
 										tokenIn: tokenAddress,
 										tokenOut: quoteToken,
 										fee: fee,
@@ -306,7 +307,7 @@ export default class PriceHelper {
 			throw new Error(`No Uniswap V2, V3, or V4 pair found for token ${tokenAddress}`)
 		} catch (error) {
 			logger.error(`Error getting Uniswap price for ${tokenAddress}: ${error}`)
-			return new Decimal(1)
+			return new Decimal(0)
 		}
 	}
 


### PR DESCRIPTION
Closes #951
Closes #952

Adds a `chain` field to the dust entities and a per-chain USD rollup.

- Add `chain: String! @index` to `ProtocolDustCollected` / `ProtocolDustSwept` (renamed from `DustCollected` / `DustSwept`), threading the resolved host state machine from the event handlers and composing the ID as `${chain}-${tokenAddress}`
- Add `CumulativeDustCollectedPerChain` / `CumulativeDustSweptPerChain` entities tracking a running USD total per chain (1e18 fixed-point, mirroring `CumulativeVolumeUSD`)
- Roll the USD value of each new dust amount into the cumulative entity via `TokenPriceService`; tokens without price data are skipped from the rollup and logged