### PR TITLE
[simplex]: pay vault sweep/redeem gas via the Circle paymaster

### DIFF
--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/simplex",
-	"version": "0.5.8",
+	"version": "0.5.9",
 	"license": "Apache-2.0",
 	"description": "IntentGateway simplex package for hyperbridge",
 	"main": "dist/index.js",

--- a/sdk/packages/simplex/src/bin/simplex.ts
+++ b/sdk/packages/simplex/src/bin/simplex.ts
@@ -23,6 +23,7 @@ import {
 } from "@/services/FillerConfigService"
 import { ChainClientManager } from "@/services/ChainClientManager"
 import { ContractInteractionService } from "@/services/ContractInteractionService"
+import { UserOpSender } from "@/services/UserOpSender"
 import { RebalancingService } from "@/services/RebalancingService"
 import { getLogger, configureLogger, type LogLevel } from "@/services/Logger"
 import { CacheService } from "@/services/CacheService"
@@ -382,6 +383,10 @@ program
 				"Bid storage initialized for fund recovery tracking",
 			)
 
+			// Sponsors self-initiated UserOps (delegation, vault sweep/redeem) via the
+			// Circle paymaster so gas is paid in USDC instead of native token.
+			const userOpSender = new UserOpSender(chainClientManager, configService, runtimeSigner)
+
 			// Build the shared vault venue (withdraw sourcing + threshold sweeping).
 			// A single instance is shared across strategies and the sweep timer.
 			let vaultVenue: VaultFundingPlanner | undefined
@@ -396,10 +401,14 @@ program
 						redeemOnShutdown: row.redeemOnShutdown,
 					})
 				}
-				vaultVenue = new VaultFundingPlanner(chainClientManager, {
-					vaultsByChain,
-					sweepIntervalMs: config.vault.sweepIntervalMs,
-				})
+				vaultVenue = new VaultFundingPlanner(
+					chainClientManager,
+					{
+						vaultsByChain,
+						sweepIntervalMs: config.vault.sweepIntervalMs,
+					},
+					userOpSender,
+				)
 			}
 
 			// Initialize strategies with shared services

--- a/sdk/packages/simplex/src/funding/vault/VaultFundingPlanner.ts
+++ b/sdk/packages/simplex/src/funding/vault/VaultFundingPlanner.ts
@@ -3,6 +3,7 @@ import { ERC4626_ABI } from "@/config/abis/Erc4626"
 import { VaultLiquidityState } from "@/funding/vault/VaultLiquidityState"
 import type { VaultOutputFundingConfig, FundingPlanResult, FundingVenue } from "@/funding/types"
 import type { ChainClientManager } from "@/services/ChainClientManager"
+import type { UserOpSender } from "@/services/UserOpSender"
 import { getLogger } from "@/services/Logger"
 import { encodeERC7821ExecuteBatch, type ERC7821Call, type HexString } from "@hyperbridge/sdk"
 import { Mutex } from "async-mutex"
@@ -36,9 +37,15 @@ export class VaultFundingPlanner implements FundingVenue {
 	private solver: HexString | null = null
 	private sweepInterval?: NodeJS.Timeout
 
+	/**
+	 * @param userOpSender When provided, sweep/redeem batches are sent as Circle-
+	 * Paymaster-sponsored UserOps (gas paid in USDC) where the chain supports it,
+	 * falling back to a native EOA tx. Omit to always use native txs.
+	 */
 	constructor(
 		private readonly clientManager: ChainClientManager,
 		private readonly config: VaultOutputFundingConfig,
+		private readonly userOpSender?: UserOpSender,
 	) {}
 
 	/**
@@ -299,16 +306,46 @@ export class VaultFundingPlanner implements FundingVenue {
 
 			if (calls.length === 0) return
 
-			const walletClient = this.clientManager.getWalletClient(chain)
-			const tx = await walletClient.sendTransaction({
-				to: solver,
-				data: encodeERC7821ExecuteBatch(calls),
-				value: 0n,
-				chain: walletClient.chain,
-			})
-			const receipt = await publicClient.waitForTransactionReceipt({ hash: tx, confirmations: 1 })
-			logger.info({ chain, tx, status: receipt.status, pairs: calls.length / 2 }, "Vault sweep submitted")
+			const { txHash, sponsored } = await this.submitBatch(chain, solver, calls)
+			logger.info({ chain, tx: txHash, sponsored, pairs: calls.length / 2 }, "Vault sweep submitted")
 		})
+	}
+
+	/**
+	 * Sends an ERC-7821 batch to the solver account. Prefers a Circle-Paymaster-
+	 * sponsored UserOp (gas paid in USDC) when a sender is wired and the chain
+	 * supports it, falling back to a native EOA tx.
+	 *
+	 * The sponsored path only falls back to native when the op was **never
+	 * submitted**; a submitted-but-unconfirmed op throws so a native resend can't
+	 * double-execute the batch (the caller's timer logs and retries next cycle).
+	 */
+	private async submitBatch(
+		chain: string,
+		solver: HexString,
+		calls: ERC7821Call[],
+	): Promise<{ txHash: HexString; sponsored: boolean }> {
+		const callData = encodeERC7821ExecuteBatch(calls)
+
+		if (this.userOpSender?.canSponsor(chain)) {
+			const result = await this.userOpSender.trySendSponsored({ chain, callData })
+			if (result) return { txHash: result.txHash, sponsored: true }
+			logger.warn({ chain }, "Sponsored batch unavailable, sending native tx")
+		}
+
+		const walletClient = this.clientManager.getWalletClient(chain)
+		const publicClient = this.clientManager.getPublicClient(chain)
+		const tx = await walletClient.sendTransaction({
+			to: solver,
+			data: callData,
+			value: 0n,
+			chain: walletClient.chain,
+		})
+		const receipt = await publicClient.waitForTransactionReceipt({ hash: tx, confirmations: 1, timeout: 60_000 })
+		if (receipt.status !== "success") {
+			throw new Error(`Vault batch tx reverted: ${tx}`)
+		}
+		return { txHash: tx, sponsored: false }
 	}
 
 	// =========================================================================
@@ -369,19 +406,8 @@ export class VaultFundingPlanner implements FundingVenue {
 
 			if (calls.length === 0) return
 
-			const walletClient = this.clientManager.getWalletClient(chain)
-			const tx = await walletClient.sendTransaction({
-				to: solver,
-				data: encodeERC7821ExecuteBatch(calls),
-				value: 0n,
-				chain: walletClient.chain,
-			})
-			const receipt = await publicClient.waitForTransactionReceipt({
-				hash: tx,
-				confirmations: 1,
-				timeout: 60_000,
-			})
-			logger.info({ chain, tx, status: receipt.status, vaults: calls.length }, "Vault shutdown redeem submitted")
+			const { txHash, sponsored } = await this.submitBatch(chain, solver, calls)
+			logger.info({ chain, tx: txHash, sponsored, vaults: calls.length }, "Vault shutdown redeem submitted")
 		})
 	}
 }

