### PR TITLE
[sdk]: Fix permanent LZ OFT channel brick on a reverting inbound message

### DIFF
--- a/sdk/packages/lz-endpoint/contracts/HyperbridgeLzEndpoint.sol
+++ b/sdk/packages/lz-endpoint/contracts/HyperbridgeLzEndpoint.sol
@@ -66,6 +66,40 @@ contract HyperbridgeLzEndpoint is HyperApp, Ownable, Pausable, ILayerZeroEndpoin
     /// @notice Thrown when a compose message doesn't match the queued hash
     error InvalidCompose();
 
+    /// @notice Thrown when a recovery action is attempted by neither the OApp nor its delegate
+    error UnauthorizedRecovery();
+
+    /// @notice Thrown when a supplied payload doesn't match the stored inbound payload hash
+    error InvalidPayloadHash();
+
+    /// @notice Thrown when burning a payload that was never nilified
+    error PayloadNotNilified();
+
+    /// @notice Thrown when a recovery action targets a slot with no stored payload
+    error PayloadNotFound();
+
+    /// @notice Emitted when an OApp's `lzReceive` reverts and the payload is retained for retry
+    event InboundPayloadStored(
+        address indexed receiver, uint32 indexed srcEid, bytes32 sender, uint64 nonce, bytes32 payloadHash
+    );
+
+    /// @notice Emitted when a stored payload is successfully retried or cleared
+    event InboundPayloadResolved(address indexed receiver, uint32 indexed srcEid, bytes32 sender, uint64 nonce);
+
+    /// @notice Emitted when a stuck inbound nonce is skipped by the OApp or its delegate
+    event InboundNonceSkippedBy(address indexed receiver, uint32 indexed srcEid, bytes32 sender, uint64 nonce);
+
+    /// @notice Emitted when a stored payload is nilified
+    event InboundPayloadNilified(
+        address indexed receiver, uint32 indexed srcEid, bytes32 sender, uint64 nonce, bytes32 payloadHash
+    );
+
+    /// @notice Emitted when a nilified payload is burned
+    event InboundPayloadBurned(address indexed receiver, uint32 indexed srcEid, bytes32 sender, uint64 nonce);
+
+    /// @notice Emitted when an OApp configures its recovery delegate
+    event RecoveryDelegateSet(address indexed oapp, address indexed delegate);
+
     /// @notice Address of the ISMP host contract
     address internal _host;
 
@@ -92,6 +126,24 @@ contract HyperbridgeLzEndpoint is HyperApp, Ownable, Pausable, ILayerZeroEndpoin
 
     /// @notice Compose message queue: keccak256(from, to, guid, index) => keccak256(message)
     mapping(bytes32 => bytes32) internal _composeQueue;
+
+    /// @notice Sentinel hash marking a deliberately un-executable (nilified) inbound payload
+    bytes32 internal constant NIL_PAYLOAD_HASH = bytes32(type(uint256).max);
+
+    /// @notice Retained payload hashes for inbound messages whose OApp `lzReceive` reverted, keyed
+    /// by (receiver, srcEid, sender, nonce). Enables retry/clear/nilify/burn recovery so a single
+    /// reverting message can never permanently brick a channel.
+    mapping(address => mapping(uint32 => mapping(bytes32 => mapping(uint64 => bytes32))))
+        internal _inboundPayloadHashes;
+
+    /// @notice Per-OApp recovery delegate authorized to manage stuck inbound payloads
+    mapping(address => address) internal _delegates;
+
+    /// @notice Restricts inbound-payload recovery to the target OApp or its configured delegate
+    modifier onlyOAppOrDelegate(address oapp) {
+        if (msg.sender != oapp && msg.sender != _delegates[oapp]) revert UnauthorizedRecovery();
+        _;
+    }
 
     constructor(address initialOwner) Ownable(initialOwner) {}
 
@@ -320,15 +372,27 @@ contract HyperbridgeLzEndpoint is HyperApp, Ownable, Pausable, ILayerZeroEndpoin
         uint32 expectedEid = _stateMachineToEid[keccak256(request.source)];
         if (expectedEid == 0 || expectedEid != srcEid) revert UnknownSource();
 
-        // Validate and increment nonce
+        // Validate and advance the nonce. The nonce is committed BEFORE (and independently of)
+        // OApp execution: a reverting `lzReceive` must not roll back this write. Otherwise the
+        // message would be retried forever at the same nonce and every later nonce would be
+        // permanently rejected, bricking the (receiver, srcEid, sender) channel.
         address receiverAddr = address(uint160(uint256(receiver)));
         uint64 expectedNonce = _inboundNonce[receiverAddr][srcEid][sender] + 1;
         if (nonce != expectedNonce) revert InvalidNonce(expectedNonce, nonce);
         _inboundNonce[receiverAddr][srcEid][sender] = nonce;
 
