### PR TITLE
[simplex]: one-sided LP for the FX strategy

### DIFF
--- a/docs/content/developers/evm/intent-gateway/simplex.mdx
+++ b/docs/content/developers/evm/intent-gateway/simplex.mdx
@@ -88,7 +88,7 @@ With both curves set HyperFX fills in both directions. Omitting one curve restri
 - **Ask only** (omit `bidPriceCurve`) — the filler only *sells* exotic, filling orders where the user sends stable and receives exotic. It accumulates the stablecoin and gives away the exotic token (for example, take USDC, hand out cNGN).
 - **Bid only** (omit `askPriceCurve`) — the filler only *buys* exotic, filling orders where the user sends exotic and receives stable. It accumulates the exotic token and gives away the stablecoin.
 
-Orders in the disabled direction are rejected before bidding (an order with mixed-direction legs is rejected as a whole, since the IntentGateway settles all legs atomically). With Uniswap V4 pool pricing, the same applies: provide just one curve to price and enable a single side.
+Orders in the disabled direction are rejected before bidding (an order with mixed-direction legs is rejected as a whole, since the IntentGateway settles all legs atomically).
 
 ```toml lineNumbers
 [[strategies]]
@@ -105,6 +105,23 @@ askPriceCurve = [
 [strategies.token1]
 "EVM-56"  = "0xExoticTokenAddressOnBsc"
 "EVM-137" = "0xExoticTokenAddressOnPolygon"
+```
+
+When pricing from a [Uniswap V4 pool](#pool-based-pricing) (no curves), there is no curve to omit, so set **`side`** on the `[strategies.vault.uniswapV4]` block instead — `"ask"` to only sell exotic (accumulate stablecoins) or `"bid"` to only buy exotic. Omit `side` to fill both directions. `side` cannot be combined with static curves.
+
+```toml lineNumbers
+[[strategies]]
+type = "hyperfx"
+maxOrderUsd = 5000
+
+[strategies.token1]
+"EVM-8453" = "0x46C85152bFe9f96829aA94755D9f915F9B10EF5F"
+
+[strategies.vault.uniswapV4]
+side = "ask"  # only sell exotic; keep accumulating stablecoins
+positions = [
+    { chain = "EVM-8453", tokenId = "2087350" },
+]
 ```
 
 

--- a/docs/content/developers/evm/intent-gateway/simplex.mdx
+++ b/docs/content/developers/evm/intent-gateway/simplex.mdx
@@ -81,6 +81,26 @@ askPriceCurve = [
 "EVM-137" = "0xExoticTokenAddressOnPolygon"
 ```
 
+#### One-sided LP
+
+By default HyperFX fills in both directions. The optional **`accumulate`** field restricts the filler to a single direction so it keeps accumulating one asset while only giving away the other:
+
+- **`"stable"`** — fill only orders where the user sends stable and receives exotic. The filler accumulates the stablecoin and gives away the exotic token (for example, take USDC, hand out cNGN).
+- **`"exotic"`** — fill only orders where the user sends exotic and receives stable. The filler accumulates the exotic token and gives away the stablecoin (for example, take cNGN, hand out USDC).
+
+Omit the field to keep filling both directions. Orders whose direction runs against the configured side are rejected before bidding (an order with mixed-direction legs is rejected as a whole, since the IntentGateway settles all legs atomically).
+
+```toml lineNumbers
+[[strategies]]
+type = "hyperfx"
+maxOrderUsd = 5000
+accumulate = "stable"  # only fill stable-in/exotic-out orders; keep accumulating USDC
+
+[strategies.token1]
+"EVM-56"  = "0xExoticTokenAddressOnBsc"
+"EVM-137" = "0xExoticTokenAddressOnPolygon"
+```
+
 
 #### Uniswap V4 LP funding
 

--- a/docs/content/developers/evm/intent-gateway/simplex.mdx
+++ b/docs/content/developers/evm/intent-gateway/simplex.mdx
@@ -83,18 +83,24 @@ askPriceCurve = [
 
 #### One-sided LP
 
-By default HyperFX fills in both directions. The optional **`accumulate`** field restricts the filler to a single direction so it keeps accumulating one asset while only giving away the other:
+With both curves set HyperFX fills in both directions. Omitting one curve restricts the filler to a single direction, so it keeps accumulating one asset while only giving away the other:
 
-- **`"stable"`** — fill only orders where the user sends stable and receives exotic. The filler accumulates the stablecoin and gives away the exotic token (for example, take USDC, hand out cNGN).
-- **`"exotic"`** — fill only orders where the user sends exotic and receives stable. The filler accumulates the exotic token and gives away the stablecoin (for example, take cNGN, hand out USDC).
+- **Ask only** (omit `bidPriceCurve`) — the filler only *sells* exotic, filling orders where the user sends stable and receives exotic. It accumulates the stablecoin and gives away the exotic token (for example, take USDC, hand out cNGN).
+- **Bid only** (omit `askPriceCurve`) — the filler only *buys* exotic, filling orders where the user sends exotic and receives stable. It accumulates the exotic token and gives away the stablecoin.
 
-Omit the field to keep filling both directions. Orders whose direction runs against the configured side are rejected before bidding (an order with mixed-direction legs is rejected as a whole, since the IntentGateway settles all legs atomically).
+Orders in the disabled direction are rejected before bidding (an order with mixed-direction legs is rejected as a whole, since the IntentGateway settles all legs atomically). With Uniswap V4 pool pricing, the same applies: provide just one curve to price and enable a single side.
 
 ```toml lineNumbers
 [[strategies]]
 type = "hyperfx"
 maxOrderUsd = 5000
-accumulate = "stable"  # only fill stable-in/exotic-out orders; keep accumulating USDC
+
+# Ask curve only — keep accumulating USDC by only selling cNGN
+askPriceCurve = [
+    { amount = "100",  price = "1560" },
+    { amount = "1000", price = "1555" },
+    { amount = "5000", price = "1550" },
+]
 
 [strategies.token1]
 "EVM-56"  = "0xExoticTokenAddressOnBsc"

--- a/sdk/packages/simplex/filler-config-example.toml
+++ b/sdk/packages/simplex/filler-config-example.toml
@@ -200,6 +200,11 @@ points = [
 # # Optional spread (basis points) around Uniswap V4 mid when using vault.uniswapV4 for pricing
 # spreadBps = 50
 #
+# # One-sided LP (optional). Omit to fill both directions.
+# # "stable" fills only stable-in/exotic-out orders (accumulate USDC, give away cNGN);
+# # "exotic" fills only exotic-in/stable-out orders (accumulate cNGN, give away USDC).
+# accumulate = "stable"
+#
 # # Bid/ask curves: omit both when [strategies.vault.uniswapV4].positions is set (pool-based pricing).
 # # Bid price curve: exotic per USD when *buying* exotic from a user (exotic→stable leg)
 # bidPriceCurve = [

--- a/sdk/packages/simplex/filler-config-example.toml
+++ b/sdk/packages/simplex/filler-config-example.toml
@@ -224,8 +224,13 @@ points = [
 #
 # # Auto-funding from on-chain liquidity (optional)
 # # When wallet balance is insufficient, Simplex withdraws from these positions atomically
+# #
+# # One-sided LP under pool pricing (no bid/ask curves): set `side` to fill a single direction.
+# # "ask" sells exotic (accumulate stablecoins); "bid" buys exotic (accumulate the exotic token).
+# # Omit `side` to fill both directions.
 #
 # [strategies.vault.uniswapV4]
+# side = "ask"
 # positions = [
 #     { chain = "EVM-8453", tokenId = "123456789" },
 # ]

--- a/sdk/packages/simplex/filler-config-example.toml
+++ b/sdk/packages/simplex/filler-config-example.toml
@@ -200,12 +200,10 @@ points = [
 # # Optional spread (basis points) around Uniswap V4 mid when using vault.uniswapV4 for pricing
 # spreadBps = 50
 #
-# # One-sided LP (optional). Omit to fill both directions.
-# # "stable" fills only stable-in/exotic-out orders (accumulate USDC, give away cNGN);
-# # "exotic" fills only exotic-in/stable-out orders (accumulate cNGN, give away USDC).
-# accumulate = "stable"
-#
 # # Bid/ask curves: omit both when [strategies.vault.uniswapV4].positions is set (pool-based pricing).
+# # One-sided LP: omit one curve to fill in a single direction. Keep only askPriceCurve to
+# # accumulate stablecoins (sell exotic, e.g. give away cNGN); keep only bidPriceCurve to
+# # accumulate the exotic token (buy exotic).
 # # Bid price curve: exotic per USD when *buying* exotic from a user (exotic→stable leg)
 # bidPriceCurve = [
 #     { amount = "100",  price = "1580" },

--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/simplex",
-	"version": "0.5.5",
+	"version": "0.5.6",
 	"license": "Apache-2.0",
 	"description": "IntentGateway simplex package for hyperbridge",
 	"main": "dist/index.js",

--- a/sdk/packages/simplex/src/bin/simplex.ts
+++ b/sdk/packages/simplex/src/bin/simplex.ts
@@ -7,7 +7,7 @@ import { parse } from "toml"
 import { isAddress } from "viem"
 import { IntentFiller } from "@/core/filler"
 import { StableFiller } from "@/strategies/stable"
-import { FXFiller, AccumulationSide } from "@/strategies/fx"
+import { FXFiller } from "@/strategies/fx"
 import type { VaultConfig, FundingVenue, UniswapV4PositionConfig } from "@/funding/types"
 import { UniswapV4FundingPlanner } from "@/funding/uniswapV4/UniswapV4FundingPlanner"
 import { VaultFundingPlanner } from "@/funding/vault/VaultFundingPlanner"
@@ -107,7 +107,9 @@ interface FxStrategyConfig {
 	 * the filler pays out fewer stablecoins per exotic token received.
 	 *
 	 * Optional when `[strategies.vault.uniswapV4]` lists at least one position — bid/ask
-	 * are then derived from the Uniswap V4 pool after startup.
+	 * are then derived from the Uniswap V4 pool after startup. Omitting only this curve
+	 * (while keeping the ask) is one-sided LP: the filler stops buying exotic and only
+	 * sells it, accumulating stablecoins.
 	 */
 	bidPriceCurve?: Array<{
 		amount: string
@@ -119,7 +121,9 @@ interface FxStrategyConfig {
 	 * the filler sends fewer exotic tokens per stablecoin received.
 	 *
 	 * Optional when `[strategies.vault.uniswapV4]` lists at least one position — bid/ask
-	 * are then derived from the Uniswap V4 pool after startup.
+	 * are then derived from the Uniswap V4 pool after startup. Omitting only this curve
+	 * (while keeping the bid) is one-sided LP: the filler stops selling exotic and only
+	 * buys it, accumulating the exotic token.
 	 */
 	askPriceCurve?: Array<{
 		amount: string
@@ -132,12 +136,6 @@ interface FxStrategyConfig {
 	spreadBps?: number
 	/** Maximum USD value per order */
 	maxOrderUsd: number
-	/**
-	 * One-sided LP. Omit to fill both directions (default).
-	 * - "stable": only fill stable-in/exotic-out legs (accumulate stable, give away exotic)
-	 * - "exotic": only fill exotic-in/stable-out legs (accumulate exotic, give away stable)
-	 */
-	accumulate?: AccumulationSide
 	/** Map of chain identifier (e.g. "EVM-97") to exotic token contract address */
 	token1: Record<string, HexString>
 	/** Optional per-chain confirmation policies for cross-chain orders */
@@ -461,7 +459,6 @@ program
 								confirmationPolicy: fxConfirmationPolicy,
 								fundingVenues,
 								spreadBps: strategyConfig.spreadBps,
-								accumulate: strategyConfig.accumulate,
 							},
 						)
 					}
@@ -705,19 +702,15 @@ function validateConfig(config: FillerTomlConfig): void {
 
 			const bidLen = strategy.bidPriceCurve?.length ?? 0
 			const askLen = strategy.askPriceCurve?.length ?? 0
-			if (bidLen > 0 !== askLen > 0) {
-				throw new Error(
-					"hyperfx: set both 'bidPriceCurve' and 'askPriceCurve', or omit both when using vault.uniswapV4 for pricing",
-				)
-			}
 
 			// A single point is a valid flat curve — FillerPricePolicy returns that price at every size.
-			const hasStaticCurves = bidLen >= 1 && askLen >= 1
+			// One-sided LP: providing only one of bid/ask restricts the filler to that direction.
+			const hasAnyCurve = bidLen >= 1 || askLen >= 1
 			const hasUniswapV4Positions = (strategy.vault?.uniswapV4?.positions?.length ?? 0) > 0
 
-			if (!hasStaticCurves && !hasUniswapV4Positions) {
+			if (!hasAnyCurve && !hasUniswapV4Positions) {
 				throw new Error(
-					"hyperfx: provide bid+ask price curves (≥1 point each) or configure [strategies.vault.uniswapV4].positions for pool-based pricing",
+					"hyperfx: provide a bid and/or ask price curve, or configure [strategies.vault.uniswapV4].positions for pool-based pricing",
 				)
 			}
 
@@ -725,13 +718,6 @@ function validateConfig(config: FillerTomlConfig): void {
 				if (!Number.isFinite(strategy.spreadBps) || strategy.spreadBps < 0 || strategy.spreadBps > 10_000) {
 					throw new Error("hyperfx: 'spreadBps' must be a number between 0 and 10000")
 				}
-			}
-
-			if (
-				strategy.accumulate !== undefined &&
-				!Object.values(AccumulationSide).includes(strategy.accumulate)
-			) {
-				throw new Error("hyperfx: 'accumulate' must be either 'stable' or 'exotic'")
 			}
 
 			if (bidLen > 0) {

--- a/sdk/packages/simplex/src/bin/simplex.ts
+++ b/sdk/packages/simplex/src/bin/simplex.ts
@@ -144,6 +144,12 @@ interface FxStrategyConfig {
 	vault?: {
 		uniswapV4?: {
 			positions?: UniswapV4PositionToml[]
+			/**
+			 * One-sided LP under pool pricing. "bid" buys exotic (accumulate exotic);
+			 * "ask" sells exotic (accumulate stable). Only valid with pool pricing — i.e.
+			 * no `bidPriceCurve`/`askPriceCurve` set. Omit to fill both directions.
+			 */
+			side?: "bid" | "ask"
 		}
 	}
 }
@@ -459,6 +465,7 @@ program
 								confirmationPolicy: fxConfirmationPolicy,
 								fundingVenues,
 								spreadBps: strategyConfig.spreadBps,
+								side: strategyConfig.vault?.uniswapV4?.side,
 							},
 						)
 					}
@@ -717,6 +724,23 @@ function validateConfig(config: FillerTomlConfig): void {
 			if (strategy.spreadBps !== undefined) {
 				if (!Number.isFinite(strategy.spreadBps) || strategy.spreadBps < 0 || strategy.spreadBps > 10_000) {
 					throw new Error("hyperfx: 'spreadBps' must be a number between 0 and 10000")
+				}
+			}
+
+			// One-sided LP under pool pricing: `side` enables a single direction. Only valid
+			// with venue pricing and no static curves (curves express one-sided by omission).
+			const side = strategy.vault?.uniswapV4?.side
+			if (side !== undefined) {
+				if (side !== "bid" && side !== "ask") {
+					throw new Error("hyperfx: 'vault.uniswapV4.side' must be either 'bid' or 'ask'")
+				}
+				if (!hasUniswapV4Positions) {
+					throw new Error("hyperfx: 'vault.uniswapV4.side' requires [strategies.vault.uniswapV4].positions")
+				}
+				if (hasAnyCurve) {
+					throw new Error(
+						"hyperfx: 'vault.uniswapV4.side' only applies to pool pricing; omit 'bidPriceCurve'/'askPriceCurve' (or drop one curve to do one-sided LP with static pricing)",
+					)
 				}
 			}
 

--- a/sdk/packages/simplex/src/bin/simplex.ts
+++ b/sdk/packages/simplex/src/bin/simplex.ts
@@ -7,7 +7,7 @@ import { parse } from "toml"
 import { isAddress } from "viem"
 import { IntentFiller } from "@/core/filler"
 import { StableFiller } from "@/strategies/stable"
-import { FXFiller } from "@/strategies/fx"
+import { FXFiller, AccumulationSide } from "@/strategies/fx"
 import type { VaultConfig, FundingVenue, UniswapV4PositionConfig } from "@/funding/types"
 import { UniswapV4FundingPlanner } from "@/funding/uniswapV4/UniswapV4FundingPlanner"
 import { VaultFundingPlanner } from "@/funding/vault/VaultFundingPlanner"
@@ -132,6 +132,12 @@ interface FxStrategyConfig {
 	spreadBps?: number
 	/** Maximum USD value per order */
 	maxOrderUsd: number
+	/**
+	 * One-sided LP. Omit to fill both directions (default).
+	 * - "stable": only fill stable-in/exotic-out legs (accumulate stable, give away exotic)
+	 * - "exotic": only fill exotic-in/stable-out legs (accumulate exotic, give away stable)
+	 */
+	accumulate?: AccumulationSide
 	/** Map of chain identifier (e.g. "EVM-97") to exotic token contract address */
 	token1: Record<string, HexString>
 	/** Optional per-chain confirmation policies for cross-chain orders */
@@ -455,6 +461,7 @@ program
 								confirmationPolicy: fxConfirmationPolicy,
 								fundingVenues,
 								spreadBps: strategyConfig.spreadBps,
+								accumulate: strategyConfig.accumulate,
 							},
 						)
 					}
@@ -718,6 +725,13 @@ function validateConfig(config: FillerTomlConfig): void {
 				if (!Number.isFinite(strategy.spreadBps) || strategy.spreadBps < 0 || strategy.spreadBps > 10_000) {
 					throw new Error("hyperfx: 'spreadBps' must be a number between 0 and 10000")
 				}
+			}
+
+			if (
+				strategy.accumulate !== undefined &&
+				!Object.values(AccumulationSide).includes(strategy.accumulate)
+			) {
+				throw new Error("hyperfx: 'accumulate' must be either 'stable' or 'exotic'")
 			}
 
 			if (bidLen > 0) {

--- a/sdk/packages/simplex/src/index.ts
+++ b/sdk/packages/simplex/src/index.ts
@@ -6,7 +6,7 @@ export { EventMonitor } from "@/core/event-monitor"
 
 // Strategy exports
 export { StableFiller } from "@/strategies/stable"
-export { FXFiller } from "@/strategies/fx"
+export { FXFiller, AccumulationSide } from "@/strategies/fx"
 
 // Configuration exports
 export { InterpolatedCurve, ConfirmationPolicy, FillerBpsPolicy } from "@/config/interpolated-curve"

--- a/sdk/packages/simplex/src/index.ts
+++ b/sdk/packages/simplex/src/index.ts
@@ -6,7 +6,7 @@ export { EventMonitor } from "@/core/event-monitor"
 
 // Strategy exports
 export { StableFiller } from "@/strategies/stable"
-export { FXFiller, AccumulationSide } from "@/strategies/fx"
+export { FXFiller } from "@/strategies/fx"
 
 // Configuration exports
 export { InterpolatedCurve, ConfirmationPolicy, FillerBpsPolicy } from "@/config/interpolated-curve"

--- a/sdk/packages/simplex/src/strategies/fx.ts
+++ b/sdk/packages/simplex/src/strategies/fx.ts
@@ -97,9 +97,13 @@ export class FXFiller implements FillerStrategy {
 	 * @param options.fundingVenues  Optional funding venues for on-chain liquidity sourcing and live pricing.
 	 * @param options.spreadBps      Spread in basis points applied when redeeming from the pool (default 50).
 	 *
-	 * One-sided LP: omitting one of `bidPricePolicy`/`askPricePolicy` (while providing the
-	 * other) restricts the filler to that side's direction. Omitting both (venue pricing
-	 * only) keeps both directions open.
+	 * One-sided LP, two ways depending on the pricing mode:
+	 * - Static curves: omit one of `bidPricePolicy`/`askPricePolicy` to fill only the other
+	 *   side. Providing both keeps both directions open.
+	 * - Venue (pool) pricing with no curves: set `side` to restrict to one direction.
+	 *   Omitting `side` keeps both directions open.
+	 * @param options.side Pool-pricing one-sided switch ("bid" buys exotic, "ask" sells exotic).
+	 *   Only valid with venue pricing and no static curves.
 	 */
 	constructor(
 		signer: SigningAccount,
@@ -114,6 +118,7 @@ export class FXFiller implements FillerStrategy {
 			confirmationPolicy?: ConfirmationPolicy
 			fundingVenues?: FundingVenue[]
 			spreadBps?: number
+			side?: "bid" | "ask"
 		},
 	) {
 		const {
@@ -122,6 +127,7 @@ export class FXFiller implements FillerStrategy {
 			confirmationPolicy,
 			fundingVenues = [],
 			spreadBps = 50,
+			side,
 		} = options ?? {}
 
 		const hasAnyPolicy = !!(bidPricePolicy || askPricePolicy)
@@ -130,11 +136,15 @@ export class FXFiller implements FillerStrategy {
 		if (!hasAnyPolicy && !hasVenues) {
 			throw new Error("FXFiller requires a bid and/or ask price policy, or funding venues")
 		}
+		if (side && hasAnyPolicy) {
+			throw new Error("FXFiller 'side' only applies to venue (pool) pricing; omit bid/ask price policies")
+		}
 
-		// Direction enablement. With at least one curve, only the side(s) with a curve are
-		// filled (one-sided LP). With no curves (venue pricing only), both sides are open.
-		this.bidEnabled = hasAnyPolicy ? !!bidPricePolicy : true
-		this.askEnabled = hasAnyPolicy ? !!askPricePolicy : true
+		// Direction enablement. With static curves, only the side(s) with a curve are filled
+		// (one-sided LP). With venue pricing (no curves), `side` optionally restricts to one
+		// direction; without it both sides are open.
+		this.bidEnabled = hasAnyPolicy ? !!bidPricePolicy : side ? side === "bid" : true
+		this.askEnabled = hasAnyPolicy ? !!askPricePolicy : side ? side === "ask" : true
 
 		this.configService = configService
 		this.clientManager = clientManager
@@ -795,10 +805,10 @@ export class FXFiller implements FillerStrategy {
 			}
 
 			// One-sided LP: reject the whole order if any leg runs in a disabled
-			// direction (its pricing curve was omitted). A stable-in leg sells exotic
-			// and needs the ask side; an exotic-in leg buys exotic and needs the bid
-			// side. The IntentGateway fills all legs atomically, so a mixed-direction
-			// order can't be partially honoured.
+			// direction (curve omitted, or excluded by the venue `side`). A stable-in
+			// leg sells exotic and needs the ask side; an exotic-in leg buys exotic and
+			// needs the bid side. The IntentGateway fills all legs atomically, so a
+			// mixed-direction order can't be partially honoured.
 			const leg = pairs[pairs.length - 1]
 			if ((leg.inputIsStable && !this.askEnabled) || (!leg.inputIsStable && !this.bidEnabled)) {
 				this.logger.debug(
@@ -809,7 +819,7 @@ export class FXFiller implements FillerStrategy {
 						bidEnabled: this.bidEnabled,
 						askEnabled: this.askEnabled,
 					},
-					"Rejecting order: leg direction disabled (price curve omitted for this side)",
+					"Rejecting order: leg direction disabled for one-sided LP",
 				)
 				return null
 			}

--- a/sdk/packages/simplex/src/strategies/fx.ts
+++ b/sdk/packages/simplex/src/strategies/fx.ts
@@ -232,6 +232,10 @@ export class FXFiller implements FillerStrategy {
 				return false
 			}
 
+			if (!this.isOrderDirectionEnabled(pairs, order.id)) {
+				return false
+			}
+
 			return true
 		} catch (error) {
 			this.logger.error({ err: error }, "Error in canFill")
@@ -273,6 +277,10 @@ export class FXFiller implements FillerStrategy {
 			const pairs = this.classifyAllPairs(order)
 			if (!pairs) {
 				this.logger.info({ orderId: order.id }, "Skipping order: could not classify token pairs")
+				return 0
+			}
+
+			if (!this.isOrderDirectionEnabled(pairs, order.id)) {
 				return 0
 			}
 
@@ -803,26 +811,6 @@ export class FXFiller implements FillerStrategy {
 			} else {
 				return null
 			}
-
-			// One-sided LP: reject the whole order if any leg runs in a disabled
-			// direction (curve omitted, or excluded by the venue `side`). A stable-in
-			// leg sells exotic and needs the ask side; an exotic-in leg buys exotic and
-			// needs the bid side. The IntentGateway fills all legs atomically, so a
-			// mixed-direction order can't be partially honoured.
-			const leg = pairs[pairs.length - 1]
-			if ((leg.inputIsStable && !this.askEnabled) || (!leg.inputIsStable && !this.bidEnabled)) {
-				this.logger.debug(
-					{
-						orderId: order.id,
-						leg: i,
-						inputIsStable: leg.inputIsStable,
-						bidEnabled: this.bidEnabled,
-						askEnabled: this.askEnabled,
-					},
-					"Rejecting order: leg direction disabled for one-sided LP",
-				)
-				return null
-			}
 		}
 
 		if (order.id) {
@@ -830,6 +818,37 @@ export class FXFiller implements FillerStrategy {
 		}
 
 		return pairs
+	}
+
+	/**
+	 * One-sided LP gate: returns false if any leg runs in a disabled direction
+	 * (curve omitted, or excluded by the venue `side`). A stable-in leg sells exotic
+	 * and needs the ask side; an exotic-in leg buys exotic and needs the bid side.
+	 * The IntentGateway settles all legs atomically, so a mixed-direction order can't
+	 * be partially honoured.
+	 *
+	 * Kept separate from `classifyAllPairs`: that result is cached and shared across
+	 * strategies, whereas enablement is per-strategy, so this must run on every
+	 * evaluation regardless of cache state.
+	 */
+	private isOrderDirectionEnabled(pairs: CachedPairClassification[], orderId: string | undefined): boolean {
+		for (let i = 0; i < pairs.length; i++) {
+			const leg = pairs[i]
+			if ((leg.inputIsStable && !this.askEnabled) || (!leg.inputIsStable && !this.bidEnabled)) {
+				this.logger.debug(
+					{
+						orderId,
+						leg: i,
+						inputIsStable: leg.inputIsStable,
+						bidEnabled: this.bidEnabled,
+						askEnabled: this.askEnabled,
+					},
+					"Rejecting order: leg direction disabled for one-sided LP",
+				)
+				return false
+			}
+		}
+		return true
 	}
 
 	private getStableType(normalizedAddress: string, chain: string): boolean {

--- a/sdk/packages/simplex/src/strategies/fx.ts
+++ b/sdk/packages/simplex/src/strategies/fx.ts
@@ -22,6 +22,17 @@ import type { FundingVenue } from "@/funding/types"
 import type { SigningAccount } from "@/services/wallet"
 
 /**
+ * One-sided LP accumulation side for {@link FXFiller}. String-valued so it maps
+ * directly onto the `accumulate` value parsed from the filler's TOML config.
+ */
+export enum AccumulationSide {
+	/** Only fill stable-in/exotic-out legs (accumulate stable, give away exotic). */
+	Stable = "stable",
+	/** Only fill exotic-in/stable-out legs (accumulate exotic, give away stable). */
+	Exotic = "exotic",
+}
+
+/**
  * Strategy for swaps between USD-pegged stablecoins (USDC/USDT) and a single
  * configurable exotic token priced via a `FillerPricePolicy`.
  * Supports both same-chain and cross-chain orders.
@@ -75,6 +86,12 @@ export class FXFiller implements FillerStrategy {
 	confirmationPolicy?: { getConfirmationBlocks: (chainId: number, amountUsd: number) => number }
 	private fundingVenues: FundingVenue[]
 	private spreadBps: number
+	/**
+	 * One-sided LP constraint. When set, the filler only fills orders in a single
+	 * direction so it keeps accumulating one asset while giving away the other.
+	 * Undefined fills both directions.
+	 */
+	private accumulate?: AccumulationSide
 
 	/**
 	 * @param signer                 Filler's signing account for UserOp signatures.
@@ -102,6 +119,7 @@ export class FXFiller implements FillerStrategy {
 			confirmationPolicy?: ConfirmationPolicy
 			fundingVenues?: FundingVenue[]
 			spreadBps?: number
+			accumulate?: AccumulationSide
 		},
 	) {
 		const {
@@ -110,6 +128,7 @@ export class FXFiller implements FillerStrategy {
 			confirmationPolicy,
 			fundingVenues = [],
 			spreadBps = 50,
+			accumulate,
 		} = options ?? {}
 
 		const hasPolicies = bidPricePolicy && askPricePolicy
@@ -128,6 +147,7 @@ export class FXFiller implements FillerStrategy {
 		this.token1 = token1
 		this.fundingVenues = fundingVenues
 		this.spreadBps = spreadBps
+		this.accumulate = accumulate
 
 		// When no policies provided, create placeholder flat policies (overwritten in initialise by venue prices)
 		this.bidPricePolicy = bidPricePolicy ?? new FillerPricePolicy({ points: [{ amount: "0", price: "1" }] })
@@ -776,6 +796,21 @@ export class FXFiller implements FillerStrategy {
 					exoticToken: order.inputs[i].token,
 				})
 			} else {
+				return null
+			}
+
+			// One-sided LP: reject the whole order if any leg runs against the
+			// configured accumulation side. The IntentGateway fills all legs
+			// atomically, so a mixed-direction order can't be partially honoured.
+			const leg = pairs[pairs.length - 1]
+			if (
+				(this.accumulate === AccumulationSide.Stable && !leg.inputIsStable) ||
+				(this.accumulate === AccumulationSide.Exotic && leg.inputIsStable)
+			) {
+				this.logger.debug(
+					{ orderId: order.id, leg: i, accumulate: this.accumulate, inputIsStable: leg.inputIsStable },
+					"Rejecting order: leg direction conflicts with one-sided LP accumulation side",
+				)
 				return null
 			}
 		}

--- a/sdk/packages/simplex/src/strategies/fx.ts
+++ b/sdk/packages/simplex/src/strategies/fx.ts
@@ -22,17 +22,6 @@ import type { FundingVenue } from "@/funding/types"
 import type { SigningAccount } from "@/services/wallet"
 
 /**
- * One-sided LP accumulation side for {@link FXFiller}. String-valued so it maps
- * directly onto the `accumulate` value parsed from the filler's TOML config.
- */
-export enum AccumulationSide {
-	/** Only fill stable-in/exotic-out legs (accumulate stable, give away exotic). */
-	Stable = "stable",
-	/** Only fill exotic-in/stable-out legs (accumulate exotic, give away stable). */
-	Exotic = "exotic",
-}
-
-/**
  * Strategy for swaps between USD-pegged stablecoins (USDC/USDT) and a single
  * configurable exotic token priced via a `FillerPricePolicy`.
  * Supports both same-chain and cross-chain orders.
@@ -87,11 +76,13 @@ export class FXFiller implements FillerStrategy {
 	private fundingVenues: FundingVenue[]
 	private spreadBps: number
 	/**
-	 * One-sided LP constraint. When set, the filler only fills orders in a single
-	 * direction so it keeps accumulating one asset while giving away the other.
-	 * Undefined fills both directions.
+	 * Whether the filler buys exotic from users (exotic-in/stable-out legs), priced
+	 * with the bid curve. Disabled by omitting the bid curve — the basis for one-sided
+	 * LP: drop a side and the filler skips orders in that direction.
 	 */
-	private accumulate?: AccumulationSide
+	private bidEnabled: boolean
+	/** Whether the filler sells exotic to users (stable-in/exotic-out legs), priced with the ask curve. */
+	private askEnabled: boolean
 
 	/**
 	 * @param signer                 Filler's signing account for UserOp signatures.
@@ -105,6 +96,10 @@ export class FXFiller implements FillerStrategy {
 	 * @param options.confirmationPolicy Optional per-chain confirmation policy for cross-chain orders.
 	 * @param options.fundingVenues  Optional funding venues for on-chain liquidity sourcing and live pricing.
 	 * @param options.spreadBps      Spread in basis points applied when redeeming from the pool (default 50).
+	 *
+	 * One-sided LP: omitting one of `bidPricePolicy`/`askPricePolicy` (while providing the
+	 * other) restricts the filler to that side's direction. Omitting both (venue pricing
+	 * only) keeps both directions open.
 	 */
 	constructor(
 		signer: SigningAccount,
@@ -119,7 +114,6 @@ export class FXFiller implements FillerStrategy {
 			confirmationPolicy?: ConfirmationPolicy
 			fundingVenues?: FundingVenue[]
 			spreadBps?: number
-			accumulate?: AccumulationSide
 		},
 	) {
 		const {
@@ -128,18 +122,19 @@ export class FXFiller implements FillerStrategy {
 			confirmationPolicy,
 			fundingVenues = [],
 			spreadBps = 50,
-			accumulate,
 		} = options ?? {}
 
-		const hasPolicies = bidPricePolicy && askPricePolicy
+		const hasAnyPolicy = !!(bidPricePolicy || askPricePolicy)
 		const hasVenues = fundingVenues.length > 0
 
-		if (!hasPolicies && !hasVenues) {
-			throw new Error("FXFiller requires either bid/ask price policies or funding venues (or both)")
+		if (!hasAnyPolicy && !hasVenues) {
+			throw new Error("FXFiller requires a bid and/or ask price policy, or funding venues")
 		}
-		if ((bidPricePolicy && !askPricePolicy) || (!bidPricePolicy && askPricePolicy)) {
-			throw new Error("FXFiller requires both bidPricePolicy and askPricePolicy, or neither")
-		}
+
+		// Direction enablement. With at least one curve, only the side(s) with a curve are
+		// filled (one-sided LP). With no curves (venue pricing only), both sides are open.
+		this.bidEnabled = hasAnyPolicy ? !!bidPricePolicy : true
+		this.askEnabled = hasAnyPolicy ? !!askPricePolicy : true
 
 		this.configService = configService
 		this.clientManager = clientManager
@@ -147,9 +142,9 @@ export class FXFiller implements FillerStrategy {
 		this.token1 = token1
 		this.fundingVenues = fundingVenues
 		this.spreadBps = spreadBps
-		this.accumulate = accumulate
 
-		// When no policies provided, create placeholder flat policies (overwritten in initialise by venue prices)
+		// Absent policies get a placeholder flat curve. A side without a curve is either
+		// disabled (so never priced) or venue-priced at runtime, so the placeholder is unused.
 		this.bidPricePolicy = bidPricePolicy ?? new FillerPricePolicy({ points: [{ amount: "0", price: "1" }] })
 		this.askPricePolicy = askPricePolicy ?? new FillerPricePolicy({ points: [{ amount: "0", price: "1" }] })
 
@@ -799,17 +794,22 @@ export class FXFiller implements FillerStrategy {
 				return null
 			}
 
-			// One-sided LP: reject the whole order if any leg runs against the
-			// configured accumulation side. The IntentGateway fills all legs
-			// atomically, so a mixed-direction order can't be partially honoured.
+			// One-sided LP: reject the whole order if any leg runs in a disabled
+			// direction (its pricing curve was omitted). A stable-in leg sells exotic
+			// and needs the ask side; an exotic-in leg buys exotic and needs the bid
+			// side. The IntentGateway fills all legs atomically, so a mixed-direction
+			// order can't be partially honoured.
 			const leg = pairs[pairs.length - 1]
-			if (
-				(this.accumulate === AccumulationSide.Stable && !leg.inputIsStable) ||
-				(this.accumulate === AccumulationSide.Exotic && leg.inputIsStable)
-			) {
+			if ((leg.inputIsStable && !this.askEnabled) || (!leg.inputIsStable && !this.bidEnabled)) {
 				this.logger.debug(
-					{ orderId: order.id, leg: i, accumulate: this.accumulate, inputIsStable: leg.inputIsStable },
-					"Rejecting order: leg direction conflicts with one-sided LP accumulation side",
+					{
+						orderId: order.id,
+						leg: i,
+						inputIsStable: leg.inputIsStable,
+						bidEnabled: this.bidEnabled,
+						askEnabled: this.askEnabled,
+					},
+					"Rejecting order: leg direction disabled (price curve omitted for this side)",
 				)
 				return null
 			}

--- a/sdk/packages/simplex/src/tests/strategies/fx.one-sided-lp.test.ts
+++ b/sdk/packages/simplex/src/tests/strategies/fx.one-sided-lp.test.ts
@@ -1,18 +1,21 @@
-import { FXFiller, AccumulationSide } from "@/strategies/fx"
+import { FXFiller } from "@/strategies/fx"
 import { FillerPricePolicy } from "@/config/interpolated-curve"
 import { bytes20ToBytes32, type HexString, type Order, type TokenInfo } from "@hyperbridge/sdk"
 import { describe, it, expect } from "vitest"
 import { parseUnits } from "viem"
 
-// Pure unit tests for the one-sided LP (`accumulate`) constraint on FXFiller.
-// Exercises `canFill` directly with mocked services so no chain access is needed.
+// Pure unit tests for one-sided LP on FXFiller. One-sided LP is expressed by omitting
+// a bid/ask price curve: a side without a curve is disabled, so the filler skips orders
+// in that direction. Exercises `canFill` with mocked services so no chain access is needed.
 
 const CHAIN = "EVM-97"
 const STABLE = "0x1111111111111111111111111111111111111111" as HexString
 const EXOTIC = "0x2222222222222222222222222222222222222222" as HexString
 const SOLVER = "0x3333333333333333333333333333333333333333" as HexString
 
-function makeFiller(accumulate?: AccumulationSide): FXFiller {
+const FLAT = new FillerPricePolicy({ points: [{ amount: "0", price: "1500" }] })
+
+function makeFiller(options: { bidPricePolicy?: FillerPricePolicy; askPricePolicy?: FillerPricePolicy }): FXFiller {
 	const configService = {
 		getUsdcAsset: () => STABLE,
 		getUsdtAsset: () => "0x0000000000000000000000000000000000000000" as HexString,
@@ -31,11 +34,7 @@ function makeFiller(accumulate?: AccumulationSide): FXFiller {
 	const signer = { account: { address: SOLVER } } as any
 	const clientManager = {} as any
 
-	return new FXFiller(signer, configService, clientManager, contractService, 5000, { [CHAIN]: EXOTIC }, {
-		bidPricePolicy: new FillerPricePolicy({ points: [{ amount: "0", price: "1500" }] }),
-		askPricePolicy: new FillerPricePolicy({ points: [{ amount: "0", price: "1500" }] }),
-		accumulate,
-	})
+	return new FXFiller(signer, configService, clientManager, contractService, 5000, { [CHAIN]: EXOTIC }, options)
 }
 
 function makeOrder(id: string, input: HexString, output: HexString): Order {
@@ -57,22 +56,22 @@ function makeOrder(id: string, input: HexString, output: HexString): Order {
 }
 
 describe("FXFiller one-sided LP", () => {
-	it("fills both directions when accumulate is unset", async () => {
-		const filler = makeFiller()
+	it("fills both directions when both curves are set", async () => {
+		const filler = makeFiller({ bidPricePolicy: FLAT, askPricePolicy: FLAT })
 		// stable in, exotic out
 		expect(await filler.canFill(makeOrder("a", STABLE, EXOTIC))).toBe(true)
 		// exotic in, stable out
 		expect(await filler.canFill(makeOrder("b", EXOTIC, STABLE))).toBe(true)
 	})
 
-	it("accumulate=stable accepts stable-in/exotic-out and rejects the reverse", async () => {
-		const filler = makeFiller(AccumulationSide.Stable)
+	it("ask-only accepts stable-in/exotic-out (sell exotic) and rejects the reverse", async () => {
+		const filler = makeFiller({ askPricePolicy: FLAT })
 		expect(await filler.canFill(makeOrder("c", STABLE, EXOTIC))).toBe(true)
 		expect(await filler.canFill(makeOrder("d", EXOTIC, STABLE))).toBe(false)
 	})
 
-	it("accumulate=exotic accepts exotic-in/stable-out and rejects the reverse", async () => {
-		const filler = makeFiller(AccumulationSide.Exotic)
+	it("bid-only accepts exotic-in/stable-out (buy exotic) and rejects the reverse", async () => {
+		const filler = makeFiller({ bidPricePolicy: FLAT })
 		expect(await filler.canFill(makeOrder("e", EXOTIC, STABLE))).toBe(true)
 		expect(await filler.canFill(makeOrder("f", STABLE, EXOTIC))).toBe(false)
 	})

--- a/sdk/packages/simplex/src/tests/strategies/fx.one-sided-lp.test.ts
+++ b/sdk/packages/simplex/src/tests/strategies/fx.one-sided-lp.test.ts
@@ -15,7 +15,12 @@ const SOLVER = "0x3333333333333333333333333333333333333333" as HexString
 
 const FLAT = new FillerPricePolicy({ points: [{ amount: "0", price: "1500" }] })
 
-function makeFiller(options: { bidPricePolicy?: FillerPricePolicy; askPricePolicy?: FillerPricePolicy }): FXFiller {
+function makeFiller(options: {
+	bidPricePolicy?: FillerPricePolicy
+	askPricePolicy?: FillerPricePolicy
+	fundingVenues?: any[]
+	side?: "bid" | "ask"
+}): FXFiller {
 	const configService = {
 		getUsdcAsset: () => STABLE,
 		getUsdtAsset: () => "0x0000000000000000000000000000000000000000" as HexString,
@@ -74,5 +79,30 @@ describe("FXFiller one-sided LP", () => {
 		const filler = makeFiller({ bidPricePolicy: FLAT })
 		expect(await filler.canFill(makeOrder("e", EXOTIC, STABLE))).toBe(true)
 		expect(await filler.canFill(makeOrder("f", STABLE, EXOTIC))).toBe(false)
+	})
+
+	// Pool pricing (no curves): one-sided LP via the venue `side` switch.
+	const VENUE = [{ name: "UniswapV4" }]
+
+	it("venue side=ask sells exotic only and rejects the reverse", async () => {
+		const filler = makeFiller({ fundingVenues: VENUE, side: "ask" })
+		expect(await filler.canFill(makeOrder("g", STABLE, EXOTIC))).toBe(true)
+		expect(await filler.canFill(makeOrder("h", EXOTIC, STABLE))).toBe(false)
+	})
+
+	it("venue side=bid buys exotic only and rejects the reverse", async () => {
+		const filler = makeFiller({ fundingVenues: VENUE, side: "bid" })
+		expect(await filler.canFill(makeOrder("i", EXOTIC, STABLE))).toBe(true)
+		expect(await filler.canFill(makeOrder("j", STABLE, EXOTIC))).toBe(false)
+	})
+
+	it("venue with no side fills both directions", async () => {
+		const filler = makeFiller({ fundingVenues: VENUE })
+		expect(await filler.canFill(makeOrder("k", STABLE, EXOTIC))).toBe(true)
+		expect(await filler.canFill(makeOrder("l", EXOTIC, STABLE))).toBe(true)
+	})
+
+	it("rejects 'side' combined with static curves", () => {
+		expect(() => makeFiller({ fundingVenues: VENUE, side: "ask", askPricePolicy: FLAT })).toThrow()
 	})
 })

--- a/sdk/packages/simplex/src/tests/strategies/fx.one-sided-lp.test.ts
+++ b/sdk/packages/simplex/src/tests/strategies/fx.one-sided-lp.test.ts
@@ -15,11 +15,24 @@ const SOLVER = "0x3333333333333333333333333333333333333333" as HexString
 
 const FLAT = new FillerPricePolicy({ points: [{ amount: "0", price: "1500" }] })
 
+// Mirrors how simplex.ts shares one contractService (and its classification cache)
+// across every strategy. Pass the same instance to two fillers to exercise that.
+function makeContractService(): any {
+	const cache = new Map<string, unknown>()
+	return {
+		cacheService: {
+			getPairClassifications: (id: string) => cache.get(id),
+			setPairClassifications: (id: string, pairs: unknown) => cache.set(id, pairs),
+		},
+	}
+}
+
 function makeFiller(options: {
 	bidPricePolicy?: FillerPricePolicy
 	askPricePolicy?: FillerPricePolicy
 	fundingVenues?: any[]
 	side?: "bid" | "ask"
+	contractService?: any
 }): FXFiller {
 	const configService = {
 		getUsdcAsset: () => STABLE,
@@ -28,18 +41,13 @@ function makeFiller(options: {
 		getMaxConsecutiveClamps: () => 3,
 	} as any
 
-	const cache = new Map<string, unknown>()
-	const contractService = {
-		cacheService: {
-			getPairClassifications: (id: string) => cache.get(id),
-			setPairClassifications: (id: string, pairs: unknown) => cache.set(id, pairs),
-		},
-	} as any
+	const { contractService: provided, ...fillerOptions } = options
+	const contractService = provided ?? makeContractService()
 
 	const signer = { account: { address: SOLVER } } as any
 	const clientManager = {} as any
 
-	return new FXFiller(signer, configService, clientManager, contractService, 5000, { [CHAIN]: EXOTIC }, options)
+	return new FXFiller(signer, configService, clientManager, contractService, 5000, { [CHAIN]: EXOTIC }, fillerOptions)
 }
 
 function makeOrder(id: string, input: HexString, output: HexString): Order {
@@ -104,5 +112,18 @@ describe("FXFiller one-sided LP", () => {
 
 	it("rejects 'side' combined with static curves", () => {
 		expect(() => makeFiller({ fundingVenues: VENUE, side: "ask", askPricePolicy: FLAT })).toThrow()
+	})
+
+	// Regression: the gate must run even when another strategy already cached the
+	// (intrinsic) classification for this order id under the shared cache.
+	it("enforces one-sided even when the classification is already cached by another strategy", async () => {
+		const shared = makeContractService()
+		const twoSided = makeFiller({ bidPricePolicy: FLAT, askPricePolicy: FLAT, contractService: shared })
+		const askOnly = makeFiller({ askPricePolicy: FLAT, contractService: shared })
+
+		// Two-sided filler classifies and caches the exotic-in order.
+		expect(await twoSided.canFill(makeOrder("shared-1", EXOTIC, STABLE))).toBe(true)
+		// Ask-only filler reads the cached classification but must still reject the bid-side order.
+		expect(await askOnly.canFill(makeOrder("shared-1", EXOTIC, STABLE))).toBe(false)
 	})
 })

--- a/sdk/packages/simplex/src/tests/strategies/fx.one-sided-lp.test.ts
+++ b/sdk/packages/simplex/src/tests/strategies/fx.one-sided-lp.test.ts
@@ -1,0 +1,79 @@
+import { FXFiller, AccumulationSide } from "@/strategies/fx"
+import { FillerPricePolicy } from "@/config/interpolated-curve"
+import { bytes20ToBytes32, type HexString, type Order, type TokenInfo } from "@hyperbridge/sdk"
+import { describe, it, expect } from "vitest"
+import { parseUnits } from "viem"
+
+// Pure unit tests for the one-sided LP (`accumulate`) constraint on FXFiller.
+// Exercises `canFill` directly with mocked services so no chain access is needed.
+
+const CHAIN = "EVM-97"
+const STABLE = "0x1111111111111111111111111111111111111111" as HexString
+const EXOTIC = "0x2222222222222222222222222222222222222222" as HexString
+const SOLVER = "0x3333333333333333333333333333333333333333" as HexString
+
+function makeFiller(accumulate?: AccumulationSide): FXFiller {
+	const configService = {
+		getUsdcAsset: () => STABLE,
+		getUsdtAsset: () => "0x0000000000000000000000000000000000000000" as HexString,
+		getMaxOverfillBps: () => 500n,
+		getMaxConsecutiveClamps: () => 3,
+	} as any
+
+	const cache = new Map<string, unknown>()
+	const contractService = {
+		cacheService: {
+			getPairClassifications: (id: string) => cache.get(id),
+			setPairClassifications: (id: string, pairs: unknown) => cache.set(id, pairs),
+		},
+	} as any
+
+	const signer = { account: { address: SOLVER } } as any
+	const clientManager = {} as any
+
+	return new FXFiller(signer, configService, clientManager, contractService, 5000, { [CHAIN]: EXOTIC }, {
+		bidPricePolicy: new FillerPricePolicy({ points: [{ amount: "0", price: "1500" }] }),
+		askPricePolicy: new FillerPricePolicy({ points: [{ amount: "0", price: "1500" }] }),
+		accumulate,
+	})
+}
+
+function makeOrder(id: string, input: HexString, output: HexString): Order {
+	const inputs: TokenInfo[] = [{ token: bytes20ToBytes32(input), amount: parseUnits("100", 18) }]
+	const outputs: TokenInfo[] = [{ token: bytes20ToBytes32(output), amount: parseUnits("100", 18) }]
+	return {
+		id,
+		user: bytes20ToBytes32(SOLVER),
+		source: CHAIN,
+		destination: CHAIN,
+		deadline: 0n,
+		nonce: 0n,
+		fees: 0n,
+		session: "0x0000000000000000000000000000000000000000" as HexString,
+		predispatch: { assets: [], call: "0x" as HexString },
+		inputs,
+		output: { beneficiary: bytes20ToBytes32(SOLVER), assets: outputs, call: "0x" as HexString },
+	} as unknown as Order
+}
+
+describe("FXFiller one-sided LP", () => {
+	it("fills both directions when accumulate is unset", async () => {
+		const filler = makeFiller()
+		// stable in, exotic out
+		expect(await filler.canFill(makeOrder("a", STABLE, EXOTIC))).toBe(true)
+		// exotic in, stable out
+		expect(await filler.canFill(makeOrder("b", EXOTIC, STABLE))).toBe(true)
+	})
+
+	it("accumulate=stable accepts stable-in/exotic-out and rejects the reverse", async () => {
+		const filler = makeFiller(AccumulationSide.Stable)
+		expect(await filler.canFill(makeOrder("c", STABLE, EXOTIC))).toBe(true)
+		expect(await filler.canFill(makeOrder("d", EXOTIC, STABLE))).toBe(false)
+	})
+
+	it("accumulate=exotic accepts exotic-in/stable-out and rejects the reverse", async () => {
+		const filler = makeFiller(AccumulationSide.Exotic)
+		expect(await filler.canFill(makeOrder("e", EXOTIC, STABLE))).toBe(true)
+		expect(await filler.canFill(makeOrder("f", STABLE, EXOTIC))).toBe(false)
+	})
+})


### PR DESCRIPTION
Closes #974.

Adds one-sided liquidity provisioning to the HyperFX strategy, so the filler can fill in a single direction and keep accumulating one asset while only giving away the other. The mechanism follows the pricing mode, with no new config in the static-curve case:

- Static curves: omit one curve to restrict the direction.
  - Ask curve only (omit `bidPriceCurve`): only sells exotic — accumulates the stablecoin (e.g. take USDC, hand out cNGN).
  - Bid curve only (omit `askPriceCurve`): only buys exotic — accumulates the exotic token.
- Uniswap V4 pool pricing (no curves): set `side` on `[strategies.vault.uniswapV4]` — `"ask"` to only sell exotic, `"bid"` to only buy exotic.
- Both curves set, or pool pricing with no `side`: fills both directions (unchanged default).

```toml
[strategies.vault.uniswapV4]
side = "ask"  # only sell exotic; keep accumulating stablecoins
positions = [
    { chain = "EVM-8453", tokenId = "2087350" },
]
```

Enforcement runs in both `canFill` and `calculateProfitability`, so off-side orders are rejected consistently. The direction gate is deliberately kept out of `classifyAllPairs` — that result is cached and shared across strategies, whereas enablement is per-strategy, so the gate must run on every evaluation regardless of cache state. Mixed-direction orders are rejected as a whole, since the IntentGateway settles all legs atomically. `side` is rejected when combined with static curves (which already express one-sided by omission).

Validation relaxed from "set both curves or neither" to "a bid and/or ask curve, or Uniswap V4 positions". Config example and docs updated; unit tests cover curve-based (both/ask-only/bid-only), pool `side` (ask/bid/none), the side-plus-curve rejection, and a regression test that the gate still rejects when another strategy has cached the classification under the shared cache.