### PR TITLE
[sdk]: fix cross-chain fillOrder gas estimation

### DIFF
--- a/sdk/packages/sdk/package.json
+++ b/sdk/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/sdk",
-	"version": "2.3.1",
+	"version": "2.3.2",
 	"description": "The hyperclient SDK provides utilities for querying proofs and statuses for cross-chain requests from HyperBridge.",
 	"type": "module",
 	"types": "./dist/node/index.d.ts",

--- a/sdk/packages/sdk/src/chains/evm.ts
+++ b/sdk/packages/sdk/src/chains/evm.ts
@@ -746,16 +746,23 @@ export class EvmChain implements IChain {
 	async quoteNative(request: IPostRequest | IGetRequest, fee: bigint): Promise<bigint> {
 		const totalFee = (await this.quote(request)) + fee
 		const feeToken = await this.getFeeTokenWithDecimals()
-		return this.getAmountsIn(totalFee, feeToken.address, request.source)
+		// Quote against the router the host actually swaps through on dispatch,
+		// which may price differently than the canonical Uniswap V2 router.
+		const hostRouter = await this.publicClient.readContract({
+			address: this.params.host,
+			abi: EvmHost.ABI,
+			functionName: "uniswapV2Router",
+		})
+		return this.getAmountsIn(totalFee, feeToken.address, request.source, hostRouter)
 	}
 
 	/**
 	 * Given a desired output amount of a token, returns how much native is needed as input.
-	 * Uses the chain's Uniswap V2 router: WETH → tokenOut path.
+	 * Uses the chain's Uniswap V2 router (or `router` when provided): WETH → tokenOut path.
 	 */
-	async getAmountsIn(amountOut: bigint, tokenOutForQuote: HexString, chain?: string): Promise<bigint> {
+	async getAmountsIn(amountOut: bigint, tokenOutForQuote: HexString, chain?: string, router?: HexString): Promise<bigint> {
 		const chainId = chain ?? `EVM-${this.params.chainId}`
-		const v2Router = this.configService.getUniswapRouterV2Address(chainId)
+		const v2Router = router ?? this.configService.getUniswapRouterV2Address(chainId)
 		const WETH = this.configService.getWrappedNativeAssetWithDecimals(chainId).asset
 		const v2AmountIn = await this.publicClient.simulateContract({
 			address: v2Router,

--- a/sdk/packages/sdk/src/protocols/intents/GasEstimator.ts
+++ b/sdk/packages/sdk/src/protocols/intents/GasEstimator.ts
@@ -383,12 +383,13 @@ export class GasEstimator {
 			to: this.ctx.source.configService.getIntentGatewayAddress(sourceChainId),
 		}
 
+		postRequestFeeInDestFeeToken = (postRequestFeeInDestFeeToken * 1005n) / 1000n
+
 		let protocolFeeInNativeToken = await this.ctx.dest
 			.quoteNative(postRequest, postRequestFeeInDestFeeToken)
 			.catch(() => 0n)
 
 		protocolFeeInNativeToken = (protocolFeeInNativeToken * 1005n) / 1000n
-		postRequestFeeInDestFeeToken = (postRequestFeeInDestFeeToken * 1005n) / 1000n
 
 		return { postRequestFee: postRequestFeeInDestFeeToken, protocolFee: protocolFeeInNativeToken }
 	}

--- a/sdk/packages/sdk/src/tests/sequential/intentGateway.test.ts
+++ b/sdk/packages/sdk/src/tests/sequential/intentGateway.test.ts
@@ -11,6 +11,7 @@ import {
 	UNISWAP_INTENT_QUOTE_CHAIN,
 } from "@/protocols/intents/quote/uniswapV4"
 import { ChainConfigService } from "@/configs/ChainConfigService"
+import { bytes20ToBytes32 } from "@/utils"
 import { UniswapQuoteEngine, type UniswapQuoteAdapter, type UniswapQuoteToken } from "@/utils/uniswapQuote"
 
 // ---------------------------------------------------------------------------
@@ -24,6 +25,12 @@ describe.skip("IntentGateway cross-chain estimate tests", () => {
 			await runCrossChainEstimate(src, dest)
 		}, 1_000_000)
 	}
+})
+
+describe("IntentGateway BSC => Base cross-chain estimate (simplex repro)", () => {
+	it("estimates fillOrder without falling back to default gas values", async () => {
+		await runCrossChainEstimate("bsc", "base")
+	}, 300_000)
 })
 
 // Skipped: IntentGateway contracts not redeployed in the testnet redeployment.
@@ -206,7 +213,13 @@ const CHAINS: Record<string, ChainDef> = {
 }
 
 function bundlerUrl(chainId: number): string | undefined {
-	const apiKey = process.env.BUNDLER_API_KEY
+	let apiKey = process.env.BUNDLER_API_KEY
+	if (!apiKey && process.env.BUNDLER_URL) {
+		try {
+			const url = new URL(process.env.BUNDLER_URL)
+			apiKey = url.searchParams.get("apikey") ?? url.searchParams.get("apiKey") ?? undefined
+		} catch {}
+	}
 	return apiKey ? `https://api.pimlico.io/v2/${chainId}/rpc?apikey=${apiKey}` : undefined
 }
 
@@ -226,8 +239,8 @@ function buildOrder(
 	outputToken: HexString,
 	amount: bigint,
 ): Order {
-	const inputs: TokenInfo[] = [{ token: inputToken, amount }]
-	const outputAssets: TokenInfo[] = [{ token: outputToken, amount }]
+	const inputs: TokenInfo[] = [{ token: bytes20ToBytes32(inputToken), amount }]
+	const outputAssets: TokenInfo[] = [{ token: bytes20ToBytes32(outputToken), amount }]
 
 	return {
 		user: BENEFICIARY,
@@ -243,6 +256,11 @@ function buildOrder(
 	}
 }
 
+/**
+ * Estimates a cross-chain fill and fails if GasEstimator fell back to its
+ * default gas values. estimateFillOrder swallows simulation reverts and only
+ * emits a console.warn, so the warning is the observable failure signal.
+ */
 async function runCrossChainEstimate(srcKey: string, destKey: string) {
 	const src = CHAINS[srcKey]
 	const dest = CHAINS[destKey]
@@ -261,12 +279,29 @@ async function runCrossChainEstimate(srcKey: string, destKey: string) {
 		100n,
 	)
 
-	const estimate = await intentGateway.estimateFillOrder({ order })
+	const warnings: string[] = []
+	const originalWarn = console.warn
+	console.warn = (...args: unknown[]) => {
+		warnings.push(args.map((a) => (a instanceof Error ? a.message : String(a))).join(" "))
+		originalWarn(...args)
+	}
+
+	let estimate
+	try {
+		estimate = await intentGateway.estimateFillOrder({ order })
+	} finally {
+		console.warn = originalWarn
+	}
 
 	console.log(`${srcKey} => ${destKey}`)
+	console.log("callGasLimit:", estimate.callGasLimit)
+	console.log("relayerFee:", estimate.fillOptions.relayerFee)
+	console.log("nativeDispatchFee:", estimate.fillOptions.nativeDispatchFee)
 	console.log("Estimated cost (totalGasCostWei):", estimate.totalGasCostWei)
 	console.log("Estimated fee (totalGasInFeeToken):", estimate.totalGasInFeeToken)
 
+	const fallbackWarning = warnings.find((w) => w.includes("gas estimation failed"))
+	assert.equal(fallbackWarning, undefined, `estimateFillOrder fell back to default gas values: ${fallbackWarning}`)
 	assert(estimate.totalGasCostWei > 0n)
 	assert(estimate.totalGasInFeeToken > 0n)
 }

--- a/sdk/packages/simplex/src/core/filler.ts
+++ b/sdk/packages/simplex/src/core/filler.ts
@@ -450,13 +450,18 @@ export class IntentFiller {
 				const isCrossChain = order.source !== order.destination
 				let requiredConfirmations = 0
 				if (isCrossChain) {
-					const hasConfirmationPolicy = [...canFillCache].some(
-						([strategy, canFill]) => canFill && strategy.confirmationPolicy,
-					)
-					if (!hasConfirmationPolicy) {
+					const fillableStrategies = [...canFillCache].filter(([, canFill]) => canFill)
+					if (fillableStrategies.length === 0) {
+						this.logger.debug(
+							{ orderId: order.id, source: order.source, destination: order.destination },
+							"Skipping cross-chain order: no strategy can fill it",
+						)
+						return
+					}
+					if (!fillableStrategies.some(([strategy]) => strategy.confirmationPolicy)) {
 						this.logger.warn(
 							{ orderId: order.id, source: order.source, destination: order.destination },
-							"Skipping cross-chain order: no strategy has a confirmation policy configured",
+							"Skipping cross-chain order: no fillable strategy has a confirmation policy configured",
 						)
 						return
 					}

--- a/sdk/packages/simplex/src/tests/strategies/fx.mainnet.test.ts
+++ b/sdk/packages/simplex/src/tests/strategies/fx.mainnet.test.ts
@@ -186,7 +186,7 @@ describe.skip("Filler V2 FX - Polygon mainnet same-chain swap", () => {
 })
 
 describe.skip("Filler V2 FX - Base mainnet same-chain swap", () => {
-	it.only("Should place USDC->EXT order on Base and fill on Base using FX strategy only", async () => {
+	it("Should place USDC->EXT order on Base and fill on Base using FX strategy only", async () => {
 		const {
 			baseIntentGatewayV2,
 			basePublicClient,


### PR DESCRIPTION
Cross-chain fill estimation always reverted (`V4TooMuchRequested`) while same-chain worked, because the native dispatch fee never covered the host's exact-output swap:

- `estimateCrossChainFees` quoted the native amount for the unbumped relayer fee, then bumped both the fee and the native amount by 0.5%. Since exact-output swaps need superlinearly more input, the bump on the swap target consumed the entire native headroom. Now the fee is bumped before quoting.
- `EvmChain.quoteNative` quoted the canonical Uniswap V2 router, but the host swaps through its own router (`host.uniswapV2Router()`), which prices differently. Now it quotes the host's router.