--- a/sdk/packages/simplex/src/services/DelegationService.ts
+++ b/sdk/packages/simplex/src/services/DelegationService.ts
@@ -1,12 +1,11 @@
 import type { HexString } from "@hyperbridge/sdk"
-import { CryptoUtils, BundlerMethod } from "@hyperbridge/sdk"
-import { concat, formatEther, formatUnits, keccak256, toHex, toRlp, zeroAddress } from "viem"
+import { concat, formatEther, keccak256, toHex, toRlp, zeroAddress } from "viem"
 import { ChainClientManager } from "./ChainClientManager"
 import { FillerConfigService } from "./FillerConfigService"
 import { getLogger } from "./Logger"
 import type { SigningAccount } from "./wallet"
-import { buildPaymasterAndData, getUsdcBalanceStatus, hasPaymaster } from "./paymaster"
-import { ENTRYPOINT_ABI } from "@/config/abis/Entrypoint"
+import { hasPaymaster } from "./paymaster"
+import { UserOpSender } from "./UserOpSender"
 
 /** EIP-7702 delegation indicator prefix */
 const DELEGATION_INDICATOR_PREFIX = "0xef0100"
@@ -27,12 +26,15 @@ const DELEGATION_TX_GAS_FLOOR = 650_000n
  */
 export class DelegationService {
 	private logger = getLogger("delegation-service")
+	private readonly userOpSender: UserOpSender
 
 	constructor(
 		private clientManager: ChainClientManager,
 		private configService: FillerConfigService,
 		private signer: SigningAccount,
-	) {}
+	) {
+		this.userOpSender = new UserOpSender(clientManager, configService, signer)
+	}
 
 	private computeAuthorizationHash(chainId: number, contractAddress: HexString, nonce: number): HexString {
 		// EIP-7702 requires canonical RLP: integer 0 encodes as empty bytes (0x80), not 0x00.
@@ -147,182 +149,49 @@ export class DelegationService {
 	 */
 	private async setupDelegationViaBundler(chain: string): Promise<boolean> {
 		const solverAccountContract = this.configService.getSolverAccountContractAddress(chain)
-		const entryPointAddress = this.configService.getEntryPointAddress(chain)
-		const bundlerUrl = this.configService.getBundlerUrl(chain)
 
-		if (!solverAccountContract || !hasPaymaster(chain, this.configService) || !entryPointAddress || !bundlerUrl) {
+		if (!solverAccountContract || !this.userOpSender.canSponsor(chain)) {
 			this.logger.warn({ chain }, "Missing config for bundler-based delegation, falling back to direct tx")
 			return false
 		}
 
-		const publicClient = this.clientManager.getPublicClient(chain)
-		const walletClient = this.clientManager.getWalletClient(chain)
-		const solverAccount = this.signer.account.address as HexString
-		const chainId = this.configService.getChainId(chain)
-
 		try {
-			// The paymaster sponsors gas in USDC; without enough USDC it can't pay and the
-			// bundler path is impossible. Check up front so we log a precise reason rather
-			// than a generic "no paymaster" further down.
-			const usdcDecimals = this.configService.getUsdcDecimals(chain)
-			const usdc = await getUsdcBalanceStatus(
-				publicClient,
-				solverAccount,
-				this.configService.getUsdcAsset(chain),
-				usdcDecimals,
-			)
-			if (!usdc.sufficient) {
-				this.logger.warn(
-					{
-						chain,
-						solverAccount,
-						usdcBalance: formatUnits(usdc.balance, usdcDecimals),
-						requiredUsdc: formatUnits(usdc.required, usdcDecimals),
-					},
-					"Insufficient USDC balance to sponsor delegation via paymaster; falling back to direct tx",
-				)
-				return false
-			}
-
-			// Build EIP-7702 authorization (bundler submits tx, so use current nonce)
+			// Build EIP-7702 authorization (bundler submits the tx, so use the current nonce)
+			// and carry it inside the UserOp so a not-yet-delegated EOA is delegated in the op.
 			const authorization = await this.buildAuthorization(chain, solverAccountContract, true)
 
 			this.logger.info(
-				{ chain, solverAccount, solverAccountContract, mode: "bundler" },
+				{ chain, solverAccount: this.signer.account.address, solverAccountContract, mode: "bundler" },
 				"Setting up EIP-7702 delegation via bundler with paymaster",
 			)
 
-			// Build paymaster data — Circle (USDC permit) or none
-			const pmResult = await buildPaymasterAndData({
+			const result = await this.userOpSender.trySendSponsored({
 				chain,
-				solverAccount,
-				publicClient,
-				walletClient,
-				signer: this.signer,
-				configService: this.configService,
-			})
-			if (pmResult.type === "none") {
-				this.logger.warn(
-					{ chain, solverAccount },
-					"Paymaster data unavailable despite sufficient USDC; falling back to direct tx",
-				)
-				return false
-			}
-			const paymasterAndData = pmResult.paymasterAndData
-			this.logger.info(
-				{ chain, paymaster: pmResult.address, type: pmResult.type },
-				"Using paymaster for delegation UserOp",
-			)
-
-			// Get gas prices — detect bundler type and use appropriate RPC method
-			let maxFeePerGas: bigint
-			let maxPriorityFeePerGas: bigint
-
-			const bundlerUrlLower = bundlerUrl.toLowerCase()
-			const isPimlico = bundlerUrlLower.includes("pimlico.io")
-			const isAlchemy = bundlerUrlLower.includes("alchemy.com")
-
-			if (isPimlico) {
-				const gasPriceResult = await this.sendBundlerRpc<{
-					fast: { maxFeePerGas: string; maxPriorityFeePerGas: string }
-				}>(bundlerUrl, BundlerMethod.PIMLICO_GET_USER_OPERATION_GAS_PRICE, [])
-				maxFeePerGas = BigInt(gasPriceResult.fast.maxFeePerGas)
-				maxPriorityFeePerGas = BigInt(gasPriceResult.fast.maxPriorityFeePerGas)
-			} else if (isAlchemy) {
-				const [rundlerPriorityFee, latestBlock] = await Promise.all([
-					this.sendBundlerRpc<HexString>(bundlerUrl, BundlerMethod.RUNDLER_MAX_PRIORITY_FEE_PER_GAS, []),
-					publicClient.getBlock({ blockTag: "latest" }),
-				])
-				const baseFeePerGas = latestBlock.baseFeePerGas ?? (await publicClient.getGasPrice())
-				const chainIdBigInt = BigInt(chainId)
-				const isArbitrum = chainIdBigInt === 42161n
-				const alchemyPrioBump = isArbitrum ? 0n : 25n
-				maxPriorityFeePerGas =
-					BigInt(rundlerPriorityFee) + (BigInt(rundlerPriorityFee) * alchemyPrioBump) / 100n
-				const bufferedBaseFee = baseFeePerGas + (baseFeePerGas * 50n) / 100n
-				maxFeePerGas = bufferedBaseFee + maxPriorityFeePerGas
-			} else {
-				const gasPrice = await publicClient.getGasPrice()
-				maxPriorityFeePerGas = gasPrice + (gasPrice * 8n) / 100n
-				maxFeePerGas = gasPrice + (gasPrice * 10n) / 100n
-			}
-
-			// Get nonce from EntryPoint (key = 0 for delegation UserOps)
-			const nonce = (await publicClient.readContract({
-				address: entryPointAddress,
-				abi: ENTRYPOINT_ABI,
-				functionName: "getNonce",
-				args: [solverAccount, 0n],
-			})) as bigint
-
-			// 5. Build minimal no-op UserOp
-			const verificationGasLimit = 150_000n
-			const callGasLimit = 50_000n
-			const preVerificationGas = 100_000n
-			const accountGasLimits = CryptoUtils.packGasLimits(verificationGasLimit, callGasLimit)
-			const gasFees = CryptoUtils.packGasFees(maxPriorityFeePerGas, maxFeePerGas)
-
-			const userOp = {
-				sender: solverAccount,
-				nonce,
-				initCode: "0x" as HexString,
 				callData: "0x" as HexString,
-				accountGasLimits,
-				preVerificationGas,
-				gasFees,
-				paymasterAndData,
-				signature: "0x" as HexString,
-			}
+				eip7702Auth: authorization,
+				// Fixed limits for the no-op delegation op. The EOA has no code to
+				// simulate on a first delegation, and bundler estimation of EIP-7702 ops
+				// is unreliable (Alchemy echoes the input limits rather than simulating).
+				gas: { verificationGasLimit: 150_000n, callGasLimit: 50_000n, preVerificationGas: 100_000n },
+			})
 
-			// Compute UserOp hash (EIP-712) and sign with raw ECDSA (no eth prefix)
-			//    SolverAccount._rawSignatureValidation expects ECDSA.recover(userOpHash, sig) == address(this)
-			const userOpHash = CryptoUtils.computeUserOpHash(
-				userOp,
-				entryPointAddress as `0x${string}`,
-				BigInt(chainId),
-			)
-			const { r, s, yParity } = await this.signer.signRawHash(userOpHash as HexString)
-			const v = yParity === 0 ? 27 : 28
-			userOp.signature = concat([r, s, toHex(v)]) as HexString
-
-			// Prepare bundler call format using CryptoUtils
-			const bundlerUserOp = CryptoUtils.prepareBundlerCall(userOp)
-
-			// Attach EIP-7702 authorization inside the UserOp object for Pimlico
-			bundlerUserOp.eip7702Auth = {
-				address: authorization.address,
-				chainId: toHex(authorization.chainId),
-				nonce: toHex(authorization.nonce),
-				r: authorization.r,
-				s: authorization.s,
-				yParity: toHex(authorization.yParity),
-			}
-
-			// Send to bundler: eth_sendUserOperation(userOp, entryPoint)
-			const userOpHashResult = await this.sendBundlerRpc<HexString>(
-				bundlerUrl,
-				BundlerMethod.ETH_SEND_USER_OPERATION,
-				[bundlerUserOp, entryPointAddress],
-			)
-
-			this.logger.info({ chain, userOpHash: userOpHashResult }, "Delegation UserOp submitted to bundler")
-
-			// Wait for receipt
-			const receipt = await this.waitForUserOpReceipt(bundlerUrl, userOpHashResult)
-
-			if (receipt) {
+			if (result) {
 				this.logger.info(
-					{ chain, txHash: receipt.receipt?.transactionHash },
+					{ chain, txHash: result.txHash },
 					"Delegation via bundler successful — paymaster paid gas",
 				)
 				return true
 			}
 
-			this.logger.warn({ chain }, "Delegation UserOp receipt not received, checking on-chain status")
-			return this.isDelegated(chain)
-		} catch (error) {
-			this.logger.warn({ chain, error }, "Bundler delegation failed, will fall back to direct tx")
+			// null → the op was never submitted (no paymaster/bundler, insufficient USDC,
+			// or the bundler rejected it). Safe to fall back to a direct tx.
+			this.logger.warn({ chain }, "Sponsored delegation unavailable, falling back to direct tx")
 			return false
+		} catch (error) {
+			// The op may have been submitted but not yet confirmed — check on-chain status
+			// rather than blindly re-submitting via a direct tx.
+			this.logger.warn({ chain, error }, "Bundler delegation did not confirm, checking on-chain status")
+			return this.isDelegated(chain)
 		}
 	}
 
@@ -452,45 +321,5 @@ export class DelegationService {
 			this.logger.error({ chain, error }, "Failed to revoke delegation")
 			return false
 		}
-	}
-
-	// ── Helpers ──────────────────────────────────────────────────────
-
-	private async sendBundlerRpc<T>(bundlerUrl: string, method: string, params: unknown[]): Promise<T> {
-		const response = await fetch(bundlerUrl, {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
-		})
-
-		const result = (await response.json()) as { result?: T; error?: { message?: string } }
-
-		if (result.error) {
-			throw new Error(`Bundler RPC error (${method}): ${result.error.message || JSON.stringify(result.error)}`)
-		}
-
-		return result.result as T
-	}
-
-	private async waitForUserOpReceipt(
-		bundlerUrl: string,
-		userOpHash: HexString,
-		maxAttempts = 30,
-		intervalMs = 2000,
-	): Promise<{ receipt?: { transactionHash: HexString } } | null> {
-		for (let i = 0; i < maxAttempts; i++) {
-			try {
-				const receipt = await this.sendBundlerRpc<{ receipt: { transactionHash: HexString } } | null>(
-					bundlerUrl,
-					BundlerMethod.ETH_GET_USER_OPERATION_RECEIPT,
-					[userOpHash],
-				)
-				if (receipt) return receipt
-			} catch {
-				// Not found yet
-			}
-			await new Promise((resolve) => setTimeout(resolve, intervalMs))
-		}
-		return null
 	}
 }

--- a/sdk/packages/simplex/src/services/DelegationService.ts
+++ b/sdk/packages/simplex/src/services/DelegationService.ts
@@ -165,14 +165,29 @@ export class DelegationService {
 				"Setting up EIP-7702 delegation via bundler with paymaster",
 			)
 
+			// Fixed limits for the no-op delegation op — bundler estimation of EIP-7702
+			// ops is unreliable (Alchemy echoes the input limits rather than simulating).
+			//
+			// A FRESH delegation (EOA has no code) burns far more verification gas on
+			// first-time cold storage, so the proven 150k account + default 200k paymaster
+			// limits clear rundler's verification-efficiency policy. A RE-delegation
+			// (EOA already delegated) uses much less (warm slots, paymaster allowance
+			// reused) — actual ~96k — so those loose limits fall below the 0.4 floor
+			// (`actual / (accountVerif + paymasterVerif)`). Tighten both verification
+			// limits for that case so the ratio clears 0.4 while still covering usage.
+			const code = await this.clientManager.getPublicClient(chain).getCode({
+				address: this.signer.account.address as HexString,
+			})
+			const isFreshEoa = !code || code === "0x"
+
 			const result = await this.userOpSender.trySendSponsored({
 				chain,
 				callData: "0x" as HexString,
 				eip7702Auth: authorization,
-				// Fixed limits for the no-op delegation op. The EOA has no code to
-				// simulate on a first delegation, and bundler estimation of EIP-7702 ops
-				// is unreliable (Alchemy echoes the input limits rather than simulating).
-				gas: { verificationGasLimit: 150_000n, callGasLimit: 50_000n, preVerificationGas: 100_000n },
+				gas: isFreshEoa
+					? { verificationGasLimit: 150_000n, callGasLimit: 50_000n, preVerificationGas: 100_000n }
+					: { verificationGasLimit: 80_000n, callGasLimit: 50_000n, preVerificationGas: 100_000n },
+				paymasterVerificationGasLimit: isFreshEoa ? undefined : 110_000n,
 			})
 
 			if (result) {

--- a/sdk/packages/simplex/src/services/UserOpSender.ts
+++ b/sdk/packages/simplex/src/services/UserOpSender.ts
@@ -1,0 +1,370 @@
+import { CryptoUtils, BundlerMethod, type PackedUserOperation, type HexString } from "@hyperbridge/sdk"
+import { concat, toHex, type PublicClient } from "viem"
+import { ENTRYPOINT_ABI } from "@/config/abis/Entrypoint"
+import { ChainClientManager } from "./ChainClientManager"
+import { FillerConfigService } from "./FillerConfigService"
+import { getLogger } from "./Logger"
+import type { SigningAccount } from "./wallet"
+import { buildPaymasterAndData, getUsdcBalanceStatus, hasPaymaster } from "./paymaster"
+
+/**
+ * Raw EIP-7702 authorization, as produced by the delegation flow. Attached to the
+ * bundler UserOp so a not-yet-delegated EOA can be delegated in the same op.
+ */
+export interface Eip7702Authorization {
+	chainId: number
+	address: HexString
+	nonce: number
+	r: HexString
+	s: HexString
+	yParity: number
+}
+
+export interface UserOpGasLimits {
+	verificationGasLimit: bigint
+	callGasLimit: bigint
+	preVerificationGas: bigint
+}
+
+export interface SponsoredUserOpRequest {
+	chain: string
+	/** ERC-7821 batch (or "0x" for a no-op, e.g. delegation). */
+	callData: HexString
+	/** Attach when the EOA still needs delegating in this op. */
+	eip7702Auth?: Eip7702Authorization
+	/** EntryPoint nonce key. Defaults to 0. */
+	nonceKey?: bigint
+	/**
+	 * Explicit gas limits. Provide them to skip bundler estimation — required for
+	 * the not-yet-delegated EIP-7702 case, where the account has no code to
+	 * simulate so estimation is unreliable. When omitted, limits are estimated.
+	 */
+	gas?: UserOpGasLimits
+}
+
+// Generous fallbacks used only when bundler gas estimation fails. The paymaster
+// refunds unused gas in postOp, and the permit ceiling caps the validation-phase
+// prefund regardless of these, so over-estimating here is safe (it does not pull
+// more USDC than the allowance).
+const FALLBACK_VERIFICATION_GAS_LIMIT = 250_000n
+const FALLBACK_CALL_GAS_LIMIT = 1_500_000n
+const FALLBACK_PRE_VERIFICATION_GAS = 150_000n
+
+/**
+ * Submits self-initiated, Circle-Paymaster-sponsored UserOperations through the
+ * bundler, so the solver pays gas in USDC rather than native token. Shared by the
+ * delegation setup and the vault sweep/redeem paths.
+ *
+ * Submission contract (so callers can safely fall back to a native tx without
+ * risking a double-execution):
+ * - Returns `null` when the op was **never submitted** — paymaster/bundler not
+ *   configured, insufficient USDC, or the bundler rejected `eth_sendUserOperation`
+ *   outright (it never entered the mempool). The caller may fall back to native.
+ * - Returns `{ txHash }` once a receipt is observed.
+ * - **Throws** only when the op **was submitted** but no receipt arrived. The
+ *   caller must NOT fall back (the op may still land) — retry on the next cycle.
+ */
+export class UserOpSender {
+	private logger = getLogger("userop-sender")
+
+	constructor(
+		private readonly clientManager: ChainClientManager,
+		private readonly configService: FillerConfigService,
+		private readonly signer: SigningAccount,
+	) {}
+
+	/** True when a sponsored UserOp is even possible on this chain (paymaster + bundler configured). */
+	canSponsor(chain: string): boolean {
+		return (
+			hasPaymaster(chain, this.configService) &&
+			!!this.configService.getEntryPointAddress(chain) &&
+			!!this.configService.getBundlerUrl(chain)
+		)
+	}
+
+	async trySendSponsored(req: SponsoredUserOpRequest): Promise<{ txHash: HexString } | null> {
+		const { chain, callData, eip7702Auth, nonceKey = 0n, gas } = req
+
+		const entryPoint = this.configService.getEntryPointAddress(chain)
+		const bundlerUrl = this.configService.getBundlerUrl(chain)
+		if (!hasPaymaster(chain, this.configService) || !entryPoint || !bundlerUrl) {
+			return null
+		}
+
+		const publicClient = this.clientManager.getPublicClient(chain)
+		const walletClient = this.clientManager.getWalletClient(chain)
+		const solverAccount = this.signer.account.address as HexString
+		const chainId = this.configService.getChainId(chain)
+
+		// The paymaster sponsors gas in USDC; without enough USDC it can't pay.
+		const usdcDecimals = this.configService.getUsdcDecimals(chain)
+		const usdc = await getUsdcBalanceStatus(
+			publicClient,
+			solverAccount,
+			this.configService.getUsdcAsset(chain),
+			usdcDecimals,
+		)
+		if (!usdc.sufficient) {
+			this.logger.warn(
+				{ chain, solverAccount, usdcBalance: usdc.balance.toString(), required: usdc.required.toString() },
+				"Insufficient USDC to sponsor UserOp via paymaster; caller should fall back to native",
+			)
+			return null
+		}
+
+		const pm = await buildPaymasterAndData({
+			chain,
+			solverAccount,
+			publicClient,
+			walletClient,
+			signer: this.signer,
+			configService: this.configService,
+		})
+		if (pm.type === "none") {
+			this.logger.warn({ chain }, "Paymaster data unavailable; caller should fall back to native")
+			return null
+		}
+		const paymasterAndData = pm.paymasterAndData
+
+		const { maxFeePerGas, maxPriorityFeePerGas } = await this.getGasPrice(bundlerUrl, publicClient, chainId)
+
+		const nonce = (await publicClient.readContract({
+			address: entryPoint,
+			abi: ENTRYPOINT_ABI,
+			functionName: "getNonce",
+			args: [solverAccount, nonceKey],
+		})) as bigint
+
+		const formattedAuth = eip7702Auth
+			? {
+					address: eip7702Auth.address,
+					chainId: toHex(eip7702Auth.chainId),
+					nonce: toHex(eip7702Auth.nonce),
+					r: eip7702Auth.r,
+					s: eip7702Auth.s,
+					yParity: toHex(eip7702Auth.yParity),
+				}
+			: undefined
+
+		// Explicit limits skip estimation (needed for the not-yet-delegated EIP-7702
+		// case, where there is no account code to simulate).
+		const { verificationGasLimit, callGasLimit, preVerificationGas } =
+			gas ??
+			(await this.estimateGas({
+				bundlerUrl,
+				entryPoint,
+				chainId,
+				solverAccount,
+				nonce,
+				callData,
+				paymasterAndData,
+				maxFeePerGas,
+				maxPriorityFeePerGas,
+				formattedAuth,
+			}))
+
+		const userOp = await this.buildSignedUserOp({
+			entryPoint,
+			chainId,
+			solverAccount,
+			nonce,
+			callData,
+			paymasterAndData,
+			maxFeePerGas,
+			maxPriorityFeePerGas,
+			verificationGasLimit,
+			callGasLimit,
+			preVerificationGas,
+		})
+
+		const bundlerUserOp = CryptoUtils.prepareBundlerCall(userOp)
+		if (formattedAuth) bundlerUserOp.eip7702Auth = formattedAuth
+
+		let userOpHash: HexString
+		try {
+			userOpHash = await this.sendBundlerRpc<HexString>(bundlerUrl, BundlerMethod.ETH_SEND_USER_OPERATION, [
+				bundlerUserOp,
+				entryPoint,
+			])
+		} catch (error) {
+			// Rejected before entering the mempool — never submitted, safe to fall back.
+			this.logger.warn({ chain, error }, "Bundler rejected UserOp; caller should fall back to native")
+			return null
+		}
+
+		this.logger.info({ chain, userOpHash }, "Sponsored UserOp submitted to bundler")
+
+		const receipt = await this.waitForUserOpReceipt(bundlerUrl, userOpHash)
+		const txHash = receipt?.receipt?.transactionHash
+		if (!txHash) {
+			// Submitted but unconfirmed — it may still land, so the caller must NOT
+			// fall back to a native tx (that would double-execute).
+			throw new Error(`Sponsored UserOp ${userOpHash} submitted but no receipt within timeout`)
+		}
+		if (receipt?.success === false) {
+			// Included but the inner execution reverted — surface it rather than report
+			// success. The caller must not fall back (the op was mined).
+			throw new Error(`Sponsored UserOp ${userOpHash} reverted on-chain (tx ${txHash})`)
+		}
+
+		this.logger.info({ chain, userOpHash, txHash }, "Sponsored UserOp confirmed — paymaster paid gas")
+		return { txHash }
+	}
+
+	// ── Internals ────────────────────────────────────────────────────────
+
+	/**
+	 * Estimates account gas limits via the bundler. The op is signed first so the
+	 * estimation simulation passes the account's ECDSA validation. Falls back to
+	 * generous constants when the bundler estimate is unavailable.
+	 */
+	private async estimateGas(p: {
+		bundlerUrl: string
+		entryPoint: HexString
+		chainId: number
+		solverAccount: HexString
+		nonce: bigint
+		callData: HexString
+		paymasterAndData: HexString
+		maxFeePerGas: bigint
+		maxPriorityFeePerGas: bigint
+		formattedAuth?: Record<string, unknown>
+	}): Promise<{ verificationGasLimit: bigint; callGasLimit: bigint; preVerificationGas: bigint }> {
+		try {
+			const prelim = await this.buildSignedUserOp({
+				entryPoint: p.entryPoint,
+				chainId: p.chainId,
+				solverAccount: p.solverAccount,
+				nonce: p.nonce,
+				callData: p.callData,
+				paymasterAndData: p.paymasterAndData,
+				maxFeePerGas: p.maxFeePerGas,
+				maxPriorityFeePerGas: p.maxPriorityFeePerGas,
+				verificationGasLimit: FALLBACK_VERIFICATION_GAS_LIMIT,
+				callGasLimit: FALLBACK_CALL_GAS_LIMIT,
+				preVerificationGas: FALLBACK_PRE_VERIFICATION_GAS,
+			})
+
+			const bundlerUserOp = CryptoUtils.prepareBundlerCall(prelim)
+			if (p.formattedAuth) bundlerUserOp.eip7702Auth = p.formattedAuth
+
+			const est = await this.sendBundlerRpc<{
+				callGasLimit: string
+				verificationGasLimit: string
+				preVerificationGas: string
+			}>(p.bundlerUrl, BundlerMethod.ETH_ESTIMATE_USER_OPERATION_GAS, [bundlerUserOp, p.entryPoint])
+
+			return {
+				// Bias the execution limit up — sweep/redeem batches vary in size.
+				callGasLimit: (BigInt(est.callGasLimit) * 160n) / 100n,
+				verificationGasLimit: (BigInt(est.verificationGasLimit) * 110n) / 100n,
+				preVerificationGas: (BigInt(est.preVerificationGas) * 110n) / 100n,
+			}
+		} catch (error) {
+			this.logger.warn({ error }, "UserOp gas estimation failed, using generous fallback limits")
+			return {
+				verificationGasLimit: FALLBACK_VERIFICATION_GAS_LIMIT,
+				callGasLimit: FALLBACK_CALL_GAS_LIMIT,
+				preVerificationGas: FALLBACK_PRE_VERIFICATION_GAS,
+			}
+		}
+	}
+
+	private async buildSignedUserOp(p: {
+		entryPoint: HexString
+		chainId: number
+		solverAccount: HexString
+		nonce: bigint
+		callData: HexString
+		paymasterAndData: HexString
+		maxFeePerGas: bigint
+		maxPriorityFeePerGas: bigint
+		verificationGasLimit: bigint
+		callGasLimit: bigint
+		preVerificationGas: bigint
+	}): Promise<PackedUserOperation> {
+		const userOp: PackedUserOperation = {
+			sender: p.solverAccount,
+			nonce: p.nonce,
+			initCode: "0x" as HexString,
+			callData: p.callData,
+			accountGasLimits: CryptoUtils.packGasLimits(p.verificationGasLimit, p.callGasLimit),
+			preVerificationGas: p.preVerificationGas,
+			gasFees: CryptoUtils.packGasFees(p.maxPriorityFeePerGas, p.maxFeePerGas),
+			paymasterAndData: p.paymasterAndData,
+			signature: "0x" as HexString,
+		}
+
+		// SolverAccount._rawSignatureValidation expects ECDSA.recover(userOpHash, sig) == account.
+		const userOpHash = CryptoUtils.computeUserOpHash(userOp, p.entryPoint, BigInt(p.chainId))
+		const { r, s, yParity } = await this.signer.signRawHash(userOpHash as HexString)
+		const v = yParity === 0 ? 27 : 28
+		userOp.signature = concat([r, s, toHex(v)]) as HexString
+		return userOp
+	}
+
+	/** Mirrors the gas-price selection used by the delegation and fill paths. */
+	private async getGasPrice(
+		bundlerUrl: string,
+		publicClient: PublicClient,
+		chainId: number,
+	): Promise<{ maxFeePerGas: bigint; maxPriorityFeePerGas: bigint }> {
+		const lower = bundlerUrl.toLowerCase()
+		if (lower.includes("pimlico.io")) {
+			const res = await this.sendBundlerRpc<{ fast: { maxFeePerGas: string; maxPriorityFeePerGas: string } }>(
+				bundlerUrl,
+				BundlerMethod.PIMLICO_GET_USER_OPERATION_GAS_PRICE,
+				[],
+			)
+			return { maxFeePerGas: BigInt(res.fast.maxFeePerGas), maxPriorityFeePerGas: BigInt(res.fast.maxPriorityFeePerGas) }
+		}
+		if (lower.includes("alchemy.com")) {
+			const [rundlerPriorityFee, latestBlock] = await Promise.all([
+				this.sendBundlerRpc<HexString>(bundlerUrl, BundlerMethod.RUNDLER_MAX_PRIORITY_FEE_PER_GAS, []),
+				publicClient.getBlock({ blockTag: "latest" }),
+			])
+			const baseFeePerGas = latestBlock.baseFeePerGas ?? (await publicClient.getGasPrice())
+			const isArbitrum = BigInt(chainId) === 42161n
+			const prioBump = isArbitrum ? 0n : 25n
+			const maxPriorityFeePerGas = BigInt(rundlerPriorityFee) + (BigInt(rundlerPriorityFee) * prioBump) / 100n
+			const bufferedBaseFee = baseFeePerGas + (baseFeePerGas * 50n) / 100n
+			return { maxFeePerGas: bufferedBaseFee + maxPriorityFeePerGas, maxPriorityFeePerGas }
+		}
+		const gasPrice = await publicClient.getGasPrice()
+		return { maxFeePerGas: gasPrice + (gasPrice * 10n) / 100n, maxPriorityFeePerGas: gasPrice + (gasPrice * 8n) / 100n }
+	}
+
+	private async sendBundlerRpc<T>(bundlerUrl: string, method: string, params: unknown[]): Promise<T> {
+		const response = await fetch(bundlerUrl, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+		})
+		const result = (await response.json()) as { result?: T; error?: { message?: string } }
+		if (result.error) {
+			throw new Error(`Bundler RPC error (${method}): ${result.error.message || JSON.stringify(result.error)}`)
+		}
+		return result.result as T
+	}
+
+	private async waitForUserOpReceipt(
+		bundlerUrl: string,
+		userOpHash: HexString,
+		maxAttempts = 30,
+		intervalMs = 2000,
+	): Promise<{ success?: boolean; receipt?: { transactionHash: HexString } } | null> {
+		for (let i = 0; i < maxAttempts; i++) {
+			try {
+				const receipt = await this.sendBundlerRpc<{
+					success?: boolean
+					receipt: { transactionHash: HexString }
+				} | null>(bundlerUrl, BundlerMethod.ETH_GET_USER_OPERATION_RECEIPT, [userOpHash])
+				if (receipt) return receipt
+			} catch {
+				// Not indexed yet.
+			}
+			await new Promise((resolve) => setTimeout(resolve, intervalMs))
+		}
+		return null
+	}
+}

--- a/sdk/packages/simplex/src/services/UserOpSender.ts
+++ b/sdk/packages/simplex/src/services/UserOpSender.ts
@@ -40,6 +40,13 @@ export interface SponsoredUserOpRequest {
 	 * simulate so estimation is unreliable. When omitted, limits are estimated.
 	 */
 	gas?: UserOpGasLimits
+	/**
+	 * Override for the Circle paymaster verification gas limit (default 200k).
+	 * Lower it for a known cheap op so rundler's verification-gas-limit efficiency
+	 * policy — which divides actual usage by `accountVerif + paymasterVerif` —
+	 * accepts the op (e.g. re-delegation).
+	 */
+	paymasterVerificationGasLimit?: bigint
 }
 
 // Generous fallbacks used only when bundler gas estimation fails. The paymaster
@@ -83,7 +90,7 @@ export class UserOpSender {
 	}
 
 	async trySendSponsored(req: SponsoredUserOpRequest): Promise<{ txHash: HexString } | null> {
-		const { chain, callData, eip7702Auth, nonceKey = 0n, gas } = req
+		const { chain, callData, eip7702Auth, nonceKey = 0n, gas, paymasterVerificationGasLimit } = req
 
 		const entryPoint = this.configService.getEntryPointAddress(chain)
 		const bundlerUrl = this.configService.getBundlerUrl(chain)
@@ -119,6 +126,7 @@ export class UserOpSender {
 			walletClient,
 			signer: this.signer,
 			configService: this.configService,
+			paymasterVerificationGasLimit,
 		})
 		if (pm.type === "none") {
 			this.logger.warn({ chain }, "Paymaster data unavailable; caller should fall back to native")

--- a/sdk/packages/simplex/src/services/paymaster/index.ts
+++ b/sdk/packages/simplex/src/services/paymaster/index.ts
@@ -23,7 +23,7 @@ export function hasPaymaster(chain: string, configService: FillerConfigService):
  * 2. None — returns "0x" (caller falls back to EntryPoint deposit)
  */
 export async function buildPaymasterAndData(options: PaymasterOptions): Promise<PaymasterDataResult> {
-	const { chain, solverAccount, publicClient, signer, configService } = options
+	const { chain, solverAccount, publicClient, signer, configService, paymasterVerificationGasLimit } = options
 
 	const circleAddr = configService.getCirclePaymasterAddress(chain)
 	if (!circleAddr) {
@@ -42,7 +42,15 @@ export async function buildPaymasterAndData(options: PaymasterOptions): Promise<
 		return { paymasterAndData: "0x" as HexString, type: "none" }
 	}
 
-	const pm = await buildCirclePaymasterData(publicClient, signer, solverAccount, circleAddr, chain, configService)
+	const pm = await buildCirclePaymasterData(
+		publicClient,
+		signer,
+		solverAccount,
+		circleAddr,
+		chain,
+		configService,
+		paymasterVerificationGasLimit,
+	)
 	return {
 		paymasterAndData: packPaymasterAndData(pm),
 		type: "circle",

--- a/sdk/packages/simplex/src/services/paymaster/provider/circle.ts
+++ b/sdk/packages/simplex/src/services/paymaster/provider/circle.ts
@@ -24,6 +24,13 @@ export async function buildCirclePaymasterData(
 	paymasterAddress: HexString,
 	chain: string,
 	configService: FillerConfigService,
+	/**
+	 * Override for the paymaster verification gas limit. Defaults to the
+	 * Circle-recommended {@link VERIFICATION_GAS_LIMIT_CIRCLE}. A caller can pass a
+	 * tighter value for a known, cheap op (e.g. a re-delegation) so the bundler's
+	 * verification-gas-limit efficiency policy accepts it — see the delegation path.
+	 */
+	paymasterVerificationGasLimit: bigint = VERIFICATION_GAS_LIMIT_CIRCLE,
 ): Promise<PaymasterResult> {
 	const usdcAddress = configService.getUsdcAsset(chain)
 	const usdcDecimals = configService.getUsdcDecimals(chain)
@@ -47,7 +54,7 @@ export async function buildCirclePaymasterData(
 		return {
 			paymaster: paymasterAddress,
 			paymasterData,
-			paymasterVerificationGasLimit: VERIFICATION_GAS_LIMIT_CIRCLE,
+			paymasterVerificationGasLimit,
 			paymasterPostOpGasLimit: POST_OP_GAS_LIMIT,
 		}
 	}

--- a/sdk/packages/simplex/src/services/paymaster/types.ts
+++ b/sdk/packages/simplex/src/services/paymaster/types.ts
@@ -20,6 +20,8 @@ export interface PaymasterOptions {
 	walletClient: WalletClient
 	signer: { signTypedData: (typedData: unknown, chainId?: number) => Promise<HexString> }
 	configService: FillerConfigService
+	/** Override for the Circle paymaster verification gas limit (default 200k). */
+	paymasterVerificationGasLimit?: bigint
 }
 
 export interface PaymasterDataResult {

--- a/sdk/packages/simplex/src/tests/funding/vault.test.ts
+++ b/sdk/packages/simplex/src/tests/funding/vault.test.ts
@@ -4,6 +4,7 @@ import { VaultFundingPlanner } from "@/funding/vault/VaultFundingPlanner"
 import { ERC4626_ABI } from "@/config/abis/Erc4626"
 import type { VaultOutputFundingConfig } from "@/funding/types"
 import type { ChainClientManager } from "@/services/ChainClientManager"
+import type { UserOpSender } from "@/services/UserOpSender"
 import type { HexString } from "@hyperbridge/sdk"
 
 const CHAIN = "EVM-8453"
@@ -75,6 +76,7 @@ function makeSweepPlanner(
 	vaults: VaultOutputFundingConfig["vaultsByChain"][string],
 	shares: Record<string, bigint> = {},
 	maxDeposit = 10_000_000_000n,
+	userOpSender?: UserOpSender,
 ) {
 	const sendTransaction = vi.fn(async (_tx: { to: HexString; data: HexString; value: bigint }) => "0xtx" as HexString)
 
@@ -116,7 +118,7 @@ function makeSweepPlanner(
 		getWalletClient: () => walletClient,
 	} as unknown as ChainClientManager
 
-	const planner = new VaultFundingPlanner(clientManager, { vaultsByChain: { [CHAIN]: vaults } })
+	const planner = new VaultFundingPlanner(clientManager, { vaultsByChain: { [CHAIN]: vaults } }, userOpSender)
 	return { planner, sendTransaction }
 }
 
@@ -385,5 +387,54 @@ describe("VaultFundingPlanner.redeemAll", () => {
 		await planner.redeemAll()
 
 		expect(sendTransaction).not.toHaveBeenCalled()
+	})
+})
+
+describe("VaultFundingPlanner — paymaster-sponsored sweep", () => {
+	const sweepVault: VaultOutputFundingConfig["vaultsByChain"][string] = [
+		{ vault: VAULT_USDC, threshold: "5000", minBalance: "3000" },
+	]
+	const sweepWallet = { [USDC.toLowerCase()]: u("6000") }
+
+	function makeSender(opts: {
+		canSponsor: boolean
+		result?: { txHash: HexString } | null
+	}): { sender: UserOpSender; trySendSponsored: ReturnType<typeof vi.fn> } {
+		const trySendSponsored = vi.fn(async () => opts.result ?? null)
+		const sender = {
+			canSponsor: () => opts.canSponsor,
+			trySendSponsored,
+		} as unknown as UserOpSender
+		return { sender, trySendSponsored }
+	}
+
+	it("submits the sweep as a sponsored UserOp, not a native tx", async () => {
+		const { sender, trySendSponsored } = makeSender({ canSponsor: true, result: { txHash: "0xabc" as HexString } })
+		const { planner, sendTransaction } = makeSweepPlanner(sweepWallet, sweepVault, {}, undefined, sender)
+		await planner.initialise(SOLVER)
+		await planner.sweepExcessToVault(CHAIN)
+
+		expect(trySendSponsored).toHaveBeenCalledOnce()
+		expect(sendTransaction).not.toHaveBeenCalled()
+	})
+
+	it("falls back to a native tx when the op was never submitted (null)", async () => {
+		const { sender, trySendSponsored } = makeSender({ canSponsor: true, result: null })
+		const { planner, sendTransaction } = makeSweepPlanner(sweepWallet, sweepVault, {}, undefined, sender)
+		await planner.initialise(SOLVER)
+		await planner.sweepExcessToVault(CHAIN)
+
+		expect(trySendSponsored).toHaveBeenCalledOnce()
+		expect(sendTransaction).toHaveBeenCalledOnce()
+	})
+
+	it("uses a native tx when the chain cannot be sponsored", async () => {
+		const { sender, trySendSponsored } = makeSender({ canSponsor: false })
+		const { planner, sendTransaction } = makeSweepPlanner(sweepWallet, sweepVault, {}, undefined, sender)
+		await planner.initialise(SOLVER)
+		await planner.sweepExcessToVault(CHAIN)
+
+		expect(trySendSponsored).not.toHaveBeenCalled()
+		expect(sendTransaction).toHaveBeenCalledOnce()
 	})
 })

--- a/sdk/packages/simplex/src/tests/services/DelegationService.test.ts
+++ b/sdk/packages/simplex/src/tests/services/DelegationService.test.ts
@@ -43,9 +43,14 @@ const PIMLICO_BUNDLER_URL = process.env.BASE_PIMLICO_BUNDLER_URL
 // Alchemy's bundler shares its RPC endpoint; reuse BASE_MAINNET unless a separate URL is needed.
 const ALCHEMY_BUNDLER_URL = RPC_URL
 
+interface SendBundlerRpc {
+	sendBundlerRpc: <T>(bundlerUrl: string, method: string, params: unknown[]) => Promise<T>
+}
+
 interface DelegationServicePrivates {
 	setupDelegationViaBundler: (chain: string) => Promise<boolean>
-	sendBundlerRpc: <T>(bundlerUrl: string, method: string, params: unknown[]) => Promise<T>
+	/** The shared sender now owns the bundler RPC; the test patches it to surface send errors. */
+	userOpSender: SendBundlerRpc
 }
 
 function build(bundlerUrl: string) {
@@ -60,8 +65,9 @@ function build(bundlerUrl: string) {
 	// `eth_sendUserOperation` error instead — a bare `false` would hide why it failed.
 	let capturedError: Error | null = null
 	const privates = service as unknown as DelegationServicePrivates
-	const original = privates.sendBundlerRpc.bind(service)
-	privates.sendBundlerRpc = async (url, method, params) => {
+	const sender = privates.userOpSender
+	const original = sender.sendBundlerRpc.bind(sender)
+	sender.sendBundlerRpc = async (url, method, params) => {
 		try {
 			return await original(url, method, params)
 		} catch (err) {


### PR DESCRIPTION
The vault sweep and shutdown redeem previously sent native EOA transactions, requiring the solver to hold native gas. They now go through a Circle-Paymaster-sponsored UserOp (gas paid in USDC), falling back to a native tx when the paymaster path is unavailable.

A shared `UserOpSender` is extracted to build, sign, and submit sponsored UserOps through the bundler; `DelegationService` is migrated onto it (removing the duplicated bundler/gas-price/receipt logic), and `VaultFundingPlanner` sweep/redeem route through it.

The submission contract avoids double-execution: the sender returns null only when the op was never submitted (caller falls back to native), and throws once an op is in the mempool (caller skips and retries) so a native resend can't replay the batch.

The USDC sweep already reserves `minBalance`, which covers the paymaster's gas pull during `validatePaymasterUserOp`, so a sponsored sweep is safe as long as `minBalance` exceeds the prefund — the same operator guidance as #984.

## Re-delegation on Alchemy
EIP-7702 delegation is sponsored via the bundler too. Alchemy's rundler enforces a verification-gas-limit efficiency policy: it rejects a UserOp when `verification_gas_used / (accountVerificationGasLimit + paymasterVerificationGasLimit) < 0.4` (rundler's `total_verification_gas_limit` sums both). A first delegation of a fresh EOA burns enough verification gas on cold storage to clear it, but a re-delegation — when the SolverAccount implementation changes, on an already-delegated EOA — uses far less (warm slots, paymaster allowance reused; actual ~96k), and the fixed 200k Circle paymaster verification limit alone drags the ratio below 0.4.

The fix detects the re-delegation case (the EOA already has code) and submits tighter verification limits for that op only — account 80k plus a paymaster-verification override of 110k (denominator 190k, ratio ~0.51) — leaving the fresh-delegation path on its proven limits. The override is plumbed through `buildPaymasterAndData`; the global default (200k, used by fills and sweeps) is unchanged.

Verified live on Base against the Alchemy bundler (`base-mainnet.g.alchemy.com`): the same EOA that was rejected with the loose limits (efficiency 0.275) is now sponsored and confirmed on-chain (tx `0x5224f98d2e02fb522175548875545969a94fb2ef5cb542253c2d18195856e1ac`). So re-delegation no longer requires Pimlico or a native ETH backstop. If a rare re-delegation needs a fresh USDC permit (allowance below threshold) and exceeds the tightened paymaster limit, the bundler rejects it and the existing native fallback takes over.
