### PR TITLE
[simplex]: Uniswap price guards for the FX strategy

### DIFF
--- a/docs/content/developers/evm/intent-gateway/simplex.mdx
+++ b/docs/content/developers/evm/intent-gateway/simplex.mdx
@@ -141,9 +141,9 @@ Startup validation requires a pricing source: **either** full static `bidPriceCu
 
 #### Uniswap price guards
 
-Pool-based pricing trusts the live pool, which leaves the filler exposed to a manipulated, stale, or thin pool returning a bad quote. The optional **`[strategies.priceGuard]`** block bounds that risk: it sets a static reference price per chain and a tolerance in basis points. Whenever the pool quote drifts more than `maxDeviationBps` above or below the reference, the filler refuses to fill — the order is rejected before any bid is submitted.
+Pool-based pricing trusts the live pool, which leaves the filler exposed to a manipulated, stale, or thin pool returning a bad quote. To bound that risk, give a position a **`referencePrice`** and **`maxDeviationBps`**. Whenever the pool quote on that chain drifts more than `maxDeviationBps` above or below the reference, the filler refuses to fill — the order is rejected before any bid is submitted.
 
-Reference prices are expressed in **exotic tokens per USD**, the same units as the bid/ask curves, and are keyed by chain (each key must also appear in `token1`). The guard only applies when Uniswap V4 venue pricing is configured.
+`referencePrice` is expressed in **exotic tokens per USD**, the same units as the bid/ask curves. The two fields must be set together; omit both to leave the chain unguarded.
 
 ```toml lineNumbers
 [[strategies]]
@@ -155,14 +155,9 @@ maxOrderUsd = 5000
 
 [strategies.vault.uniswapV4]
 positions = [
-    { chain = "EVM-8453", tokenId = "2087350" },
+    # referencePrice is the expected cNGN per USD; reject if the quote is more than 2% off
+    { chain = "EVM-8453", tokenId = "2087350", referencePrice = "1575", maxDeviationBps = 200 },
 ]
