### PR TITLE
[tesseract]: Use messaging providers in claim-rewards

### DIFF
--- a/.github/workflows/publish-tesseract-messaging.yml
+++ b/.github/workflows/publish-tesseract-messaging.yml
@@ -62,7 +62,7 @@ jobs:
             - name: Resolve version
               id: version
               run: |
-                  VERSION=$(cargo get package.version --entry ./tesseract/messaging/relayer)
+                  VERSION=$(cargo get package.version --entry ./tesseract/relayer)
                   echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
             - name: Login to Docker Hub

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28026,7 +28026,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tesseract"
-version = "2.4.4"
+version = "2.4.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/tesseract/relayer/Cargo.toml
+++ b/tesseract/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tesseract"
-version = "2.4.4"
+version = "2.4.5"
 edition = "2021"
 description = "Consolidated Hyperbridge relayer — inbound and outbound consensus + messaging"
 authors = ["Polytope Labs <hello@polytope.technology>"]

--- a/tesseract/relayer/src/claim_rewards.rs
+++ b/tesseract/relayer/src/claim_rewards.rs
@@ -141,16 +141,21 @@ impl ClaimRewards {
 				continue;
 			};
 
+			let Some(messaging) = clients.get(sm) else {
+				tracing::warn!(
+					target: LOG_TARGET,
+					%sm,
+					"no messaging client configured for Polkadot Hub; cannot query \
+					 Hyperbridge's state machine height",
+				);
+				continue;
+			};
+
 			let max_delivery_height =
 				claims.iter().map(|c| c.delivery_height).max().unwrap_or_default();
 
 			let hb_height = hyperbridge_provider
-				.query_latest_height(
-					clients
-						.get(sm)
-						.map(|p| p.state_machine_id())
-						.unwrap_or_else(|| host.provider().state_machine_id()),
-				)
+				.query_latest_height(messaging.state_machine_id())
 				.await
 				.unwrap_or(0) as u64;
 
@@ -272,16 +277,21 @@ impl ClaimRewards {
 				continue;
 			};
 
+			let Some(messaging) = clients.get(sm) else {
+				tracing::warn!(
+					target: LOG_TARGET,
+					%sm,
+					"no messaging client configured for Polkadot Hub; cannot query \
+					 Hyperbridge's state machine height for request claims",
+				);
+				continue;
+			};
+
 			let max_delivery_height =
 				claims.iter().map(|c| c.delivery_height).max().unwrap_or_default();
 
 			let hb_height = hyperbridge_provider
-				.query_latest_height(
-					clients
-						.get(sm)
-						.map(|p| p.state_machine_id())
-						.unwrap_or_else(|| host.provider().state_machine_id()),
-				)
+				.query_latest_height(messaging.state_machine_id())
 				.await
 				.unwrap_or(0) as u64;
 


### PR DESCRIPTION
- claim-rewards CLI now queries Hyperbridge's latest state machine height via the messaging-only providers built from each chain's messaging config, instead of falling back to the consensus host's provider.
- publish-tesseract-messaging workflow resolves the version from the tesseract crate (./tesseract/relayer) it actually builds, not from tesseract-messaging (./tesseract/messaging/relayer).
- Bump tesseract to 2.4.5.