### PR TITLE
[indexer]: index GET responses (guard lowercase `get`)

### DIFF
--- a/sdk/packages/indexer/src/handlers/events/substrateChains/handleResponseEvent.handler.ts
+++ b/sdk/packages/indexer/src/handlers/events/substrateChains/handleResponseEvent.handler.ts
@@ -61,8 +61,10 @@ export const handleSubstrateResponseEvent = wrap(async (event: SubstrateEvent): 
 	}
 
 	// Only handling get response here as we not using post response anywhere.
-	if (data.result[0].Get) {
-		const getResponse = data.result[0].Get as Get
+	// `ismp_queryResponses` returns the GetResponse unwrapped as `{ get, values }`
+	// (lowercase `get`), not enum-tagged as `{ Get: … }` — guard on the actual shape.
+	if (data.result[0].get) {
+		const getResponse = data.result[0] as Get
 
 		await GetResponseService.findOrCreate({
 			chain: host,


### PR DESCRIPTION
## Problem

`getResponses` (and `responseV2s`) have been **empty across the entire indexer** — 0 rows ever — even though Hyperbridge dispatches a response for every GET request and the substrate response handler fires on every `ismp.Response` event.

## Root cause

`ismp_queryResponses` returns the GetResponse **unwrapped** as `{ get, values }` (lowercase `get`), but `handleSubstrateResponseEvent` guarded on the uppercase enum tag `data.result[0].Get`, which is always `undefined`. So the `findOrCreate` branch never ran.

Confirmed in production logs (gargantua indexer):

```
Saw Ismp.ResponseV2:        10
Creating GetResponse Event:  0
Created new get response:    0
No responses found:          0
```

The handler fired 10 times, fetched the response with values each time (`No responses found` = 0), and created 0 rows.

## Fix

Guard on the actual shape (`data.result[0].get`) and use the object directly. The body already reads `getResponse.values` and `getResponse.get.timeoutTimestamp`, which match `Get = { get, values }`.

## Impact

Unblocks the SDK GET request stream — `getRequestStatusStream` finalizes via `queryResponseByRequestId`, which reads `getResponses`. With this fix the round-trip (…→ HYPERBRIDGE_DELIVERED → HYPERBRIDGE_FINALIZED → DESTINATION) can complete.

## Note (separate, not fixed here)

`handleRequestEvent.handler.ts:72` uses the same uppercase pattern `data.result[0].Post` (with a `// todo: support GET requests`). If `ismp_queryRequests` likewise returns lowercase `post`, that path is also affected — worth a separate look.