### PR TITLE
[runtime] Prevent BSC consensus client from reaching an inconsistent  state

### DIFF
--- a/modules/consensus/bsc/prover/src/test.rs
+++ b/modules/consensus/bsc/prover/src/test.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use bsc_verifier::{
+	ensure_finalized_epoch_consistent,
 	primitives::{compute_epoch, parse_extra, Testnet, VALIDATOR_BIT_SET_SIZE},
 	verify_bsc_header,
 };
@@ -176,6 +177,13 @@ async fn verify_bsc_pos_headers() {
 
 		let next = result.next_validators.expect("sync update must carry next validator set");
 		finalized_height = update.source_header.number.low_u64();
+
+		// The sync update crossed into `next_epoch` and staged the next validator set, so the
+		// on-chain invariant must hold: finalized epoch is at most one ahead of `current_epoch`
+		// *because* a rotation is now staged.
+		ensure_finalized_epoch_consistent(finalized_height, current_epoch, true, EPOCH_LENGTH)
+			.expect("post-sync state must satisfy the finalized-epoch invariant");
+
 		println!(
 			"Sync accepted at block {block}: new {}-validator set staged, rotation at {}",
 			next.validators.len(),
@@ -264,6 +272,19 @@ async fn verify_bsc_pos_headers() {
 					(source_header={}, target_header={})",
 					update.source_header.number, update.target_header.number,
 				);
+
+				// Rotation is now enacted: `current_epoch` advances to `next_epoch`, the pending
+				// set is promoted, and the finalized header sits in `next_epoch`. With the staged
+				// set consumed (no longer pending), the invariant must still hold — the finalized
+				// epoch now equals the new `current_epoch`.
+				ensure_finalized_epoch_consistent(
+					update.source_header.number.low_u64(),
+					next_epoch,
+					false,
+					EPOCH_LENGTH,
+				)
+				.expect("post-enactment state must satisfy the finalized-epoch invariant");
+
 				println!(
 					"VALIDATOR SET ROTATED SUCCESSFULLY at block {block} \
 					(source_header={})",

--- a/modules/consensus/bsc/verifier/src/error.rs
+++ b/modules/consensus/bsc/verifier/src/error.rs
@@ -86,6 +86,25 @@ pub enum Error {
 		/// Epoch derived from the source header number.
 		source_epoch: u64,
 	},
+	/// An update would advance `finalized_height` into an epoch beyond the one the
+	/// client holds validators for, without a staged rotation. Accepting it would
+	/// strand the client: `current_epoch`/`current_validators` would lag a full
+	/// epoch behind `finalized_height`, and the relayer (which targets
+	/// `max(epoch(finalized_height), current_epoch)`) could never sync the skipped
+	/// epoch. The finalized height may only cross an epoch boundary via a
+	/// validator-set-staging (sync) update.
+	#[error(
+		"Update would strand the client: finalized epoch {finalized_epoch} exceeds current \
+		 epoch {current_epoch} (next validators staged: {next_validators_staged})"
+	)]
+	StaleValidatorSet {
+		/// Epoch derived from the update's finalized (source) header.
+		finalized_epoch: u64,
+		/// The client's current validator-set epoch.
+		current_epoch: u64,
+		/// Whether a next validator set was staged for rotation.
+		next_validators_staged: bool,
+	},
 	/// Fraud-proof header pair didn't satisfy "same height, different hash".
 	#[error("Invalid fraud proof")]
 	InvalidFraudProof,

--- a/modules/consensus/bsc/verifier/src/lib.rs
+++ b/modules/consensus/bsc/verifier/src/lib.rs
@@ -22,7 +22,7 @@ use alloc::vec::Vec;
 use bls_utils::aggregate_public_keys;
 use geth_primitives::{CodecHeader, Header};
 use ismp::messaging::Keccak256;
-use primitives::{parse_extra, BscClientUpdate, Config, VALIDATOR_BIT_SET_SIZE};
+use primitives::{compute_epoch, parse_extra, BscClientUpdate, Config, VALIDATOR_BIT_SET_SIZE};
 use sp_core::H256;
 use ssz_rs::{Bitvector, Deserialize};
 use sync_committee_primitives::constants::BlsPublicKey;
@@ -209,6 +209,38 @@ pub fn verify_bsc_header<H: Keccak256, C: Config>(
 		finalized_header: update.source_header,
 		next_validators: next_validator_addresses,
 	})
+}
+
+/// Enforce that `finalized_height` never runs ahead of the validator set the client holds.
+///
+/// A BSC epoch-N validator set signs for `current_epoch` and remains valid into the first half of
+/// `current_epoch + 1` (until the mid-epoch rotation block), so an update finalizing a header early
+/// in the next epoch verifies fine against it. But the client may only *rely* on that overlap once
+/// the next set has been staged (`next_validators_staged`) so the rotation can subsequently be
+/// enacted. An update that finalizes a header in a new epoch without staging that rotation leaves
+/// `current_epoch`/`current_validators` a full epoch behind `finalized_height`; the relayer derives
+/// its sync target from `max(epoch(finalized_height), current_epoch)`, so it would skip the
+/// un-staged epoch forever and the client would be permanently stuck (also a griefing vector).
+///
+/// The finalized height may therefore cross an epoch boundary only via a validator-set-staging
+/// (sync) update, and by at most one epoch: `epoch(finalized_height) <= current_epoch +
+/// next_validators_staged`.
+pub fn ensure_finalized_epoch_consistent(
+	finalized_height: u64,
+	current_epoch: u64,
+	next_validators_staged: bool,
+	epoch_length: u64,
+) -> Result<(), Error> {
+	let finalized_epoch = compute_epoch(finalized_height, epoch_length);
+	let max_finalized_epoch = current_epoch + next_validators_staged as u64;
+	if finalized_epoch > max_finalized_epoch {
+		return Err(Error::StaleValidatorSet {
+			finalized_epoch,
+			current_epoch,
+			next_validators_staged,
+		});
+	}
+	Ok(())
 }
 
 #[cfg(test)]

