### PR TITLE
[relayer]:  Wait out the challenge period before submitting reward claims

### DIFF
--- a/tesseract/messaging/messaging/src/outbound_claim.rs
+++ b/tesseract/messaging/messaging/src/outbound_claim.rs
@@ -33,7 +33,8 @@ use sp_core::Pair;
 use subxt_utils::outbound_consensus_rotations_claimed_storage_key;
 use tesseract_evm::derive_map_key;
 use tesseract_primitives::{
-	IsmpHost, IsmpProvider, PendingConsensusDeliveryClaim, StateProofQueryType,
+	observe_challenge_period, IsmpHost, IsmpProvider, PendingConsensusDeliveryClaim,
+	StateProofQueryType,
 };
 use tesseract_substrate::{config::KeccakSubstrateChain, SubstrateClient};
 use tokio::time::MissedTickBehavior;
@@ -326,6 +327,10 @@ pub async fn process_claim(
 	}
 
 	let dest_height = committed as u64;
+
+	observe_challenge_period(dest.clone(), hb_provider.clone(), dest_height)
+		.await
+		.context("observe_challenge_period")?;
 
 	let evm_host = dest
 		.ismp_host_contract()

--- a/tesseract/messaging/messaging/src/outbound_request_claim.rs
+++ b/tesseract/messaging/messaging/src/outbound_request_claim.rs
@@ -36,7 +36,8 @@ use sp_core::Pair;
 use subxt_utils::outbound_requests_claimed_storage_key;
 use tesseract_evm::derive_map_key;
 use tesseract_primitives::{
-	IsmpHost, IsmpProvider, PendingRequestDeliveryClaim, StateProofQueryType,
+	observe_challenge_period, IsmpHost, IsmpProvider, PendingRequestDeliveryClaim,
+	StateProofQueryType,
 };
 use tesseract_substrate::{config::KeccakSubstrateChain, SubstrateClient};
 use tokio::time::MissedTickBehavior;
@@ -256,6 +257,10 @@ pub async fn process_claim(
 	}
 
 	let dest_height = committed as u64;
+
+	observe_challenge_period(dest.clone(), hb_provider.clone(), dest_height)
+		.await
+		.context("observe_challenge_period")?;
 
 	let key = receipt_key_for(destination, commitment, dest.ismp_host_contract())?;
 


### PR DESCRIPTION
The outbound consensus and request claim tasks built their state proof against the latest height Hyperbridge had committed without checking whether that height had cleared its challenge period, so the pallet rejected the claim as `OutboundDestinationStateNotKnown` and it only succeeded by luck on a later tick. Both `process_claim` functions now call the existing `observe_challenge_period` before submitting. 