### PR TITLE
[simplex]: fix verification-gas efficiency rejection on sponsored vault sweep/redeem

### DIFF
--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/simplex",
-	"version": "0.5.9",
+	"version": "0.5.10",
 	"license": "Apache-2.0",
 	"description": "IntentGateway simplex package for hyperbridge",
 	"main": "dist/index.js",

--- a/sdk/packages/simplex/src/funding/vault/VaultFundingPlanner.ts
+++ b/sdk/packages/simplex/src/funding/vault/VaultFundingPlanner.ts
@@ -328,7 +328,20 @@ export class VaultFundingPlanner implements FundingVenue {
 		const callData = encodeERC7821ExecuteBatch(calls)
 
 		if (this.userOpSender?.canSponsor(chain)) {
-			const result = await this.userOpSender.trySendSponsored({ chain, callData })
+			// The bundler echoes input gas limits for these ops instead of simulating, so
+			// pass measured fixed limits. Verification efficiency `used / (verif + pmVerif)`
+			// must clear rundler's 0.4 floor — the Circle paymaster verification (~75k) is
+			// the dominant term, account validation only ~24k.
+			const result = await this.userOpSender.trySendSponsored({
+				chain,
+				callData,
+				gas: {
+					verificationGasLimit: 60_000n,
+					callGasLimit: 350_000n * BigInt(calls.length) + 100_000n,
+					preVerificationGas: 150_000n,
+				},
+				paymasterVerificationGasLimit: 140_000n,
+			})
 			if (result) return { txHash: result.txHash, sponsored: true }
 			logger.warn({ chain }, "Sponsored batch unavailable, sending native tx")
 		}

--- a/sdk/packages/simplex/src/services/UserOpSender.ts
+++ b/sdk/packages/simplex/src/services/UserOpSender.ts
@@ -154,8 +154,8 @@ export class UserOpSender {
 				}
 			: undefined
 
-		// Explicit limits skip estimation (needed for the not-yet-delegated EIP-7702
-		// case, where there is no account code to simulate).
+		// Explicit limits skip estimation — the bundler echoes the input limits for
+		// these ops rather than simulating, so callers pass measured fixed limits.
 		const { verificationGasLimit, callGasLimit, preVerificationGas } =
 			gas ??
 			(await this.estimateGas({

--- a/sdk/packages/simplex/src/services/paymaster/provider/circle.ts
+++ b/sdk/packages/simplex/src/services/paymaster/provider/circle.ts
@@ -78,7 +78,7 @@ export async function buildCirclePaymasterData(
 	return {
 		paymaster: paymasterAddress,
 		paymasterData,
-		paymasterVerificationGasLimit: VERIFICATION_GAS_LIMIT_CIRCLE,
+		paymasterVerificationGasLimit,
 		paymasterPostOpGasLimit: POST_OP_GAS_LIMIT,
 	}
 }


### PR DESCRIPTION
Sponsored vault sweep/redeem UserOps were rejected by the Alchemy bundler ("Verification gas limit efficiency too low. Required: 0.4, Actual: 0.20") and fell back to native txs, paying gas in ETH instead of USDC.

Root cause: the sweep/redeem path used the 200k Circle paymaster verification default. The bundler echoes input gas limits for these ops rather than simulating, so the verification-gas efficiency ratio `used / (accountVerif + paymasterVerif)` fell below rundler's 0.4 floor.

Fix: pass measured fixed gas limits for these ops instead of relying on the default. Measured on Base via the bundler — account validation ~24k, Circle paymaster verification ~75k (the dominant term) — set to account 60k, paymaster 140k, with callGas scaled by batch size. Predicted efficiency 0.49.