### PR TITLE
[sdk]: lock StreamingYieldVault deposits during vesting

### DIFF
--- a/docs/content/developers/evm/streaming-yield-vault.mdx
+++ b/docs/content/developers/evm/streaming-yield-vault.mdx
@@ -10,7 +10,7 @@ description: An ERC-4626 vault that distributes yield by streaming it linearly o
 It is a self-contained primitive with **no Hyperbridge/ISMP dependency** — it can be used on any EVM chain on its own.
 
 <Callout type="info">
-The vault assumes a **standard ERC-20** asset: non-rebasing, non-fee-on-transfer, and without transfer callbacks (no ERC-777 hooks). Wrap exotic tokens before using them as the underlying.
+The vault assumes a **standard ERC-20** asset: non-rebasing, non-fee-on-transfer, and without *automatic* transfer callbacks (no ERC-777 `tokensReceived` hooks). [ERC-1363](https://eips.ethereum.org/EIPS/eip-1363) assets are supported and let the owner fund yield in a single transaction (see [Adding yield](#adding-yield)). Wrap exotic tokens before using them as the underlying.
 </Callout>
 
 ## How it works
@@ -136,6 +136,16 @@ function addYield(uint256 amount) external onlyOwner;
 
 It reverts with `YieldStillVesting(vestedAt)` if the previous tranche has not fully vested, `DepositWindowOpen(closesAt)` if it is called during the guaranteed deposit window (before `MIN_WINDOW` has elapsed past the vest end), and `ZeroAmount()` for a zero amount.
 
+### Single-transaction top-ups (ERC-1363)
+
+If the underlying asset is an [ERC-1363](https://eips.ethereum.org/EIPS/eip-1363) ("payable") token, the owner can fund a tranche in **one transaction** via `transferAndCall` — no separate `approve` + `addYield`. The asset transfers to the vault and then calls the vault's `onTransferReceived` hook, which arms the tranche.
+
+```solidity lineNumbers
+asset.transferAndCall(address(vault), amount); // equivalent to approve + addYield
+```
+
+Authorization and guards mirror `addYield`: the funds must come from the **owner** (otherwise it reverts), and a top-up while a tranche is still vesting or inside the deposit window reverts — rolling the transfer back. `onTransferReceived` is callable only by the asset.
+
 ## Reference
 
 | Member | Description |
@@ -147,10 +157,12 @@ It reverts with `YieldStillVesting(vestedAt)` if the previous tranche has not fu
 | `vestedAt()` | Timestamp the active tranche finishes vesting and the deposit window opens. |
 | `nextYieldAt()` | Earliest time the next `addYield` is allowed; close of the guaranteed deposit window. |
 | `maxDeposit` / `maxMint` | `0` while a tranche is vesting (deposits closed), unbounded otherwise. |
+| `onTransferReceived(...)` | ERC-1363 hook; single-tx yield top-up via the asset's `transferAndCall`. Owner + asset only. |
 | `totalAssets()` | `balanceOf(vault) − lockedYield`. |
 | `YieldAdded(amount, vestingStart)` | Emitted when a tranche begins vesting. |
 | `YieldStillVesting(vestedAt)` | Reverts `addYield` while the prior tranche is vesting. |
 | `DepositWindowOpen(closesAt)` | Reverts `addYield` during the guaranteed deposit window. |
+| `CallerNotAsset(caller)` | Reverts `onTransferReceived` when the caller isn't the underlying asset. |
 | `ZeroAmount()` | Reverts `addYield` for a zero amount. |
 
 ## Security considerations

--- a/docs/content/developers/evm/streaming-yield-vault.mdx
+++ b/docs/content/developers/evm/streaming-yield-vault.mdx
@@ -15,7 +15,7 @@ The vault assumes a **standard ERC-20** asset: non-rebasing, non-fee-on-transfer
 
 ## How it works
 
-Yield is not recognized instantly. Instead, each contribution is recognized **linearly over a fixed window** (`VEST`, 23 hours). The exchange rate is:
+Yield is not recognized instantly. Instead, each contribution is recognized **linearly over a fixed window** (`VEST`, 22 hours). The exchange rate is:
 
 ```
 totalAssets = asset.balanceOf(vault) − lockedYield
@@ -26,6 +26,8 @@ where `lockedYield` is the not-yet-vested portion of the current tranche. This d
 - **No yield sniping.** Because recognition is keyed on `block.timestamp`, a deposit and withdrawal in the *same block* observe an identical share price and capture nothing. An attacker can only collect the dust that vests across blocks while bearing real exposure — so they can't sandwich a yield event.
 - **No instant jump.** Adding yield never moves `totalAssets` in the same block; it only raises the price as the tranche vests.
 - **No backlog.** `addYield` reverts until the previous tranche has fully vested, so tranches never overlap and no yield is left permanently locked.
+- **No mid-tranche dilution.** Deposits and mints are **disabled while a tranche is vesting** — `maxDeposit`/`maxMint` report `0` and `deposit`/`mint` revert. New capital can only enter *after* a tranche fully vests and *before* the next `addYield`, so a latecomer never shares yield meant for the holders already in.
+- **A guaranteed deposit window.** `addYield` must wait at least `MIN_WINDOW` (2 hours) past the end of vesting, so every cycle has a deposit window of at least `MIN_WINDOW` regardless of how promptly the keeper runs. The window is the interval `[vestedAt(), nextYieldAt()]`.
 
 The first-depositor inflation/donation attack is mitigated with OpenZeppelin's virtual shares/assets (a non-zero decimals offset). A **seed-and-burn** at deployment is still recommended.
 
@@ -66,12 +68,12 @@ StreamingYieldVault vault = new StreamingYieldVault(
     IERC20(USDC),        // underlying asset (standard ERC-20)
     "Yield USDC",        // share token name
     "yUSDC",             // share token symbol
-    MULTISIG             // owner (controls addYield, pause/unpause)
+    MULTISIG             // owner (controls addYield)
 );
 ```
 
 <Callout type="warn">
-Set the owner to a **multisig or timelock**, never an EOA. The owner can pause the vault and supply yield.
+Set the owner to a **multisig or timelock**, never an EOA. The owner supplies yield via `addYield`.
 </Callout>
 </Step>
 <Step>
@@ -88,14 +90,14 @@ vault.transfer(address(0xdead), shares); // burn
 <Step>
 ### Schedule yield top-ups
 
-Have your treasury/keeper call `addYield` on a regular cadence (e.g. daily). Because `VEST` is 23h, scheduling daily leaves margin so the call never reverts on the vesting guard.
+Have your treasury/keeper call `addYield` on a regular cadence (e.g. daily). With `VEST = 22h` and `MIN_WINDOW = 2h` the minimum cadence is **24h**: `addYield` reverts until the prior tranche has vested *and* its 2h deposit window has elapsed, which keeps a deposit window open every cycle.
 
 ```solidity lineNumbers
 IERC20(USDC).approve(address(vault), amount);
-vault.addYield(amount); // owner only; reverts if the prior tranche is still vesting
+vault.addYield(amount); // owner only; reverts while the prior tranche vests or its deposit window is open
 ```
 
-Use the `vestedAt()` view to know the earliest time the next `addYield` is allowed.
+Use `nextYieldAt()` for the earliest time the next `addYield` is allowed, and `vestedAt()` for when the deposit window opens.
 </Step>
 </Steps>
 
@@ -107,6 +109,10 @@ The vault is a standard ERC-4626, so integrators use the usual entrypoints. Depo
 asset.approve(address(vault), amount);
 uint256 shares = vault.deposit(amount, receiver); // fixed asset amount in
 ```
+
+<Callout type="info">
+Deposits and mints are only open **between tranches** — after a tranche fully vests and before the next `addYield`. While a tranche is vesting, `maxDeposit`/`maxMint` return `0` and `deposit`/`mint` revert with the standard `ERC4626ExceededMaxDeposit`/`ERC4626ExceededMaxMint`. Check `maxDeposit(receiver)` (or `vestedAt()`/`nextYieldAt()`) to find the open window. Withdrawals and redeems are always available.
+</Callout>
 
 Exiting uses `redeem` (clean full exit) or `withdraw` (fixed asset amount out):
 
@@ -128,40 +134,30 @@ uint256 burned = vault.withdraw(assets, receiver, owner);
 function addYield(uint256 amount) external onlyOwner;
 ```
 
-It reverts with `YieldStillVesting(vestedAt)` if the previous tranche has not fully vested, and `ZeroAmount()` for a zero amount. Yield may be added while the vault is paused — it simply can't be withdrawn until unpaused.
-
-## Pausing
-
-The owner can freeze all share movement — transfers, deposits, and withdrawals — in an emergency. Pausing is enforced at a single `_update` chokepoint that every mint, burn, and transfer flows through.
-
-```solidity lineNumbers
-vault.pause();    // owner only — blocks transfers, deposits, withdrawals
-vault.unpause();  // owner only — restores share movement
-```
-
-<Callout type="warn">
-While paused, holders **cannot withdraw**. Treat the pause as an emergency stop and restrict it to a trusted owner.
-</Callout>
+It reverts with `YieldStillVesting(vestedAt)` if the previous tranche has not fully vested, `DepositWindowOpen(closesAt)` if it is called during the guaranteed deposit window (before `MIN_WINDOW` has elapsed past the vest end), and `ZeroAmount()` for a zero amount.
 
 ## Reference
 
 | Member | Description |
 | --- | --- |
-| `VEST` | Vesting window per tranche (constant, `23 hours`). Keep `≤` your `addYield` cadence. |
+| `VEST` | Vesting window per tranche (constant, `22 hours`). |
+| `MIN_WINDOW` | Minimum gap `addYield` must leave after the vest end (constant, `2 hours`); guarantees a deposit window each cycle. Minimum cadence is `VEST + MIN_WINDOW` (24h). |
 | `addYield(uint256)` | Owner-only; streams a yield tranche over `VEST`. |
 | `lockedYield()` | The not-yet-recognized portion of the active tranche. |
-| `vestedAt()` | Timestamp the active tranche finishes vesting / next `addYield` is allowed. |
-| `pause()` / `unpause()` | Owner-only emergency stop for all share movement. |
+| `vestedAt()` | Timestamp the active tranche finishes vesting and the deposit window opens. |
+| `nextYieldAt()` | Earliest time the next `addYield` is allowed; close of the guaranteed deposit window. |
+| `maxDeposit` / `maxMint` | `0` while a tranche is vesting (deposits closed), unbounded otherwise. |
 | `totalAssets()` | `balanceOf(vault) − lockedYield`. |
 | `YieldAdded(amount, vestingStart)` | Emitted when a tranche begins vesting. |
 | `YieldStillVesting(vestedAt)` | Reverts `addYield` while the prior tranche is vesting. |
+| `DepositWindowOpen(closesAt)` | Reverts `addYield` during the guaranteed deposit window. |
 | `ZeroAmount()` | Reverts `addYield` for a zero amount. |
 
 ## Security considerations
 
 - **Standard ERC-20 only.** Fee-on-transfer and rebasing assets desync the vault's accounting; ERC-777 callbacks reintroduce reentrancy vectors the design otherwise avoids.
 - **Seed-and-burn at deploy.** Combined with the decimals offset, this removes the empty-vault inflation attack.
-- **Tune `VEST` to your cadence.** It must be `≤` the interval between `addYield` calls; otherwise the guard rejects timely top-ups. 23h suits a daily cadence.
-- **Owner is trusted.** The owner can pause withdrawals and supply yield — use a multisig/timelock.
+- **Mind the cadence.** Minimum cadence is `VEST + MIN_WINDOW` (24h): `addYield` reverts until the prior tranche has vested *and* its deposit window has elapsed. Deposits are closed while a tranche vests, so capital enters in bursts during the window.
+- **Owner is trusted.** The owner supplies yield via `addYield` — use a multisig/timelock.
 
-The contract is covered by an extensive Foundry suite exercising the inflation attack, yield sniping, vesting math, the `addYield` guard, the pause chokepoint, access control, and ERC-4626 rounding/preview parity.
+The contract is covered by an extensive Foundry suite exercising the inflation attack, yield sniping, vesting math, the `addYield` guard, the deposit lock and guaranteed window, access control, and ERC-4626 rounding/preview parity.

--- a/sdk/packages/core/contracts/vaults/StreamingYieldVault.sol
+++ b/sdk/packages/core/contracts/vaults/StreamingYieldVault.sol
@@ -18,7 +18,6 @@ import {ERC4626} from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.so
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
-import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 
 /// @title StreamingYieldVault
 /// @author Polytope Labs (hello@polytope.technology)
@@ -28,23 +27,29 @@ import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 ///         around a yield event ("yield sniping"): a same-block deposit/withdraw sees an
 ///         unchanged share price and captures nothing.
 ///
-/// @dev Design notes:
-///      - The exchange rate is `(balanceOf(this) - lockedYield) / totalSupply`. Yield that has
-///        not yet vested is masked out of `totalAssets`, so it cannot be claimed early.
-///      - The owner may `pause()` to freeze all share movement (transfers, deposits, withdrawals)
-///        in an emergency. Yield may still be added while paused; it simply cannot be withdrawn.
-///      - The first-depositor inflation/donation attack is mitigated by OpenZeppelin's virtual
-///        shares/assets via a non-zero `_decimalsOffset()`. Seed-and-burn at deployment as well.
-///      - No reentrancy guard is used: the only external calls are `transfer`/`transferFrom` on
-///        the asset, and OpenZeppelin's ERC4626 orders effects before interactions. This assumes
-///        a standard, non-rebasing, non-fee-on-transfer, non-hooked (no ERC-777 callbacks) asset.
-contract StreamingYieldVault is ERC4626, Pausable, Ownable {
+/// @dev The exchange rate is `(balanceOf(this) - lockedYield) / totalSupply`. Yield that has
+///      not yet vested is masked out of `totalAssets`, so it cannot be claimed early.
+///
+///      Deposits and mints are disabled while a tranche is vesting. New capital may only enter
+///      in the window after a tranche fully vests and before the next `addYield`, so no one can
+///      join mid-tranche and capture yield meant for the holders present when it began. `addYield`
+///      must wait `MIN_WINDOW` past the vest end, guaranteeing that window exists every cycle
+///      regardless of keeper timing.
+contract StreamingYieldVault is ERC4626, Ownable {
     using SafeERC20 for IERC20;
 
-    /// @notice Window over which each yield tranche is linearly recognized.
-    /// @dev Keep `VEST <= the cadence at which `addYield` is called`. For ~24h cadence, 23h
-    ///      maximizes anti-snipe protection while leaving margin for keeper jitter.
-    uint256 public constant VEST = 23 hours;
+    /// @notice Window over which each yield tranche is linearly recognized. Deposits and mints are
+    ///         disabled while a tranche vests (`maxDeposit`/`maxMint` report 0), so `VEST` must end
+    ///         before the next `addYield` to leave a window for new capital to enter. With
+    ///         `MIN_WINDOW = 2h`, a 22h vest yields a 24h minimum cadence and a guaranteed 2h
+    ///         deposit window each cycle.
+    uint256 public constant VEST = 22 hours;
+
+    /// @notice Minimum time `addYield` must wait after the current tranche finishes vesting before
+    ///         it may start the next one. Because `addYield` cannot fire during this stretch, every
+    ///         cycle has a guaranteed deposit window of at least `MIN_WINDOW`, independent of how
+    ///         eagerly the keeper runs. Minimum cadence is therefore `VEST + MIN_WINDOW`.
+    uint256 public constant MIN_WINDOW = 2 hours;
 
     /// @dev Virtual-share offset hardening the first-depositor inflation attack. Shares carry
     ///      `assetDecimals + DECIMALS_OFFSET` decimals.
@@ -63,6 +68,10 @@ contract StreamingYieldVault is ERC4626, Pausable, Ownable {
     /// @notice Thrown when `addYield` is called with a zero amount.
     error ZeroAmount();
 
+    /// @notice Thrown when `addYield` is called during the guaranteed deposit window, before
+    ///         `MIN_WINDOW` has elapsed past the end of the previous tranche's vesting.
+    error DepositWindowOpen(uint256 closesAt);
+
     /// @notice Emitted when a new yield tranche begins vesting.
     event YieldAdded(uint256 amount, uint256 vestingStart);
 
@@ -77,18 +86,59 @@ contract StreamingYieldVault is ERC4626, Pausable, Ownable {
     function totalAssets() public view override returns (uint256) {
         return IERC20(asset()).balanceOf(address(this)) - _lockedYield();
     }
+    
+    /// @inheritdoc ERC4626
+    function _decimalsOffset() internal pure override returns (uint8) {
+        return DECIMALS_OFFSET;
+    }
 
     /// @notice The portion of the current tranche that has not yet been recognized.
     function lockedYield() external view returns (uint256) {
         return _lockedYield();
     }
 
-    /// @notice The timestamp at which the current tranche finishes vesting, which is also the
-    ///         earliest time `addYield` may be called again.
+    /// @notice The timestamp at which the current tranche finishes vesting. Deposits open at this
+    ///         time; `addYield` may only be called from `nextYieldAt()` onward.
     function vestedAt() external view returns (uint256) {
         return _vestingStart + VEST;
     }
 
+    /// @notice The earliest time the next `addYield` may be called. The interval
+    ///         `[vestedAt(), nextYieldAt()]` is the guaranteed deposit window for each cycle.
+    function nextYieldAt() external view returns (uint256) {
+        return _vestingStart + VEST + MIN_WINDOW;
+    }
+
+    /// @dev True while the current tranche is still vesting, i.e. deposits are locked. Returns
+    ///      false before the first tranche has ever been added (`_vestingStart == 0`).
+    function _isVesting() internal view returns (bool) {
+        uint256 start = _vestingStart;
+        return start != 0 && block.timestamp < start + VEST;
+    }
+
+    /// @inheritdoc ERC4626
+    /// @dev Zero while a tranche is vesting so deposits are closed (and integrators can detect it);
+    ///      unbounded otherwise. This is the single lock that keeps new capital from joining
+    ///      mid-tranche: `deposit` reverts at its `maxDeposit` check with `ERC4626ExceededMaxDeposit`.
+    function maxDeposit(address) public view override returns (uint256) {
+        return _isVesting() ? 0 : type(uint256).max;
+    }
+
+    /// @inheritdoc ERC4626
+    /// @dev Zero while a tranche is vesting so integrators see mints are closed; unbounded otherwise.
+    function maxMint(address) public view override returns (uint256) {
+        return _isVesting() ? 0 : type(uint256).max;
+    }
+
+    /// @dev Linear unlock of the current tranche, keyed on `block.timestamp` so that a deposit
+    ///      and withdrawal within the same block observe an identical, unchanged share price.
+    function _lockedYield() internal view returns (uint256) {
+        uint256 start = _vestingStart;
+        uint256 elapsed = block.timestamp - start;
+        if (elapsed >= VEST) return 0;
+        return (_vestingAmount * (VEST - elapsed)) / VEST;
+    }
+    
     /// @notice Add a new yield tranche, pulled from the caller. Reverts unless the previous
     ///         tranche has fully vested, which guarantees tranches never overlap and no yield
     ///         is ever left permanently locked.
@@ -97,8 +147,11 @@ contract StreamingYieldVault is ERC4626, Pausable, Ownable {
         if (amount == 0) revert ZeroAmount();
 
         uint256 start = _vestingStart;
-        if (start != 0 && block.timestamp < start + VEST) {
-            revert YieldStillVesting(start + VEST);
+        if (start != 0) {
+            if (block.timestamp < start + VEST) revert YieldStillVesting(start + VEST);
+            // Hold off until the guaranteed deposit window has elapsed, so new capital always has
+            // a chance to enter between tranches regardless of how promptly the keeper runs.
+            if (block.timestamp < start + VEST + MIN_WINDOW) revert DepositWindowOpen(start + VEST + MIN_WINDOW);
         }
 
         // Pull the funds first so `balanceOf` already reflects `amount` before it is marked
@@ -110,34 +163,5 @@ contract StreamingYieldVault is ERC4626, Pausable, Ownable {
         _vestingStart = block.timestamp;
 
         emit YieldAdded(amount, block.timestamp);
-    }
-
-    /// @notice Freeze all share movement (transfers, deposits, withdrawals) in an emergency.
-    function pause() external onlyOwner {
-        _pause();
-    }
-
-    /// @notice Resume share movement.
-    function unpause() external onlyOwner {
-        _unpause();
-    }
-
-    /// @dev Linear unlock of the current tranche, keyed on `block.timestamp` so that a deposit
-    ///      and withdrawal within the same block observe an identical, unchanged share price.
-    function _lockedYield() internal view returns (uint256) {
-        uint256 start = _vestingStart;
-        uint256 elapsed = block.timestamp - start;
-        if (elapsed >= VEST) return 0;
-        return (_vestingAmount * (VEST - elapsed)) / VEST;
-    }
-
-    /// @inheritdoc ERC4626
-    function _decimalsOffset() internal pure override returns (uint8) {
-        return DECIMALS_OFFSET;
-    }
-
-    /// @dev Single chokepoint for all share movement (mint, burn, transfer); gated by the pause.
-    function _update(address from, address to, uint256 value) internal override whenNotPaused {
-        super._update(from, to, value);
     }
 }

--- a/sdk/packages/core/contracts/vaults/StreamingYieldVault.sol
+++ b/sdk/packages/core/contracts/vaults/StreamingYieldVault.sol
@@ -18,6 +18,7 @@ import {ERC4626} from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.so
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {IERC1363Receiver} from "@openzeppelin/contracts/interfaces/IERC1363Receiver.sol";
 
 /// @title StreamingYieldVault
 /// @author Polytope Labs (hello@polytope.technology)
@@ -35,7 +36,11 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 ///      join mid-tranche and capture yield meant for the holders present when it began. `addYield`
 ///      must wait `MIN_WINDOW` past the vest end, guaranteeing that window exists every cycle
 ///      regardless of keeper timing.
-contract StreamingYieldVault is ERC4626, Ownable {
+///
+///      When the underlying asset is an ERC-1363 token, the owner can fund a tranche in a single
+///      transaction with `asset.transferAndCall(vault, amount)` (no separate `approve` + `addYield`)
+///      via the `onTransferReceived` hook, subject to the same authorization and guards as `addYield`.
+contract StreamingYieldVault is ERC4626, Ownable, IERC1363Receiver {
     using SafeERC20 for IERC20;
 
     /// @notice Window over which each yield tranche is linearly recognized. Deposits and mints are
@@ -71,6 +76,9 @@ contract StreamingYieldVault is ERC4626, Ownable {
     /// @notice Thrown when `addYield` is called during the guaranteed deposit window, before
     ///         `MIN_WINDOW` has elapsed past the end of the previous tranche's vesting.
     error DepositWindowOpen(uint256 closesAt);
+
+    /// @notice Thrown when `onTransferReceived` is called by anything other than the vault's asset.
+    error CallerNotAsset(address caller);
 
     /// @notice Emitted when a new yield tranche begins vesting.
     event YieldAdded(uint256 amount, uint256 vestingStart);
@@ -130,6 +138,28 @@ contract StreamingYieldVault is ERC4626, Ownable {
         return _isVesting() ? 0 : type(uint256).max;
     }
 
+    /// @inheritdoc IERC1363Receiver
+    /// @notice ERC-1363 single-transaction yield top-up. With an ERC-1363 underlying asset, the
+    ///         owner can call `asset.transferAndCall(vault, amount)` to fund a yield tranche in one
+    ///         transaction (no separate `approve` + `addYield`). The asset moves `amount` to the
+    ///         vault and then invokes this, which begins streaming it over `VEST`.
+    /// @dev Only the underlying asset may call this, and the funds must come `from` the owner — the
+    ///      same authorization as `addYield`. The funds are already in the vault when this runs, so
+    ///      the tranche is armed without pulling again, subject to the same no-overlap / window
+    ///      guards as `addYield`; a revert rolls the transfer back.
+    function onTransferReceived(address, address from, uint256 value, bytes calldata)
+        external
+        override
+        returns (bytes4)
+    {
+        if (msg.sender != asset()) revert CallerNotAsset(msg.sender);
+        if (from != owner()) revert OwnableUnauthorizedAccount(from);
+
+        _startVesting(value);
+
+        return IERC1363Receiver.onTransferReceived.selector;
+    }
+
     /// @dev Linear unlock of the current tranche, keyed on `block.timestamp` so that a deposit
     ///      and withdrawal within the same block observe an identical, unchanged share price.
     function _lockedYield() internal view returns (uint256) {
@@ -144,6 +174,18 @@ contract StreamingYieldVault is ERC4626, Ownable {
     ///         is ever left permanently locked.
     /// @param amount The amount of `asset` to stream in over `VEST`.
     function addYield(uint256 amount) external onlyOwner {
+        // Pull the funds first so `balanceOf` already reflects `amount` before it is marked
+        // locked; otherwise `totalAssets` would transiently underflow when a tranche exceeds
+        // the current backing (e.g. the very first `addYield` on a near-empty vault).
+        IERC20(asset()).safeTransferFrom(msg.sender, address(this), amount);
+
+        _startVesting(amount);
+    }
+
+    /// @dev Arms a new tranche after validating the no-overlap / deposit-window guards. The caller
+    ///      must have already moved `amount` of `asset` into the vault (so `balanceOf` reflects it
+    ///      before `_vestingAmount` is set, avoiding a transient `totalAssets` underflow).
+    function _startVesting(uint256 amount) private {
         if (amount == 0) revert ZeroAmount();
 
         uint256 start = _vestingStart;
@@ -153,11 +195,6 @@ contract StreamingYieldVault is ERC4626, Ownable {
             // a chance to enter between tranches regardless of how promptly the keeper runs.
             if (block.timestamp < start + VEST + MIN_WINDOW) revert DepositWindowOpen(start + VEST + MIN_WINDOW);
         }
-
-        // Pull the funds first so `balanceOf` already reflects `amount` before it is marked
-        // locked; otherwise `totalAssets` would transiently underflow when a tranche exceeds
-        // the current backing (e.g. the very first `addYield` on a near-empty vault).
-        IERC20(asset()).safeTransferFrom(msg.sender, address(this), amount);
 
         _vestingAmount = amount;
         _vestingStart = block.timestamp;

--- a/sdk/packages/core/test/StreamingYieldVault.t.sol
+++ b/sdk/packages/core/test/StreamingYieldVault.t.sol
@@ -15,9 +15,9 @@ pragma solidity ^0.8.17;
 
 import {Test} from "forge-std/Test.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC4626} from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
-import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 
 import {StreamingYieldVault} from "../contracts/vaults/StreamingYieldVault.sol";
 
@@ -48,7 +48,8 @@ contract StreamingYieldVaultTest is Test {
     address internal attacker = makeAddr("attacker");
     address internal seeder = makeAddr("seeder");
 
-    uint256 internal constant VEST = 23 hours;
+    uint256 internal constant VEST = 22 hours;
+    uint256 internal constant MIN_WINDOW = 2 hours;
     uint256 internal constant OFFSET = 6;
 
     function setUp() public {
@@ -262,11 +263,30 @@ contract StreamingYieldVaultTest is Test {
         vault.addYield(100 ether);
     }
 
-    function test_AddYield_allowedExactlyAtVestedAt() public {
+    /// @notice After the vest ends, `addYield` is still blocked throughout the guaranteed deposit
+    ///         window, so new capital always has a chance to enter.
+    function test_AddYield_revertsDuringDepositWindow() public {
         _seedAndBurn(1_000 ether);
         _addYield(100 ether);
 
-        vm.warp(vault.vestedAt());
+        uint256 closesAt = vault.nextYieldAt();
+
+        vm.warp(vault.vestedAt()); // window just opened
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(StreamingYieldVault.DepositWindowOpen.selector, closesAt));
+        vault.addYield(50 ether);
+
+        vm.warp(closesAt - 1); // one second before it closes
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(StreamingYieldVault.DepositWindowOpen.selector, closesAt));
+        vault.addYield(50 ether);
+    }
+
+    function test_AddYield_allowedAtNextYieldAt() public {
+        _seedAndBurn(1_000 ether);
+        _addYield(100 ether);
+
+        vm.warp(vault.nextYieldAt());
         _addYield(50 ether); // must not revert
     }
 
@@ -280,6 +300,7 @@ contract StreamingYieldVaultTest is Test {
         vm.warp(block.timestamp + VEST);
         assertEq(vault.totalAssets(), base + 100 ether, "first tranche not fully recognized");
 
+        vm.warp(block.timestamp + MIN_WINDOW); // clear the guaranteed deposit window before re-arming
         _addYield(40 ether);
         assertEq(vault.lockedYield(), 40 ether, "second tranche did not start at full lock");
         vm.warp(block.timestamp + VEST);
@@ -333,7 +354,9 @@ contract StreamingYieldVaultTest is Test {
     function test_previewParity() public {
         _seedAndBurn(1_000 ether);
         _addYield(100 ether);
-        vm.warp(block.timestamp + VEST / 3);
+        // Deposits are locked while vesting, so exercise parity in the post-vest window where the
+        // price already reflects the fully recognized tranche.
+        vm.warp(vault.vestedAt());
 
         uint256 pd = vault.previewDeposit(123 ether);
         uint256 shares = _deposit(bob, 123 ether);
@@ -350,201 +373,116 @@ contract StreamingYieldVaultTest is Test {
     }
 
     // --------------------------------------------------------------------------------------
-    // 7. pausing
+    // 7. deposit lock while vesting + guaranteed deposit window
+    //
+    // Deposits/mints are disabled while a tranche vests, so no one joins mid-tranche and shares
+    // the in-flight yield. `addYield` must then wait `MIN_WINDOW` past the vest end, guaranteeing
+    // a deposit window every cycle regardless of how eagerly the keeper re-arms.
     // --------------------------------------------------------------------------------------
 
-    function test_Pause_blocksShareTransfer() public {
-        _seedAndBurn(1_000 ether);
-        _deposit(alice, 100 ether);
-
-        vm.prank(owner);
-        vault.pause();
-
-        vm.prank(alice);
-        vm.expectRevert(Pausable.EnforcedPause.selector);
-        vault.transfer(bob, 1);
+    /// @notice Test constants track the contract; the guards below assume this parity.
+    function test_constants_match() public view {
+        assertEq(vault.VEST(), VEST, "VEST drift");
+        assertEq(vault.MIN_WINDOW(), MIN_WINDOW, "MIN_WINDOW drift");
+        assertEq(vault.nextYieldAt(), vault.vestedAt() + MIN_WINDOW, "window math");
     }
 
-    function test_Pause_blocksDeposit() public {
-        vm.prank(owner);
-        vault.pause();
+    /// @notice Before any tranche exists (`_vestingStart == 0`) deposits are open, so the vault can
+    ///         be bootstrapped.
+    function test_Deposit_allowedBeforeFirstYield() public {
+        assertEq(vault.maxDeposit(alice), type(uint256).max);
+        assertGt(_deposit(alice, 100 ether), 0);
+    }
 
+    /// @notice A deposit while a tranche is vesting is blocked: `maxDeposit` is 0, so `deposit`
+    ///         reverts at its limit check with the standard ERC-4626 error.
+    function test_Deposit_revertsWhileVesting() public {
+        _seedAndBurn(1_000 ether);
+        _addYield(100 ether);
+
+        vm.warp(block.timestamp + VEST / 2);
         vm.prank(alice);
-        vm.expectRevert(Pausable.EnforcedPause.selector);
+        vm.expectRevert(abi.encodeWithSelector(ERC4626.ERC4626ExceededMaxDeposit.selector, alice, 100 ether, 0));
         vault.deposit(100 ether, alice);
     }
 
-    function test_Pause_blocksWithdraw() public {
+    /// @notice `mint` is gated by `maxMint` the same way.
+    function test_Mint_revertsWhileVesting() public {
         _seedAndBurn(1_000 ether);
-        uint256 shares = _deposit(alice, 100 ether);
-
-        vm.prank(owner);
-        vault.pause();
-
-        vm.prank(alice);
-        vm.expectRevert(Pausable.EnforcedPause.selector);
-        vault.redeem(shares, alice, alice);
-    }
-
-    function test_Unpause_restoresShareMovement() public {
-        _seedAndBurn(1_000 ether);
-        _deposit(alice, 100 ether);
-
-        vm.prank(owner);
-        vault.pause();
-        vm.prank(owner);
-        vault.unpause();
-
-        vm.prank(alice);
-        vault.transfer(bob, 1); // must not revert
-        assertEq(vault.balanceOf(bob), 1);
-    }
-
-    function test_Pause_onlyOwner() public {
-        vm.prank(attacker);
-        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, attacker));
-        vault.pause();
-    }
-
-    function test_Unpause_onlyOwner() public {
-        vm.prank(owner);
-        vault.pause();
-
-        vm.prank(attacker);
-        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, attacker));
-        vault.unpause();
-    }
-
-    /// @notice Adding yield touches no shares, so it remains possible while paused; the funds
-    ///         simply cannot be withdrawn until the vault is unpaused.
-    function test_AddYield_worksWhilePaused() public {
-        _seedAndBurn(1_000 ether);
-
-        vm.prank(owner);
-        vault.pause();
-
         _addYield(100 ether);
-        vm.warp(block.timestamp + VEST);
-        assertApproxEqAbs(vault.totalAssets(), 1_000 ether + 100 ether, 1e6);
-    }
 
-    // --------------------------------------------------------------------------------------
-    // 8. the `_update` chokepoint
-    //
-    // Every share movement — mint (deposit/mint), burn (withdraw/redeem) and transfer
-    // (transfer/transferFrom) — funnels through `_update`. These tests assert each distinct
-    // entry into `_update` is gated, that the gate sits at `_update` itself (so even a
-    // zero-value move reverts), and that it is a pure no-op when unpaused.
-    // --------------------------------------------------------------------------------------
-
-    /// @notice The share-denominated mint path (`mint`) hits `_update` via `_mint`.
-    function test_Pause_chokepoint_blocksMint() public {
-        _seedAndBurn(1_000 ether);
-
-        vm.prank(owner);
-        vault.pause();
-
+        vm.warp(block.timestamp + VEST / 2);
         vm.prank(alice);
-        vm.expectRevert(Pausable.EnforcedPause.selector);
+        vm.expectRevert(abi.encodeWithSelector(ERC4626.ERC4626ExceededMaxMint.selector, alice, 100 ether, 0));
         vault.mint(100 ether, alice);
     }
 
-    /// @notice The asset-denominated burn path (`withdraw`) hits `_update` via `_burn`.
-    function test_Pause_chokepoint_blocksWithdrawByAssets() public {
+    /// @notice The lock lifts at the vest end; deposits succeed throughout the window, right up to
+    ///         the moment the next tranche could be armed.
+    function test_Deposit_succeedsAcrossWholeWindow() public {
         _seedAndBurn(1_000 ether);
-        _deposit(alice, 100 ether);
+        _addYield(100 ether);
 
-        vm.prank(owner);
-        vault.pause();
+        vm.warp(vault.vestedAt()); // window opens
+        assertGt(_deposit(alice, 100 ether), 0, "deposit blocked at window open");
 
-        vm.prank(alice);
-        vm.expectRevert(Pausable.EnforcedPause.selector);
-        vault.withdraw(50 ether, alice, alice);
+        vm.warp(vault.nextYieldAt()); // last moment before addYield can fire
+        assertGt(_deposit(bob, 100 ether), 0, "deposit blocked later in window");
     }
 
-    /// @notice The delegated-transfer path (`transferFrom`) hits `_update` via `_transfer`.
-    function test_Pause_chokepoint_blocksTransferFrom() public {
+    /// @notice `maxDeposit`/`maxMint` report 0 while vesting and unbounded otherwise, so integrators
+    ///         can detect the closed window instead of hitting a surprise revert.
+    function test_MaxDepositMint_reflectLock() public {
         _seedAndBurn(1_000 ether);
-        uint256 shares = _deposit(alice, 100 ether);
+        _addYield(100 ether);
 
-        vm.prank(alice);
-        vault.approve(bob, shares);
+        vm.warp(block.timestamp + VEST / 2);
+        assertEq(vault.maxDeposit(alice), 0, "maxDeposit not zero while vesting");
+        assertEq(vault.maxMint(alice), 0, "maxMint not zero while vesting");
 
-        vm.prank(owner);
-        vault.pause();
-
-        vm.prank(bob);
-        vm.expectRevert(Pausable.EnforcedPause.selector);
-        vault.transferFrom(alice, bob, shares);
+        vm.warp(vault.vestedAt());
+        assertEq(vault.maxDeposit(alice), type(uint256).max, "maxDeposit still zero in window");
+        assertEq(vault.maxMint(alice), type(uint256).max, "maxMint still zero in window");
     }
 
-    /// @notice The gate lives in `_update`, not in any amount-specific branch: even a zero-value
-    ///         transfer (which still calls `_update`) reverts while paused.
-    function test_Pause_chokepoint_blocksZeroValueTransfer() public {
+    /// @notice The window is guaranteed: the instant vesting ends, an eager keeper's `addYield`
+    ///         still reverts while deposits are open — the window cannot be squeezed shut.
+    function test_GuaranteedWindow_keeperCannotSqueezeShut() public {
         _seedAndBurn(1_000 ether);
-        _deposit(alice, 100 ether);
+        _addYield(100 ether);
 
+        vm.warp(vault.vestedAt());
+        uint256 closesAt = vault.nextYieldAt(); // read before prank so the view call doesn't consume it
         vm.prank(owner);
-        vault.pause();
+        vm.expectRevert(abi.encodeWithSelector(StreamingYieldVault.DepositWindowOpen.selector, closesAt));
+        vault.addYield(100 ether);
 
-        vm.prank(alice);
-        vm.expectRevert(Pausable.EnforcedPause.selector);
-        vault.transfer(bob, 0);
+        assertEq(vault.maxDeposit(alice), type(uint256).max, "deposits not open during window");
+        assertGt(_deposit(alice, 100 ether), 0);
     }
 
-    /// @notice `paused()` tracks the toggle, and the chokepoint re-engages after a pause/unpause
-    ///         cycle (no sticky state).
-    function test_Pause_chokepoint_isRepausable() public {
+    /// @notice End-to-end: a depositor who enters in the window captures none of the tranche that
+    ///         was already streaming when they arrived, but earns the next one. Because no one can
+    ///         join mid-vest, the in-flight tranche stays with the prior holders.
+    function test_WindowDepositor_earnsNextTrancheNotCurrent() public {
         _seedAndBurn(1_000 ether);
-        _deposit(alice, 100 ether);
+        _deposit(alice, 1_000 ether); // present for tranche 1
 
-        assertFalse(vault.paused());
+        _addYield(100 ether); // tranche 1 — streams only to seed + alice
+        vm.warp(vault.vestedAt());
 
-        vm.prank(owner);
-        vault.pause();
-        assertTrue(vault.paused());
+        // Window: bob joins for the next cycle and records what he can immediately redeem.
+        uint256 aliceAfterT1 = vault.convertToAssets(vault.balanceOf(alice));
+        uint256 bobShares = _deposit(bob, 1_000 ether);
+        uint256 bobIn = vault.convertToAssets(bobShares);
+        assertApproxEqAbs(bobIn, 1_000 ether, 1e6, "window depositor did not enter at par");
 
-        vm.prank(owner);
-        vault.unpause();
-        assertFalse(vault.paused());
+        // Arm tranche 2 and let it fully vest.
+        vm.warp(vault.nextYieldAt());
+        _addYield(100 ether);
+        vm.warp(vault.vestedAt());
 
-        // pause again — movement must be blocked once more
-        vm.prank(owner);
-        vault.pause();
-        assertTrue(vault.paused());
-
-        vm.prank(alice);
-        vm.expectRevert(Pausable.EnforcedPause.selector);
-        vault.transfer(bob, 1);
-    }
-
-    /// @notice When unpaused the chokepoint is a no-op: every `_update` path (mint, transferFrom,
-    ///         burn) succeeds.
-    function test_Unpause_chokepoint_allPathsFlow() public {
-        _seedAndBurn(1_000 ether);
-
-        vm.prank(owner);
-        vault.pause();
-        vm.prank(owner);
-        vault.unpause();
-
-        // mint (mint -> _mint -> _update); mint() takes a share amount and returns assets paid
-        vm.prank(alice);
-        vault.mint(100 ether, alice);
-        uint256 shares = vault.balanceOf(alice);
-        assertEq(shares, 100 ether);
-
-        // transferFrom (-> _transfer -> _update)
-        vm.prank(alice);
-        vault.approve(bob, shares);
-        vm.prank(bob);
-        vault.transferFrom(alice, bob, shares);
-        assertEq(vault.balanceOf(bob), shares);
-
-        // burn (redeem -> _burn -> _update)
-        vm.prank(bob);
-        uint256 out = vault.redeem(shares, bob, bob);
-        assertGt(out, 0);
-        assertEq(vault.balanceOf(bob), 0);
+        assertGt(vault.convertToAssets(vault.balanceOf(bob)), bobIn, "window depositor earned nothing next cycle");
+        assertGt(vault.convertToAssets(vault.balanceOf(alice)), aliceAfterT1, "prior holder lost ground next cycle");
     }
 }

--- a/sdk/packages/core/test/StreamingYieldVault.t.sol
+++ b/sdk/packages/core/test/StreamingYieldVault.t.sol
@@ -16,6 +16,7 @@ pragma solidity ^0.8.17;
 import {Test} from "forge-std/Test.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {ERC4626} from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
+import {ERC1363} from "@openzeppelin/contracts/token/ERC20/extensions/ERC1363.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
@@ -25,6 +26,16 @@ import {StreamingYieldVault} from "../contracts/vaults/StreamingYieldVault.sol";
 ///      no transfer fee, no rebasing, no callbacks.
 contract MockERC20 is ERC20 {
     constructor() ERC20("Mock", "MOCK") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+/// @dev Mintable ERC-1363 ("payable token") used to exercise the single-tx `transferAndCall`
+///      deposit path against the vault's `onTransferReceived` hook.
+contract MockERC1363 is ERC1363 {
+    constructor() ERC20("Mock1363", "M1363") {}
 
     function mint(address to, uint256 amount) external {
         _mint(to, amount);
@@ -484,5 +495,79 @@ contract StreamingYieldVaultTest is Test {
 
         assertGt(vault.convertToAssets(vault.balanceOf(bob)), bobIn, "window depositor earned nothing next cycle");
         assertGt(vault.convertToAssets(vault.balanceOf(alice)), aliceAfterT1, "prior holder lost ground next cycle");
+    }
+
+    // --------------------------------------------------------------------------------------
+    // 8. ERC-1363 single-transaction yield top-up (`transferAndCall` -> `onTransferReceived`)
+    // --------------------------------------------------------------------------------------
+
+    /// @dev Deploy a vault over an ERC-1363 asset, funded + approved for the usual actors.
+    function _deploy1363() internal returns (MockERC1363 a, StreamingYieldVault v) {
+        a = new MockERC1363();
+        v = new StreamingYieldVault(IERC20(address(a)), "Vault 1363", "v1363", owner);
+        address[3] memory who = [alice, bob, owner];
+        for (uint256 i = 0; i < who.length; i++) {
+            a.mint(who[i], 1_000_000 ether);
+            vm.prank(who[i]);
+            a.approve(address(v), type(uint256).max);
+        }
+    }
+
+    /// @notice The owner funds a tranche in one transaction via `transferAndCall`; it streams over
+    ///         `VEST` exactly like `addYield`, with no instant jump.
+    function test_ERC1363_transferAndCall_addsYield() public {
+        (MockERC1363 a, StreamingYieldVault v) = _deploy1363();
+        vm.prank(alice);
+        v.deposit(1_000 ether, alice); // a holder for the yield to accrue to
+        uint256 base = v.totalAssets();
+
+        vm.prank(owner);
+        a.transferAndCall(address(v), 100 ether);
+
+        assertEq(v.lockedYield(), 100 ether, "tranche not locked");
+        assertEq(v.totalAssets(), base, "yield recognized instantly");
+        vm.warp(block.timestamp + VEST);
+        assertEq(v.totalAssets(), base + 100 ether, "tranche not fully recognized after VEST");
+    }
+
+    /// @notice Only the owner may fund yield this way: a non-owner `transferAndCall` reverts and the
+    ///         asset transfer rolls back.
+    function test_ERC1363_onlyOwnerMayFund() public {
+        (MockERC1363 a, StreamingYieldVault v) = _deploy1363();
+
+        uint256 balBefore = a.balanceOf(alice);
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, alice));
+        a.transferAndCall(address(v), 100 ether);
+
+        assertEq(a.balanceOf(alice), balBefore, "asset transfer was not rolled back");
+        assertEq(v.lockedYield(), 0, "yield was armed by a non-owner");
+    }
+
+    /// @notice The hook is only callable by the asset; a direct call cannot arm a tranche.
+    function test_ERC1363_onTransferReceived_onlyAsset() public {
+        (, StreamingYieldVault v) = _deploy1363();
+
+        vm.prank(owner); // even the owner can't call it directly — it must come from the asset
+        vm.expectRevert(abi.encodeWithSelector(StreamingYieldVault.CallerNotAsset.selector, owner));
+        v.onTransferReceived(owner, owner, 100 ether, "");
+    }
+
+    /// @notice The single-tx path honours the no-overlap guard: funding again while a tranche is
+    ///         vesting reverts (and the asset transfer rolls back).
+    function test_ERC1363_respectsVestingGuard() public {
+        (MockERC1363 a, StreamingYieldVault v) = _deploy1363();
+
+        vm.prank(owner);
+        a.transferAndCall(address(v), 100 ether); // tranche 1
+        vm.warp(block.timestamp + 1 hours); // mid-vest
+
+        uint256 vestEnd = v.vestedAt(); // read before prank so the view doesn't consume it
+        uint256 balBefore = a.balanceOf(owner);
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(StreamingYieldVault.YieldStillVesting.selector, vestEnd));
+        a.transferAndCall(address(v), 50 ether);
+
+        assertEq(a.balanceOf(owner), balBefore, "asset transfer was not rolled back");
     }
 }


### PR DESCRIPTION
## What

Stops new depositors from joining a `StreamingYieldVault` mid-tranche and skimming yield meant for the holders who were already in. Deposits are now confined to the window between tranches.

## Changes

- **Deposits/mints disabled while a tranche vests.** `maxDeposit`/`maxMint` return `0` during vesting, so `deposit`/`mint` revert with the standard `ERC4626ExceededMaxDeposit`/`ERC4626ExceededMaxMint`. New capital can only enter after a tranche fully vests and before the next `addYield`.
- **Guaranteed deposit window.** `addYield` must now wait `MIN_WINDOW` (2h) past the vest end, reverting with `DepositWindowOpen(closesAt)` until then. This guarantees a deposit window every cycle regardless of how promptly the keeper runs, independent of an off-chain clock.
- **`VEST` 23h → 22h**, giving a 24h minimum cadence (`VEST + MIN_WINDOW`) with a guaranteed 2h window.
- Added `nextYieldAt()` view (close of the window / earliest next `addYield`).

## Why vesting is still needed

Vesting remains the primary anti-snipe defense: it time-weights yield so momentary presence around a recognition event captures nothing, which is what keeps the open deposit window safe. The deposit lock is a complementary fairness rule (no mid-tranche joiners), not a replacement.

## Tests

Foundry suite updated and green (25 passing): deposit/mint revert while vesting, deposits open across the whole window, `maxDeposit`/`maxMint` reflect the lock, the window can't be squeezed shut by an eager keeper, and an end-to-end check that a window depositor earns the next tranche but none of the current one.

## Docs

`streaming-yield-vault.mdx` synced to the new behaviour (deposit lock, `MIN_WINDOW`, `nextYieldAt`, `DepositWindowOpen`, cadence guidance).

