### PR TITLE
[indexer]: fix EVM GET request commitment to match on-chain abi.encode

### DIFF
--- a/sdk/packages/indexer/src/services/__tests__/getRequest.service.test.ts
+++ b/sdk/packages/indexer/src/services/__tests__/getRequest.service.test.ts
@@ -1,0 +1,38 @@
+import { GetRequestService } from "../getRequest.service"
+
+// Mock the logger to avoid console output during tests
+;(global as any).logger = {
+	debug: jest.fn(),
+	info: jest.fn(),
+	warn: jest.fn(),
+	error: jest.fn(),
+}
+
+describe("GetRequestService.computeRequestCommitment", () => {
+	// Real request from https://github.com/polytope-labs/hyperbridge/issues/1013
+	// (Sepolia -> Base Sepolia GET, nonce 2). The commitment must match the value the
+	// EVM host emits on-chain: keccak256(abi.encode(GetRequest)).
+	it("matches the on-chain commitment (abi.encode parity)", () => {
+		const source = "EVM-11155111"
+		const dest = "EVM-84532"
+		const nonce = 2n
+		const height = 0n
+		const timeoutTimestamp = 0n
+		const from = "0x7d6b92fa404123e6398d2de862d967f95533c90d"
+		const keys = ["0x397cfd836f98eed9fad1041a07de20fe6abaa389ac33ff75c19e70fe83507db0d683fd3465c996598dc972688b7ace676c89077b"]
+		const context = "0x0000000000000000000000000000000000000000000000000000000000000000"
+
+		const commitment = GetRequestService.computeRequestCommitment(
+			source,
+			dest,
+			nonce,
+			height,
+			timeoutTimestamp,
+			from,
+			keys,
+			context,
+		)
+
+		expect(commitment).toBe("0xdaa89209aac40e56d0d53dd5105aef394da36a149dc3e226c10b08897303a379")
+	})
+})

--- a/sdk/packages/indexer/src/services/getRequest.service.ts
+++ b/sdk/packages/indexer/src/services/getRequest.service.ts
@@ -1,6 +1,5 @@
 import { GetRequestV2, GetRequestStatusMetadata, PendingStatusMetadata, Status } from "@/configs/src/types"
 import { ethers } from "ethers"
-import { solidityKeccak256 } from "ethers/lib/utils"
 import { timestampToDate } from "@/utils/date.helpers"
 
 const ENTITY_TYPE = "GetRequestV2"
@@ -233,18 +232,18 @@ export class GetRequestService {
 			})}`,
 		)
 
-		let keysEncoding = "0x".concat(keys.map((key) => key.slice(2)).join(""))
-
-		// Convert strings to bytes
+		// Convert source/dest from state-machine strings ("EVM-11155111" etc.) to bytes.
 		const sourceBytes = ethers.utils.toUtf8Bytes(source)
 		const destBytes = ethers.utils.toUtf8Bytes(dest)
 
-		// Pack the data in the same order as the Solidity code
-		const hash = solidityKeccak256(
-			["bytes", "bytes", "uint64", "uint64", "uint64", "bytes", "bytes", "bytes"],
-			[sourceBytes, destBytes, nonce, height, timeoutTimestamp, from, keysEncoding, context],
+		// Mirror the EVM host's commitment: keccak256(abi.encode(GetRequest)), with the
+		// outer tuple wrapper. Field order/types match the GetRequest struct in
+		// core/libraries/Message.sol: source, dest, nonce, from, timeoutTimestamp, keys, height, context.
+		const encoded = ethers.utils.defaultAbiCoder.encode(
+			["tuple(bytes,bytes,uint64,bytes,uint64,bytes[],uint64,bytes)"],
+			[[sourceBytes, destBytes, nonce, from, timeoutTimestamp, keys, height, context]],
 		)
 
-		return hash
+		return ethers.utils.keccak256(encoded)
 	}
 }


### PR DESCRIPTION
## Problem

Reported in #1013. The indexer stores a GET request `commitment` that does **not** match the commitment the EVM host emits/returns on-chain, so:

- `queryGetRequest({ commitmentHash })` with the real on-chain commitment returns nothing (SDK lookups fail).
- The source row is keyed by the wrong hash, while Hyperbridge-side status updates (`SOURCE_FINALIZED → HYPERBRIDGE_DELIVERED → DEST`) are keyed by the *real* commitment from the pallet event — so they never link and every EVM-source GET looks stuck at `SOURCE`.

## Root cause

`GetRequestService.computeRequestCommitment` used `solidityKeccak256`, i.e. `keccak256(abi.encodePacked(...))`, with the wrong field order and a concatenated `keys` blob. The host commits GET requests as `keccak256(abi.encode(GetRequest))` (tuple-wrapped standard ABI encoding — see `hash(GetRequest)` in `core/libraries/Message.sol`). Packed ≠ standard ABI, so the hashes could never match.

The **POST** path (`request.service.ts`) was already migrated to `defaultAbiCoder.encode`; the GET path was simply never updated.

## Fix

Use `defaultAbiCoder.encode` with the `GetRequest` struct tuple `(bytes, bytes, uint64, bytes, uint64, bytes[], uint64, bytes)` in struct field order (`source, dest, nonce, from, timeoutTimestamp, keys, height, context`), then `keccak256`.

## Verification

Using the real request from #1013 (Sepolia→Base Sepolia GET, nonce 2):

| | value |
|---|---|
| on-chain commitment | `0xdaa89209…7303a379` |
| old (packed) code | `0xb4d4b9b4…79b9fc4c` ❌ (what the indexer had stored) |
| **new (`abi.encode`) code** | `0xdaa89209…7303a379` ✅ matches on-chain |

Added a unit test (`getRequest.service.test.ts`) pinning this vector so GET can't silently regress against `abi.encode` again.

## Note on already-indexed data

Records already written under the wrong commitment need a re-index/backfill after this lands — re-indexing with the old code reproduces the same wrong hashes, so the code fix must be deployed first.

Fixes #1013