### PR TITLE
[runtime]: bump gargantua and nexus spec versions

### DIFF
--- a/parachain/runtimes/gargantua/src/lib.rs
+++ b/parachain/runtimes/gargantua/src/lib.rs
@@ -251,7 +251,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("gargantua"),
 	impl_name: Cow::Borrowed("gargantua"),
 	authoring_version: 1,
-	spec_version: 7_500,
+	spec_version: 7_600,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/parachain/runtimes/nexus/src/lib.rs
+++ b/parachain/runtimes/nexus/src/lib.rs
@@ -238,7 +238,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("nexus"),
 	impl_name: Cow::Borrowed("nexus"),
 	authoring_version: 1,
-	spec_version: 7_700,
+	spec_version: 7_800,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
Bumps runtime spec_version for the next upgrade: gargantua 7_500 → 7_600, nexus 7_700 → 7_800.