### PR TITLE
[sdk]: buff same chain and cross chain fees

### DIFF
--- a/sdk/packages/sdk/package.json
+++ b/sdk/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/sdk",
-	"version": "2.4.1",
+	"version": "2.4.2",
 	"description": "The hyperclient SDK provides utilities for querying proofs and statuses for cross-chain requests from HyperBridge.",
 	"type": "module",
 	"types": "./dist/node/index.d.ts",

--- a/sdk/packages/sdk/src/protocols/intents/GasEstimator.ts
+++ b/sdk/packages/sdk/src/protocols/intents/GasEstimator.ts
@@ -360,7 +360,7 @@ export class GasEstimator {
 		destChainId: string,
 		order: Order,
 	): Promise<{ postRequestFee: bigint; protocolFee: bigint }> {
-		const postRequestGas = 1_000_000n
+		const postRequestGas = 400_000n
 
 		const [postRequestFeeInSourceFeeToken, nonce] = await Promise.all([
 			convertGasToFeeToken(this.ctx, postRequestGas, "source", sourceChainId),

--- a/sdk/packages/sdk/src/protocols/intents/GasEstimator.ts
+++ b/sdk/packages/sdk/src/protocols/intents/GasEstimator.ts
@@ -360,7 +360,7 @@ export class GasEstimator {
 		destChainId: string,
 		order: Order,
 	): Promise<{ postRequestFee: bigint; protocolFee: bigint }> {
-		const postRequestGas = 400_000n
+		const postRequestGas = 1_000_000n
 
 		const [postRequestFeeInSourceFeeToken, nonce] = await Promise.all([
 			convertGasToFeeToken(this.ctx, postRequestGas, "source", sourceChainId),

--- a/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
+++ b/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
@@ -234,8 +234,9 @@ export class IntentGateway {
 	 * placement, fee estimation, bid collection, and execution.
 	 *
 	 * **Yield/receive protocol:**
-	 * 1. If `order.fees` is unset or zero, estimates gas and sets `order.fees`
-	 *    with a 1% buffer and the wei cost with a 2% buffer for the `value` field.
+	 * 1. If `order.fees` is unset or zero, estimates gas and sets same-chain
+	 *    `order.fees` to twice the estimate (cross-chain orders retain a 1% buffer),
+	 *    while applying a 2% buffer to the wei cost used for the `value` field.
 	 * 2. Yields `AWAITING_PLACE_ORDER` with `{ to, data, value, sessionPrivateKey }`.
 	 *    The caller must sign the transaction and pass it back via `gen.next(signedTx)`.
 	 * 3. Yields `ORDER_PLACED` with the finalised order and transaction hash once
@@ -280,9 +281,12 @@ export class IntentGateway {
 				throw new Error("Gas estimation failed")
 			}
 
-			// Solvers using the same estimate algo will have tighter bounds, so we add a buffer.
+			const isSameChain = this.source.config.stateMachineId === this.dest.config.stateMachineId
 			value = estimate.totalGasCostWei + (estimate.totalGasCostWei * 2n) / 100n
-			order.fees = estimate.totalGasInFeeToken + (estimate.totalGasInFeeToken * 1n) / 100n
+			// Same-chain fills need a larger solver fee margin; retain the cross-chain buffer.
+			order.fees = isSameChain
+				? estimate.totalGasInFeeToken * 2n
+				: estimate.totalGasInFeeToken + (estimate.totalGasInFeeToken * 1n) / 100n
 		}
 
 		const placeOrderGen = this.orderPlacer.placeOrder(order, graffiti)

--- a/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
+++ b/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
@@ -44,6 +44,9 @@ import {
 } from "./quote"
 import type { ERC7821Call } from "@/types"
 import { DEFAULT_GRAFFITI, DEFAULT_POLL_INTERVAL, ADDRESS_ZERO, sleep } from "@/utils"
+import { convertGasToFeeToken } from "./utils"
+
+const CROSS_CHAIN_ORDER_FEE_GAS_BUMP = 600_000n
 
 /**
  * High-level facade for the IntentGatewayV2 protocol.
@@ -235,8 +238,9 @@ export class IntentGateway {
 	 *
 	 * **Yield/receive protocol:**
 	 * 1. If `order.fees` is unset or zero, estimates gas and sets same-chain
-	 *    `order.fees` to twice the estimate (cross-chain orders retain a 1% buffer),
-	 *    while applying a 2% buffer to the wei cost used for the `value` field.
+	 *    `order.fees` to twice the estimate. Cross-chain orders retain a 1% buffer
+	 *    and include an additional 600k-gas fee uplift, while the wei cost used for
+	 *    the `value` field receives a 2% buffer.
 	 * 2. Yields `AWAITING_PLACE_ORDER` with `{ to, data, value, sessionPrivateKey }`.
 	 *    The caller must sign the transaction and pass it back via `gen.next(signedTx)`.
 	 * 3. Yields `ORDER_PLACED` with the finalised order and transaction hash once
@@ -283,10 +287,21 @@ export class IntentGateway {
 
 			const isSameChain = this.source.config.stateMachineId === this.dest.config.stateMachineId
 			value = estimate.totalGasCostWei + (estimate.totalGasCostWei * 2n) / 100n
-			// Same-chain fills need a larger solver fee margin; retain the cross-chain buffer.
+			const crossChainFeeBump = isSameChain
+				? 0n
+				: await convertGasToFeeToken(
+						this.ctx,
+						CROSS_CHAIN_ORDER_FEE_GAS_BUMP,
+						"source",
+						this.source.config.stateMachineId,
+					)
+
+			// Same-chain fills need a larger solver fee margin. Keep cross-chain cost estimation
+			// unchanged for Simplex, and apply the user-order fee uplift only at placement.
 			order.fees = isSameChain
 				? estimate.totalGasInFeeToken * 2n
-				: estimate.totalGasInFeeToken + (estimate.totalGasInFeeToken * 1n) / 100n
+				: estimate.totalGasInFeeToken +
+					(crossChainFeeBump + (estimate.totalGasInFeeToken * 1n) / 100n)
 		}
 
 		const placeOrderGen = this.orderPlacer.placeOrder(order, graffiti)


### PR DESCRIPTION
## Summary

- Double the automatically estimated solver fee for same-chain Intent Gateway V2 swaps.
- Keep the shared cross-chain redemption POST-request estimate at `400_000` gas, so Simplex evaluates orders against the baseline execution cost.
- Add a `600_000`-gas cross-chain uplift only when the SDK assigns a user's `order.fees`, converted to the source-chain fee token.

## Rationale

Simplex uses the shared fill-order estimate to evaluate solver profitability. Applying the additional cross-chain gas in that shared estimate would increase both the user fee and Simplex’s cost basis, cancelling out the intended extra solver incentive.

Applying the uplift only during SDK order placement preserves the additional incentive without affecting Simplex’s evaluation.