### PR TITLE
[runtime, tesseract]: Improvements to optimistic detection of disputed op-stack state proposals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28026,7 +28026,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tesseract"
-version = "2.4.5"
+version = "2.4.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/modules/ismp/clients/optimism/src/error.rs
+++ b/modules/ismp/clients/optimism/src/error.rs
@@ -34,11 +34,11 @@ pub enum Error {
 	/// A storage-trie leaf is longer than 32 bytes — not a valid uint256/address.
 	#[error("Storage value longer than 32 bytes")]
 	StorageValueTooLong,
-	/// The `FaultDisputeGame.claimData[0]` storage word couldn't be RLP-decoded.
-	#[error("Error decoding claimData[0] value {0}")]
+	/// The `FaultDisputeGame.claimData` length slot couldn't be RLP-decoded.
+	#[error("Error decoding claimData length value {0}")]
 	DecodeClaimData(String),
-	/// The `claimData[0]` storage word is longer than 32 bytes.
-	#[error("claimData[0] storage value longer than 32 bytes")]
+	/// The `claimData` length storage word is longer than 32 bytes.
+	#[error("claimData length storage value longer than 32 bytes")]
 	ClaimDataTooLong,
 	/// The `AggregateVerifier.counteredByIntermediateRootIndexPlusOne` storage value
 	/// couldn't be RLP-decoded.
@@ -84,11 +84,12 @@ pub enum Error {
 		/// The implementation address configured for this game type.
 		expected: H160,
 	},
-	/// The `FaultDisputeGame.claimData[0]` storage word wasn't present in the proxy storage proof.
-	#[error("claimData[0] slot not found in proxy storage")]
+	/// The `FaultDisputeGame.claimData` length slot wasn't present in the proxy storage proof.
+	#[error("claimData length slot not found in proxy storage")]
 	ClaimDataSlotMissing,
-	/// The `FaultDisputeGame.claimData[0].counteredBy` field is non-zero — the game is challenged.
-	#[error("FaultDisputeGame has been challenged: claimData[0].counteredBy != 0")]
+	/// The `FaultDisputeGame.claimData.length` is not `1` — a `move()` has appended a
+	/// counter-claim, so the game has been challenged.
+	#[error("FaultDisputeGame has been challenged: claimData.length != 1")]
 	FaultDisputeGameChallenged,
 	/// The `AggregateVerifier.counteredByIntermediateRootIndexPlusOne` value is non-zero — the
 	/// game is challenged.

--- a/modules/ismp/clients/optimism/src/lib.rs
+++ b/modules/ismp/clients/optimism/src/lib.rs
@@ -48,11 +48,14 @@ pub const GAME_IMPLS_SLOT: u64 = 101;
 /// Slot for the l2Outputs array in the L2Oracle contract
 pub const L2_OUTPUTS_SLOT: u64 = 3;
 
-/// Slot of `claimData[]` inside a FaultDisputeGame proxy. Offset 4 bytes into element 0 is
-/// `counteredBy`. Matches the FaultDisputeGame implementation currently deployed across the
-/// Superchain (mainnet impl `0x6dDBa0…7499`) where `createdAt`/`resolvedAt`/`status` and
-/// assorted flags pack into slot 0 and `l2BlockNumberChallenger` takes slot 1, leaving
-/// `claimData` at slot 2.
+/// Slot of the `claimData[]` dynamic array inside a FaultDisputeGame proxy. For a dynamic array
+/// Solidity stores the element count in this slot itself (the elements live at
+/// `keccak256(slot)`). A freshly created, unchallenged game holds exactly one entry — the root
+/// claim appended in `initialize()` — and every `move()` appends another, so `claimData.length`
+/// reads `1` iff the game is unchallenged. Matches the FaultDisputeGame implementation currently
+/// deployed across the Superchain (mainnet impl `0x6dDBa0…7499`) where
+/// `createdAt`/`resolvedAt`/`status` and assorted flags pack into slot 0 and
+/// `l2BlockNumberChallenger` takes slot 1, leaving `claimData` at slot 2.
 pub const FAULT_DISPUTE_CLAIM_DATA_SLOT: u64 = 2;
 
 /// Slot of `counteredByIntermediateRootIndexPlusOne` inside Base's AggregateVerifier.
@@ -74,7 +77,8 @@ pub enum DisputeGameImpl {
 	/// Succinct's `OPSuccinctDisputeGame` — no challenge mechanism, unchallenged by construction.
 	OPSuccinct,
 	/// Optimism's `FaultDisputeGame` (and the inheriting `PermissionedDisputeGame`). Unchallenged
-	/// when `claimData[0].counteredBy == address(0)`.
+	/// when `claimData.length == 1` — i.e. only the root claim has been registered and no `move()`
+	/// (attack or defense) has appended a counter-claim.
 	FaultDisputeGame,
 	/// Base's multiproof `AggregateVerifier`. Unchallenged when
 	/// `counteredByIntermediateRootIndexPlusOne == 0`.
@@ -424,18 +428,17 @@ fn verify_not_challenged<H: Keccak256 + Send + Sync>(
 
 	match kind {
 		DisputeGameImpl::FaultDisputeGame => {
-			// claimData[0] is at keccak256(abi.encode(claimDataSlot)). The first 32-byte word
-			// holds `parentIndex (uint32)` at struct offset 0 and `counteredBy (address)` at
-			// offset 4. Viewed as a big-endian byte array, parentIndex occupies word[28..32]
-			// and counteredBy occupies word[8..28]. Absence is invalid here — a registered
-			// game must have written its root claim.
+			// `claimData` is a dynamic `ClaimData[]` at `FAULT_DISPUTE_CLAIM_DATA_SLOT`. Solidity
+			// stores a dynamic array's element count in the slot itself (the elements live at
+			// `keccak256(slot)`). A freshly created, unchallenged game holds exactly one entry —
+			// the root claim appended in `initialize()` — and every `move()` (attack or defense)
+			// appends another. So `claimData.length == 1` iff the game has not been challenged.
+			// Any other length (including absence, i.e. length 0 for a game that never registered
+			// its root claim) is rejected.
 			//
-			// The MPT trie path for a storage slot is `keccak256(storage_key)`, so we hash
-			// once more here: the storage key for the array's first element is itself a
-			// keccak256 of the slot number.
-			let storage_key =
-				H::keccak256(&U256::from(FAULT_DISPUTE_CLAIM_DATA_SLOT).to_big_endian());
-			let trie_path = H::keccak256(&storage_key.0);
+			// The MPT trie path for a direct storage slot is `keccak256(slot)`.
+			let storage_key = U256::from(FAULT_DISPUTE_CLAIM_DATA_SLOT).to_big_endian();
+			let trie_path = H::keccak256(&storage_key);
 			let value = get_value_from_proof::<H>(
 				trie_path.0.to_vec(),
 				proxy_storage_root,
@@ -449,18 +452,9 @@ fn verify_not_challenged<H: Keccak256 + Send + Sync>(
 			if raw.len() > 32 {
 				Err(Error::ClaimDataTooLong)?
 			}
-			let mut word = vec![0u8; 32 - raw.len()];
-			word.extend_from_slice(&raw);
-			// counteredBy sits at bytes [4..24] of the 32-byte word (little-endian packing: the
-			// struct's first word is laid out low-to-high in the word, so byte index from the
-			// LEFT when viewed big-endian is 32 - 4 - 20 = 8, spanning [8..28]).
-			//
-			// Solidity packs `parentIndex (uint32)` at offset 0 and `counteredBy (address)` at
-			// offset 4 within the struct. In the 32-byte storage word (big-endian), fields are
-			// laid out right-to-left: counteredBy occupies bytes [8..28] from the left, parentIndex
-			// occupies bytes [28..32].
-			const ZERO_ADDRESS: [u8; 20] = [0u8; 20];
-			if &word[8..28] != ZERO_ADDRESS.as_slice() {
+			// RLP strips leading zeros from the stored length; reconstruct the uint256 and require
+			// it to be exactly one.
+			if U256::from_big_endian(&raw) != U256::one() {
 				Err(Error::FaultDisputeGameChallenged)?
 			}
 			Ok(())

--- a/tesseract/consensus/op-host/src/lib.rs
+++ b/tesseract/consensus/op-host/src/lib.rs
@@ -146,14 +146,13 @@ pub fn derive_array_item_key(index_in_array: u64, offset: u64) -> H256 {
 /// contract layouts exactly so filtered games are precisely those that `verify_not_challenged`
 /// would reject.
 pub fn game_is_challenged(kind: &DisputeGameImpl, slot_value: alloy::primitives::U256) -> bool {
-	const ZERO_ADDRESS: [u8; 20] = [0u8; 20];
 	match kind {
 		DisputeGameImpl::OPSuccinct => false,
 		DisputeGameImpl::FaultDisputeGame => {
-			// claimData[0] packs (uint32 parentIndex, address counteredBy, ...) with
-			// counteredBy at bytes [8..28] of the 32-byte word viewed big-endian.
-			let bytes = slot_value.to_be_bytes::<32>();
-			&bytes[8..28] != ZERO_ADDRESS.as_slice()
+			// `claimData` is a dynamic array; its slot stores the element count. An unchallenged
+			// game holds exactly the root claim (length 1); every `move()` appends an entry. So
+			// the game is challenged iff `claimData.length != 1`.
+			slot_value != alloy::primitives::U256::from(1)
 		},
 		// `counteredByIntermediateRootIndexPlusOne == 0` iff unchallenged.
 		DisputeGameImpl::AggregateVerifier => !slot_value.is_zero(),
@@ -166,10 +165,11 @@ pub fn challenge_slot_keys(kind: &DisputeGameImpl) -> Vec<B256> {
 	match kind {
 		DisputeGameImpl::OPSuccinct => Vec::new(),
 		DisputeGameImpl::FaultDisputeGame => {
-			// claimData[0] lives at keccak256(abi.encode(claimDataSlot)).
-			let slot = U256::from(FAULT_DISPUTE_CLAIM_DATA_SLOT).to_big_endian();
-			let hash = keccak_256(&slot);
-			vec![B256::from_slice(&hash)]
+			// `claimData.length` lives directly in the array's declaration slot (dynamic arrays
+			// store their element count in the slot itself).
+			let mut key = [0u8; 32];
+			key[24..].copy_from_slice(&FAULT_DISPUTE_CLAIM_DATA_SLOT.to_be_bytes());
+			vec![B256::from_slice(&key)]
 		},
 		DisputeGameImpl::AggregateVerifier => {
 			let mut key = [0u8; 32];

--- a/tesseract/consensus/op-host/src/tests.rs
+++ b/tesseract/consensus/op-host/src/tests.rs
@@ -46,6 +46,10 @@ async fn run_dispute_game_verification(
 	};
 	let evm_config = EvmConfig {
 		rpc_urls: vec![l2_url],
+		// Placeholders: `EvmClient::new` requires these to be resolved, but the dispute-game
+		// verification path exercised here never consults the L2 state machine id or ismp host.
+		state_machine: Some(StateMachine::Evm(0)),
+		ismp_host: Some(H160::zero()),
 		consensus_state_id: Some("ETH0".to_string()),
 		signer: Some(DUMMY_SIGNING_KEY.to_string()),
 		..Default::default()
@@ -125,18 +129,19 @@ async fn test_aggregate_verifier_dispute_game_verification() {
 		.await;
 }
 
-/// End-to-end verification of a Cannon (gameType 0) dispute game created on Ethereum mainnet:
+/// End-to-end verification of a Cannon (gameType 8) dispute game created on Ethereum mainnet:
 ///
 /// ```text
 /// DisputeGameCreated(
-///     proxy:     0xE6512d19E2bac97A2Ed17e2cC1C5Df96E29d3EA8,
-///     gameType:  0,
-///     rootClaim: 0x76B0808A7D3244F52677F7FEC036A25FAAD2FB80EE4D9504C5458775A7024FFA,
+///     proxy:     0x48dDB9bfE0e24828FF39406aEda9cE1a9107b80f,
+///     gameType:  8,
+///     rootClaim: 0x1cbae15429a91277bfef6ab3578e7e72a9968741853d6b220c02676583436aa5,
 /// )
 /// ```
 ///
-/// Factory: `0xe5965Ab5962eDc7477C8520243A95517CD252fA9` on L1 mainnet. Requires
-/// `MAINNET_RPC_URL` (L1) and `OP_MAINNET_RPC_URL` (L2 Optimism mainnet) in the environment.
+/// Factory: `0xe5965Ab5962eDc7477C8520243A95517CD252fA9` on L1 mainnet, whose `gameImpls[8]`
+/// resolves to `0x2DDA3584b51eF5236f7726Dea5A0FB6B3cA94AeC`. Requires `MAINNET_RPC_URL` (L1) and
+/// `OP_MAINNET_RPC_URL` (L2 Optimism mainnet) in the environment.
 #[tokio::test]
 #[ignore]
 async fn test_cannon_dispute_game_verification() {
@@ -147,17 +152,17 @@ async fn test_cannon_dispute_game_verification() {
 		.expect("OP_MAINNET_RPC_URL must be set to an Optimism mainnet RPC endpoint");
 
 	let event = DisputeGameCreated {
-		disputeProxy: Address::from_slice(&hex!("e6512d19e2bac97a2ed17e2cc1c5df96e29d3ea8")),
-		gameType: 0,
+		disputeProxy: Address::from_slice(&hex!("48ddb9bfe0e24828ff39406aeda9ce1a9107b80f")),
+		gameType: 8,
 		rootClaim: B256::from(hex!(
-			"76b0808a7d3244f52677f7fec036a25faad2fb80ee4d9504c5458775a7024ffa"
+			"1cbae15429a91277bfef6ab3578e7e72a9968741853d6b220c02676583436aa5"
 		)),
 	};
 	let factory_addr = H160::from(hex!("e5965ab5962edc7477c8520243a95517cd252fa9"));
 	let game_type_configs = vec![GameTypeConfig {
-		game_type: 0,
-		// Cannon implementation pinned in the migration module.
-		expected_impl: H160::from(hex!("6dDBa09bc4cCB0D6Ca9Fc5350580f74165707499")),
+		game_type: 8,
+		// Cannon implementation pinned for gameImpls[8] on the OP mainnet factory.
+		expected_impl: H160::from(hex!("2DDA3584b51eF5236f7726Dea5A0FB6B3cA94AeC")),
 		kind: DisputeGameImpl::FaultDisputeGame,
 	}];
 

--- a/tesseract/relayer/Cargo.toml
+++ b/tesseract/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tesseract"
-version = "2.4.5"
+version = "2.4.6"
 edition = "2021"
 description = "Consolidated Hyperbridge relayer — inbound and outbound consensus + messaging"
 authors = ["Polytope Labs <hello@polytope.technology>"]


### PR DESCRIPTION
Switch the FaultDisputeGame "not challenged" check from inspecting claimData[0].counteredBy to verifying claimData.length == 1. Since counteredBy is not set until the game is resolved, making it not useful for early detection of disputes.

claimData is a dynamic ClaimData[] at storage slot 2; Solidity stores the element count in the slot itself. initialize() appends exactly the root claim (length 1) and every move() (attack or defense) appends another entry, so length == 1 iff the game has not been challenged. This is stricter than the previous check, which only caught a direct counter of the root claim rather than any move in the tree.

- op-verifier: read the array-length slot directly (trie path keccak256(slot)) and reject unless the decoded length is exactly 1
- error: reword claimData-related variants for the length-based check
- op-host: challenge_slot_keys returns the array's declaration slot and game_is_challenged treats length != 1 as challenged, keeping the relayer pre-filter in lockstep with the on-chain verifier