### PR TITLE
[runtime]: Bind validator addresses to their public keys in the Tendermint client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28509,8 +28509,6 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "sha2 0.10.9",
- "sha3 0.10.8",
  "tendermint-ics23-primitives",
  "tendermint-primitives",
  "tendermint-verifier",

--- a/modules/consensus/tendermint/primitives/src/address.rs
+++ b/modules/consensus/tendermint/primitives/src/address.rs
@@ -1,0 +1,29 @@
+//! Validator account id derivation.
+
+use cometbft::{account, public_key::PublicKey};
+use sha2::{Digest, Sha256};
+use sha3::Keccak256;
+
+/// Length of a Tendermint account id in bytes.
+const ACCOUNT_ID_LEN: usize = 20;
+
+/// Recomputes the account id that a validator must present for a given public key.
+///
+/// Ed25519 keys use the usual sha256 truncation shared with vanilla CometBFT.
+/// Secp256k1 keys follow the Ethereum style derivation Heimdall adopted: keccak
+/// over the uncompressed key with its leading tag byte dropped, taking the last
+/// twenty bytes. Returns `None` for key types we do not recognise.
+pub fn account_id_from_public_key(pub_key: &PublicKey) -> Option<account::Id> {
+	match pub_key {
+		PublicKey::Ed25519(key) => {
+			let digest = Sha256::digest(key.as_bytes());
+			Some(account::Id::new(digest[..ACCOUNT_ID_LEN].try_into().ok()?))
+		},
+		PublicKey::Secp256k1(key) => {
+			let encoded = key.to_encoded_point(false);
+			let digest = Keccak256::digest(&encoded.as_bytes()[1..]);
+			Some(account::Id::new(digest[12..32].try_into().ok()?))
+		},
+		_ => None,
+	}
+}

--- a/modules/consensus/tendermint/primitives/src/lib.rs
+++ b/modules/consensus/tendermint/primitives/src/lib.rs
@@ -1,6 +1,9 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 extern crate alloc;
 