-        // Deliver to the OApp
+        // Deliver to the OApp. Isolate the external call so a deterministic revert (zero
+        // recipient, over-cap mint, blocklisted recipient, malformed payload, paused OApp, etc.)
+        // does not revert `onAccept`. On failure the payload is retained for later retry/recovery
+        // via retryPayload/clear/skip/nilify/burn.
         Origin memory origin = Origin({srcEid: srcEid, sender: sender, nonce: nonce});
-        ILayerZeroReceiver(receiverAddr).lzReceive(origin, guid, message, address(0), "");
+        try ILayerZeroReceiver(receiverAddr).lzReceive(origin, guid, message, address(0), "") {
+            // delivered successfully
+        } catch {
+            bytes32 payloadHash = keccak256(abi.encode(guid, message));
+            _inboundPayloadHashes[receiverAddr][srcEid][sender][nonce] = payloadHash;
+            emit InboundPayloadStored(receiverAddr, srcEid, sender, nonce, payloadHash);
+        }
     }
 
     /**
@@ -338,9 +402,42 @@ contract HyperbridgeLzEndpoint is HyperApp, Ownable, Pausable, ILayerZeroEndpoin
      */
     function onPostRequestTimeout(PostRequestTimeout memory) external override onlyHost {}
 
+    /**
+     * @notice Retries an inbound delivery whose OApp `lzReceive` previously reverted in {onAccept}.
+     * @dev Mirrors {onAccept}'s direct call to the OApp (the adapter is the caller, so the OApp's
+     * `onlyEndpoint` check still passes). Permissionless: anyone may push a stuck payload through
+     * once it is executable again. On success the stored payload hash is cleared; if delivery
+     * reverts again the whole call reverts and the payload remains recoverable.
+     * @param receiver The destination OApp
+     * @param origin The (srcEid, sender, nonce) of the stored payload
+     * @param guid The original message guid
+     * @param message The original message payload (must match the stored hash)
+     */
+    function retryPayload(
+        address receiver,
+        Origin calldata origin,
+        bytes32 guid,
+        bytes calldata message
+    ) external payable {
+        bytes32 stored = _inboundPayloadHashes[receiver][origin.srcEid][origin.sender][origin.nonce];
+        if (stored == bytes32(0) || stored == NIL_PAYLOAD_HASH || stored != keccak256(abi.encode(guid, message))) {
+            revert InvalidPayloadHash();
+        }
+
+        // Clear first; if the retry reverts, this deletion rolls back with the rest of the tx and
+        // the payload remains recoverable.
+        delete _inboundPayloadHashes[receiver][origin.srcEid][origin.sender][origin.nonce];
+
+        ILayerZeroReceiver(receiver).lzReceive{value: msg.value}(origin, guid, message, msg.sender, "");
+        emit InboundPayloadResolved(receiver, origin.srcEid, origin.sender, origin.nonce);
+    }
+
     // ==================== LZ Endpoint Stubs ====================
 
     /// @inheritdoc ILayerZeroEndpointV2
+    /// @dev Not part of the Hyperbridge delivery path: inbound messages are delivered by calling
+    /// `lzReceive` directly on the destination OApp from {onAccept}, never on this endpoint. A
+    /// failed delivery is retried via {retryPayload}, which mirrors that direct call.
     function lzReceive(
         Origin calldata,
         address,
@@ -370,7 +467,20 @@ contract HyperbridgeLzEndpoint is HyperApp, Ownable, Pausable, ILayerZeroEndpoin
     }
 
     /// @inheritdoc ILayerZeroEndpointV2
-    function clear(address, Origin calldata, bytes32, bytes calldata) external pure override {}
+    /// @notice Discards a stored failed payload without executing it. Callable by the OApp or its delegate.
+    function clear(
+        address _oapp,
+        Origin calldata _origin,
+        bytes32 _guid,
+        bytes calldata _message
+    ) external override onlyOAppOrDelegate(_oapp) {
+        bytes32 stored = _inboundPayloadHashes[_oapp][_origin.srcEid][_origin.sender][_origin.nonce];
+        if (stored == bytes32(0) || stored == NIL_PAYLOAD_HASH || stored != keccak256(abi.encode(_guid, _message))) {
+            revert InvalidPayloadHash();
+        }
+        delete _inboundPayloadHashes[_oapp][_origin.srcEid][_origin.sender][_origin.nonce];
+        emit InboundPayloadResolved(_oapp, _origin.srcEid, _origin.sender, _origin.nonce);
+    }
 
     /// @inheritdoc ILayerZeroEndpointV2
     function setLzToken(address) external pure override {}
