### PR TITLE
[sdk]: track Hyperbridge finalization via Hyperbridge's self state-machine update

### DIFF
--- a/sdk/packages/sdk/package.json
+++ b/sdk/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/sdk",
-	"version": "2.2.1",
+	"version": "2.2.2",
 	"description": "The hyperclient SDK provides utilities for querying proofs and statuses for cross-chain requests from HyperBridge.",
 	"type": "module",
 	"types": "./dist/node/index.d.ts",

--- a/sdk/packages/sdk/src/client/GetRequestClient.ts
+++ b/sdk/packages/sdk/src/client/GetRequestClient.ts
@@ -250,56 +250,57 @@ export class GetRequestClient {
 	): Promise<RequestStatusWithMetadata | undefined> {
 		const sourceChain = this.ctx.config.source
 		const hyperbridge = this.ctx.config.hyperbridge
+		const { config } = hyperbridge
 
+		// Check for existing finality first. Hyperbridge runs a light client of itself
+		// (pallet-beefy-consensus-proofs), so if its self state-machine update already finalizes the
+		// response, deliver with a plain GetResponse proof — no consensus proof needed.
+		const finality = await this.queries.queryStateMachineUpdateByHeight({
+			statemachineId: config.stateMachineId,
+			height: hyperbridgeDelivered.metadata.blockNumber,
+			chain: config.stateMachineId,
+		})
+		if (finality) {
+			const proof = await hyperbridge.queryProof(
+				{ Responses: [response.commitment as HexString] },
+				request.source,
+				BigInt(finality.height),
+			)
+			const calldata = sourceChain.encode({
+				kind: "GetResponse",
+				proof: {
+					stateMachine: config.stateMachineId,
+					consensusStateId: config.consensusStateId,
+					proof,
+					height: BigInt(finality.height),
+				},
+				responses: [
+					{
+						get: request,
+						values: request.keys.map((key, index) => ({
+							key,
+							value: (response.values[index] as HexString) || "0x",
+						})),
+					},
+				],
+				signer: pad("0x"),
+			})
+			return {
+				status: RequestStatus.HYPERBRIDGE_FINALIZED,
+				metadata: {
+					blockHash: finality.blockHash,
+					blockNumber: finality.height,
+					transactionHash: finality.transactionHash,
+					timestamp: finality.timestamp,
+					calldata,
+				},
+			}
+		}
+
+		// No existing finality. For an EVM source, advance its Hyperbridge light client and deliver in
+		// one batch (consensus proof + message proof).
 		if (sourceChain instanceof EvmChain) {
 			const hyperbridgeSubstrate = hyperbridge as SubstrateChain
-
-			// Fast path: if the source's Hyperbridge light client has already been advanced past the
-			// delivery height (e.g. by another message or a relayer), there's no need to build a
-			// consensus proof — submit a plain GetResponse proof at the already-finalized height.
-			const existingFinality = await this.queries.queryStateMachineUpdateByHeight({
-				statemachineId: this.ctx.config.hyperbridge.config.stateMachineId,
-				height: hyperbridgeDelivered.metadata.blockNumber,
-				chain: request.source,
-			})
-			if (existingFinality) {
-				const proof = await hyperbridge.queryProof(
-					{ Responses: [response.commitment as HexString] },
-					request.source,
-					BigInt(existingFinality.height),
-				)
-				const calldata = sourceChain.encode({
-					kind: "GetResponse",
-					proof: {
-						stateMachine: this.ctx.config.hyperbridge.config.stateMachineId,
-						consensusStateId: this.ctx.config.hyperbridge.config.consensusStateId,
-						proof,
-						height: BigInt(existingFinality.height),
-					},
-					responses: [
-						{
-							get: request,
-							values: request.keys.map((key, index) => ({
-								key,
-								value: (response.values[index] as HexString) || "0x",
-							})),
-						},
-					],
-					signer: pad("0x"),
-				})
-				return {
-					status: RequestStatus.HYPERBRIDGE_FINALIZED,
-					metadata: {
-						blockHash: existingFinality.blockHash,
-						blockNumber: existingFinality.height,
-						transactionHash: existingFinality.transactionHash,
-						timestamp: existingFinality.timestamp,
-						calldata,
-					},
-				}
-			}
-
-			// Otherwise advance the source's Hyperbridge light client and deliver in one batch.
 			const currentEpoch = await sourceChain.currentEpoch()
 			const consensusResult = await hyperbridgeSubstrate.queryConsensusProofs(
 				BigInt(hyperbridgeDelivered.metadata.blockNumber),
@@ -317,8 +318,8 @@ export class GetRequestClient {
 				kind: "BatchConsensusAndGetResponse",
 				consensusProofs: consensusResult.proofs,
 				proof: {
-					stateMachine: this.ctx.config.hyperbridge.config.stateMachineId,
-					consensusStateId: this.ctx.config.hyperbridge.config.consensusStateId,
+					stateMachine: config.stateMachineId,
+					consensusStateId: config.consensusStateId,
 					proof,
 					height: consensusResult.provenHeight,
 				},
@@ -347,52 +348,7 @@ export class GetRequestClient {
 			}
 		}
 
-		// Substrate source: wait for Hyperbridge to finalize itself. Hyperbridge runs a light client
-		// of itself (pallet-beefy-consensus-proofs), so the StateMachineUpdated event for the
-		// Hyperbridge state machine is observed on Hyperbridge — not on the source chain.
-		const hyperbridgeFinality = await this.queries.queryStateMachineUpdateByHeight({
-			statemachineId: this.ctx.config.hyperbridge.config.stateMachineId,
-			height: hyperbridgeDelivered.metadata.blockNumber,
-			chain: this.ctx.config.hyperbridge.config.stateMachineId,
-		})
-		if (!hyperbridgeFinality) return undefined
-
-		const proof = await hyperbridge.queryProof(
-			{ Responses: [response.commitment as HexString] },
-			request.source,
-			BigInt(hyperbridgeFinality.height),
-		)
-
-		const calldata = sourceChain.encode({
-			kind: "GetResponse",
-			proof: {
-				stateMachine: this.ctx.config.hyperbridge.config.stateMachineId,
-				consensusStateId: this.ctx.config.hyperbridge.config.consensusStateId,
-				proof,
-				height: BigInt(hyperbridgeFinality.height),
-			},
-			responses: [
-				{
-					get: request,
-					values: request.keys.map((key, index) => ({
-						key,
-						value: (response.values[index] as HexString) || "0x",
-					})),
-				},
-			],
-			signer: pad("0x"),
-		})
-
-		return {
-			status: RequestStatus.HYPERBRIDGE_FINALIZED,
-			metadata: {
-				blockHash: hyperbridgeFinality.blockHash,
-				blockNumber: hyperbridgeFinality.height,
-				transactionHash: hyperbridgeFinality.transactionHash,
-				timestamp: hyperbridgeFinality.timestamp,
-				calldata,
-			},
-		}
+		return undefined
 	}
 
 	/**
@@ -414,54 +370,17 @@ export class GetRequestClient {
 		const stateMachineId = this.ctx.config.hyperbridge.config.stateMachineId
 		const neededHeight = BigInt(request.statuses[hyperbridgeDeliveredIndex].metadata.blockNumber)
 
-		if (sourceChain instanceof EvmChain) {
+		// Check for existing finality first (Hyperbridge's self state-machine update).
+		let finality = await this.queries.queryStateMachineUpdateByHeight({
+			statemachineId: stateMachineId,
+			height: Number(neededHeight),
+			chain: stateMachineId,
+		})
+
+		// No existing finality and the source is EVM: advance its Hyperbridge light client and deliver
+		// in one batch (consensus proof + message proof).
+		if (!finality && sourceChain instanceof EvmChain) {
 			const hyperbridgeSubstrate = hyperbridge as SubstrateChain
-
-			// Fast path: if the source's Hyperbridge light client is already advanced past the
-			// delivery height, skip the consensus proof and submit a plain GetResponse proof.
-			const existingFinality = await this.queries.queryStateMachineUpdateByHeight({
-				statemachineId: stateMachineId,
-				height: Number(neededHeight),
-				chain: request.source,
-			})
-			if (existingFinality) {
-				const proof = await hyperbridge.queryProof(
-					{ Responses: [response?.commitment as HexString] },
-					request.source,
-					BigInt(existingFinality.height),
-				)
-				const calldata = sourceChain.encode({
-					kind: "GetResponse",
-					proof: {
-						stateMachine: stateMachineId,
-						consensusStateId: this.ctx.config.hyperbridge.config.consensusStateId,
-						proof,
-						height: BigInt(existingFinality.height),
-					},
-					responses: [
-						{
-							get: request,
-							values: request.keys.map((key, index) => ({
-								key,
-								value: (response?.values[index] as HexString) || "0x",
-							})),
-						},
-					],
-					signer: pad("0x"),
-				})
-				return {
-					status: RequestStatus.HYPERBRIDGE_FINALIZED,
-					metadata: {
-						blockHash: existingFinality.blockHash,
-						blockNumber: existingFinality.height,
-						transactionHash: existingFinality.transactionHash,
-						timestamp: existingFinality.timestamp,
-						calldata,
-					},
-				}
-			}
-
-			// Otherwise wait for Hyperbridge's consensus proof and deliver via a batch tx.
 			const currentEpoch = await sourceChain.currentEpoch()
 			const consensusResult = await waitOrAbort(this.ctx, {
 				signal,
@@ -508,23 +427,24 @@ export class GetRequestClient {
 			}
 		}
 
-		// Substrate source: wait for Hyperbridge to finalize itself. Hyperbridge runs a light client
-		// of itself (pallet-beefy-consensus-proofs), so the StateMachineUpdated event for the
-		// Hyperbridge state machine is observed on Hyperbridge — not on the source chain.
-		const hyperbridgeFinalized = await waitOrAbort(this.ctx, {
-			signal,
-			promise: () =>
-				this.queries.queryStateMachineUpdateByHeight({
-					statemachineId: stateMachineId,
-					height: Number(neededHeight),
-					chain: stateMachineId,
-				}),
-		})
+		// Otherwise wait for Hyperbridge's
+		// self-finality then deliver with a plain GetResponse proof.
+		if (!finality) {
+			finality = await waitOrAbort(this.ctx, {
+				signal,
+				promise: () =>
+					this.queries.queryStateMachineUpdateByHeight({
+						statemachineId: stateMachineId,
+						height: Number(neededHeight),
+						chain: stateMachineId,
+					}),
+			})
+		}
 
 		const proof = await hyperbridge.queryProof(
 			{ Responses: [response?.commitment as HexString] },
 			request.source,
-			BigInt(hyperbridgeFinalized.height),
+			BigInt(finality.height),
 		)
 
 		const calldata = sourceChain.encode({
@@ -533,7 +453,7 @@ export class GetRequestClient {
 				stateMachine: stateMachineId,
 				consensusStateId: this.ctx.config.hyperbridge.config.consensusStateId,
 				proof,
-				height: BigInt(hyperbridgeFinalized.height),
+				height: BigInt(finality.height),
 			},
 			responses: [
 				{
@@ -550,10 +470,10 @@ export class GetRequestClient {
 		return {
 			status: RequestStatus.HYPERBRIDGE_FINALIZED,
 			metadata: {
-				blockHash: hyperbridgeFinalized.blockHash,
-				blockNumber: hyperbridgeFinalized.height,
-				transactionHash: hyperbridgeFinalized.transactionHash,
-				timestamp: hyperbridgeFinalized.timestamp,
+				blockHash: finality.blockHash,
+				blockNumber: finality.height,
+				transactionHash: finality.transactionHash,
+				timestamp: finality.timestamp,
 				calldata,
 			},
 		}

--- a/sdk/packages/sdk/src/client/GetRequestClient.ts
+++ b/sdk/packages/sdk/src/client/GetRequestClient.ts
@@ -253,6 +253,53 @@ export class GetRequestClient {
 
 		if (sourceChain instanceof EvmChain) {
 			const hyperbridgeSubstrate = hyperbridge as SubstrateChain
+
+			// Fast path: if the source's Hyperbridge light client has already been advanced past the
+			// delivery height (e.g. by another message or a relayer), there's no need to build a
+			// consensus proof — submit a plain GetResponse proof at the already-finalized height.
+			const existingFinality = await this.queries.queryStateMachineUpdateByHeight({
+				statemachineId: this.ctx.config.hyperbridge.config.stateMachineId,
+				height: hyperbridgeDelivered.metadata.blockNumber,
+				chain: request.source,
+			})
+			if (existingFinality) {
+				const proof = await hyperbridge.queryProof(
+					{ Responses: [response.commitment as HexString] },
+					request.source,
+					BigInt(existingFinality.height),
+				)
+				const calldata = sourceChain.encode({
+					kind: "GetResponse",
+					proof: {
+						stateMachine: this.ctx.config.hyperbridge.config.stateMachineId,
+						consensusStateId: this.ctx.config.hyperbridge.config.consensusStateId,
+						proof,
+						height: BigInt(existingFinality.height),
+					},
+					responses: [
+						{
+							get: request,
+							values: request.keys.map((key, index) => ({
+								key,
+								value: (response.values[index] as HexString) || "0x",
+							})),
+						},
+					],
+					signer: pad("0x"),
+				})
+				return {
+					status: RequestStatus.HYPERBRIDGE_FINALIZED,
+					metadata: {
+						blockHash: existingFinality.blockHash,
+						blockNumber: existingFinality.height,
+						transactionHash: existingFinality.transactionHash,
+						timestamp: existingFinality.timestamp,
+						calldata,
+					},
+				}
+			}
+
+			// Otherwise advance the source's Hyperbridge light client and deliver in one batch.
 			const currentEpoch = await sourceChain.currentEpoch()
 			const consensusResult = await hyperbridgeSubstrate.queryConsensusProofs(
 				BigInt(hyperbridgeDelivered.metadata.blockNumber),
@@ -300,11 +347,13 @@ export class GetRequestClient {
 			}
 		}
 
-		// Substrate source: use state machine update from indexer
+		// Substrate source: wait for Hyperbridge to finalize itself. Hyperbridge runs a light client
+		// of itself (pallet-beefy-consensus-proofs), so the StateMachineUpdated event for the
+		// Hyperbridge state machine is observed on Hyperbridge — not on the source chain.
 		const hyperbridgeFinality = await this.queries.queryStateMachineUpdateByHeight({
 			statemachineId: this.ctx.config.hyperbridge.config.stateMachineId,
 			height: hyperbridgeDelivered.metadata.blockNumber,
-			chain: request.source,
+			chain: this.ctx.config.hyperbridge.config.stateMachineId,
 		})
 		if (!hyperbridgeFinality) return undefined
 
@@ -367,6 +416,52 @@ export class GetRequestClient {
 
 		if (sourceChain instanceof EvmChain) {
 			const hyperbridgeSubstrate = hyperbridge as SubstrateChain
+
+			// Fast path: if the source's Hyperbridge light client is already advanced past the
+			// delivery height, skip the consensus proof and submit a plain GetResponse proof.
+			const existingFinality = await this.queries.queryStateMachineUpdateByHeight({
+				statemachineId: stateMachineId,
+				height: Number(neededHeight),
+				chain: request.source,
+			})
+			if (existingFinality) {
+				const proof = await hyperbridge.queryProof(
+					{ Responses: [response?.commitment as HexString] },
+					request.source,
+					BigInt(existingFinality.height),
+				)
+				const calldata = sourceChain.encode({
+					kind: "GetResponse",
+					proof: {
+						stateMachine: stateMachineId,
+						consensusStateId: this.ctx.config.hyperbridge.config.consensusStateId,
+						proof,
+						height: BigInt(existingFinality.height),
+					},
+					responses: [
+						{
+							get: request,
+							values: request.keys.map((key, index) => ({
+								key,
+								value: (response?.values[index] as HexString) || "0x",
+							})),
+						},
+					],
+					signer: pad("0x"),
+				})
+				return {
+					status: RequestStatus.HYPERBRIDGE_FINALIZED,
+					metadata: {
+						blockHash: existingFinality.blockHash,
+						blockNumber: existingFinality.height,
+						transactionHash: existingFinality.transactionHash,
+						timestamp: existingFinality.timestamp,
+						calldata,
+					},
+				}
+			}
+
+			// Otherwise wait for Hyperbridge's consensus proof and deliver via a batch tx.
 			const currentEpoch = await sourceChain.currentEpoch()
 			const consensusResult = await waitOrAbort(this.ctx, {
 				signal,
@@ -413,14 +508,16 @@ export class GetRequestClient {
 			}
 		}
 
-		// Substrate source: wait for state machine update
+		// Substrate source: wait for Hyperbridge to finalize itself. Hyperbridge runs a light client
+		// of itself (pallet-beefy-consensus-proofs), so the StateMachineUpdated event for the
+		// Hyperbridge state machine is observed on Hyperbridge — not on the source chain.
 		const hyperbridgeFinalized = await waitOrAbort(this.ctx, {
 			signal,
 			promise: () =>
 				this.queries.queryStateMachineUpdateByHeight({
 					statemachineId: stateMachineId,
 					height: Number(neededHeight),
-					chain: request.source,
+					chain: stateMachineId,
 				}),
 		})
 

--- a/sdk/packages/sdk/src/client/PostRequestClient.ts
+++ b/sdk/packages/sdk/src/client/PostRequestClient.ts
@@ -671,11 +671,13 @@ export class PostRequestClient {
 			}
 		}
 
-		// Substrate destination: use state machine update from indexer
+		// Substrate destination: wait for Hyperbridge to finalize itself. Hyperbridge runs a light
+		// client of itself (pallet-beefy-consensus-proofs), so the StateMachineUpdated event for the
+		// Hyperbridge state machine is observed on Hyperbridge — not on the destination chain.
 		const hyperbridgeFinality = await this.queries.queryStateMachineUpdateByHeight({
 			statemachineId: this.ctx.config.hyperbridge.config.stateMachineId,
 			height: hyperbridgeDelivered.metadata.blockNumber,
-			chain: request.dest,
+			chain: this.ctx.config.hyperbridge.config.stateMachineId,
 		})
 		if (!hyperbridgeFinality) return undefined
 
@@ -771,14 +773,16 @@ export class PostRequestClient {
 			}
 		}
 
-		// Substrate destination: wait for state machine update
+		// Substrate destination: wait for Hyperbridge to finalize itself. Hyperbridge runs a light
+		// client of itself (pallet-beefy-consensus-proofs), so the StateMachineUpdated event for the
+		// Hyperbridge state machine is observed on Hyperbridge — not on the destination chain.
 		const hyperbridgeFinalized = await waitOrAbort(this.ctx, {
 			signal,
 			promise: () =>
 				this.queries.queryStateMachineUpdateByHeight({
 					statemachineId: stateMachineId,
 					height: Number(neededHeight),
-					chain: request.dest,
+					chain: stateMachineId,
 				}),
 		})
 

--- a/sdk/packages/sdk/src/client/PostRequestClient.ts
+++ b/sdk/packages/sdk/src/client/PostRequestClient.ts
@@ -629,45 +629,49 @@ export class PostRequestClient {
 	): Promise<RequestStatusWithMetadata | undefined> {
 		const destChain = this.ctx.config.dest
 		const hyperbridge = this.ctx.config.hyperbridge
+		const { config } = hyperbridge
 
+		// Check for existing finality first. Hyperbridge runs a light client of itself
+		// (pallet-beefy-consensus-proofs), so if its self state-machine update already finalizes the
+		// message, deliver with a plain PostRequest proof — no consensus proof needed.
+		const finality = await this.queries.queryStateMachineUpdateByHeight({
+			statemachineId: config.stateMachineId,
+			height: hyperbridgeDelivered.metadata.blockNumber,
+			chain: config.stateMachineId,
+		})
+		if (finality) {
+			const proof = await hyperbridge.queryProof(
+				{ Requests: [postRequestCommitment(request).commitment] },
+				request.dest,
+				BigInt(finality.height),
+			)
+			const calldata = destChain.encode({
+				kind: "PostRequest",
+				proof: {
+					stateMachine: config.stateMachineId,
+					consensusStateId: config.consensusStateId,
+					proof,
+					height: BigInt(finality.height),
+				},
+				requests: [request],
+				signer: pad("0x"),
+			})
+			return {
+				status: RequestStatus.HYPERBRIDGE_FINALIZED,
+				metadata: {
+					blockHash: finality.blockHash,
+					blockNumber: finality.height,
+					transactionHash: finality.transactionHash,
+					timestamp: finality.timestamp,
+					calldata,
+				},
+			}
+		}
+
+		// No existing finality. For an EVM destination, advance its Hyperbridge light client and
+		// deliver in one batch (consensus proof + message proof).
 		if (destChain instanceof EvmChain) {
 			const hyperbridgeSubstrate = hyperbridge as SubstrateChain
-			const commitment = postRequestCommitment(request).commitment
-
-			// Fast path: if the destination's Hyperbridge light client has already been advanced past
-			// the delivery height (e.g. by another message or a relayer), there's no need to build a
-			// consensus proof — submit a plain PostRequest proof at the already-finalized height.
-			const existingFinality = await this.queries.queryStateMachineUpdateByHeight({
-				statemachineId: this.ctx.config.hyperbridge.config.stateMachineId,
-				height: hyperbridgeDelivered.metadata.blockNumber,
-				chain: request.dest,
-			})
-			if (existingFinality) {
-				const proof = await hyperbridge.queryProof({ Requests: [commitment] }, request.dest, BigInt(existingFinality.height))
-				const calldata = destChain.encode({
-					kind: "PostRequest",
-					proof: {
-						stateMachine: this.ctx.config.hyperbridge.config.stateMachineId,
-						consensusStateId: this.ctx.config.hyperbridge.config.consensusStateId,
-						proof,
-						height: BigInt(existingFinality.height),
-					},
-					requests: [request],
-					signer: pad("0x"),
-				})
-				return {
-					status: RequestStatus.HYPERBRIDGE_FINALIZED,
-					metadata: {
-						blockHash: existingFinality.blockHash,
-						blockNumber: existingFinality.height,
-						transactionHash: existingFinality.transactionHash,
-						timestamp: existingFinality.timestamp,
-						calldata,
-					},
-				}
-			}
-
-			// Otherwise advance the destination's Hyperbridge light client and deliver in one batch.
 			const currentEpoch = await destChain.currentEpoch()
 			const consensusResult = await hyperbridgeSubstrate.queryConsensusProofs(
 				BigInt(hyperbridgeDelivered.metadata.blockNumber),
@@ -675,14 +679,18 @@ export class PostRequestClient {
 			)
 			if (!consensusResult) return undefined
 
-			const proof = await hyperbridge.queryProof({ Requests: [commitment] }, request.dest, consensusResult.provenHeight)
+			const proof = await hyperbridge.queryProof(
+				{ Requests: [postRequestCommitment(request).commitment] },
+				request.dest,
+				consensusResult.provenHeight,
+			)
 
 			const calldata = destChain.encode({
 				kind: "BatchConsensusAndPostRequest",
 				consensusProofs: consensusResult.proofs,
 				proof: {
-					stateMachine: this.ctx.config.hyperbridge.config.stateMachineId,
-					consensusStateId: this.ctx.config.hyperbridge.config.consensusStateId,
+					stateMachine: config.stateMachineId,
+					consensusStateId: config.consensusStateId,
 					proof,
 					height: consensusResult.provenHeight,
 				},
@@ -703,44 +711,7 @@ export class PostRequestClient {
 			}
 		}
 
-		// Substrate destination: wait for Hyperbridge to finalize itself. Hyperbridge runs a light
-		// client of itself (pallet-beefy-consensus-proofs), so the StateMachineUpdated event for the
-		// Hyperbridge state machine is observed on Hyperbridge — not on the destination chain.
-		const hyperbridgeFinality = await this.queries.queryStateMachineUpdateByHeight({
-			statemachineId: this.ctx.config.hyperbridge.config.stateMachineId,
-			height: hyperbridgeDelivered.metadata.blockNumber,
-			chain: this.ctx.config.hyperbridge.config.stateMachineId,
-		})
-		if (!hyperbridgeFinality) return undefined
-
-		const proof = await hyperbridge.queryProof(
-			{ Requests: [postRequestCommitment(request).commitment] },
-			request.dest,
-			BigInt(hyperbridgeFinality.height),
-		)
-
-		const calldata = destChain.encode({
-			kind: "PostRequest",
-			proof: {
-				stateMachine: this.ctx.config.hyperbridge.config.stateMachineId,
-				consensusStateId: this.ctx.config.hyperbridge.config.consensusStateId,
-				proof,
-				height: BigInt(hyperbridgeFinality.height),
-			},
-			requests: [request],
-			signer: pad("0x"),
-		})
-
-		return {
-			status: RequestStatus.HYPERBRIDGE_FINALIZED,
-			metadata: {
-				blockHash: hyperbridgeFinality.blockHash,
-				blockNumber: hyperbridgeFinality.height,
-				transactionHash: hyperbridgeFinality.transactionHash,
-				timestamp: hyperbridgeFinality.timestamp,
-				calldata,
-			},
-		}
+		return undefined
 	}
 
 	/**
@@ -761,48 +732,19 @@ export class PostRequestClient {
 
 		this.logger.trace(`[streamFinalized] neededHeight=${neededHeight}`)
 
-		if (destChain instanceof EvmChain) {
+		const commitment = postRequestCommitment(request).commitment
+
+		// Check for existing finality first (Hyperbridge's self state-machine update).
+		let finality = await this.queries.queryStateMachineUpdateByHeight({
+			statemachineId: stateMachineId,
+			height: Number(neededHeight),
+			chain: stateMachineId,
+		})
+
+		// No existing finality and the destination is EVM: advance its Hyperbridge light client and
+		// deliver in one batch (consensus proof + message proof).
+		if (!finality && destChain instanceof EvmChain) {
 			const hyperbridgeSubstrate = hyperbridge as SubstrateChain
-			const commitment = postRequestCommitment(request).commitment
-
-			// Fast path: if the destination's Hyperbridge light client is already advanced past the
-			// delivery height, skip the consensus proof and submit a plain PostRequest proof.
-			const existingFinality = await this.queries.queryStateMachineUpdateByHeight({
-				statemachineId: stateMachineId,
-				height: Number(neededHeight),
-				chain: request.dest,
-			})
-			if (existingFinality) {
-				this.logger.trace(
-					`[streamFinalized] destination already finalized at height=${existingFinality.height}; skipping consensus proof`,
-				)
-				const proof = await this.fetchProofWithRetry(signal, () =>
-					hyperbridge.queryProof({ Requests: [commitment] }, request.dest, BigInt(existingFinality.height)),
-				)
-				const calldata = destChain.encode({
-					kind: "PostRequest",
-					proof: {
-						stateMachine: stateMachineId,
-						consensusStateId: this.ctx.config.hyperbridge.config.consensusStateId,
-						proof,
-						height: BigInt(existingFinality.height),
-					},
-					requests: [request],
-					signer: pad("0x"),
-				})
-				return {
-					status: RequestStatus.HYPERBRIDGE_FINALIZED,
-					metadata: {
-						blockHash: existingFinality.blockHash,
-						blockNumber: existingFinality.height,
-						transactionHash: existingFinality.transactionHash,
-						timestamp: existingFinality.timestamp,
-						calldata,
-					},
-				}
-			}
-
-			// Otherwise wait for Hyperbridge's consensus proof and deliver via a batch tx.
 			const currentEpoch = await destChain.currentEpoch()
 			const consensusResult = await waitOrAbort(this.ctx, {
 				signal,
@@ -844,26 +786,32 @@ export class PostRequestClient {
 			}
 		}
 
-		// Substrate destination: wait for Hyperbridge to finalize itself. Hyperbridge runs a light
-		// client of itself (pallet-beefy-consensus-proofs), so the StateMachineUpdated event for the
-		// Hyperbridge state machine is observed on Hyperbridge — not on the destination chain.
-		const hyperbridgeFinalized = await waitOrAbort(this.ctx, {
-			signal,
-			promise: () =>
-				this.queries.queryStateMachineUpdateByHeight({
-					statemachineId: stateMachineId,
-					height: Number(neededHeight),
-					chain: stateMachineId,
-				}),
-		})
+		// Otherwise wait for Hyperbridge's
+		// self-finality then deliver with a plain PostRequest proof.
+		if (!finality) {
+			finality = await waitOrAbort(this.ctx, {
+				signal,
+				promise: () =>
+					this.queries.queryStateMachineUpdateByHeight({
+						statemachineId: stateMachineId,
+						height: Number(neededHeight),
+						chain: stateMachineId,
+					}),
+			})
+		}
 
 		const proof = await this.fetchProofWithRetry(signal, () =>
-			hyperbridge.queryProof(
-				{ Requests: [postRequestCommitment(request).commitment] },
-				request.dest,
-				BigInt(hyperbridgeFinalized.height),
-			),
+			hyperbridge.queryProof({ Requests: [commitment] }, request.dest, BigInt(finality.height)),
 		)
+
+		// Substrate destinations must wait out the consensus challenge period before the proof is usable.
+		if (!(destChain instanceof EvmChain)) {
+			const { stateId } = parseStateMachineId(stateMachineId)
+			await waitForChallengePeriod(destChain, {
+				height: BigInt(finality.height),
+				id: { stateId, consensusStateId: this.ctx.config.hyperbridge.config.consensusStateId },
+			})
+		}
 
 		const calldata = destChain.encode({
 			kind: "PostRequest",
@@ -871,25 +819,19 @@ export class PostRequestClient {
 				stateMachine: stateMachineId,
 				consensusStateId: this.ctx.config.hyperbridge.config.consensusStateId,
 				proof,
-				height: BigInt(hyperbridgeFinalized.height),
+				height: BigInt(finality.height),
 			},
 			requests: [request],
 			signer: pad("0x"),
 		})
 
-		const { stateId } = parseStateMachineId(stateMachineId)
-		await waitForChallengePeriod(destChain, {
-			height: BigInt(hyperbridgeFinalized.height),
-			id: { stateId, consensusStateId: this.ctx.config.hyperbridge.config.consensusStateId },
-		})
-
 		return {
 			status: RequestStatus.HYPERBRIDGE_FINALIZED,
 			metadata: {
-				blockHash: hyperbridgeFinalized.blockHash,
-				blockNumber: hyperbridgeFinalized.height,
-				transactionHash: hyperbridgeFinalized.transactionHash,
-				timestamp: hyperbridgeFinalized.timestamp,
+				blockHash: finality.blockHash,
+				blockNumber: finality.height,
+				transactionHash: finality.transactionHash,
+				timestamp: finality.timestamp,
 				calldata,
 			},
 		}

--- a/sdk/packages/sdk/src/client/PostRequestClient.ts
+++ b/sdk/packages/sdk/src/client/PostRequestClient.ts
@@ -632,6 +632,42 @@ export class PostRequestClient {
 
 		if (destChain instanceof EvmChain) {
 			const hyperbridgeSubstrate = hyperbridge as SubstrateChain
+			const commitment = postRequestCommitment(request).commitment
+
+			// Fast path: if the destination's Hyperbridge light client has already been advanced past
+			// the delivery height (e.g. by another message or a relayer), there's no need to build a
+			// consensus proof — submit a plain PostRequest proof at the already-finalized height.
+			const existingFinality = await this.queries.queryStateMachineUpdateByHeight({
+				statemachineId: this.ctx.config.hyperbridge.config.stateMachineId,
+				height: hyperbridgeDelivered.metadata.blockNumber,
+				chain: request.dest,
+			})
+			if (existingFinality) {
+				const proof = await hyperbridge.queryProof({ Requests: [commitment] }, request.dest, BigInt(existingFinality.height))
+				const calldata = destChain.encode({
+					kind: "PostRequest",
+					proof: {
+						stateMachine: this.ctx.config.hyperbridge.config.stateMachineId,
+						consensusStateId: this.ctx.config.hyperbridge.config.consensusStateId,
+						proof,
+						height: BigInt(existingFinality.height),
+					},
+					requests: [request],
+					signer: pad("0x"),
+				})
+				return {
+					status: RequestStatus.HYPERBRIDGE_FINALIZED,
+					metadata: {
+						blockHash: existingFinality.blockHash,
+						blockNumber: existingFinality.height,
+						transactionHash: existingFinality.transactionHash,
+						timestamp: existingFinality.timestamp,
+						calldata,
+					},
+				}
+			}
+
+			// Otherwise advance the destination's Hyperbridge light client and deliver in one batch.
 			const currentEpoch = await destChain.currentEpoch()
 			const consensusResult = await hyperbridgeSubstrate.queryConsensusProofs(
 				BigInt(hyperbridgeDelivered.metadata.blockNumber),
@@ -639,11 +675,7 @@ export class PostRequestClient {
 			)
 			if (!consensusResult) return undefined
 
-			const proof = await hyperbridge.queryProof(
-				{ Requests: [postRequestCommitment(request).commitment] },
-				request.dest,
-				consensusResult.provenHeight,
-			)
+			const proof = await hyperbridge.queryProof({ Requests: [commitment] }, request.dest, consensusResult.provenHeight)
 
 			const calldata = destChain.encode({
 				kind: "BatchConsensusAndPostRequest",
@@ -731,13 +763,52 @@ export class PostRequestClient {
 
 		if (destChain instanceof EvmChain) {
 			const hyperbridgeSubstrate = hyperbridge as SubstrateChain
+			const commitment = postRequestCommitment(request).commitment
+
+			// Fast path: if the destination's Hyperbridge light client is already advanced past the
+			// delivery height, skip the consensus proof and submit a plain PostRequest proof.
+			const existingFinality = await this.queries.queryStateMachineUpdateByHeight({
+				statemachineId: stateMachineId,
+				height: Number(neededHeight),
+				chain: request.dest,
+			})
+			if (existingFinality) {
+				this.logger.trace(
+					`[streamFinalized] destination already finalized at height=${existingFinality.height}; skipping consensus proof`,
+				)
+				const proof = await this.fetchProofWithRetry(signal, () =>
+					hyperbridge.queryProof({ Requests: [commitment] }, request.dest, BigInt(existingFinality.height)),
+				)
+				const calldata = destChain.encode({
+					kind: "PostRequest",
+					proof: {
+						stateMachine: stateMachineId,
+						consensusStateId: this.ctx.config.hyperbridge.config.consensusStateId,
+						proof,
+						height: BigInt(existingFinality.height),
+					},
+					requests: [request],
+					signer: pad("0x"),
+				})
+				return {
+					status: RequestStatus.HYPERBRIDGE_FINALIZED,
+					metadata: {
+						blockHash: existingFinality.blockHash,
+						blockNumber: existingFinality.height,
+						transactionHash: existingFinality.transactionHash,
+						timestamp: existingFinality.timestamp,
+						calldata,
+					},
+				}
+			}
+
+			// Otherwise wait for Hyperbridge's consensus proof and deliver via a batch tx.
 			const currentEpoch = await destChain.currentEpoch()
 			const consensusResult = await waitOrAbort(this.ctx, {
 				signal,
 				promise: () => hyperbridgeSubstrate.queryConsensusProofs(neededHeight, currentEpoch),
 			})
 
-			const commitment = postRequestCommitment(request).commitment
 			this.logger.trace(
 				`[streamFinalized] consensusProofs found (${consensusResult.proofs.length} proofs), provenHeight=${consensusResult.provenHeight}, ` +
 					`commitment=${commitment}, dest=${request.dest}`,


### PR DESCRIPTION
Improves how the SDK tracks message finalization on Hyperbridge. Applies to **both** `PostRequestClient` (POST requests, finalizing chain = destination) and `GetRequestClient` (GET responses, finalizing chain = source).

**1. Finalize against Hyperbridge's self state-machine update (Substrate destinations/sources).**
The `StateMachineUpdated` event for the Hyperbridge state machine is now read **on Hyperbridge itself** — Hyperbridge runs a light client of itself via `pallet-beefy-consensus-proofs` — instead of on the destination (POST) / source (GET) chain, which no longer holds. The `buildFinalized` / `streamFinalized` substrate paths resolve `chain` to the Hyperbridge `stateMachineId`.

**2. Skip the consensus proof when the chain has already finalized the message (EVM destinations/sources).**
Instead of always building a `BatchConsensusAndPostRequest` / `BatchConsensusAndGetResponse` (consensus proof + message proof), first ask the indexer whether the finalizing chain's Hyperbridge light client already has a `StateMachineUpdated` at/above the delivery height. If so, submit a plain `PostRequest` / `GetResponse` proof at that already-finalized height; otherwise fall back to the consensus batch.

Verified: `tsc --noEmit` clean for `PostRequestClient.ts` and `GetRequestClient.ts` (only pre-existing, unrelated test-file type errors remain).

Closes #997.