### PR TITLE
[runtime]: bump the max state commitments retained per chain

### DIFF
--- a/modules/pallets/ismp/src/lib.rs
+++ b/modules/pallets/ismp/src/lib.rs
@@ -121,7 +121,11 @@ pub mod pallet {
 	pub const RELAYER_FEE_ACCOUNT: PalletId = PalletId(*b"ISMPFEES");
 
 	/// Maximum state commitments retained per chain in [`BoundedStateCommitments`].
-	pub const MAX_STATE_MACHINE_COMMITMENTS: u32 = 1024;
+	///
+	/// One commitment is stored per consensus update, so this bounds a time window
+	/// rather than a block range: `MAX_STATE_MACHINE_COMMITMENTS * consensus_update_frequency`.
+	/// Sized to hold roughly a week of BSC updates at the 60s relayer cadence.
+	pub const MAX_STATE_MACHINE_COMMITMENTS: u32 = 10_240;
 
 	frame_support::parameter_types! {
 		/// Type-level `Get<u32>` mirror of [`MAX_STATE_MACHINE_COMMITMENTS`], used as

--- a/parachain/runtimes/nexus/src/lib.rs
+++ b/parachain/runtimes/nexus/src/lib.rs
@@ -238,7 +238,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("nexus"),
 	impl_name: Cow::Borrowed("nexus"),
 	authoring_version: 1,
-	spec_version: 7_900,
+	spec_version: 8_000,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
This PR Raises `MAX_STATE_MACHINE_COMMITMENTS` from 1024 to 10,240 so that a chain's retained commitments span roughly a week of BSC consensus updates.