+pub mod address;
+pub use address::account_id_from_public_key;
+
 pub mod verifier;
 pub use cometbft::{
 	PublicKey as PubKey,

--- a/modules/consensus/tendermint/primitives/src/verifier.rs
+++ b/modules/consensus/tendermint/primitives/src/verifier.rs
@@ -155,9 +155,11 @@ pub struct CodecTrustedState {
 	pub verification_options: VerificationOptions,
 }
 
-impl From<CodecTrustedState> for TrustedState {
-	fn from(codec_state: CodecTrustedState) -> Self {
-		Self {
+impl TryFrom<CodecTrustedState> for TrustedState {
+	type Error = String;
+
+	fn try_from(codec_state: CodecTrustedState) -> Result<Self, Self::Error> {
+		Ok(Self {
 			chain_id: codec_state.chain_id,
 			height: codec_state.height,
 			timestamp: codec_state.timestamp,
@@ -165,17 +167,17 @@ impl From<CodecTrustedState> for TrustedState {
 			validators: codec_state
 				.validators
 				.into_iter()
-				.map(|v| v.to_validator().expect("Failed to convert CodecValidator to Validator"))
-				.collect(),
+				.map(|v| v.to_validator())
+				.collect::<Result<Vec<_>, _>>()?,
 			next_validators: codec_state
 				.next_validators
 				.into_iter()
-				.map(|v| v.to_validator().expect("Failed to convert CodecValidator to Validator"))
-				.collect(),
+				.map(|v| v.to_validator())
+				.collect::<Result<Vec<_>, _>>()?,
 			next_validators_hash: codec_state.next_validators_hash,
 			trusting_period: codec_state.trusting_period,
 			verification_options: codec_state.verification_options,
-		}
+		})
 	}
 }
 
@@ -537,12 +539,24 @@ impl CodecCommitSig {
 
 impl CodecValidator {
 	/// Convert back to Validator
+	///
+	/// The address is only ever a function of the public key, so we recompute it
+	/// and reject anything that does not match. Without this a caller could keep a
+	/// genuine key and power while swapping in an address of their choosing, which
+	/// the signed validator set hash does not commit to.
 	pub fn to_validator(&self) -> Result<Validator, String> {
 		let address = cometbft::account::Id::try_from(self.address.to_vec())
 			.map_err(|e| format!("Invalid validator address: {}", e))?;
 		let pub_key = self.pub_key.to_public_key()?;
 		let power = cometbft::vote::Power::try_from(self.power)
 			.map_err(|e| format!("Invalid validator power: {}", e))?;
+
+		let derived = crate::address::account_id_from_public_key(&pub_key)
+			.ok_or_else(|| "Unsupported validator public key type".to_string())?;
+		if address != derived {
+			return Err("Validator address is not derived from its public key".to_string());
+		}
+
 		Ok(Validator {
 			address,
 			pub_key,
@@ -894,4 +908,39 @@ pub enum VerificationError {
 	/// Configuration error
 	#[error("Configuration error: {0}")]
 	ConfigurationError(String),
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{CodecPublicKey, CodecValidator};
+	use crate::address::account_id_from_public_key;
+	use alloc::{vec, vec::Vec};
+
+	// A valid ed25519 public key (RFC 8032 test vector 1).
+	const ED25519_PUBKEY: [u8; 32] = [
+		0xd7, 0x5a, 0x98, 0x01, 0x82, 0xb1, 0x0a, 0xb7, 0xd5, 0x4b, 0xfe, 0xd3, 0xc9, 0x64, 0x07,
+		0x3a, 0x0e, 0xe1, 0x72, 0xf3, 0xda, 0xa6, 0x23, 0x25, 0xaf, 0x02, 0x1a, 0x68, 0xf7, 0x07,
+		0x51, 0x1a,
+	];
+
+	fn codec_validator(address: Vec<u8>) -> CodecValidator {
+		CodecValidator {
+			address,
+			pub_key: CodecPublicKey::Ed25519(ED25519_PUBKEY.to_vec()),
+			power: 10,
+			name: None,
+		}
+	}
+
+	#[test]
+	fn accepts_address_derived_from_public_key() {
+		let pub_key = CodecPublicKey::Ed25519(ED25519_PUBKEY.to_vec()).to_public_key().unwrap();
+		let derived = account_id_from_public_key(&pub_key).unwrap();
+		assert!(codec_validator(derived.as_bytes().to_vec()).to_validator().is_ok());
+	}
+
+	#[test]
+	fn rejects_address_not_derived_from_public_key() {
+		assert!(codec_validator(vec![0x42u8; 20]).to_validator().is_err());
+	}
 }

--- a/modules/consensus/tendermint/prover/src/tests/integration_tests.rs
+++ b/modules/consensus/tendermint/prover/src/tests/integration_tests.rs
@@ -208,6 +208,24 @@ mod tests {
 		}
 	}
 
+	// Unlike the other integration tests this one asserts, so a regression fails the run
+	// rather than only surfacing in the trace log.
+	#[tokio::test]
+	#[ignore]
+	async fn test_polygon_address_poison_rejected_at_decode() {
+		let _ = tracing_subscriber::fmt::try_init();
+		match timeout(
+			Duration::from_secs(600),
+			address_poison_rejected_inner(&get_polygon_rpc_url()),
+		)
+		.await
+		{
+			Ok(Ok(())) => trace!("Address poison rejected at the SCALE decode boundary"),
+			Ok(Err(e)) => panic!("address poison test failed: {e}"),
+			Err(_) => panic!("address poison test timed out"),
+		}
+	}
+
 	// #[tokio::test]
 	// #[ignore]
 	// async fn sei_evm_state_proof() -> anyhow::Result<()> {
@@ -592,6 +610,72 @@ mod tests {
 		}
 
 		trace!("Successfully completed {} validator set transitions", VALIDATOR_SET_TRANSITIONS);
+		Ok(())
+	}
+
+	/// Rebuilds the address poisoning attack against the SCALE decode boundary with live
+	/// Heimdall data. A genuine set survives encode, decode and convert, while the same
+	/// set with every address swapped for a constant is rejected once `to_validator`
+	/// recomputes the address from the public key. This covers the path the pallet takes
+	/// on attacker bytes, which the header verification tests never reach.
+	async fn address_poison_rejected_inner(
+		rpc_url: &str,
+	) -> Result<(), Box<dyn std::error::Error>> {
+		use codec::Decode;
+		use tendermint_primitives::{CodecConsensusProof, CodecTrustedState};
+
+		let client = HeimdallClient::new(rpc_url, &[get_polygon_execution_rpc_url()])?;
+		ensure_healthy(&client).await?;
+		let chain_id = client.chain_id().await?;
+		let latest_height = client.latest_height().await?;
+
+		let trusted_height = latest_height.saturating_sub(50);
+		let trusted_header = client.signed_header(trusted_height).await?;
+		let trusted_validators = client.validators(trusted_height).await?;
+		let trusted_next_validators = client.next_validators(trusted_height).await?;
+
+		let trusted_state = TrustedState::new(
+			chain_id,
+			trusted_height,
+			trusted_header.header.time.unix_timestamp() as u64,
+			trusted_header.header.hash_with::<SpIoSha256>().as_bytes().try_into()?,
+			trusted_validators,
+			trusted_next_validators,
+			trusted_header.header.next_validators_hash.as_bytes().try_into()?,
+			7200,
+			VerificationOptions::default(),
+		);
+
+		let honest = CodecTrustedState::from(&trusted_state).encode();
+		TrustedState::try_from(CodecTrustedState::decode(&mut &honest[..])?)
+			.map_err(|e| format!("honest trusted state should convert: {e}"))?;
+
+		let mut poisoned = CodecTrustedState::from(&trusted_state);
+		for validator in poisoned.validators.iter_mut() {
+			validator.address = vec![0x42u8; 20];
+		}
+		let poisoned = poisoned.encode();
+		if TrustedState::try_from(CodecTrustedState::decode(&mut &poisoned[..])?).is_ok() {
+			return Err("poisoned validator addresses were accepted at the decode boundary".into());
+		}
+
+		// The proof's next validator set is the set the attack actually targets, so assert
+		// the same guard covers it whenever the proved update carries one.
+		let proof = prove_header_update(&client, &trusted_state, latest_height).await?;
+		let mut poisoned_proof = CodecConsensusProof::from(&proof);
+		if let Some(next_validators) = poisoned_proof.next_validators.as_mut() {
+			for validator in next_validators.iter_mut() {
+				validator.address = vec![0x42u8; 20];
+			}
+			let bytes = poisoned_proof.encode();
+			if CodecConsensusProof::decode(&mut &bytes[..])?.to_consensus_proof().is_ok() {
+				return Err("poisoned next validators were accepted at the decode boundary".into());
+			}
+			trace!("Poisoned next validator set rejected at the SCALE decode boundary");
+		} else {
+			trace!("Proved update carried no next validator set; skipped the proof variant");
+		}
+
 		Ok(())
 	}
 

--- a/modules/consensus/tendermint/verifier/src/verifier.rs
+++ b/modules/consensus/tendermint/verifier/src/verifier.rs
@@ -1,5 +1,5 @@
 use core::time::Duration;
-use prost::alloc::{format, string::ToString};
+use prost::alloc::{collections::BTreeSet, format, string::ToString};
 
 use cometbft::{block::Height, chain::Id, trust_threshold::TrustThresholdFraction, Hash, Time};
 use cometbft_light_client_verifier::{
@@ -214,6 +214,22 @@ fn convert_timestamp(timestamp: u64) -> Result<Time, VerificationError> {
 		.map_err(|e| VerificationError::Invalid(e.to_string()))
 }
 
+/// Rejects a validator set that reuses the same address twice. Each address is a
+/// hash of its public key, so a duplicate signals a set that was not built honestly.
+fn ensure_unique_addresses(
+	validators: &[cometbft::validator::Info],
+) -> Result<(), VerificationError> {
+	let mut seen = BTreeSet::new();
+	for validator in validators {
+		if !seen.insert(validator.address) {
+			return Err(VerificationError::ValidatorSetError(
+				"duplicate validator address in set".to_string(),
+			));
+		}
+	}
+	Ok(())
+}
+
 fn create_updated_trusted_state(
 	old_trusted_state: &TrustedState,
 	consensus_proof: &ConsensusProof,
@@ -223,11 +239,29 @@ fn create_updated_trusted_state(
 	// Promote next_validators to validators
 	let validators = old_trusted_state.next_validators.clone();
 
-	// Use new next_validators if present, else keep old
-	let next_validators = consensus_proof
-		.next_validators
-		.clone()
-		.unwrap_or_else(|| old_trusted_state.next_validators.clone());
+	// Only a signalled rotation may replace the stored next set, and only with a list
+	// that hashes to the new signed next_validators_hash. When the interval is unchanged
+	// we keep the trusted set and ignore any list the proof happened to carry.
+	let old_next_hash = Hash::Sha256(old_trusted_state.next_validators_hash);
+	let rotates =
+		!header.next_validators_hash.is_empty() && header.next_validators_hash != old_next_hash;
+	let next_validators = if rotates {
+		let provided = consensus_proof.next_validators.as_ref().ok_or_else(|| {
+			VerificationError::ValidatorSetError(
+				"next validator set rotated but the proof carried no next validators".to_string(),
+			)
+		})?;
+		ensure_unique_addresses(provided)?;
+		validate_validator_set_hash(
+			&ValidatorSet::new(provided.clone(), None),
+			header.next_validators_hash,
+			true,
+		)
+		.map_err(|e| VerificationError::ValidatorSetError(e.to_string()))?;
+		provided.clone()
+	} else {
+		old_trusted_state.next_validators.clone()
+	};
 
 	// Use new next_validators_hash if present, else keep old
 	let next_validators_hash =
@@ -259,4 +293,43 @@ fn create_updated_trusted_state(
 		consensus_proof.height(),
 		consensus_proof.timestamp(),
 	))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::ensure_unique_addresses;
+	use cometbft::{
+		validator::{Info, ProposerPriority},
+		vote::Power,
+		PublicKey,
+	};
+	use tendermint_primitives::account_id_from_public_key;
+
+	// A valid ed25519 public key (RFC 8032 test vector 1).
+	const ED25519_PUBKEY: [u8; 32] = [
+		0xd7, 0x5a, 0x98, 0x01, 0x82, 0xb1, 0x0a, 0xb7, 0xd5, 0x4b, 0xfe, 0xd3, 0xc9, 0x64, 0x07,
+		0x3a, 0x0e, 0xe1, 0x72, 0xf3, 0xda, 0xa6, 0x23, 0x25, 0xaf, 0x02, 0x1a, 0x68, 0xf7, 0x07,
+		0x51, 0x1a,
+	];
+
+	fn validator() -> Info {
+		let pub_key = PublicKey::from_raw_ed25519(&ED25519_PUBKEY).unwrap();
+		Info {
+			address: account_id_from_public_key(&pub_key).unwrap(),
+			pub_key,
+			power: Power::try_from(10u64).unwrap(),
+			name: None,
+			proposer_priority: ProposerPriority::from(0i64),
+		}
+	}
+
+	#[test]
+	fn accepts_unique_addresses() {
+		assert!(ensure_unique_addresses(&[validator()]).is_ok());
+	}
+
+	#[test]
+	fn rejects_duplicate_addresses() {
+		assert!(ensure_unique_addresses(&[validator(), validator()]).is_err());
+	}
 }

--- a/modules/consensus/tendermint/verifier/src/verifier.rs
+++ b/modules/consensus/tendermint/verifier/src/verifier.rs
@@ -219,13 +219,11 @@ fn convert_timestamp(timestamp: u64) -> Result<Time, VerificationError> {
 fn ensure_unique_addresses(
 	validators: &[cometbft::validator::Info],
 ) -> Result<(), VerificationError> {
-	let mut seen = BTreeSet::new();
-	for validator in validators {
-		if !seen.insert(validator.address) {
-			return Err(VerificationError::ValidatorSetError(
-				"duplicate validator address in set".to_string(),
-			));
-		}
+	let unique = validators.iter().map(|v| v.address).collect::<BTreeSet<_>>();
+	if unique.len() != validators.len() {
+		return Err(VerificationError::ValidatorSetError(
+			"duplicate validator address in set".to_string(),
+		));
 	}
 	Ok(())
 }

--- a/modules/ismp/clients/polygon/src/error.rs
+++ b/modules/ismp/clients/polygon/src/error.rs
@@ -19,6 +19,9 @@ pub enum Error {
 	/// Converting the codec-wrapped tendermint proof into its native form failed.
 	#[error("Cannot convert tendermint consensus proof: {0}")]
 	ConvertTendermintProof(String),
+	/// Converting the stored codec trusted state into its native form failed.
+	#[error("Cannot convert tendermint trusted state: {0}")]
+	ConvertTrustedState(String),
 	/// `verify_header_update` rejected the tendermint header update.
 	#[error("Tendermint header update verification failed: {0}")]
 	VerifyHeaderUpdate(String),

--- a/modules/ismp/clients/polygon/src/lib.rs
+++ b/modules/ismp/clients/polygon/src/lib.rs
@@ -236,7 +236,9 @@ impl<H: IsmpHost + Send + Sync + Default + 'static, T: HostExecutiveConfig> Cons
 			.to_consensus_proof()
 			.map_err(|e| PolygonError::ConvertTendermintProof(e.to_string()))?;
 
-		let trusted_state: TrustedState = consensus_state.clone().tendermint_state.into();
+		let trusted_state: TrustedState =
+			TrustedState::try_from(consensus_state.clone().tendermint_state)
+				.map_err(PolygonError::ConvertTrustedState)?;
 
 		let time = host.timestamp().as_secs();
 
@@ -380,7 +382,9 @@ impl<H: IsmpHost + Send + Sync + Default + 'static, T: HostExecutiveConfig> Cons
 			return Err(PolygonError::FraudProofsIdentical.into());
 		}
 
-		let trusted_state: TrustedState = consensus_state.clone().tendermint_state.into();
+		let trusted_state: TrustedState =
+			TrustedState::try_from(consensus_state.clone().tendermint_state)
+				.map_err(PolygonError::ConvertTrustedState)?;
 
 		let time = host.timestamp().as_secs();
 

--- a/modules/ismp/clients/tendermint/src/lib.rs
+++ b/modules/ismp/clients/tendermint/src/lib.rs
@@ -89,7 +89,9 @@ impl<
 			.to_consensus_proof()
 			.map_err(|e| ismp::error::Error::Custom(e.to_string()))?;
 
-		let trusted_state: TrustedState = consensus_state.clone().tendermint_state.into();
+		let trusted_state: TrustedState =
+			TrustedState::try_from(consensus_state.clone().tendermint_state)
+				.map_err(ismp::error::Error::Custom)?;
 
 		let time = host.timestamp().as_secs();
 
@@ -173,12 +175,12 @@ impl<
 		if consensus_proof_1.signed_header.header.hash() ==
 			consensus_proof_2.signed_header.header.hash()
 		{
-			return Err(Error::Custom(
-				"Fraud proofs commit to the same block header".to_string(),
-			));
+			return Err(Error::Custom("Fraud proofs commit to the same block header".to_string()));
 		}
 
-		let trusted_state: TrustedState = consensus_state.clone().tendermint_state.into();
+		let trusted_state: TrustedState =
+			TrustedState::try_from(consensus_state.clone().tendermint_state)
+				.map_err(ismp::error::Error::Custom)?;
 
 		let time = host.timestamp().as_secs();
 

--- a/tesseract/consensus/polygon/Cargo.toml
+++ b/tesseract/consensus/polygon/Cargo.toml
@@ -25,8 +25,6 @@ geth-primitives = { workspace = true }
 reqwest = { version = "0.11", features = ["json"] }
 alloy = { workspace = true, features = ["provider-http", "rpc-types", "providers", "transports", "reqwest", "reqwest-default-tls"] }
 base64 = { version = "0.21" }
-sha2 = { version = "0.10.7" }
-sha3 = { version = "0.10" }
 ics23 = { workspace = true, default-features = false }
 tendermint-ics23-primitives = { workspace = true, default-features = false }
 prost = {workspace = true, default-features = false }

--- a/tesseract/consensus/polygon/src/client.rs
+++ b/tesseract/consensus/polygon/src/client.rs
@@ -5,7 +5,6 @@ use async_trait::async_trait;
 use cometbft::{
 	account::Id as CometbftAccountId,
 	block::{signed_header::SignedHeader, Height},
-	public_key::PublicKey,
 	validator::Info as Validator,
 };
 use cometbft_rpc::{endpoint::abci_query::AbciQuery, Client as OtherClient, HttpClient, Url};
@@ -14,7 +13,7 @@ use ismp_polygon::Milestone;
 use reqwest::Client as ReqwestClient;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use tendermint_primitives::{Client as TendermintClient, ProverError};
+use tendermint_primitives::{account_id_from_public_key, Client as TendermintClient, ProverError};
 
 use base64::Engine;
 
@@ -665,7 +664,8 @@ impl From<HeimdallValidator> for cometbft::validator::Info {
 			});
 
 		let power = heimdall_val.voting_power.parse::<u64>().unwrap_or(0);
-		let address = custom_account_id_from_pubkey(&pub_key);
+		let address = account_id_from_public_key(&pub_key)
+			.unwrap_or_else(|| CometbftAccountId::new([0u8; 20]));
 
 		cometbft::validator::Info {
 			address,
@@ -756,32 +756,5 @@ fn normalize_signature_in_object(signature_obj: &mut serde_json::Map<String, Val
 				}
 			}
 		}
-	}
-}
-
-/// Custom account ID that matches Go CometBFT fork's address calculation
-/// For Secp256k1: uses Keccak256 (Ethereum-style) instead of RIPEMD160(SHA256)
-pub fn custom_account_id_from_pubkey(pub_key: &PublicKey) -> CometbftAccountId {
-	match pub_key {
-		PublicKey::Ed25519(pk) => {
-			// SHA256(pk)[:20] - same as standard
-			use sha2::{Digest, Sha256};
-			let digest = Sha256::digest(pk.as_bytes());
-			CometbftAccountId::new(digest[..20].try_into().unwrap())
-		},
-		PublicKey::Secp256k1(pk) => {
-			// Keccak256(pubkey)[12:] - Ethereum-style like Go fork
-			use sha3::{Digest, Keccak256};
-			let pubkey_bytes = pk.to_encoded_point(false).as_bytes().to_vec();
-			// Remove the 0x04 prefix (first byte) as done in Go implementation
-			let keccak_hash = Keccak256::digest(&pubkey_bytes[1..]);
-			// Take last 20 bytes (bytes 12-31)
-			CometbftAccountId::new(keccak_hash[12..32].try_into().unwrap())
-		},
-		#[allow(unreachable_patterns)]
-		_ => {
-			// Catch-all for non_exhaustive enum
-			CometbftAccountId::new([0u8; 20])
-		},
 	}
 }

--- a/tesseract/consensus/polygon/src/notification.rs
+++ b/tesseract/consensus/polygon/src/notification.rs
@@ -26,7 +26,9 @@ pub async fn consensus_notification(
 	let consensus_state: ConsensusState =
 		ConsensusState::decode(&mut &consensus_state_serialized[..])?;
 
-	let trusted_state: TrustedState = consensus_state.clone().tendermint_state.into();
+	let trusted_state: TrustedState =
+		TrustedState::try_from(consensus_state.clone().tendermint_state)
+			.map_err(anyhow::Error::msg)?;
 
 	let untrusted_header = client.prover.signed_header(latest_height).await?;
 

--- a/tesseract/consensus/tendermint/src/notification.rs
+++ b/tesseract/consensus/tendermint/src/notification.rs
@@ -21,7 +21,8 @@ pub async fn consensus_notification(
 	let consensus_state: ConsensusState =
 		ConsensusState::decode(&mut &consensus_state_serialized[..])?;
 
-	let trusted_state: TrustedState = consensus_state.tendermint_state.into();
+	let trusted_state: TrustedState =
+		TrustedState::try_from(consensus_state.tendermint_state).map_err(anyhow::Error::msg)?;
 
 	let untrusted_header = client.prover.signed_header(latest_height).await?;
 


### PR DESCRIPTION
Validator addresses are now recomputed from the public key while decoding a proof and rejected when they do not match, so the address a proof carries can no longer diverge from the key that the signed validator set hash actually commits to. The stored next validator  set is only replaced on a signalled rotation and only once the supplied list hashes to the new next_validators_hash, and any set that repeats an address is turned away. The Heimdall address derivation moved into tendermint-primitives so the relayer and the runtime share one implementation rather than keeping their own copies.