### PR TITLE
[simplex]: fill from funding venues first, reserving the wallet minBalance

### DIFF
--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/simplex",
-	"version": "0.5.7",
+	"version": "0.5.8",
 	"license": "Apache-2.0",
 	"description": "IntentGateway simplex package for hyperbridge",
 	"main": "dist/index.js",

--- a/sdk/packages/simplex/src/funding/types.ts
+++ b/sdk/packages/simplex/src/funding/types.ts
@@ -41,6 +41,13 @@ export interface FundingVenue {
 	 * Computed on-demand from the venue's current pool state.
 	 */
 	getExoticTokenPrice(chain: string, exoticToken: string): Promise<Decimal | null>
+	/**
+	 * Wallet balance of `tokenLower` the fill must keep liquid and never source
+	 * from — the vault's `minBalance` floor, reserved for gas/paymaster paid in
+	 * this token. Returns 0 when the venue has no reserve for the token (e.g. no
+	 * configured vault, or a venue without a wallet-floor concept like Uniswap V4).
+	 */
+	walletReserveForToken(chain: string, tokenLower: string): bigint
 }
 
 export interface FundingPlanResult {

--- a/sdk/packages/simplex/src/funding/uniswapV4/UniswapV4FundingPlanner.ts
+++ b/sdk/packages/simplex/src/funding/uniswapV4/UniswapV4FundingPlanner.ts
@@ -162,6 +162,11 @@ export class UniswapV4FundingPlanner implements FundingVenue {
 	// Pricing (FundingVenue)
 	// =========================================================================
 
+	/** Uniswap V4 sources from LP positions, not a wallet float — no reserve. */
+	walletReserveForToken(_chain: string, _tokenLower: string): bigint {
+		return 0n
+	}
+
 	async getExoticTokenPrice(chain: string, exoticToken: string): Promise<Decimal | null> {
 		const state = this.stateByChain.get(chain)
 		if (!state || !state.isHydrated()) return null

--- a/sdk/packages/simplex/src/funding/vault/VaultFundingPlanner.ts
+++ b/sdk/packages/simplex/src/funding/vault/VaultFundingPlanner.ts
@@ -113,6 +113,17 @@ export class VaultFundingPlanner implements FundingVenue {
 		return null
 	}
 
+	/**
+	 * The vault's `minBalance` floor for `tokenLower` on `chain` — the wallet
+	 * balance the fill must keep liquid (gas/paymaster). 0 when no configured
+	 * vault on the chain holds the token.
+	 */
+	walletReserveForToken(chain: string, tokenLower: string): bigint {
+		const state = this.stateByChain.get(chain)
+		if (!state || !state.isHydrated()) return 0n
+		return state.reserveFor(tokenLower)
+	}
+
 	// =========================================================================
 	// Planning (FundingVenue)
 	// =========================================================================

--- a/sdk/packages/simplex/src/funding/vault/VaultLiquidityState.ts
+++ b/sdk/packages/simplex/src/funding/vault/VaultLiquidityState.ts
@@ -197,6 +197,11 @@ export class VaultLiquidityState {
 		return this.vaults.get(asset.toLowerCase())?.remaining ?? 0n
 	}
 
+	/** Wallet floor (`minBalance`) for `asset` the fill must never spend below. 0 if not configured. */
+	reserveFor(asset: string): bigint {
+		return this.vaults.get(asset.toLowerCase())?.minBalanceScaled ?? 0n
+	}
+
 	consume(asset: string, amount: bigint): void {
 		const key = asset.toLowerCase()
 		const list = this.reservations.get(key) ?? []

--- a/sdk/packages/simplex/src/services/ContractInteractionService.ts
+++ b/sdk/packages/simplex/src/services/ContractInteractionService.ts
@@ -636,6 +636,10 @@ export class ContractInteractionService {
 	/**
 	 * Builds ERC-7821 batch calldata that prepends any required ERC20 approvals
 	 * before the fillOrder call, all within a single UserOp payload.
+	 *
+	 * Same-chain fills release escrow locally with no Hyperbridge dispatch, so the
+	 * gateway never pulls the fee token — its approval is skipped. Only cross-chain
+	 * fills, which dispatch a RedeemEscrow message paid in the fee token, need it.
 	 */
 	public async buildApprovalAndFillCalldata(
 		order: Order,
@@ -656,9 +660,11 @@ export class ContractInteractionService {
 			perTokenRequired.set(key, (perTokenRequired.get(key) ?? 0n) + output.amount)
 		}
 
-		const feeToken = await this.getFeeTokenWithDecimals(chain)
-		const feeKey = feeToken.address.toLowerCase()
-		perTokenRequired.set(feeKey, (perTokenRequired.get(feeKey) ?? 0n) + requiredFeeTokenAmount)
+		if (order.source !== order.destination) {
+			const feeToken = await this.getFeeTokenWithDecimals(chain)
+			const feeKey = feeToken.address.toLowerCase()
+			perTokenRequired.set(feeKey, (perTokenRequired.get(feeKey) ?? 0n) + requiredFeeTokenAmount)
+		}
 
 		// Check allowances in parallel
 		const entries = [...perTokenRequired.entries()]

--- a/sdk/packages/simplex/src/strategies/fx.ts
+++ b/sdk/packages/simplex/src/strategies/fx.ts
@@ -455,10 +455,10 @@ export class FXFiller implements FillerStrategy {
 					)
 				}
 
-				// Source the output from funding venues first (the vault), leaving the wallet
-				// untouched. Only what the venues can't cover is drawn from the wallet, and
-				// never below the configured minBalance reserve — kept liquid for the
-				// gas/paymaster pull during validatePaymasterUserOp.
+				// Spend the free wallet balance first, down to the configured minBalance
+				// reserve — kept liquid for the gas/paymaster pull during
+				// validatePaymasterUserOp — then source any remaining shortfall from the
+				// funding venues (the vault).
 				const tokenAddress = bytes32ToBytes20(output.token).toLowerCase()
 				const balance = await this.getAndCacheBalance(tokenAddress, walletAddress, destClient, balanceCache)
 
@@ -468,8 +468,10 @@ export class FXFiller implements FillerStrategy {
 				}
 				const usableWallet = balance > reserve ? balance - reserve : 0n
 
+				const walletContribution = policyMaxOutput < usableWallet ? policyMaxOutput : usableWallet
+
 				let credited = 0n
-				let needed = policyMaxOutput
+				let needed = policyMaxOutput - walletContribution
 				for (const venue of this.fundingVenues) {
 					if (needed <= 0n) break
 					const planned = await venue.planWithdrawalForToken(destChain, walletAddress, tokenAddress, needed, deadlineTimestamp)
@@ -480,8 +482,7 @@ export class FXFiller implements FillerStrategy {
 					}
 				}
 
-				const walletContribution = needed < usableWallet ? needed : usableWallet
-				const effectiveBalance = credited + walletContribution
+				const effectiveBalance = walletContribution + credited
 
 				const finalOutputAmount = effectiveBalance > policyMaxOutput ? policyMaxOutput : effectiveBalance
 

--- a/sdk/packages/simplex/src/strategies/fx.ts
+++ b/sdk/packages/simplex/src/strategies/fx.ts
@@ -455,21 +455,33 @@ export class FXFiller implements FillerStrategy {
 					)
 				}
 
-				// Cap by wallet balance on the destination chain, optionally topped up via LP removal.
+				// Source the output from funding venues first (the vault), leaving the wallet
+				// untouched. Only what the venues can't cover is drawn from the wallet, and
+				// never below the configured minBalance reserve — kept liquid for the
+				// gas/paymaster pull during validatePaymasterUserOp.
 				const tokenAddress = bytes32ToBytes20(output.token).toLowerCase()
 				const balance = await this.getAndCacheBalance(tokenAddress, walletAddress, destClient, balanceCache)
 
-				let effectiveBalance = balance
-				let deficit = policyMaxOutput > balance ? policyMaxOutput - balance : 0n
+				let reserve = 0n
 				for (const venue of this.fundingVenues) {
-					if (deficit <= 0n) break
-					const planned = await venue.planWithdrawalForToken(destChain, walletAddress, tokenAddress, deficit, deadlineTimestamp)
+					reserve += venue.walletReserveForToken(destChain, tokenAddress)
+				}
+				const usableWallet = balance > reserve ? balance - reserve : 0n
+
+				let credited = 0n
+				let needed = policyMaxOutput
+				for (const venue of this.fundingVenues) {
+					if (needed <= 0n) break
+					const planned = await venue.planWithdrawalForToken(destChain, walletAddress, tokenAddress, needed, deadlineTimestamp)
 					if (planned.calls.length > 0) {
 						fundingCalls.push(...planned.calls)
-						effectiveBalance += planned.credited
-						deficit -= planned.credited
+						credited += planned.credited
+						needed -= planned.credited
 					}
 				}
+
+				const walletContribution = needed < usableWallet ? needed : usableWallet
+				const effectiveBalance = credited + walletContribution
 
 				const finalOutputAmount = effectiveBalance > policyMaxOutput ? policyMaxOutput : effectiveBalance
 
@@ -511,9 +523,11 @@ export class FXFiller implements FillerStrategy {
 					return 0
 				}
 
-				// Decrement remaining balance for this token so repeated outputs share the same pool.
-				const remaining = effectiveBalance - finalOutputAmount
-				balanceCache.set(tokenAddress, remaining > 0n ? remaining : 0n)
+				// Decrement the wallet pool by what this leg drew from it (vault-sourced
+				// tokens are tracked by the venue's own reservations) so repeated outputs
+				// of the same token share one wallet balance.
+				const walletRemaining = balance - walletContribution
+				balanceCache.set(tokenAddress, walletRemaining > 0n ? walletRemaining : 0n)
 
 				fillerOutputs.push({ token: output.token, amount: finalOutputAmount })
 				fillerOutputLegs.push(i)

--- a/sdk/packages/simplex/src/strategies/stable.ts
+++ b/sdk/packages/simplex/src/strategies/stable.ts
@@ -346,22 +346,31 @@ export class StableFiller implements FillerStrategy {
 			// Native outputs can't be sourced from token venues.
 			if (tokenLower === ADDRESS_ZERO.toLowerCase()) continue
 
-			let available = await this.getAndCacheBalance(tokenLower, solver, destClient, balanceCache)
-			if (available >= out.amount) {
-				balanceCache.set(tokenLower, available - out.amount)
-				continue
-			}
+			const walletBalance = await this.getAndCacheBalance(tokenLower, solver, destClient, balanceCache)
 
-			let deficit = out.amount - available
+			// Wallet floor reserved for gas/paymaster (the vault minBalance) — never filled from.
+			let reserve = 0n
 			for (const venue of this.fundingVenues) {
-				if (deficit <= 0n) break
-				const planned = await venue.planWithdrawalForToken(order.destination, solver, tokenLower, deficit)
+				reserve += venue.walletReserveForToken(order.destination, tokenLower)
+			}
+			const usableWallet = walletBalance > reserve ? walletBalance - reserve : 0n
+
+			// Vault-first: source the full output from venues, leaving the wallet untouched.
+			// Only the venues' shortfall is drawn from the wallet, above the reserve.
+			let credited = 0n
+			let needed = out.amount
+			for (const venue of this.fundingVenues) {
+				if (needed <= 0n) break
+				const planned = await venue.planWithdrawalForToken(order.destination, solver, tokenLower, needed)
 				if (planned.calls.length > 0) {
 					fundingCalls.push(...planned.calls)
-					available += planned.credited
-					deficit -= planned.credited
+					credited += planned.credited
+					needed -= planned.credited
 				}
 			}
+
+			const walletContribution = needed < usableWallet ? needed : usableWallet
+			const available = credited + walletContribution
 
 			const effectiveOutput = out.amount < available ? out.amount : available
 			if (effectiveOutput < userMin) {
@@ -390,7 +399,9 @@ export class StableFiller implements FillerStrategy {
 				)
 				out.amount = effectiveOutput
 			}
-			balanceCache.set(tokenLower, available - effectiveOutput)
+			// Decrement the wallet pool by what this leg drew from it (vault-sourced tokens
+			// are tracked by the venue's own reservations) so repeated outputs share one pool.
+			balanceCache.set(tokenLower, walletBalance - walletContribution)
 		}
 
 		if (fundingCalls.length > 0) {

--- a/sdk/packages/simplex/src/strategies/stable.ts
+++ b/sdk/packages/simplex/src/strategies/stable.ts
@@ -355,10 +355,12 @@ export class StableFiller implements FillerStrategy {
 			}
 			const usableWallet = walletBalance > reserve ? walletBalance - reserve : 0n
 
-			// Vault-first: source the full output from venues, leaving the wallet untouched.
-			// Only the venues' shortfall is drawn from the wallet, above the reserve.
+			// Spend the free wallet balance (above the reserve) first, then source any
+			// remaining shortfall from the funding venues (the vault).
+			const walletContribution = out.amount < usableWallet ? out.amount : usableWallet
+
 			let credited = 0n
-			let needed = out.amount
+			let needed = out.amount - walletContribution
 			for (const venue of this.fundingVenues) {
 				if (needed <= 0n) break
 				const planned = await venue.planWithdrawalForToken(order.destination, solver, tokenLower, needed)
@@ -369,8 +371,7 @@ export class StableFiller implements FillerStrategy {
 				}
 			}
 
-			const walletContribution = needed < usableWallet ? needed : usableWallet
-			const available = credited + walletContribution
+			const available = walletContribution + credited
 
 			const effectiveOutput = out.amount < available ? out.amount : available
 			if (effectiveOutput < userMin) {

--- a/sdk/packages/simplex/src/tests/funding/vault.test.ts
+++ b/sdk/packages/simplex/src/tests/funding/vault.test.ts
@@ -28,7 +28,10 @@ interface Balances {
  * `readContract` dispatches on functionName/address to return controlled
  * vault data and balances.
  */
-function makeWithdrawPlanner(balances: Balances) {
+function makeWithdrawPlanner(
+	balances: Balances,
+	vaultCfg: VaultOutputFundingConfig["vaultsByChain"][string][number] = { vault: VAULT_USDC },
+) {
 	const fakeClient = {
 		async readContract({
 			address,
@@ -57,7 +60,7 @@ function makeWithdrawPlanner(balances: Balances) {
 	}
 
 	const clientManager = { getPublicClient: () => fakeClient } as unknown as ChainClientManager
-	const config: VaultOutputFundingConfig = { vaultsByChain: { [CHAIN]: [{ vault: VAULT_USDC }] } }
+	const config: VaultOutputFundingConfig = { vaultsByChain: { [CHAIN]: [vaultCfg] } }
 	return new VaultFundingPlanner(clientManager, config)
 }
 
@@ -212,6 +215,30 @@ describe("VaultFundingPlanner", () => {
 		} finally {
 			vi.useRealTimers()
 		}
+	})
+
+	it("exposes the configured minBalance as the wallet reserve for the token", async () => {
+		const planner = makeWithdrawPlanner(
+			{ positionAssets: 1_000_000n, maxWithdrawable: 1_000_000n },
+			{ vault: VAULT_USDC, minBalance: "3000" },
+		)
+		await planner.initialise(SOLVER)
+		expect(planner.walletReserveForToken(CHAIN, USDC.toLowerCase())).toBe(u("3000"))
+	})
+
+	it("reports a zero reserve when the vault sets no minBalance", async () => {
+		const planner = makeWithdrawPlanner({ positionAssets: 1_000_000n, maxWithdrawable: 1_000_000n })
+		await planner.initialise(SOLVER)
+		expect(planner.walletReserveForToken(CHAIN, USDC.toLowerCase())).toBe(0n)
+	})
+
+	it("reports a zero reserve for tokens with no configured vault", async () => {
+		const planner = makeWithdrawPlanner(
+			{ positionAssets: 1_000_000n, maxWithdrawable: 1_000_000n },
+			{ vault: VAULT_USDC, minBalance: "3000" },
+		)
+		await planner.initialise(SOLVER)
+		expect(planner.walletReserveForToken(CHAIN, USDT.toLowerCase())).toBe(0n)
 	})
 
 	it("returns null for exotic-token pricing (stable-only venue)", async () => {


### PR DESCRIPTION
Fills now reserve the vault's `minBalance` floor in the wallet and never spend below it, keeping it liquid for the gas/paymaster pull. Output is sourced from the free wallet balance (above the reserve) first, then any remaining shortfall is withdrawn from the configured funding venue (the ERC-4626 vault).

Previously the fill spent the full wallet balance, ignoring `minBalance`. The Circle paymaster pulls USDC during `validatePaymasterUserOp`, which runs before the fill executes, so on a small fill the paymaster took its gas out of the same wallet USDC the fill was about to pay out, and `fillOrder` reverted with `ERC20: transfer amount exceeds balance` (basescan tx `0xd5c8c0…fa94f9`: output 797,833, balance 772,247, short by the paymaster's exact 25,586 pull). Reserving `minBalance` keeps the paymaster's slice liquid.

Applies to both the FX and stable strategies. A new `walletReserveForToken` on the funding-venue interface exposes the floor; the vault venue returns its `minBalance`, Uniswap V4 returns zero.

Note for operators: set `minBalance` on the USDC vault to comfortably exceed the worst-case paymaster prefund per chain.

Also skips the fee-token (USDC) approval on same-chain fills. Same-chain orders release escrow locally with no Hyperbridge dispatch, so the gateway never pulls the fee token; only cross-chain fills, which dispatch a RedeemEscrow message paid in the fee token, still approve it. Output-token approvals are unchanged.