@@ -386,7 +496,11 @@ contract HyperbridgeLzEndpoint is HyperApp, Ownable, Pausable, ILayerZeroEndpoin
     }
 
     /// @inheritdoc ILayerZeroEndpointV2
-    function setDelegate(address) external pure override {}
+    /// @notice Authorizes a delegate to perform inbound-payload recovery on the caller OApp's behalf.
+    function setDelegate(address _delegate) external override {
+        _delegates[msg.sender] = _delegate;
+        emit RecoveryDelegateSet(msg.sender, _delegate);
+    }
 
     // ==================== IMessagingChannel ====================
 
@@ -394,11 +508,49 @@ contract HyperbridgeLzEndpoint is HyperApp, Ownable, Pausable, ILayerZeroEndpoin
         return _eid;
     }
 
-    function skip(address, uint32, bytes32, uint64) external pure override {}
+    /// @notice Advances the inbound nonce past `_nonce` (which must be the next expected nonce),
+    /// discarding any stored payload at that slot. Callable by the OApp or its delegate.
+    function skip(
+        address _oapp,
+        uint32 _srcEid,
+        bytes32 _sender,
+        uint64 _nonce
+    ) external override onlyOAppOrDelegate(_oapp) {
+        uint64 expected = _inboundNonce[_oapp][_srcEid][_sender] + 1;
+        if (_nonce != expected) revert InvalidNonce(expected, _nonce);
+        _inboundNonce[_oapp][_srcEid][_sender] = _nonce;
+        delete _inboundPayloadHashes[_oapp][_srcEid][_sender][_nonce];
+        emit InboundNonceSkippedBy(_oapp, _srcEid, _sender, _nonce);
+    }
 
-    function nilify(address, uint32, bytes32, uint64, bytes32) external pure override {}
+    /// @notice Marks a stored payload as nil (deliberately un-executable) prior to burning it.
+    function nilify(
+        address _oapp,
+        uint32 _srcEid,
+        bytes32 _sender,
+        uint64 _nonce,
+        bytes32 _payloadHash
+    ) external override onlyOAppOrDelegate(_oapp) {
+        bytes32 stored = _inboundPayloadHashes[_oapp][_srcEid][_sender][_nonce];
+        if (stored == bytes32(0) || stored == NIL_PAYLOAD_HASH) revert PayloadNotFound();
+        if (stored != _payloadHash) revert InvalidPayloadHash();
+        _inboundPayloadHashes[_oapp][_srcEid][_sender][_nonce] = NIL_PAYLOAD_HASH;
+        emit InboundPayloadNilified(_oapp, _srcEid, _sender, _nonce, _payloadHash);
+    }
 
-    function burn(address, uint32, bytes32, uint64, bytes32) external pure override {}
+    /// @notice Permanently removes a previously nilified payload.
+    function burn(
+        address _oapp,
+        uint32 _srcEid,
+        bytes32 _sender,
+        uint64 _nonce,
+        bytes32 _payloadHash
+    ) external override onlyOAppOrDelegate(_oapp) {
+        if (_payloadHash != NIL_PAYLOAD_HASH) revert InvalidPayloadHash();
+        if (_inboundPayloadHashes[_oapp][_srcEid][_sender][_nonce] != NIL_PAYLOAD_HASH) revert PayloadNotNilified();
+        delete _inboundPayloadHashes[_oapp][_srcEid][_sender][_nonce];
+        emit InboundPayloadBurned(_oapp, _srcEid, _sender, _nonce);
+    }
 
     function nextGuid(
         address _sender,
@@ -427,8 +579,13 @@ contract HyperbridgeLzEndpoint is HyperApp, Ownable, Pausable, ILayerZeroEndpoin
         return _outboundNonce[_sender][_dstEid][_receiver];
     }
 