-
-[strategies.priceGuard]
-maxDeviationBps = 200  # reject if the pool quote is more than 2% off the reference
-
-[strategies.priceGuard.referencePrices]
-"EVM-8453" = "1575"  # expected cNGN per USD
 ```
 
 #### Example profit calculation

--- a/docs/content/developers/evm/intent-gateway/simplex.mdx
+++ b/docs/content/developers/evm/intent-gateway/simplex.mdx
@@ -139,6 +139,32 @@ positions = [
 Startup validation requires a pricing source: **either** full static `bidPriceCurve` and `askPriceCurve` (≥2 points each), **or** at least one `[strategies.vault.uniswapV4]` position. Omitting both curves without Uniswap V4 positions fails validation.
 </Callout>
 
+#### Uniswap price guards
+
+Pool-based pricing trusts the live pool, which leaves the filler exposed to a manipulated, stale, or thin pool returning a bad quote. The optional **`[strategies.priceGuard]`** block bounds that risk: it sets a static reference price per chain and a tolerance in basis points. Whenever the pool quote drifts more than `maxDeviationBps` above or below the reference, the filler refuses to fill — the order is rejected before any bid is submitted.
+
+Reference prices are expressed in **exotic tokens per USD**, the same units as the bid/ask curves, and are keyed by chain (each key must also appear in `token1`). The guard only applies when Uniswap V4 venue pricing is configured.
+
+```toml lineNumbers
+[[strategies]]
+type = "hyperfx"
+maxOrderUsd = 5000
+
+[strategies.token1]
+"EVM-8453" = "0x46C85152bFe9f96829aA94755D9f915F9B10EF5F"
+
+[strategies.vault.uniswapV4]
+positions = [
+    { chain = "EVM-8453", tokenId = "2087350" },
+]
+
+[strategies.priceGuard]
+maxDeviationBps = 200  # reject if the pool quote is more than 2% off the reference
+
+[strategies.priceGuard.referencePrices]
+"EVM-8453" = "1575"  # expected cNGN per USD
+```
+
 #### Example profit calculation
 
 For a \$1000 USDC → cNGN order, the curve interpolates to bid 1575, ask 1555 at the $1000 size:

--- a/sdk/packages/simplex/filler-config-example.toml
+++ b/sdk/packages/simplex/filler-config-example.toml
@@ -221,22 +221,15 @@ points = [
 #
 # # Auto-funding from on-chain liquidity (optional)
 # # When wallet balance is insufficient, Simplex withdraws from these positions atomically
+# #
+# # Optional per-position price guard: set referencePrice (exotic per USD, same units as the
+# # bid/ask curves) and maxDeviationBps together to reject orders whenever the live pool quote
+# # on that chain drifts beyond the band. Guards against a manipulated, stale, or thin pool.
 #
 # [strategies.vault.uniswapV4]
 # positions = [
-#     { chain = "EVM-8453", tokenId = "123456789" },
+#     { chain = "EVM-8453", tokenId = "123456789", referencePrice = "1575", maxDeviationBps = 200 },
 # ]
-#
-# # Uniswap price guard (optional). Only applies with Uniswap V4 venue pricing.
-# # Rejects orders when the live pool quote drifts more than maxDeviationBps from the
-# # chain's static reference price (exotic per USD, same units as the bid/ask curves).
-# # Guards against a manipulated, stale, or thin pool. Reference chains must exist in token1.
-# [strategies.priceGuard]
-# maxDeviationBps = 200    # reject if the pool quote is more than 2% off the reference
-#
-# [strategies.priceGuard.referencePrices]
-# "EVM-56"  = "1575"
-# "EVM-137" = "1575"
 #
 
 

--- a/sdk/packages/simplex/filler-config-example.toml
+++ b/sdk/packages/simplex/filler-config-example.toml
@@ -227,6 +227,17 @@ points = [
 #     { chain = "EVM-8453", tokenId = "123456789" },
 # ]
 #
+# # Uniswap price guard (optional). Only applies with Uniswap V4 venue pricing.
+# # Rejects orders when the live pool quote drifts more than maxDeviationBps from the
+# # chain's static reference price (exotic per USD, same units as the bid/ask curves).
+# # Guards against a manipulated, stale, or thin pool. Reference chains must exist in token1.
+# [strategies.priceGuard]
+# maxDeviationBps = 200    # reject if the pool quote is more than 2% off the reference
+#
+# [strategies.priceGuard.referencePrices]
+# "EVM-56"  = "1575"
+# "EVM-137" = "1575"
+#
 
 
 # Chain configuration - RPC and bundler URLs are required

--- a/sdk/packages/simplex/src/bin/simplex.ts
+++ b/sdk/packages/simplex/src/bin/simplex.ts
@@ -142,6 +142,15 @@ interface FxStrategyConfig {
 			positions?: UniswapV4PositionToml[]
 		}
 	}
+	/**
+	 * Optional Uniswap price guard. Only meaningful with Uniswap V4 venue pricing.
+	 * Rejects orders when the pool quote drifts more than `maxDeviationBps` from the
+	 * chain's static `referencePrices` value (exotic per USD, same units as the curves).
+	 */
+	priceGuard?: {
+		maxDeviationBps: number
+		referencePrices: Record<string, string>
+	}
 }
 
 type StrategyConfig = StableStrategyConfig | FxStrategyConfig
@@ -455,6 +464,7 @@ program
 								confirmationPolicy: fxConfirmationPolicy,
 								fundingVenues,
 								spreadBps: strategyConfig.spreadBps,
+								priceGuard: strategyConfig.priceGuard,
 							},
 						)
 					}
@@ -717,6 +727,30 @@ function validateConfig(config: FillerTomlConfig): void {
 			if (strategy.spreadBps !== undefined) {
 				if (!Number.isFinite(strategy.spreadBps) || strategy.spreadBps < 0 || strategy.spreadBps > 10_000) {
 					throw new Error("hyperfx: 'spreadBps' must be a number between 0 and 10000")
+				}
+			}
+
+			if (strategy.priceGuard !== undefined) {
+				const { maxDeviationBps, referencePrices } = strategy.priceGuard
+				if (!hasUniswapV4Positions) {
+					throw new Error(
+						"hyperfx: 'priceGuard' only applies to Uniswap V4 venue pricing; configure [strategies.vault.uniswapV4].positions",
+					)
+				}
+				if (!Number.isFinite(maxDeviationBps) || maxDeviationBps <= 0 || maxDeviationBps > 10_000) {
+					throw new Error("hyperfx: 'priceGuard.maxDeviationBps' must be a number between 0 (exclusive) and 10000")
+				}
+				if (!referencePrices || Object.keys(referencePrices).length === 0) {
+					throw new Error("hyperfx: 'priceGuard.referencePrices' must have at least one chain entry")
+				}
+				for (const [chain, price] of Object.entries(referencePrices)) {
+					if (!(chain in strategy.token1)) {
+						throw new Error(`hyperfx: 'priceGuard.referencePrices' chain '${chain}' is not present in 'token1'`)
+					}
+					const parsed = Number(price)
+					if (!Number.isFinite(parsed) || parsed <= 0) {
+						throw new Error(`hyperfx: 'priceGuard.referencePrices.${chain}' must be a positive number`)
+					}
 				}
 			}
 

--- a/sdk/packages/simplex/src/bin/simplex.ts
+++ b/sdk/packages/simplex/src/bin/simplex.ts
@@ -74,10 +74,19 @@ interface StableStrategyConfig {
 	confirmationPolicies?: Record<string, ChainConfirmationPolicy>
 }
 
-/** TOML row for a Uniswap V4 position; only chain + tokenId needed. */
+/** TOML row for a Uniswap V4 position; only chain + tokenId required. */
 interface UniswapV4PositionToml {
 	chain: string
 	tokenId: string // bigint as string in TOML
+	/**
+	 * Optional price guard. When set (alongside `maxDeviationBps`), the filler rejects
+	 * orders whenever the pool quote on this chain drifts more than `maxDeviationBps`
+	 * from this static reference price (exotic per USD, same units as the bid/ask curves).
+	 * Guards against a manipulated, stale, or thin pool.
+	 */
+	referencePrice?: string
+	/** Tolerance in basis points for the price guard. Required when `referencePrice` is set. */
+	maxDeviationBps?: number
 }
 
 /**
@@ -141,15 +150,6 @@ interface FxStrategyConfig {
 		uniswapV4?: {
 			positions?: UniswapV4PositionToml[]
 		}
-	}
-	/**
-	 * Optional Uniswap price guard. Only meaningful with Uniswap V4 venue pricing.
-	 * Rejects orders when the pool quote drifts more than `maxDeviationBps` from the
-	 * chain's static `referencePrices` value (exotic per USD, same units as the curves).
-	 */
-	priceGuard?: {
-		maxDeviationBps: number
-		referencePrices: Record<string, string>
 	}
 }
 
@@ -433,6 +433,7 @@ program
 						if (vaultVenue) {
 							fundingVenues.push(vaultVenue)
 						}
+						const priceGuard: Record<string, { referencePrice: string; maxDeviationBps: number }> = {}
 						if (strategyConfig.vault?.uniswapV4?.positions?.length) {
 							const positionsByChain: Record<string, UniswapV4PositionConfig[]> = {}
 							for (const row of strategyConfig.vault.uniswapV4.positions) {
@@ -441,6 +442,12 @@ program
 								positionsByChain[chain].push({
 									tokenId: BigInt(row.tokenId),
 								})
+								if (row.referencePrice !== undefined) {
+									priceGuard[chain] = {
+										referencePrice: row.referencePrice,
+										maxDeviationBps: row.maxDeviationBps!,
+									}
+								}
 							}
 							fundingVenues.push(
 								new UniswapV4FundingPlanner(
@@ -464,7 +471,7 @@ program
 								confirmationPolicy: fxConfirmationPolicy,
 								fundingVenues,
 								spreadBps: strategyConfig.spreadBps,
-								priceGuard: strategyConfig.priceGuard,
+								priceGuard,
 							},
 						)
 					}
@@ -730,27 +737,42 @@ function validateConfig(config: FillerTomlConfig): void {
 				}
 			}
 
-			if (strategy.priceGuard !== undefined) {
-				const { maxDeviationBps, referencePrices } = strategy.priceGuard
-				if (!hasUniswapV4Positions) {
+			// Per-position price guard: referencePrice and maxDeviationBps are optional but
+			// must be set together. A given chain may not carry conflicting guard values.
+			const guardByChain: Record<string, { referencePrice: string; maxDeviationBps: number }> = {}
+			for (const position of strategy.vault?.uniswapV4?.positions ?? []) {
+				const hasRef = position.referencePrice !== undefined
+				const hasBps = position.maxDeviationBps !== undefined
+				if (hasRef !== hasBps) {
 					throw new Error(
-						"hyperfx: 'priceGuard' only applies to Uniswap V4 venue pricing; configure [strategies.vault.uniswapV4].positions",
+						"hyperfx: a Uniswap V4 position price guard needs both 'referencePrice' and 'maxDeviationBps', or neither",
 					)
 				}
-				if (!Number.isFinite(maxDeviationBps) || maxDeviationBps <= 0 || maxDeviationBps > 10_000) {
-					throw new Error("hyperfx: 'priceGuard.maxDeviationBps' must be a number between 0 (exclusive) and 10000")
+				if (!hasRef) continue
+
+				const parsedRef = Number(position.referencePrice)
+				if (!Number.isFinite(parsedRef) || parsedRef <= 0) {
+					throw new Error(`hyperfx: position 'referencePrice' for chain '${position.chain}' must be a positive number`)
 				}
-				if (!referencePrices || Object.keys(referencePrices).length === 0) {
-					throw new Error("hyperfx: 'priceGuard.referencePrices' must have at least one chain entry")
+				if (
+					!Number.isFinite(position.maxDeviationBps!) ||
+					position.maxDeviationBps! <= 0 ||
+					position.maxDeviationBps! > 10_000
+				) {
+					throw new Error(
+						`hyperfx: position 'maxDeviationBps' for chain '${position.chain}' must be a number between 0 (exclusive) and 10000`,
+					)
 				}
-				for (const [chain, price] of Object.entries(referencePrices)) {
-					if (!(chain in strategy.token1)) {
-						throw new Error(`hyperfx: 'priceGuard.referencePrices' chain '${chain}' is not present in 'token1'`)
-					}
-					const parsed = Number(price)
-					if (!Number.isFinite(parsed) || parsed <= 0) {
-						throw new Error(`hyperfx: 'priceGuard.referencePrices.${chain}' must be a positive number`)
-					}
+				const existing = guardByChain[position.chain]
+				if (
+					existing &&
+					(existing.referencePrice !== position.referencePrice || existing.maxDeviationBps !== position.maxDeviationBps)
+				) {
+					throw new Error(`hyperfx: conflicting price guard values for chain '${position.chain}'`)
+				}
+				guardByChain[position.chain] = {
+					referencePrice: position.referencePrice!,
+					maxDeviationBps: position.maxDeviationBps!,
 				}
 			}
 

--- a/sdk/packages/simplex/src/strategies/fx.ts
+++ b/sdk/packages/simplex/src/strategies/fx.ts
@@ -76,12 +76,13 @@ export class FXFiller implements FillerStrategy {
 	private fundingVenues: FundingVenue[]
 	private spreadBps: number
 	/**
-	 * Optional Uniswap price guard. When set, a venue (pool) quote is only trusted
-	 * if it stays within `maxDeviationBps` of the chain's static reference price
-	 * (exotic per USD). A quote outside the band rejects the order — defence against
-	 * a manipulated, stale, or thin pool. Keyed by chain, mirroring `token1`.
+	 * Optional Uniswap price guard, keyed by chain. When a chain has an entry, a
+	 * venue (pool) quote is only trusted if it stays within `maxDeviationBps` of the
+	 * static `reference` price (exotic per USD); a quote outside the band rejects the
+	 * order — defence against a manipulated, stale, or thin pool. Sourced from the
+	 * per-position config under `[strategies.vault.uniswapV4]`.
 	 */
-	private priceGuard?: { maxDeviationBps: number; referencePrices: Map<string, Decimal> }
+	private priceGuard?: Map<string, { reference: Decimal; maxDeviationBps: number }>
 
 	/**
 	 * @param signer                 Filler's signing account for UserOp signatures.
@@ -109,7 +110,7 @@ export class FXFiller implements FillerStrategy {
 			confirmationPolicy?: ConfirmationPolicy
 			fundingVenues?: FundingVenue[]
 			spreadBps?: number
-			priceGuard?: { maxDeviationBps: number; referencePrices: Record<string, string> }
+			priceGuard?: Record<string, { referencePrice: string; maxDeviationBps: number }>
 		},
 	) {
 		const {
@@ -137,12 +138,14 @@ export class FXFiller implements FillerStrategy {
 		this.token1 = token1
 		this.fundingVenues = fundingVenues
 		this.spreadBps = spreadBps
-		if (priceGuard) {
-			const referencePrices = new Map<string, Decimal>()
-			for (const [chain, price] of Object.entries(priceGuard.referencePrices)) {
-				referencePrices.set(chain, new Decimal(price))
+		if (priceGuard && Object.keys(priceGuard).length > 0) {
+			this.priceGuard = new Map()
+			for (const [chain, guard] of Object.entries(priceGuard)) {
+				this.priceGuard.set(chain, {
+					reference: new Decimal(guard.referencePrice),
+					maxDeviationBps: guard.maxDeviationBps,
+				})
 			}
-			this.priceGuard = { maxDeviationBps: priceGuard.maxDeviationBps, referencePrices }
 		}
 
 		// When no policies provided, create placeholder flat policies (overwritten in initialise by venue prices)
@@ -210,20 +213,19 @@ export class FXFiller implements FillerStrategy {
 	 * by more than `maxDeviationBps`, in which case the order must not be filled.
 	 */
 	private checkPriceGuard(orderId: string | undefined, chain: string, venueExoticPerUsd: Decimal): boolean {
-		if (!this.priceGuard) return true
-		const reference = this.priceGuard.referencePrices.get(chain)
-		if (!reference || reference.lte(0)) return true
+		const guard = this.priceGuard?.get(chain)
+		if (!guard || guard.reference.lte(0)) return true
 
-		const deviationBps = venueExoticPerUsd.minus(reference).abs().div(reference).mul(10000)
-		if (deviationBps.gt(this.priceGuard.maxDeviationBps)) {
+		const deviationBps = venueExoticPerUsd.minus(guard.reference).abs().div(guard.reference).mul(10000)
+		if (deviationBps.gt(guard.maxDeviationBps)) {
 			this.logger.warn(
 				{
 					orderId,
 					chain,
 					venuePrice: venueExoticPerUsd.toString(),
-					referencePrice: reference.toString(),
+					referencePrice: guard.reference.toString(),
 					deviationBps: deviationBps.toFixed(2),
-					maxDeviationBps: this.priceGuard.maxDeviationBps,
+					maxDeviationBps: guard.maxDeviationBps,
 				},
 				"Rejecting order: Uniswap venue quote outside price-guard band",
 			)

--- a/sdk/packages/simplex/src/strategies/fx.ts
+++ b/sdk/packages/simplex/src/strategies/fx.ts
@@ -75,6 +75,13 @@ export class FXFiller implements FillerStrategy {
 	confirmationPolicy?: { getConfirmationBlocks: (chainId: number, amountUsd: number) => number }
 	private fundingVenues: FundingVenue[]
 	private spreadBps: number
+	/**
+	 * Optional Uniswap price guard. When set, a venue (pool) quote is only trusted
+	 * if it stays within `maxDeviationBps` of the chain's static reference price
+	 * (exotic per USD). A quote outside the band rejects the order — defence against
+	 * a manipulated, stale, or thin pool. Keyed by chain, mirroring `token1`.
+	 */
+	private priceGuard?: { maxDeviationBps: number; referencePrices: Map<string, Decimal> }
 
 	/**
 	 * @param signer                 Filler's signing account for UserOp signatures.
@@ -102,6 +109,7 @@ export class FXFiller implements FillerStrategy {
 			confirmationPolicy?: ConfirmationPolicy
 			fundingVenues?: FundingVenue[]
 			spreadBps?: number
+			priceGuard?: { maxDeviationBps: number; referencePrices: Record<string, string> }
 		},
 	) {
 		const {
@@ -110,6 +118,7 @@ export class FXFiller implements FillerStrategy {
 			confirmationPolicy,
 			fundingVenues = [],
 			spreadBps = 50,
+			priceGuard,
 		} = options ?? {}
 
 		const hasPolicies = bidPricePolicy && askPricePolicy
@@ -128,6 +137,13 @@ export class FXFiller implements FillerStrategy {
 		this.token1 = token1
 		this.fundingVenues = fundingVenues
 		this.spreadBps = spreadBps
+		if (priceGuard) {
+			const referencePrices = new Map<string, Decimal>()
+			for (const [chain, price] of Object.entries(priceGuard.referencePrices)) {
+				referencePrices.set(chain, new Decimal(price))
+			}
+			this.priceGuard = { maxDeviationBps: priceGuard.maxDeviationBps, referencePrices }
+		}
 
 		// When no policies provided, create placeholder flat policies (overwritten in initialise by venue prices)
 		this.bidPricePolicy = bidPricePolicy ?? new FillerPricePolicy({ points: [{ amount: "0", price: "1" }] })
@@ -185,6 +201,35 @@ export class FXFiller implements FillerStrategy {
 			}
 		}
 		return null
+	}
+
+	/**
+	 * Validates a live venue quote against the static reference price for the chain.
+	 * Returns true (pass) when no guard is configured, or no reference exists for the
+	 * chain. Returns false when the quote (exotic per USD) deviates from the reference
+	 * by more than `maxDeviationBps`, in which case the order must not be filled.
+	 */
+	private checkPriceGuard(orderId: string | undefined, chain: string, venueExoticPerUsd: Decimal): boolean {
+		if (!this.priceGuard) return true
+		const reference = this.priceGuard.referencePrices.get(chain)
+		if (!reference || reference.lte(0)) return true
+
+		const deviationBps = venueExoticPerUsd.minus(reference).abs().div(reference).mul(10000)
+		if (deviationBps.gt(this.priceGuard.maxDeviationBps)) {
+			this.logger.warn(
+				{
+					orderId,
+					chain,
+					venuePrice: venueExoticPerUsd.toString(),
+					referencePrice: reference.toString(),
+					deviationBps: deviationBps.toFixed(2),
+					maxDeviationBps: this.priceGuard.maxDeviationBps,
+				},
+				"Rejecting order: Uniswap venue quote outside price-guard band",
+			)
+			return false
+		}
+		return true
 	}
 
 	async canFill(order: Order): Promise<boolean> {
@@ -292,6 +337,15 @@ export class FXFiller implements FillerStrategy {
 			const sourceVenuePrice = this.fundingVenues.length > 0 ? await this.getVenuePrice(sourceChain) : null
 			const destVenuePrice = sourceChain !== destChain && this.fundingVenues.length > 0
 				? await this.getVenuePrice(destChain) : sourceVenuePrice
+
+			// Price guard: reject the whole order if a venue quote on any involved chain
+			// has drifted beyond the configured band from its static reference price.
+			if (sourceVenuePrice && !this.checkPriceGuard(order.id, sourceChain, sourceVenuePrice.bid)) {
+				return 0
+			}
+			if (sourceChain !== destChain && destVenuePrice && !this.checkPriceGuard(order.id, destChain, destVenuePrice.bid)) {
+				return 0
+			}
 
 			let deadlineTimestamp: bigint | undefined
 			try {

--- a/sdk/packages/simplex/src/tests/strategies/fx.price-guard.test.ts
+++ b/sdk/packages/simplex/src/tests/strategies/fx.price-guard.test.ts
@@ -11,7 +11,7 @@ const CHAIN = "EVM-8453"
 const EXOTIC = "0x2222222222222222222222222222222222222222" as HexString
 const REFERENCE = "1575" // exotic per USD
 
-function makeFiller(priceGuard?: { maxDeviationBps: number; referencePrices: Record<string, string> }): FXFiller {
+function makeFiller(priceGuard?: Record<string, { referencePrice: string; maxDeviationBps: number }>): FXFiller {
 	const configService = {
 		getMaxOverfillBps: () => 500n,
 		getMaxConsecutiveClamps: () => 3,
@@ -39,7 +39,7 @@ describe("FXFiller Uniswap price guard", () => {
 	})
 
 	it("passes a quote inside the band", () => {
-		const filler = makeFiller({ maxDeviationBps: 200, referencePrices: { [CHAIN]: REFERENCE } })
+		const filler = makeFiller({ [CHAIN]: { referencePrice: REFERENCE, maxDeviationBps: 200 } })
 		// 1% above and below — within the 2% band
 		expect(check(filler, "1590")).toBe(true)
 		expect(check(filler, "1560")).toBe(true)
@@ -48,17 +48,17 @@ describe("FXFiller Uniswap price guard", () => {
 	})
 
 	it("rejects a quote above the band", () => {
-		const filler = makeFiller({ maxDeviationBps: 200, referencePrices: { [CHAIN]: REFERENCE } })
+		const filler = makeFiller({ [CHAIN]: { referencePrice: REFERENCE, maxDeviationBps: 200 } })
 		expect(check(filler, "1700")).toBe(false) // ~7.9% above
 	})
 
 	it("rejects a quote below the band", () => {
-		const filler = makeFiller({ maxDeviationBps: 200, referencePrices: { [CHAIN]: REFERENCE } })
+		const filler = makeFiller({ [CHAIN]: { referencePrice: REFERENCE, maxDeviationBps: 200 } })
 		expect(check(filler, "1400")).toBe(false) // ~11% below
 	})
 
 	it("passes when no reference exists for the chain", () => {
-		const filler = makeFiller({ maxDeviationBps: 200, referencePrices: { "EVM-137": REFERENCE } })
+		const filler = makeFiller({ "EVM-137": { referencePrice: REFERENCE, maxDeviationBps: 200 } })
 		expect(check(filler, "5000")).toBe(true)
 	})
 })

--- a/sdk/packages/simplex/src/tests/strategies/fx.price-guard.test.ts
+++ b/sdk/packages/simplex/src/tests/strategies/fx.price-guard.test.ts
@@ -1,0 +1,64 @@
+import { FXFiller } from "@/strategies/fx"
+import { FillerPricePolicy } from "@/config/interpolated-curve"
+import { type HexString } from "@hyperbridge/sdk"
+import { describe, it, expect } from "vitest"
+import { Decimal } from "decimal.js"
+
+// Pure unit tests for the Uniswap price guard. Exercises the private
+// `checkPriceGuard` directly so no chain access or venue mocking is needed.
+
+const CHAIN = "EVM-8453"
+const EXOTIC = "0x2222222222222222222222222222222222222222" as HexString
+const REFERENCE = "1575" // exotic per USD
+
+function makeFiller(priceGuard?: { maxDeviationBps: number; referencePrices: Record<string, string> }): FXFiller {
+	const configService = {
+		getMaxOverfillBps: () => 500n,
+		getMaxConsecutiveClamps: () => 3,
+	} as any
+	const contractService = {} as any
+	const signer = { account: { address: "0x3333333333333333333333333333333333333333" } } as any
+	const clientManager = {} as any
+
+	return new FXFiller(signer, configService, clientManager, contractService, 5000, { [CHAIN]: EXOTIC }, {
+		bidPricePolicy: new FillerPricePolicy({ points: [{ amount: "0", price: REFERENCE }] }),
+		askPricePolicy: new FillerPricePolicy({ points: [{ amount: "0", price: REFERENCE }] }),
+		priceGuard,
+	})
+}
+
+function check(filler: FXFiller, exoticPerUsd: string): boolean {
+	return (filler as any).checkPriceGuard("order-1", CHAIN, new Decimal(exoticPerUsd))
+}
+
+describe("FXFiller Uniswap price guard", () => {
+	it("passes every quote when no guard is configured", () => {
+		const filler = makeFiller()
+		expect(check(filler, "1575")).toBe(true)
+		expect(check(filler, "5000")).toBe(true)
+	})
+
+	it("passes a quote inside the band", () => {
+		const filler = makeFiller({ maxDeviationBps: 200, referencePrices: { [CHAIN]: REFERENCE } })
+		// 1% above and below — within the 2% band
+		expect(check(filler, "1590")).toBe(true)
+		expect(check(filler, "1560")).toBe(true)
+		// exactly at the 2% edge (1575 * 1.02 = 1606.5)
+		expect(check(filler, "1606.5")).toBe(true)
+	})
+
+	it("rejects a quote above the band", () => {
+		const filler = makeFiller({ maxDeviationBps: 200, referencePrices: { [CHAIN]: REFERENCE } })
+		expect(check(filler, "1700")).toBe(false) // ~7.9% above
+	})
+
+	it("rejects a quote below the band", () => {
+		const filler = makeFiller({ maxDeviationBps: 200, referencePrices: { [CHAIN]: REFERENCE } })
+		expect(check(filler, "1400")).toBe(false) // ~11% below
+	})
+
+	it("passes when no reference exists for the chain", () => {
+		const filler = makeFiller({ maxDeviationBps: 200, referencePrices: { "EVM-137": REFERENCE } })
+		expect(check(filler, "5000")).toBe(true)
+	})
+})


### PR DESCRIPTION
Closes #975.

Adds an optional price guard to the HyperFX strategy's Uniswap V4 positions. When pricing the exotic token from a Uniswap V4 pool, a manipulated, stale, or thin pool can return a bad quote. Setting `referencePrice` and `maxDeviationBps` on a position makes the filler reject orders whenever the live pool quote on that chain drifts beyond the band, before any bid is submitted.

- `referencePrice`: static expected price in exotic-per-USD (same units as the bid/ask curves).
- `maxDeviationBps`: tolerance in basis points; the two fields must be set together.
- Configured per position under `[strategies.vault.uniswapV4]`; omit both to leave a chain unguarded.

```toml
[strategies.vault.uniswapV4]
positions = [
    { chain = "EVM-8453", tokenId = "2087350", referencePrice = "1575", maxDeviationBps = 200 },
]
```

Enforcement lives in `calculateProfitability` right after venue prices are fetched — returning 0 rejects the whole order (legs settle atomically). Returning 0 rather than null is deliberate: null would silently fall back to the static/placeholder curve and still fill.

Config example and docs updated; unit test covers inside-band (incl. the edge), above, below, no-reference, and no-guard cases.