### PR TITLE
[sdk]: skip timeout inference for terminal post requests

### DIFF
--- a/sdk/packages/sdk/package.json
+++ b/sdk/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/sdk",
-	"version": "2.2.2",
+	"version": "2.2.3",
 	"description": "The hyperclient SDK provides utilities for querying proofs and statuses for cross-chain requests from HyperBridge.",
 	"type": "module",
 	"types": "./dist/node/index.d.ts",

--- a/sdk/packages/sdk/src/client/PostRequestClient.ts
+++ b/sdk/packages/sdk/src/client/PostRequestClient.ts
@@ -264,12 +264,7 @@ export class PostRequestClient {
 	 * accompanying timeout-proof calldata.
 	 */
 	async addTimeoutFinalityEvents(request: PostRequestWithStatus): Promise<PostRequestWithStatus> {
-		const destChain = this.ctx.config.dest
-		const hyperbridge = this.ctx.config.hyperbridge
 		const events: RequestStatusWithMetadata[] = []
-		const commitment = postRequestCommitment(request).commitment
-		const receipt = await destChain.queryRequestReceipt(commitment)
-		const destTimestamp = await destChain.timestamp()
 
 		const commit = (req: PostRequestWithStatus) => {
 			this.logger.trace(`Added ${events.length} timeout events`, events)
@@ -278,15 +273,26 @@ export class PostRequestClient {
 		}
 
 		if (request.timeoutTimestamp === 0n) return commit(request)
+		// Skip timeout inference once the request has reached a terminal status.
+		if (
+			request.statuses.some(
+				(item) => item.status === RequestStatus.DESTINATION || item.status === TimeoutStatus.TIMED_OUT,
+			)
+		)
+			return commit(request)
+
+		const destChain = this.ctx.config.dest
+		const hyperbridge = this.ctx.config.hyperbridge
+		const commitment = postRequestCommitment(request).commitment
+		const receipt = await destChain.queryRequestReceipt(commitment)
+		const destTimestamp = await destChain.timestamp()
+
 		if (receipt || request.timeoutTimestamp > destTimestamp) return commit(request)
 
-		const is_finished = request.statuses.find((item) => item.status === RequestStatus.DESTINATION)
-		if (!is_finished) {
-			events.push({
-				status: TimeoutStatus.PENDING_TIMEOUT,
-				metadata: { blockHash: "0x", blockNumber: 0, transactionHash: "0x" },
-			})
-		}
+		events.push({
+			status: TimeoutStatus.PENDING_TIMEOUT,
+			metadata: { blockHash: "0x", blockNumber: 0, transactionHash: "0x" },
+		})
 
 		const delivered = request.statuses.find((item) => item.status === RequestStatus.HYPERBRIDGE_DELIVERED)
 


### PR DESCRIPTION
Fixes SDK status snapshots so completed post requests no longer get timeout events appended.

The change skips timeout inference when the indexed request statuses already contain a terminal status (`DESTINATION` or `TIMED_OUT`). This prevents stale or missing destination receipt lookups from causing completed Bifrost messages to appear timed out.