--- a/modules/ismp/clients/bsc/src/lib.rs
+++ b/modules/ismp/clients/bsc/src/lib.rs
@@ -147,6 +147,28 @@ impl<
 			consensus_state.next_validators = Some(next_validators);
 		}
 		consensus_state.finalized_height = finalized_header.number.low_u64();
+
+		// Invariant: `finalized_height` must never run ahead of the validator set the client
+		// holds. `current_validators` sign for `current_epoch` and remain valid into the first
+		// half of `current_epoch + 1`, but the client may only *rely* on that overlap once the
+		// next set has been staged (`next_validators`) so the rotation can subsequently be
+		// enacted. An update that finalizes a header in a new epoch without staging that rotation
+		// leaves `current_epoch`/`current_validators` a full epoch behind `finalized_height`; the
+		// relayer derives its sync target from `max(epoch(finalized_height), current_epoch)`, so it
+		// would skip the un-staged epoch forever and the client would be permanently stuck (also a
+		// griefing vector). Reject such updates: the finalized height may only cross an epoch
+		// boundary via a validator-set-staging (sync) update, and by at most one epoch.
+		let finalized_epoch = compute_epoch(consensus_state.finalized_height, epoch_length);
+		let max_finalized_epoch =
+			consensus_state.current_epoch + consensus_state.next_validators.is_some() as u64;
+		if finalized_epoch > max_finalized_epoch {
+			Err(Error::StaleValidatorSet {
+				finalized_epoch,
+				current_epoch: consensus_state.current_epoch,
+				next_validators_staged: consensus_state.next_validators.is_some(),
+			})?
+		}
+
 		state_machine_map.insert(
 			StateMachineId {
 				state_id: StateMachine::Evm(consensus_state.chain_id),

--- a/modules/ismp/clients/bsc/src/lib.rs
+++ b/modules/ismp/clients/bsc/src/lib.rs
@@ -6,6 +6,7 @@ extern crate alloc;
 use alloc::{boxed::Box, collections::BTreeMap, vec, vec::Vec};
 pub use bsc_verifier::primitives::{Mainnet, Testnet};
 use bsc_verifier::{
+	ensure_finalized_epoch_consistent,
 	primitives::{compute_epoch, parse_extra, BscClientUpdate},
 	verify_bsc_header, Error, NextValidators, VerificationResult,
 };
@@ -148,26 +149,16 @@ impl<
 		}
 		consensus_state.finalized_height = finalized_header.number.low_u64();
 
-		// Invariant: `finalized_height` must never run ahead of the validator set the client
-		// holds. `current_validators` sign for `current_epoch` and remain valid into the first
-		// half of `current_epoch + 1`, but the client may only *rely* on that overlap once the
-		// next set has been staged (`next_validators`) so the rotation can subsequently be
-		// enacted. An update that finalizes a header in a new epoch without staging that rotation
-		// leaves `current_epoch`/`current_validators` a full epoch behind `finalized_height`; the
-		// relayer derives its sync target from `max(epoch(finalized_height), current_epoch)`, so it
-		// would skip the un-staged epoch forever and the client would be permanently stuck (also a
-		// griefing vector). Reject such updates: the finalized height may only cross an epoch
-		// boundary via a validator-set-staging (sync) update, and by at most one epoch.
-		let finalized_epoch = compute_epoch(consensus_state.finalized_height, epoch_length);
-		let max_finalized_epoch =
-			consensus_state.current_epoch + consensus_state.next_validators.is_some() as u64;
-		if finalized_epoch > max_finalized_epoch {
-			Err(Error::StaleValidatorSet {
-				finalized_epoch,
-				current_epoch: consensus_state.current_epoch,
-				next_validators_staged: consensus_state.next_validators.is_some(),
-			})?
-		}
+		// Reject any update that would leave `finalized_height` running ahead of the validator set
+		// the client holds — this would permanently strand the client (see
+		// `ensure_finalized_epoch_consistent`). The finalized height may only cross an epoch
+		// boundary via a validator-set-staging (sync) update.
+		ensure_finalized_epoch_consistent(
+			consensus_state.finalized_height,
+			consensus_state.current_epoch,
+			consensus_state.next_validators.is_some(),
+			epoch_length,
+		)?;
 
 		state_machine_map.insert(
 			StateMachineId {

--- a/parachain/runtimes/gargantua/src/lib.rs
+++ b/parachain/runtimes/gargantua/src/lib.rs
@@ -251,7 +251,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("gargantua"),
 	impl_name: Cow::Borrowed("gargantua"),
 	authoring_version: 1,
-	spec_version: 7_700,
+	spec_version: 7_800,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/parachain/runtimes/nexus/src/lib.rs
+++ b/parachain/runtimes/nexus/src/lib.rs
@@ -238,7 +238,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("nexus"),
 	impl_name: Cow::Borrowed("nexus"),
 	authoring_version: 1,
-	spec_version: 7_800,
+	spec_version: 7_900,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
 This fix stops a BSC client from entering the inconsistent state. Fixes an issue noticed on testnet due to a lot of relay chain reorgs.