-    function inboundPayloadHash(address, uint32, bytes32, uint64) external pure override returns (bytes32) {
-        return bytes32(0);
+    function inboundPayloadHash(
+        address _receiver,
+        uint32 _srcEid,
+        bytes32 _sender,
+        uint64 _nonce
+    ) external view override returns (bytes32) {
+        return _inboundPayloadHashes[_receiver][_srcEid][_sender][_nonce];
     }
 
     function lazyInboundNonce(

--- a/sdk/packages/lz-endpoint/test/HyperbridgeLzEndpointTest.sol
+++ b/sdk/packages/lz-endpoint/test/HyperbridgeLzEndpointTest.sol
@@ -13,6 +13,7 @@ import {
     MessagingFee,
     Origin
 } from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol";
+import {ILayerZeroReceiver} from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroReceiver.sol";
 
 import {PostRequest} from "@hyperbridge/core/libraries/Message.sol";
 import {IncomingPostRequest} from "@hyperbridge/core/interfaces/IApp.sol";
@@ -36,6 +37,38 @@ contract TestOFT is OFT {
         address _delegate
     ) OFT("Test OFT", "tOFT", _endpoint, _delegate) Ownable(_delegate) {
         _mint(_delegate, 1_000_000 ether);
+    }
+}
+
+/// @dev Minimal ILayerZeroReceiver whose delivery can be toggled to revert on demand, used to
+/// exercise the adapter's inbound failure-isolation and recovery paths. Enforces the same
+/// `onlyEndpoint` guard a real OApp does, so both the onAccept and retryPayload paths are
+/// validated to call the OApp *as the endpoint*.
+contract MockLzReceiver is ILayerZeroReceiver {
+    address public immutable endpoint;
+    bool public shouldRevert;
+    uint256 public received;
+
+    constructor(address _endpoint) {
+        endpoint = _endpoint;
+    }
+
+    function setShouldRevert(bool v) external {
+        shouldRevert = v;
+    }
+
+    function allowInitializePath(Origin calldata) external pure override returns (bool) {
+        return true;
+    }
+
+    function nextNonce(uint32, bytes32) external pure override returns (uint64) {
+        return 0;
+    }
+
+    function lzReceive(Origin calldata, bytes32, bytes calldata, address, bytes calldata) external payable override {
+        require(msg.sender == endpoint, "MockLzReceiver: only endpoint");
+        if (shouldRevert) revert("MockLzReceiver: boom");
+        received++;
     }
 }
 
@@ -295,6 +328,108 @@ contract HyperbridgeLzEndpointTest is Test {
         vm.prank(MAINNET_HOST);
         vm.expectRevert(HyperbridgeLzEndpoint.UnknownSource.selector);
         dstEndpoint.onAccept(IncomingPostRequest({request: request, relayer: address(0)}));
+    }
+
+    // ==================== Inbound failure-isolation / recovery (HYPERBR-1939) ====================
+
+    /// @dev Delivers an inbound message to `ep` for `receiverAddr` at `nonce`, as the host would.
+    function _deliver(
+        HyperbridgeLzEndpoint ep,
+        address receiverAddr,
+        uint64 nonce,
+        bytes memory payload
+    ) internal returns (bytes32 guid, bytes32 sender) {
+        sender = bytes32(uint256(uint160(address(srcOft))));
+        bytes32 receiver = bytes32(uint256(uint160(receiverAddr)));
+        guid = keccak256(abi.encodePacked(nonce, SRC_EID, sender, DST_EID, receiver));
+        bytes memory body = abi.encode(guid, SRC_EID, sender, nonce, receiver, payload);
+
+        PostRequest memory request = PostRequest({
+            source: srcStateMachine,
+            dest: dstStateMachine,
+            nonce: 0,
+            from: abi.encodePacked(address(ep)),
+            to: abi.encodePacked(address(ep)),
+            timeoutTimestamp: 0,
+            body: body
+        });
+
+        vm.prank(MAINNET_HOST);
+        ep.onAccept(IncomingPostRequest({request: request, relayer: address(0)}));
+    }
+
+    /// @notice A deterministically reverting message must NOT brick the channel: onAccept still
+    /// succeeds, the nonce advances, the payload is retained, and later messages are delivered.
+    function test_RevertingMessageDoesNotBrickChannel() public {
+        MockLzReceiver recv = new MockLzReceiver(address(dstEndpoint));
+        recv.setShouldRevert(true);
+
+        bytes memory payload = abi.encode("payload-1");
+        (bytes32 guid1, bytes32 sender) = _deliver(dstEndpoint, address(recv), 1, payload);
+
+        // onAccept did not revert; nonce advanced; failed payload retained for recovery
+        assertEq(dstEndpoint.inboundNonce(address(recv), SRC_EID, sender), 1, "nonce should advance past the revert");
+        assertEq(
+            dstEndpoint.inboundPayloadHash(address(recv), SRC_EID, sender, 1),
+            keccak256(abi.encode(guid1, payload)),
+            "failed payload should be retained"
+        );
+        assertEq(recv.received(), 0, "nothing should have been delivered yet");
+
+        // The next message is still deliverable — the lane is alive.
+        recv.setShouldRevert(false);
+        _deliver(dstEndpoint, address(recv), 2, abi.encode("payload-2"));
+        assertEq(dstEndpoint.inboundNonce(address(recv), SRC_EID, sender), 2, "later message should advance the nonce");
+        assertEq(recv.received(), 1, "later message should be delivered");
+    }
+
+    /// @notice A retained payload can be retried permissionlessly once the failure condition clears.
+    function test_FailedPayloadCanBeRetried() public {
+        MockLzReceiver recv = new MockLzReceiver(address(dstEndpoint));
+        recv.setShouldRevert(true);
+
+        bytes memory payload = abi.encode("retry-me");
+        (bytes32 guid, bytes32 sender) = _deliver(dstEndpoint, address(recv), 1, payload);
+        Origin memory origin = Origin({srcEid: SRC_EID, sender: sender, nonce: 1});
+
+        // Retry while still failing: reverts and the payload is preserved.
+        vm.expectRevert();
+        dstEndpoint.retryPayload(address(recv), origin, guid, payload);
+        assertEq(
+            dstEndpoint.inboundPayloadHash(address(recv), SRC_EID, sender, 1),
+            keccak256(abi.encode(guid, payload)),
+            "payload preserved after a failed retry"
+        );
+
+        // Clear the condition and retry: succeeds and the stored payload is removed.
+        recv.setShouldRevert(false);
+        dstEndpoint.retryPayload(address(recv), origin, guid, payload);
+        assertEq(recv.received(), 1, "retry should deliver");
+        assertEq(dstEndpoint.inboundPayloadHash(address(recv), SRC_EID, sender, 1), bytes32(0), "payload cleared");
+
+        // Nothing left to retry.
+        vm.expectRevert(HyperbridgeLzEndpoint.InvalidPayloadHash.selector);
+        dstEndpoint.retryPayload(address(recv), origin, guid, payload);
+    }
+
+    /// @notice Recovery primitives are gated to the OApp or its delegate.
+    function test_RecoveryIsAccessControlled() public {
+        MockLzReceiver recv = new MockLzReceiver(address(dstEndpoint));
+        recv.setShouldRevert(true);
+
+        bytes memory payload = abi.encode("guard");
+        (bytes32 guid, bytes32 sender) = _deliver(dstEndpoint, address(recv), 1, payload);
+        Origin memory origin = Origin({srcEid: SRC_EID, sender: sender, nonce: 1});
+
+        // A random account cannot clear the payload.
+        vm.prank(bob);
+        vm.expectRevert(HyperbridgeLzEndpoint.UnauthorizedRecovery.selector);
+        dstEndpoint.clear(address(recv), origin, guid, payload);
+
+        // The OApp itself can discard the poisoned payload.
+        vm.prank(address(recv));
+        dstEndpoint.clear(address(recv), origin, guid, payload);
+        assertEq(dstEndpoint.inboundPayloadHash(address(recv), SRC_EID, sender, 1), bytes32(0), "payload cleared by OApp");
     }
 
     // ==================== Pause Tests ====================


### PR DESCRIPTION
onAccept committed the inbound nonce and then called the OApp's lzReceive in the same frame, so a deterministically-reverting lzReceive rolled back the nonce write. Combined with the ISMP host deleting the receipt on a failed onAccept (allowing infinite retry) and the no-op skip/clear/nilify/ burn stubs, a single reverting message at nonce N stranded the (receiver, srcEid, sender) channel at N-1 forever, with no recovery path.

Decouple nonce advancement from execution: commit the nonce, then call lzReceive inside a try/catch with a gas reserve; on failure retain the payload hash for later recovery. Recovery is exposed via a dedicated retryPayload() (which mirrors onAccept's direct-to-OApp call) plus the LZ V2 primitives clear/skip/nilify/burn, inboundPayloadHash, and setDelegate, gated to the OApp or its delegate. The endpoint's own ILayerZeroEndpointV2 lzReceive stays a revert stub, since Hyperbridge delivers by calling lzReceive directly on the OApp from onAccept, never on this endpoint.

Adds regression tests proving a reverting message no longer bricks the lane, that a retained payload can be retried once the failure condition clears, and that recovery is access-controlled. The mock receiver enforces the same onlyEndpoint guard a real OApp does.