### PR TITLE
[indexer]: index intent gateway volumes with FX pricing from phantom snapshots

### DIFF
--- a/sdk/packages/indexer/src/configs/schema.graphql
+++ b/sdk/packages/indexer/src/configs/schema.graphql
@@ -2664,3 +2664,80 @@ type VaultSnapshot @entity @compositeIndexes(fields: [["chain", "vault"]]) {
 	"""
 	snapshotTime: Date! @index
 }
+
+"""
+Cumulative raw token volume through IntentGatewayV3, per chain, token and volume type.
+Raw amounts are kept so USD values can also be computed off-indexer with any price source.
+"""
+type IntentGatewayTokenVolume @entity {
+	"""
+	Composite identifier: {chain}-{tokenAddress}-{volumeType}
+	"""
+	id: ID!
+
+	"""
+	Host state machine that emitted the event
+	"""
+	chain: String! @index
+
+	"""
+	EVM address of the token, as a lowercase 0x-prefixed hex string
+	"""
+	tokenAddress: String! @index
+
+	"""
+	Token symbol
+	"""
+	tokenSymbol: String! @index
+
+	"""
+	Token decimals
+	"""
+	decimals: Int!
+
+	"""
+	PLACED (order inputs on the source chain) or FILLED (order outputs on the destination chain)
+	"""
+	volumeType: String! @index
+
+	"""
+	Cumulative token amount in the token's smallest unit
+	"""
+	amount: BigInt!
+
+	"""
+	Last updated at
+	"""
+	lastUpdatedAt: BigInt!
+}
+
+"""
+Cumulative IntentGatewayV3 volume per chain and volume type, denominated in USD.
+FX tokens (e.g. cNGN) are priced via the latest PhantomOrderPriceSnapshot exchange rate.
+"""
+type CumulativeIntentGatewayVolumeUSD @entity {
+	"""
+	Composite identifier: {chain}-{volumeType}
+	"""
+	id: ID!
+
+	"""
+	Host state machine
+	"""
+	chain: String! @index
+
+	"""
+	PLACED (order inputs on the source chain) or FILLED (order outputs on the destination chain)
+	"""
+	volumeType: String! @index
+
+	"""
+	Cumulative volume in USD, scaled by 1e18 (18-decimal fixed-point integer)
+	"""
+	volumeUSD: BigInt!
+
+	"""
+	Last updated at
+	"""
+	lastUpdatedAt: BigInt!
+}

--- a/sdk/packages/indexer/src/handlers/events/intentGatewayV3/orderFilledV3.event.handler.ts
+++ b/sdk/packages/indexer/src/handlers/events/intentGatewayV3/orderFilledV3.event.handler.ts
@@ -55,5 +55,10 @@ export const handleOrderFilledEventV3 = wrap(async (event: OrderFilledLog): Prom
 		filler,
 	)
 
-	await IntentGatewayV3Service.recordOrderVolume("FILLED", mappedOutputs, timestamp)
+	// Volume metrics are best-effort: a failure here must not fail the handler and stall indexing.
+	try {
+		await IntentGatewayV3Service.recordOrderVolume("FILLED", mappedOutputs, timestamp)
+	} catch (e: any) {
+		logger.error(`Failed to record FILLED volume for order ${commitment}: ${e.message}`)
+	}
 })

--- a/sdk/packages/indexer/src/handlers/events/intentGatewayV3/orderFilledV3.event.handler.ts
+++ b/sdk/packages/indexer/src/handlers/events/intentGatewayV3/orderFilledV3.event.handler.ts
@@ -23,13 +23,15 @@ export const handleOrderFilledEventV3 = wrap(async (event: OrderFilledLog): Prom
 		})} by ${stringify({ filler })}, outputs: ${stringify(outputs)}, inputs: ${stringify(inputs)}`,
 	)
 
+	const mappedOutputs = outputs.map((token) => ({
+		token: token.token as Hex,
+		amount: BigInt(token.amount.toString()),
+	}))
+
 	await IntentGatewayV3Service.recordFill(
 		commitment,
 		filler,
-		outputs.map((token) => ({
-			token: token.token as Hex,
-			amount: BigInt(token.amount.toString()),
-		})),
+		mappedOutputs,
 		inputs.map((token) => ({
 			token: token.token as Hex,
 			amount: BigInt(token.amount.toString()),
@@ -52,4 +54,6 @@ export const handleOrderFilledEventV3 = wrap(async (event: OrderFilledLog): Prom
 		},
 		filler,
 	)
+
+	await IntentGatewayV3Service.recordOrderVolume("FILLED", mappedOutputs, timestamp)
 })

--- a/sdk/packages/indexer/src/handlers/events/intentGatewayV3/orderPlacedV3.event.handler.ts
+++ b/sdk/packages/indexer/src/handlers/events/intentGatewayV3/orderPlacedV3.event.handler.ts
@@ -98,7 +98,12 @@ export const handleOrderPlacedEventV3 = wrap(async (event: OrderPlacedLog): Prom
 
 	await IntentGatewayV3Service.updateOrderStatus(commitment, OrderStatus.PLACED, txMeta)
 
-	await IntentGatewayV3Service.recordOrderVolume("PLACED", order.inputs, timestamp)
+	// Volume metrics are best-effort: a failure here must not fail the handler and stall indexing.
+	try {
+		await IntentGatewayV3Service.recordOrderVolume("PLACED", order.inputs, timestamp)
+	} catch (e: any) {
+		logger.error(`Failed to record PLACED volume for order ${commitment}: ${e.message}`)
+	}
 })
 
 /**

--- a/sdk/packages/indexer/src/handlers/events/intentGatewayV3/orderPlacedV3.event.handler.ts
+++ b/sdk/packages/indexer/src/handlers/events/intentGatewayV3/orderPlacedV3.event.handler.ts
@@ -97,6 +97,8 @@ export const handleOrderPlacedEventV3 = wrap(async (event: OrderPlacedLog): Prom
 	)
 
 	await IntentGatewayV3Service.updateOrderStatus(commitment, OrderStatus.PLACED, txMeta)
+
+	await IntentGatewayV3Service.recordOrderVolume("PLACED", order.inputs, timestamp)
 })
 
 /**

--- a/sdk/packages/indexer/src/services/intentGatewayV3.service.ts
+++ b/sdk/packages/indexer/src/services/intentGatewayV3.service.ts
@@ -33,10 +33,14 @@ import { IOrderV3EscrowRelease } from "@/configs/src/types/models/IOrderV3Escrow
 import { IOrderV3EscrowReleaseToken } from "@/configs/src/types/models/IOrderV3EscrowReleaseToken"
 import { IOrderV3EscrowRefund } from "@/configs/src/types/models/IOrderV3EscrowRefund"
 import { IOrderV3EscrowRefundToken } from "@/configs/src/types/models/IOrderV3EscrowRefundToken"
+import { IntentGatewayTokenVolume } from "@/configs/src/types/models/IntentGatewayTokenVolume"
+import { CumulativeIntentGatewayVolumeUSD } from "@/configs/src/types/models/CumulativeIntentGatewayVolumeUSD"
+import { PhantomOrderPriceSnapshot } from "@/configs/src/types/models/PhantomOrderPriceSnapshot"
 import { timestampToDate } from "@/utils/date.helpers"
+import { getHostStateMachine } from "@/utils/substrate.helpers"
 
 import { PointsService } from "./points.service"
-import { VolumeService } from "./volume.service"
+import { VolumeService, toScaledUsd } from "./volume.service"
 import PriceHelper from "@/utils/price.helpers"
 import { TokenPriceService } from "./token-price.service"
 import stringify from "safe-stable-stringify"
@@ -47,6 +51,16 @@ export interface TokenInfo {
 }
 
 const ENTITY_TYPE = "IOrderV3"
+
+export type IntentVolumeType = "PLACED" | "FILLED"
+
+// USDC and USDT share one exchange rate: the USDC TokenPrice row.
+const STABLE_SYMBOLS = ["USDC", "USDT"]
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+// Snapshots are scanned newest-first; a small window is enough to skip rows with no valid bids.
+const SNAPSHOT_SCAN_LIMIT = 10
 
 const decodeChain = (value: string): string =>
 	value.startsWith("0x") ? ethers.utils.toUtf8String(value) : value
@@ -351,6 +365,167 @@ export class IntentGatewayV3Service {
 			total: total.toFixed(18),
 			values: valuesUSD.map((value) => value.amountValueInUSD),
 		}
+	}
+
+	/**
+	 * Record intent gateway volume for a list of order tokens: cumulative raw amounts per
+	 * chain-token, plus a per-chain USD rollup priced via TokenPrice for stables and the
+	 * latest PhantomOrderPriceSnapshot exchange rate for FX tokens.
+	 */
+	static async recordOrderVolume(
+		volumeType: IntentVolumeType,
+		tokens: { token: string; amount: bigint }[],
+		timestamp: bigint,
+	): Promise<void> {
+		const chain = getHostStateMachine(chainId)
+		let usdDelta = new Decimal(0)
+
+		for (const { token, amount } of tokens) {
+			const tokenAddress = bytes32ToBytes20(token).toLowerCase()
+			const { symbol, decimals } = await this.getTokenMetadata(tokenAddress)
+
+			const id = `${chain}-${tokenAddress}-${volumeType}`
+			let tokenVolume = await IntentGatewayTokenVolume.get(id)
+			if (!tokenVolume) {
+				tokenVolume = IntentGatewayTokenVolume.create({
+					id,
+					chain,
+					tokenAddress,
+					tokenSymbol: symbol,
+					decimals,
+					volumeType,
+					amount,
+					lastUpdatedAt: timestamp,
+				})
+			} else {
+				tokenVolume.amount = tokenVolume.amount + amount
+				tokenVolume.lastUpdatedAt = timestamp
+			}
+			await tokenVolume.save()
+
+			const price = await this.getTokenUsdPriceWithFx(tokenAddress, symbol, decimals)
+			if (price) {
+				const { amountValueInUSD } = PriceHelper.getAmountValueInUSD(amount, decimals, price.toFixed(18))
+				usdDelta = usdDelta.plus(amountValueInUSD)
+			} else {
+				logger.warn(
+					`[IntentGatewayV3Service.recordOrderVolume] No USD price for ${symbol} (${tokenAddress}) on ${chain}; skipping USD rollup, raw amount retained`,
+				)
+			}
+		}
+
+		if (usdDelta.isZero()) return
+
+		const cumulativeId = `${chain}-${volumeType}`
+		const scaled = toScaledUsd(usdDelta.toFixed(18))
+		let cumulative = await CumulativeIntentGatewayVolumeUSD.get(cumulativeId)
+		if (!cumulative) {
+			cumulative = CumulativeIntentGatewayVolumeUSD.create({
+				id: cumulativeId,
+				chain,
+				volumeType,
+				volumeUSD: scaled,
+				lastUpdatedAt: timestamp,
+			})
+		} else {
+			cumulative.volumeUSD = cumulative.volumeUSD + scaled
+			cumulative.lastUpdatedAt = timestamp
+		}
+		await cumulative.save()
+	}
+
+	private static async getTokenMetadata(tokenAddress: string): Promise<{ symbol: string; decimals: number }> {
+		if (tokenAddress === ZERO_ADDRESS) {
+			return { symbol: "ETH", decimals: 18 }
+		}
+
+		try {
+			const tokenContract = ERC6160Ext20Abi__factory.connect(tokenAddress, api)
+			const symbol = await tokenContract.symbol()
+			const decimals = await tokenContract.decimals()
+			return { symbol, decimals }
+		} catch (error) {
+			logger.warn(
+				`[IntentGatewayV3Service.getTokenMetadata] Failed to get metadata for token ${tokenAddress}: ${stringify(
+					{ error: error as unknown as Error },
+				)}`,
+			)
+			return { symbol: "UNKNOWN", decimals: 18 }
+		}
+	}
+
+	private static async getTokenUsdPriceWithFx(
+		tokenAddress: string,
+		symbol: string,
+		decimals: number,
+	): Promise<Decimal | null> {
+		if (STABLE_SYMBOLS.includes(symbol.toUpperCase())) {
+			return this.getStableUsdPrice()
+		}
+
+		const fxPrice = await this.getFxPriceFromSnapshots(tokenAddress, decimals)
+		if (fxPrice) return fxPrice
+
+		const price = await TokenPriceService.getPrice(symbol)
+		return price > 0 ? new Decimal(price) : null
+	}
+
+	private static async getStableUsdPrice(): Promise<Decimal | null> {
+		const price = await TokenPriceService.getPrice("USDC")
+		return price > 0 ? new Decimal(price) : null
+	}
+
+	/**
+	 * Price an FX token from the latest PhantomOrderPriceSnapshot quoting it against a
+	 * stablecoin, in either direction. The snapshot rate is medianPrice / standardAmount
+	 * adjusted for decimals; the stable leg is converted to USD via the USDC TokenPrice row.
+	 */
+	private static async getFxPriceFromSnapshots(tokenAddress: string, decimals: number): Promise<Decimal | null> {
+		const [asInput, asOutput] = await Promise.all([
+			PhantomOrderPriceSnapshot.getByFields([["tokenA", "=", tokenAddress]], {
+				limit: SNAPSHOT_SCAN_LIMIT,
+				orderBy: "blockNumber",
+				orderDirection: "DESC",
+			}),
+			PhantomOrderPriceSnapshot.getByFields([["tokenB", "=", tokenAddress]], {
+				limit: SNAPSHOT_SCAN_LIMIT,
+				orderBy: "blockNumber",
+				orderDirection: "DESC",
+			}),
+		])
+
+		const snapshot = [...asInput, ...asOutput]
+			.filter((s) => s.medianPrice && s.medianPrice > 0n && s.standardAmount > 0n)
+			.sort((a, b) => (a.blockNumber > b.blockNumber ? -1 : 1))[0]
+		if (!snapshot) return null
+
+		const tokenIsInput = snapshot.tokenA === tokenAddress
+		const quoteAddress = tokenIsInput ? snapshot.tokenB : snapshot.tokenA
+		const quote = await this.getTokenMetadata(quoteAddress)
+		if (!STABLE_SYMBOLS.includes(quote.symbol.toUpperCase())) {
+			logger.warn(
+				`[IntentGatewayV3Service.getFxPriceFromSnapshots] Latest snapshot for ${tokenAddress} quotes against non-stable ${quote.symbol}; cannot derive USD price`,
+			)
+			return null
+		}
+
+		const stableUsd = await this.getStableUsdPrice()
+		if (!stableUsd) return null
+
+		const median = new Decimal(snapshot.medianPrice!.toString())
+		const standard = new Decimal(snapshot.standardAmount.toString())
+
+		// tokenIsInput: medianPrice is tokenB units received per standardAmount of this token,
+		// so its price in stable units is median/standard; otherwise the reciprocal.
+		const rate = tokenIsInput
+			? median
+					.div(new Decimal(10).pow(quote.decimals))
+					.div(standard.div(new Decimal(10).pow(decimals)))
+			: standard
+					.div(new Decimal(10).pow(quote.decimals))
+					.div(median.div(new Decimal(10).pow(decimals)))
+
+		return rate.mul(stableUsd)
 	}
 
 	static async updateOrderStatus(

--- a/sdk/packages/indexer/src/services/intentGatewayV3.service.ts
+++ b/sdk/packages/indexer/src/services/intentGatewayV3.service.ts
@@ -503,7 +503,20 @@ export class IntentGatewayV3Service {
 
 		const tokenIsInput = snapshot.tokenA === tokenAddress
 		const quoteAddress = tokenIsInput ? snapshot.tokenB : snapshot.tokenA
-		const quote = await this.getTokenMetadata(quoteAddress)
+
+		// Snapshots are not chain-scoped, so the quote token may not exist on this chain and the
+		// metadata call can revert. That must not fail the handler — fall back to CoinGecko instead.
+		let quote: { symbol: string; decimals: number }
+		try {
+			quote = await this.getTokenMetadata(quoteAddress)
+		} catch (error) {
+			logger.warn(
+				`[IntentGatewayV3Service.getFxPriceFromSnapshots] Failed to read quote token ${quoteAddress} metadata for snapshot ${snapshot.id}: ${stringify(
+					{ error: error as unknown as Error },
+				)}`,
+			)
+			return null
+		}
 		if (!STABLE_SYMBOLS.includes(quote.symbol.toUpperCase())) {
 			logger.warn(
 				`[IntentGatewayV3Service.getFxPriceFromSnapshots] Latest snapshot for ${tokenAddress} quotes against non-stable ${quote.symbol}; cannot derive USD price`,

--- a/sdk/packages/indexer/src/services/intentGatewayV3.service.ts
+++ b/sdk/packages/indexer/src/services/intentGatewayV3.service.ts
@@ -378,42 +378,53 @@ export class IntentGatewayV3Service {
 		timestamp: bigint,
 	): Promise<void> {
 		const chain = getHostStateMachine(chainId)
-		let usdDelta = new Decimal(0)
 
+		const amountByToken = new Map<string, bigint>()
 		for (const { token, amount } of tokens) {
 			const tokenAddress = bytes32ToBytes20(token).toLowerCase()
-			const { symbol, decimals } = await this.getTokenMetadata(tokenAddress)
-
-			const id = `${chain}-${tokenAddress}-${volumeType}`
-			let tokenVolume = await IntentGatewayTokenVolume.get(id)
-			if (!tokenVolume) {
-				tokenVolume = IntentGatewayTokenVolume.create({
-					id,
-					chain,
-					tokenAddress,
-					tokenSymbol: symbol,
-					decimals,
-					volumeType,
-					amount,
-					lastUpdatedAt: timestamp,
-				})
-			} else {
-				tokenVolume.amount = tokenVolume.amount + amount
-				tokenVolume.lastUpdatedAt = timestamp
-			}
-			await tokenVolume.save()
-
-			const price = await this.getTokenUsdPriceWithFx(tokenAddress, symbol, decimals)
-			if (price) {
-				const { amountValueInUSD } = PriceHelper.getAmountValueInUSD(amount, decimals, price.toFixed(18))
-				usdDelta = usdDelta.plus(amountValueInUSD)
-			} else {
-				logger.warn(
-					`[IntentGatewayV3Service.recordOrderVolume] No USD price for ${symbol} (${tokenAddress}) on ${chain}; skipping USD rollup, raw amount retained`,
-				)
-			}
+			amountByToken.set(tokenAddress, (amountByToken.get(tokenAddress) ?? 0n) + amount)
 		}
 
+		const values = await Promise.all(
+			Array.from(amountByToken, async ([tokenAddress, amount]) => {
+				const id = `${chain}-${tokenAddress}-${volumeType}`
+				let tokenVolume = await IntentGatewayTokenVolume.get(id)
+				let symbol: string
+				let decimals: number
+
+				if (tokenVolume) {
+					symbol = tokenVolume.tokenSymbol
+					decimals = tokenVolume.decimals
+					tokenVolume.amount = tokenVolume.amount + amount
+					tokenVolume.lastUpdatedAt = timestamp
+				} else {
+					;({ symbol, decimals } = await this.getTokenMetadata(tokenAddress))
+					tokenVolume = IntentGatewayTokenVolume.create({
+						id,
+						chain,
+						tokenAddress,
+						tokenSymbol: symbol,
+						decimals,
+						volumeType,
+						amount,
+						lastUpdatedAt: timestamp,
+					})
+				}
+				await tokenVolume.save()
+
+				const price = await this.getTokenUsdPriceWithFx(tokenAddress, symbol, decimals)
+				if (!price) {
+					logger.warn(
+						`[IntentGatewayV3Service.recordOrderVolume] No USD price for ${symbol} (${tokenAddress}) on ${chain}; skipping USD rollup, raw amount retained`,
+					)
+					return new Decimal(0)
+				}
+
+				return new Decimal(PriceHelper.getAmountValueInUSD(amount, decimals, price.toFixed(18)).amountValueInUSD)
+			}),
+		)
+
+		const usdDelta = values.reduce((acc, curr) => acc.plus(curr), new Decimal(0))
 		if (usdDelta.isZero()) return
 
 		const cumulativeId = `${chain}-${volumeType}`
@@ -439,19 +450,10 @@ export class IntentGatewayV3Service {
 			return { symbol: "ETH", decimals: 18 }
 		}
 
-		try {
-			const tokenContract = ERC6160Ext20Abi__factory.connect(tokenAddress, api)
-			const symbol = await tokenContract.symbol()
-			const decimals = await tokenContract.decimals()
-			return { symbol, decimals }
-		} catch (error) {
-			logger.warn(
-				`[IntentGatewayV3Service.getTokenMetadata] Failed to get metadata for token ${tokenAddress}: ${stringify(
-					{ error: error as unknown as Error },
-				)}`,
-			)
-			return { symbol: "UNKNOWN", decimals: 18 }
-		}
+		const tokenContract = ERC6160Ext20Abi__factory.connect(tokenAddress, api)
+		const symbol = await tokenContract.symbol()
+		const decimals = await tokenContract.decimals()
+		return { symbol, decimals }
 	}
 
 	private static async getTokenUsdPriceWithFx(


### PR DESCRIPTION
Closes #1032

Indexes intent gateway volumes separately: cumulative raw token amounts per chain (`IntentGatewayTokenVolume`) and a USD rollup per chain (`CumulativeIntentGatewayVolumeUSD`), recorded on order placed (inputs) and filled (outputs).

USD conversion prices USDC/USDT via the indexer's USDC `TokenPrice` row (one rate for both) and FX tokens like cNGN via the latest `PhantomOrderPriceSnapshot` exchange rate, falling back to the existing CoinGecko path for other tokens. Raw amounts are always retained so USD values can also be computed off-indexer.