### PR TITLE
[simplex]: pair-based FX markets, in-repo asset registry & hardened RPC quorum

### DIFF
--- a/docs/content/developers/evm/intent-gateway/simplex.mdx
+++ b/docs/content/developers/evm/intent-gateway/simplex.mdx
@@ -43,68 +43,111 @@ The Stable strategy requires pre-positioned stablecoins on each destination chai
 
 ### HyperFX
 
-HyperFX fills swaps between USD-pegged stablecoins (USDC/USDT) and a single configurable exotic token — for example, cNGN (a Nigerian naira stablecoin). It supports both **same-chain** and **cross-chain** orders.
+HyperFX fills swaps across a configurable set of **trading pairs** — for example USDC/cNGN, USDT/cNGN, or ZARP/cNGN — each priced by its own bid/ask curves. Pairs reference assets by symbol from the built-in [asset registry](#the-asset-registry), and an LP can declare any number of them; one FX engine serves them all. Both **same-chain** and **cross-chain** orders are supported.
 
 Same-chain orders (`source == destination`) are filled immediately without waiting for additional confirmations. Cross-chain orders use the configured **confirmation policy** for HyperFX to determine how many confirmations to wait for before bidding.
 
-Profit comes from two sources: the **bid/ask spread** on the exotic token, and **order fees** minus gas. The filler holds both stablecoins and the exotic token. When a user swaps stable→exotic the filler sells exotic at the ask price; when the user swaps exotic→stable the filler buys at the bid price. The spread between the two curves is the filler's margin per trade.
+Profit comes from two sources: the **bid/ask spread** on each pair, and **order fees** minus gas. The filler holds inventory on both sides of its pairs. When a user swaps token0→token1 the filler sells token1 at the pair's ask price; when the user swaps token1→token0 the filler buys at the bid price. The spread between the two curves is the filler's margin per trade.
 
-Both curves are expressed in **exotic tokens per USD**. A higher bid means the filler acknowledges fewer stables are owed per exotic received (the filler profits more on the exotic→stable leg). A lower ask means the filler sends fewer exotic tokens per stable received (the filler profits more on the stable→exotic leg).
+Curves are expressed in **token1 per 1 token0** and keyed by the order's token0 notional. A higher bid means the filler owes less token0 per token1 received (it profits more buying token1). A lower ask means the filler sends fewer token1 per token0 received (it profits more selling token1).
 
-`maxOrderUsd` caps the filler's exposure per order. Orders larger than the cap are partially filled up to that amount — the IntentGateway releases inputs proportionally to the fraction of outputs provided, so partial fills work without any extra on-chain logic.
+Each pair's **`maxOrderSize`** caps the filler's exposure per order, denominated in that pair's token0. Orders larger than the cap are partially filled up to that amount — the IntentGateway releases inputs proportionally to the fraction of outputs provided, so partial fills work without any extra on-chain logic.
 
 HyperFX always uses the solver selection path: it submits a signed bid to Hyperbridge via `IntentsCoprocessor` rather than calling `fillOrder` directly. This requires `substratePrivateKey` and `hyperbridgeWsUrl` in `[simplex]`, plus a `bundlerUrl` on each `[[chains]]` entry.
 
 On startup, Simplex automatically delegates the filler's EOA to the `SolverAccount` contract via EIP-7702 — submitting a no-op UserOp through the bundler so the delegation lands without requiring the EOA to hold native gas. Circle Paymaster covers the delegation tx (and subsequent fills) in USDC on chains where it is deployed; on chains without the paymaster (e.g. BSC), Simplex falls back to a direct type-0x04 delegation tx and tops up the ERC-4337 EntryPoint deposit to cover `targetGasUnits` (default 3M) at current gas price.
 
 ```toml lineNumbers
-[[strategies]]
-type = "hyperfx"
-maxOrderUsd = 5000
-
-# Bid price curve: exotic per USD when *buying* exotic from a user (exotic→stable leg).
+# Trading pairs — assets are referenced by symbol from Simplex's built-in
+# registry; declare as many pairs as you like, one FX engine serves them all.
+[[pairs]]
+token0 = "USDC"
+token1 = "CNGN"
+maxOrderSize = "5000"       # per-order cap, in token0 units (5000 USDC)
+# Bid: CNGN per USDC when *buying* CNGN from a user (CNGN→USDC leg).
 bidPriceCurve = [
     { amount = "100",  price = "1580" },
     { amount = "1000", price = "1575" },
     { amount = "5000", price = "1570" },
 ]
-
-# Ask price curve: exotic per USD when *selling* exotic to a user (stable→exotic leg).
+# Ask: CNGN per USDC when *selling* CNGN to a user (USDC→CNGN leg).
 askPriceCurve = [
     { amount = "100",  price = "1560" },
     { amount = "1000", price = "1555" },
     { amount = "5000", price = "1550" },
 ]
 
-[strategies.token1]
-"EVM-56"  = "0xExoticTokenAddressOnBsc"
-"EVM-137" = "0xExoticTokenAddressOnPolygon"
+[[pairs]]
+token0 = "USDT"
+token1 = "CNGN"
+maxOrderSize = "5000"
+bidPriceCurve = [ { amount = "0", price = "1578" } ]
+askPriceCurve = [ { amount = "0", price = "1552" } ]
+
+# A rand/naira book — no USD asset involved; sized entirely in ZARP:
+[[pairs]]
+token0 = "ZARP"
+token1 = "CNGN"
+maxOrderSize = "90000"      # 90,000 ZARP per order
+bidPriceCurve = [ { amount = "0", price = "86" } ]   # CNGN per ZARP
+askPriceCurve = [ { amount = "0", price = "84" } ]
+
+# Engine-level settings live on the strategy block.
+[[strategies]]
+type = "hyperfx"
 ```
+
+#### The asset registry
+
+Simplex maintains the symbol → contract-address registry, so pairs reference assets purely by symbol — no address configuration. It ships **USDC, USDT, DAI, cNGN** (resolved per chain from the SDK chain registry, testnets included) plus a curated table of stablecoin deployments on the supported mainnets: **ZARP** (South African rand — Ethereum, Polygon, Base), **EURC** (Circle euro — Ethereum, Base), **XSGD** (StraitsX Singapore dollar — Ethereum, Polygon) and **TRYB** (BiLira Turkish lira — Ethereum). Curated addresses are taken from the issuer's official documentation and verified on-chain (`symbol()`/`decimals()`) before inclusion. Symbols are case-insensitive; a pair simply doesn't trade on chains where an asset isn't deployed.
+
+The registry holds addresses only — there are no reference prices anywhere. Every quantity that sizes a pair is denominated in the pair's own `token0`: the curve `amount` axis, the per-order `maxOrderSize` cap, and the order value fed to confirmation policies. The curves are the only price source.
+
+For assets the registry doesn't ship — or to override an address for your deployment — the optional **`[assets]`** table is the escape hatch, a bare symbol → chain → address map:
+
+```toml lineNumbers
+# Only needed for assets the registry does not ship (or overrides):
+[assets.BRZ]
+"EVM-137" = "0xBrzOnPolygon"
+
+[[pairs]]
+token0 = "USDC"
+token1 = "BRZ"
+maxOrderSize = "5000"
+askPriceCurve = [ { amount = "0", price = "5.4" } ]
+```
+
+#### Trading pairs
+
+Each **`[[pairs]]`** entry is one market: `token0`/`token1` symbols, a per-order **`maxOrderSize`** cap in token0 units, and bid/ask curves in **token1 per token0** keyed by token0 notional. Every pair is priced, capped, and sized independently — USDC/cNGN and USDT/cNGN can carry different rates, so a USDT depeg is handled by adjusting one pair's curves (live, via the admin server started with `--admin-port`) instead of being silently absorbed. Orders whose legs match no configured pair are rejected, so the pair list doubles as an allowlist of the markets the LP serves.
+
+Cross-chain confirmation policies are sized with the order's **token0 notional** (each leg converted through its pair's own curve) — for USD-quoted pairs that is a dollar amount; for others it is denominated in the quote asset, so tune the per-chain confirmation curves accordingly.
+
+Declaring `[[pairs]]` requires exactly one `hyperfx` strategy block, which carries the engine-level settings (confirmation policies, venue funding, `spreadBps`). The legacy strategy-level `token1` + `bidPriceCurve`/`askPriceCurve` + `maxOrderUsd` form is still accepted (translated internally into USDC/exotic and USDT/exotic pairs at par) but deprecated — new configs should declare pairs.
 
 #### One-sided LP
 
-With both curves set HyperFX fills in both directions. Omitting one curve restricts the filler to a single direction, so it keeps accumulating one asset while only giving away the other:
+With both curves set a pair fills in both directions. Omitting one curve restricts that pair to a single direction, so the filler keeps accumulating one asset while only giving away the other — and each pair is gated independently:
 
-- **Ask only** (omit `bidPriceCurve`) — the filler only *sells* exotic, filling orders where the user sends stable and receives exotic. It accumulates the stablecoin and gives away the exotic token (for example, take USDC, hand out cNGN).
-- **Bid only** (omit `askPriceCurve`) — the filler only *buys* exotic, filling orders where the user sends exotic and receives stable. It accumulates the exotic token and gives away the stablecoin.
+- **Ask only** (omit `bidPriceCurve`) — the filler only *sells* token1 on that pair, filling orders where the user sends token0 and receives token1. It accumulates token0 and gives away token1 (for example, take USDC, hand out cNGN).
+- **Bid only** (omit `askPriceCurve`) — the filler only *buys* token1 on that pair, filling orders where the user sends token1 and receives token0.
 
 Orders in the disabled direction are rejected before bidding (an order with mixed-direction legs is rejected as a whole, since the IntentGateway settles all legs atomically).
 
 ```toml lineNumbers
-[[strategies]]
-type = "hyperfx"
-maxOrderUsd = 5000
-
 # Ask curve only — keep accumulating USDC by only selling cNGN
+[[pairs]]
+token0 = "USDC"
+token1 = "CNGN"
+maxOrderSize = "5000"
 askPriceCurve = [
     { amount = "100",  price = "1560" },
     { amount = "1000", price = "1555" },
     { amount = "5000", price = "1550" },
 ]
 
-[strategies.token1]
-"EVM-56"  = "0xExoticTokenAddressOnBsc"
-"EVM-137" = "0xExoticTokenAddressOnPolygon"
+[[strategies]]
+type = "hyperfx"
 ```
 
 When pricing from a [Uniswap V4 pool](#pool-based-pricing) (no curves), there is no curve to omit, so set **`side`** on the `[strategies.vault.uniswapV4]` block instead — `"ask"` to only sell exotic (accumulate stablecoins) or `"bid"` to only buy exotic. Omit `side` to fill both directions. `side` cannot be combined with static curves.
@@ -489,7 +532,17 @@ When two or more URLs are configured, the event monitor fans every `eth_getLogs`
 
 Provider errors, timeouts, and divergent results are all tolerated up to the BFT bound. Beyond it, the batch fails with a `QuorumError` that enumerates each failing URL and the size of the largest agreeing group — the scan cursor does not advance, so the same range is retried on the next tick. Agreement is computed by sorting logs by `(blockNumber, logIndex, transactionHash)` and comparing only the consensus-relevant JSON-RPC fields (`address`, `blockHash`, `blockNumber`, `data`, `logIndex`, `removed`, `topics`, `transactionHash`, `transactionIndex`); provider-added extras such as `blockTimestamp` are deliberately excluded so debug metadata on one node does not manufacture a quorum failure. `getBlockNumber` resolves to the highest block at which `floor(2N/3) + 1` providers have indexed — preventing the scanner from running ahead of BFT-supported state.
 
-A single-entry `rpcUrls` array is legal and keeps the pre-existing single-provider behaviour; the quorum machinery only engages when you list more than one endpoint. **To actually tolerate a faulty or co-opted provider you need at least four endpoints** — with three, the threshold is still three and any single failure halts scanning.
+#### Public RPC registry
+
+On the supported mainnets — **Ethereum, Arbitrum, Base, Polygon, and BNB Chain** — Simplex ships a registry of well-known keyless public endpoints (the network's official gateway where one exists, plus PublicNode, dRPC, and 1RPC) and automatically **appends them to your configured endpoints for all quorum-checked reads**. Your endpoints always come first and are never replaced; the merge is deduplicated by hostname, so listing a public endpoint yourself does not double-count it in the quorum.
+
+This means even a single-entry `rpcUrls` array gets BFT protection on those chains: one operator endpoint plus four public ones forms a five-provider quorum (threshold 4) that tolerates a faulty or lying provider. The public endpoints participate **only** in quorum reads — `eth_getLogs`, `eth_blockNumber`, and `eth_getTransactionReceipt` during confirmation counting. Latency-sensitive and write paths (gas estimation, balance reads, transaction submission) stay exclusively on your configured endpoints, which is why premium providers are still required.
+
+Chains outside the registry (testnets, other networks) keep the pre-existing behaviour: the quorum is exactly the endpoints you configure. **To tolerate a faulty provider there you need at least four endpoints** — with three, the threshold is still three and any single failure halts scanning.
+
+#### Quorum-checked confirmations
+
+Cross-chain orders wait for source-chain confirmations (per the strategy's confirmation policy) before a bid is submitted. That count is also computed with quorum semantics: every provider is asked for the transaction receipt and its chain head, a BFT threshold of providers must agree on the *inclusion block* — the receipt's `(blockHash, blockNumber)` — and the count is derived from the threshold-th highest head among the agreeing providers. A minority of providers serving a reorged or fabricated inclusion can neither inflate the confirmation count nor vouch for a transaction the honest majority has not seen.
 
 #### Why this matters for cross-chain orders
 
@@ -499,7 +552,7 @@ On a cross-chain fill, Simplex observes an `OrderPlaced` (or `PartialFill` / `Or
 Co-opted RPC nodes are not hypothetical. LayerZero has publicly disclosed an incident where an RPC endpoint serving part of their relaying path was compromised — see [LayerZero's post-mortem thread](https://x.com/LayerZero_Core/status/2046081551574983137?s=20). Quorum queries turn that failure mode from "one bad node silently succeeds" into "one bad node fails the batch and halts the scan".
 </Callout>
 
-The practical guidance is to configure **at least two organisationally independent providers** (e.g. Alchemy **and** Infura, not two Alchemy regions) for every chain that can act as a source of a cross-chain order. Three or more is better for chains with large notional flow — each additional independent provider raises the bar for an attacker from "compromise one vendor" to "compromise all of them simultaneously for the duration of the fill window". The cost is a slightly higher RPC bill and the tail latency of the slowest provider in each batch; the benefit is that event-driven bids are only acted on when every independent witness agrees on what the source chain actually emitted.
+The practical guidance is to configure **at least two organisationally independent providers** (e.g. Alchemy **and** Infura, not two Alchemy regions) for every chain that can act as a source of a cross-chain order. The [public RPC registry](#public-rpc-registry) hardens this baseline automatically on the supported mainnets, but public endpoints are best-effort infrastructure — your own premium endpoints anchor the quorum's availability. Each additional independent provider raises the bar for an attacker from "compromise one vendor" to "compromise all of them simultaneously for the duration of the fill window". The cost is a slightly higher RPC bill and the tail latency of the slowest provider in each batch; the benefit is that event-driven bids are only acted on when every independent witness agrees on what the source chain actually emitted.
 
 
 ## Setup
@@ -618,7 +671,7 @@ bundlerUrl = "https://polygon-mainnet.g.alchemy.com/v2/YOUR_ALCHEMY_KEY"
 
 You need an EVM wallet (configured via `[simplex.signer]`) funded with native tokens for gas and stablecoins to fill orders with — minimum $10,000 equivalent per chain is a reasonable starting point. For HyperFX, also hold the exotic token on each chain, plus a Substrate account with BRIDGE tokens for Hyperbridge extrinsic fees. These extrinsic fees are claimable — Simplex claims them automatically after each batch of bids is executed on-chain or when the filler stops.
 
-RPC endpoints must be from a premium provider (Alchemy Pro, Infura Growth+, QuickNode Pro). Archive node access is required for storage slot queries and gas simulation. Free-tier RPCs will not work reliably. For chains that can source cross-chain orders, configure at least two organisationally independent providers in `rpcUrls` so the event monitor runs in quorum mode — see [RPC Quorum](#rpc-quorum).
+RPC endpoints must be from a premium provider (Alchemy Pro, Infura Growth+, QuickNode Pro). Archive node access is required for storage slot queries and gas simulation. Free-tier RPCs will not work reliably. For chains that can source cross-chain orders, configure at least two organisationally independent providers in `rpcUrls` — on the supported mainnets Simplex additionally merges its [public RPC registry](#public-rpc-registry) into the quorum, but the public endpoints only serve quorum-checked reads, never the latency-sensitive fill path — see [RPC Quorum](#rpc-quorum).
 
 ## Troubleshooting
 

--- a/sdk/packages/simplex/filler-config-example.toml
+++ b/sdk/packages/simplex/filler-config-example.toml
@@ -203,35 +203,65 @@ points = [
     { amount = "8000", value = 10 },
 ]
 
-# HyperFX strategy for exotic token swaps (e.g. stablecoin <-> cNGN)
-# Uncomment and configure to enable
-# [[strategies]]
-# type = "hyperfx"
-# maxOrderUsd = 5000
-# # Optional spread (basis points) around Uniswap V4 mid when using vault.uniswapV4 for pricing
-# spreadBps = 50
+# ===== Trading pairs (HyperFX) =====
 #
-# # Bid/ask curves: omit both when [strategies.vault.uniswapV4].positions is set (pool-based pricing).
-# # One-sided LP: omit one curve to fill in a single direction. Keep only askPriceCurve to
-# # accumulate stablecoins (sell exotic, e.g. give away cNGN); keep only bidPriceCurve to
-# # accumulate the exotic token (buy exotic).
-# # Bid price curve: exotic per USD when *buying* exotic from a user (exotic→stable leg)
-# bidPriceCurve = [
+# Assets are referenced by symbol from Simplex's built-in registry — no address
+# configuration needed. The registry ships USDC, USDT, DAI, CNGN (per-chain via
+# the SDK, testnets included) plus curated mainnet deployments of ZARP, EURC,
+# XSGD and TRYB, all verified on-chain. The registry holds addresses only; the
+# pair curves are the only price source.
+#
+# [[pairs]] declares the markets the FX engine serves — any number of pairs,
+# each priced by its own curves in token1 per 1 token0 and capped per order by
+# maxOrderSize, all denominated in token0 (the curve amount axis, the cap, and
+# the value fed to confirmation policies share that unit). Omit one curve for
+# one-sided LP on that pair (keep only askPriceCurve to sell token1 /
+# accumulate token0; only bidPriceCurve to buy token1). Omit both curves only
+# with [strategies.vault.uniswapV4] pool pricing. Orders whose legs match no
+# pair are rejected.
+#
+# [[pairs]]
+# token0 = "USDC"
+# token1 = "CNGN"
+# maxOrderSize = "5000"       # per-order cap in token0 units (5000 USDC)
+# bidPriceCurve = [           # CNGN per USDC when *buying* CNGN from a user
 #     { amount = "100",  price = "1580" },
 #     { amount = "1000", price = "1575" },
 #     { amount = "5000", price = "1570" },
 # ]
-#
-# # Ask price curve: exotic per USD when *selling* exotic to a user (stable→exotic leg)
-# askPriceCurve = [
+# askPriceCurve = [           # CNGN per USDC when *selling* CNGN to a user
 #     { amount = "100",  price = "1560" },
 #     { amount = "1000", price = "1555" },
 #     { amount = "5000", price = "1550" },
 # ]
 #
-# [strategies.token1]
-# "EVM-56"  = "0xExoticTokenAddressOnBsc"
-# "EVM-137" = "0xExoticTokenAddressOnPolygon"
+# [[pairs]]
+# token0 = "USDT"             # priced independently of the USDC pair
+# token1 = "CNGN"
+# maxOrderSize = "5000"
+# bidPriceCurve = [ { amount = "0", price = "1578" } ]
+# askPriceCurve = [ { amount = "0", price = "1552" } ]
+#
+# [[pairs]]
+# token0 = "ZARP"             # non-USD quote side — shipped by the registry
+# token1 = "CNGN"
+# maxOrderSize = "90000"      # 90,000 ZARP per order
+# bidPriceCurve = [ { amount = "0", price = "86" } ]
+# askPriceCurve = [ { amount = "0", price = "84" } ]
+#
+# [assets] is an OPTIONAL escape hatch: only needed for assets the registry
+# does not ship, or to override a shipped address for your deployment.
+# [assets.BRZ]
+# "EVM-137" = "0xBrzOnPolygon"
+#
+# The hyperfx strategy block carries engine-level settings; [[pairs]] requires
+# exactly one. (The legacy strategy-level token1 + curves + maxOrderUsd form
+# still works — translated into USDC/exotic and USDT/exotic pairs — but is
+# deprecated.)
+# [[strategies]]
+# type = "hyperfx"
+# # Optional spread (basis points) around Uniswap V4 mid when using vault.uniswapV4 for pricing
+# spreadBps = 50
 #
 # # Auto-funding from on-chain liquidity (optional)
 # # When wallet balance is insufficient, Simplex withdraws from these positions atomically
@@ -276,6 +306,13 @@ points = [
 # the event monitor fans every `eth_getLogs` batch out to all providers and requires identical
 # results. Any provider failure or divergence fails the batch. URLs must resolve to different
 # hostnames.
+#
+# On Ethereum, Arbitrum, Base, Polygon and BNB Chain, Simplex automatically appends its
+# built-in registry of public endpoints (official gateway, PublicNode, dRPC, 1RPC) to the
+# quorum set — deduplicated by hostname, your URLs first — hardening order detection and
+# cross-chain confirmation counting even with a single configured endpoint. Public endpoints
+# only serve quorum-checked reads; fills, gas estimation and balance reads always use the
+# URLs configured here.
 [[chains]]
 rpcUrls = [""]      # Ethereum Mainnet — add more endpoints to enable quorum
 bundlerUrl = ""     # ERC-4337 bundler (e.g. Pimlico)

--- a/sdk/packages/simplex/src/bin/simplex.ts
+++ b/sdk/packages/simplex/src/bin/simplex.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { Command } from "commander"
+import { Decimal } from "decimal.js"
 import { readFileSync } from "fs"
 import { resolve, dirname } from "path"
 import { fileURLToPath } from "url"
@@ -7,11 +8,13 @@ import { parse } from "toml"
 import { isAddress } from "viem"
 import { IntentFiller } from "@/core/filler"
 import { StableFiller } from "@/strategies/stable"
-import { FXFiller } from "@/strategies/fx"
+import { FXFiller, legacyExoticPairs, type TradingPair } from "@/strategies/fx"
 import type { VaultConfig, FundingVenue, UniswapV4PositionConfig } from "@/funding/types"
 import { UniswapV4FundingPlanner } from "@/funding/uniswapV4/UniswapV4FundingPlanner"
 import { VaultFundingPlanner } from "@/funding/vault/VaultFundingPlanner"
 import { ConfirmationPolicy, FillerBpsPolicy, FillerPricePolicy } from "@/config/interpolated-curve"
+import { AssetRegistry, validateAssetDefinitions, type AssetDefinition } from "@/config/asset-registry"
+import { validatePairConfigs, type PairConfig } from "@/config/pairs"
 import { ChainConfig, FillerConfig, HexString } from "@hyperbridge/sdk"
 import {
 	FillerConfigService,
@@ -115,28 +118,20 @@ interface VaultTomlConfig {
 interface FxStrategyConfig {
 	type: "hyperfx"
 	/**
-	 * Bid price curve: exotic tokens per 1 USD when the filler *buys* exotic from a user
-	 * (exotic→stable leg). Should have a higher exotic-per-USD rate than the ask curve so
-	 * the filler pays out fewer stablecoins per exotic token received.
+	 * DEPRECATED (legacy single-exotic mode) — declare top-level `[[pairs]]` instead.
 	 *
-	 * Optional when `[strategies.vault.uniswapV4]` lists at least one position — bid/ask
-	 * are then derived from the Uniswap V4 pool after startup. Omitting only this curve
-	 * (while keeping the ask) is one-sided LP: the filler stops buying exotic and only
-	 * sells it, accumulating stablecoins.
+	 * Bid price curve: exotic tokens per 1 USD when the filler *buys* exotic from
+	 * a user. Translated internally into USDC/exotic and USDT/exotic pairs.
 	 */
 	bidPriceCurve?: Array<{
 		amount: string
 		price: string
 	}>
 	/**
-	 * Ask price curve: exotic tokens per 1 USD when the filler *sells* exotic to a user
-	 * (stable→exotic leg). Should have a lower exotic-per-USD rate than the bid curve so
-	 * the filler sends fewer exotic tokens per stablecoin received.
+	 * DEPRECATED (legacy single-exotic mode) — declare top-level `[[pairs]]` instead.
 	 *
-	 * Optional when `[strategies.vault.uniswapV4]` lists at least one position — bid/ask
-	 * are then derived from the Uniswap V4 pool after startup. Omitting only this curve
-	 * (while keeping the bid) is one-sided LP: the filler stops selling exotic and only
-	 * buys it, accumulating the exotic token.
+	 * Ask price curve: exotic tokens per 1 USD when the filler *sells* exotic to
+	 * a user. Translated internally into USDC/exotic and USDT/exotic pairs.
 	 */
 	askPriceCurve?: Array<{
 		amount: string
@@ -147,10 +142,17 @@ interface FxStrategyConfig {
 	 * Ignored when only static bid/ask curves apply.
 	 */
 	spreadBps?: number
-	/** Maximum USD value per order */
-	maxOrderUsd: number
-	/** Map of chain identifier (e.g. "EVM-97") to exotic token contract address */
-	token1: Record<string, HexString>
+	/**
+	 * DEPRECATED (legacy single-exotic mode) — declare per-pair `maxOrderSize`
+	 * on `[[pairs]]` instead. Maximum USD value per order.
+	 */
+	maxOrderUsd?: number
+	/**
+	 * DEPRECATED (legacy single-exotic mode) — declare top-level `[[pairs]]` and
+	 * `[assets]` instead. Map of chain identifier (e.g. "EVM-97") to exotic token
+	 * contract address; translated internally into USDC/exotic and USDT/exotic pairs.
+	 */
+	token1?: Record<string, HexString>
 	/** Optional per-chain confirmation policies for cross-chain orders */
 	confirmationPolicies?: Record<string, ChainConfirmationPolicy>
 	/** Optional on-chain liquidity funding for destination-chain outputs */
@@ -229,6 +231,20 @@ interface BinanceConfig {
 }
 
 interface FillerTomlConfig {
+	/**
+	 * Optional asset-registry escape hatch: symbol → { chain → address }. Only
+	 * needed for assets the built-in registry does not ship, or to override a
+	 * shipped address for a deployment. Shipped symbols: USDC, USDT, DAI, CNGN
+	 * (SDK chain registry) + curated ZARP, EURC, XSGD, TRYB.
+	 */
+	assets?: Record<string, AssetDefinition>
+	/**
+	 * Trading pairs for the FX engine. Each pair prices `token1` in units of
+	 * `token0` via its own bid/ask curves; any number of pairs may be declared.
+	 * Requires exactly one `[[strategies]]` entry of type "hyperfx" (which carries
+	 * engine-level settings: maxOrderUsd, confirmation policies, venue funding).
+	 */
+	pairs?: PairConfig[]
 	simplex: {
 		// The signer is optional to keep the watch-only mode compatible
 		signer?: SignerConfig
@@ -424,6 +440,11 @@ program
 
 			// Initialize strategies with shared services
 			logger.info("Initializing strategies...")
+
+			// Asset symbol registry: built-ins (USDC/USDT/DAI/CNGN) resolved from the
+			// SDK chain registry, extended/overridden by the user's [assets] table.
+			const assetRegistry = new AssetRegistry(configService, config.assets)
+
 			// Editable price curves for the admin server, collected at construction so the
 			// server mutates the exact policy instances the strategies price with.
 			const adminStrategies: AdminStrategy[] = []
@@ -448,18 +469,64 @@ program
 						)
 					}
 					case "hyperfx": {
-						const bidPricePolicy = strategyConfig.bidPriceCurve?.length
-							? new FillerPricePolicy({ points: strategyConfig.bidPriceCurve })
-							: undefined
-						const askPricePolicy = strategyConfig.askPriceCurve?.length
-							? new FillerPricePolicy({ points: strategyConfig.askPriceCurve })
-							: undefined
-						adminStrategies.push({
-							index: strategyIndex,
-							bid: bidPricePolicy,
-							ask: askPricePolicy,
-						})
-						adminTokenMaps.set(strategyIndex, strategyConfig.token1)
+						// Build the engine's trading pairs: top-level [[pairs]] (each with
+						// its own bid/ask policies), or the legacy single-exotic config
+						// translated into USDC/exotic + USDT/exotic pairs.
+						let tradingPairs: TradingPair[]
+						let strategyRegistry = assetRegistry
+						if (config.pairs?.length) {
+							tradingPairs = config.pairs.map((pair) => ({
+								token0: pair.token0,
+								token1: pair.token1,
+								maxOrderSize: new Decimal(pair.maxOrderSize),
+								bidPricePolicy: pair.bidPriceCurve?.length
+									? new FillerPricePolicy({ points: pair.bidPriceCurve })
+									: undefined,
+								askPricePolicy: pair.askPriceCurve?.length
+									? new FillerPricePolicy({ points: pair.askPriceCurve })
+									: undefined,
+							}))
+							for (const pair of tradingPairs) {
+								if (pair.bidPricePolicy || pair.askPricePolicy) {
+									adminStrategies.push({
+										index: adminStrategies.length,
+										exotic: `${pair.token0}/${pair.token1}`,
+										bid: pair.bidPricePolicy,
+										ask: pair.askPricePolicy,
+									})
+								}
+							}
+						} else {
+							const bidPricePolicy = strategyConfig.bidPriceCurve?.length
+								? new FillerPricePolicy({ points: strategyConfig.bidPriceCurve })
+								: undefined
+							const askPricePolicy = strategyConfig.askPriceCurve?.length
+								? new FillerPricePolicy({ points: strategyConfig.askPriceCurve })
+								: undefined
+							// Legacy curves are exotic-per-USD; with USD-pegged token0 they are
+							// identical to token1-per-token0, so both pairs share the same
+							// policy instances (admin edits update both, as before).
+							const legacy = legacyExoticPairs(
+								configService,
+								strategyConfig.token1!,
+								strategyConfig.maxOrderUsd!,
+								bidPricePolicy,
+								askPricePolicy,
+							)
+							tradingPairs = legacy.pairs
+							strategyRegistry = legacy.registry
+							logger.warn(
+								{ strategyIndex },
+								"hyperfx 'token1'/'bidPriceCurve'/'askPriceCurve' are deprecated — declare top-level [[pairs]] and [assets] instead",
+							)
+							adminStrategies.push({
+								index: strategyIndex,
+								bid: bidPricePolicy,
+								ask: askPricePolicy,
+							})
+							adminTokenMaps.set(strategyIndex, strategyConfig.token1!)
+						}
+
 						const mergedFxPolicies = {
 							...DEFAULT_CONFIRMATION_POLICIES,
 							...(strategyConfig.confirmationPolicies ?? {}),
@@ -503,11 +570,9 @@ program
 							configService,
 							chainClientManager,
 							contractService,
-							strategyConfig.maxOrderUsd,
-							strategyConfig.token1,
+							tradingPairs,
+							strategyRegistry,
 							{
-								bidPricePolicy,
-								askPricePolicy,
 								confirmationPolicy: fxConfirmationPolicy,
 								fundingVenues,
 								spreadBps: strategyConfig.spreadBps,
@@ -582,11 +647,19 @@ program
 				if (isNaN(metricsPort) || metricsPort < 1 || metricsPort > 65535) {
 					logger.warn({ bind: options.port }, "Invalid metrics address, skipping")
 				} else {
-					// Collect exotic token addresses from FX strategies
+					// Collect exotic token addresses from FX strategies (legacy token1
+					// maps) and from top-level pairs via the asset registry.
 					const token1: Record<string, string> = {}
 					for (const s of config.strategies) {
 						if (s.type === "hyperfx" && s.token1) {
 							Object.assign(token1, s.token1)
+						}
+					}
+					for (const pair of config.pairs ?? []) {
+						for (const chain of resolvedChains) {
+							const chainName = `EVM-${chain.chainId}`
+							const address = assetRegistry.getAddress(pair.token1, chainName)
+							if (address) token1[chainName] = address
 						}
 					}
 					metrics = new MetricsService({
@@ -819,6 +892,35 @@ function validateConfig(config: FillerTomlConfig): void {
 		VaultFundingPlanner.validateConfig(config.vault.vaults)
 	}
 
+	// Asset registry and trading pairs (new-style FX configuration)
+	if (config.assets) {
+		validateAssetDefinitions(config.assets)
+	}
+	const usingPairs = (config.pairs?.length ?? 0) > 0
+	if (usingPairs) {
+		const hyperfxStrategies = (config.strategies ?? []).filter(
+			(s): s is FxStrategyConfig => s.type === "hyperfx",
+		)
+		if (hyperfxStrategies.length !== 1) {
+			throw new Error(
+				"[[pairs]] requires exactly one 'hyperfx' strategy to carry engine settings (maxOrderUsd, confirmation policies, venue funding)",
+			)
+		}
+		const fx = hyperfxStrategies[0]
+		if (fx.token1 || fx.bidPriceCurve?.length || fx.askPriceCurve?.length) {
+			throw new Error(
+				"hyperfx: legacy 'token1'/'bidPriceCurve'/'askPriceCurve' cannot be combined with top-level [[pairs]] — move the curves onto the pairs",
+			)
+		}
+		if (fx.maxOrderUsd !== undefined) {
+			throw new Error(
+				"hyperfx: 'maxOrderUsd' does not apply with [[pairs]] — set a per-pair 'maxOrderSize' (in token0 units) instead",
+			)
+		}
+		const hasVenuePricing = (fx.vault?.uniswapV4?.positions?.length ?? 0) > 0
+		validatePairConfigs(config.pairs!, config.assets, hasVenuePricing)
+	}
+
 	// Validate strategies
 	for (const strategy of config.strategies) {
 		if (!strategy.type) {
@@ -871,9 +973,9 @@ function validateConfig(config: FillerTomlConfig): void {
 			const hasAnyCurve = bidLen >= 1 || askLen >= 1
 			const hasUniswapV4Positions = (strategy.vault?.uniswapV4?.positions?.length ?? 0) > 0
 
-			if (!hasAnyCurve && !hasUniswapV4Positions) {
+			if (!usingPairs && !hasAnyCurve && !hasUniswapV4Positions) {
 				throw new Error(
-					"hyperfx: provide a bid and/or ask price curve, or configure [strategies.vault.uniswapV4].positions for pool-based pricing",
+					"hyperfx: declare top-level [[pairs]] with price curves, or configure [strategies.vault.uniswapV4].positions for pool-based pricing",
 				)
 			}
 
@@ -932,32 +1034,37 @@ function validateConfig(config: FillerTomlConfig): void {
 				if (!hasUniswapV4Positions) {
 					throw new Error("hyperfx: 'vault.uniswapV4.side' requires [strategies.vault.uniswapV4].positions")
 				}
-				if (hasAnyCurve) {
+				const anyCurves = usingPairs
+					? (config.pairs ?? []).some(
+							(p) => (p.bidPriceCurve?.length ?? 0) > 0 || (p.askPriceCurve?.length ?? 0) > 0,
+						)
+					: hasAnyCurve
+				if (anyCurves) {
 					throw new Error(
-						"hyperfx: 'vault.uniswapV4.side' only applies to pool pricing; omit 'bidPriceCurve'/'askPriceCurve' (or drop one curve to do one-sided LP with static pricing)",
+						"hyperfx: 'vault.uniswapV4.side' only applies to pool pricing; omit the bid/ask price curves (or drop one curve to do one-sided LP with static pricing)",
 					)
 				}
 			}
 
-			if (bidLen > 0) {
-				for (const point of strategy.bidPriceCurve!) {
-					if (point.amount === undefined || point.price === undefined) {
-						throw new Error("Each FX bidPriceCurve point must have 'amount' and 'price'")
-					}
+			for (const point of strategy.bidPriceCurve ?? []) {
+				if (point.amount === undefined || point.price === undefined) {
+					throw new Error("Each FX bidPriceCurve point must have 'amount' and 'price'")
 				}
-				for (const point of strategy.askPriceCurve!) {
-					if (point.amount === undefined || point.price === undefined) {
-						throw new Error("Each FX askPriceCurve point must have 'amount' and 'price'")
-					}
+			}
+			for (const point of strategy.askPriceCurve ?? []) {
+				if (point.amount === undefined || point.price === undefined) {
+					throw new Error("Each FX askPriceCurve point must have 'amount' and 'price'")
 				}
 			}
 
-			if (!strategy.maxOrderUsd) {
-				throw new Error("FX strategy must have 'maxOrderUsd'")
+			if (!usingPairs && !strategy.maxOrderUsd) {
+				throw new Error("FX strategy must have 'maxOrderUsd' (legacy mode; with [[pairs]] use per-pair 'maxOrderSize')")
 			}
 
-			if (!strategy.token1 || Object.keys(strategy.token1).length === 0) {
-				throw new Error("FX strategy must have at least one entry in 'token1'")
+			if (!usingPairs && (!strategy.token1 || Object.keys(strategy.token1).length === 0)) {
+				throw new Error(
+					"FX strategy must have at least one entry in 'token1' (or declare top-level [[pairs]] instead)",
+				)
 			}
 
 			if (strategy.confirmationPolicies) {

--- a/sdk/packages/simplex/src/config/asset-registry.ts
+++ b/sdk/packages/simplex/src/config/asset-registry.ts
@@ -1,0 +1,188 @@
+import { isAddress } from "viem"
+import type { HexString } from "@hyperbridge/sdk"
+
+/**
+ * A user-supplied asset entry in the `[assets]` TOML table: symbol → chain
+ * state machine id → contract address.
+ *
+ * ```toml
+ * [assets.BRZ]
+ * "EVM-1"   = "0x..."
+ * "EVM-137" = "0x..."
+ * ```
+ */
+export type AssetDefinition = Record<string, HexString>
+
+/**
+ * The subset of `FillerConfigService` used to resolve built-in symbols to
+ * per-chain addresses from the SDK chain registry.
+ */
+export interface BuiltinAssetResolver {
+	getUsdcAsset(chain: string): HexString
+	getUsdtAsset(chain: string): HexString
+	getDaiAsset(chain: string): HexString
+	getCNgnAsset(chain: string): HexString | undefined
+}
+
+interface BuiltinSpec {
+	resolve: (resolver: BuiltinAssetResolver, chain: string) => HexString | undefined
+}
+
+/**
+ * Symbols resolved per chain from the SDK chain registry (which maintains their
+ * addresses across mainnets and testnets).
+ */
+const BUILTIN_ASSETS: Record<string, BuiltinSpec> = {
+	USDC: { resolve: (r, chain) => r.getUsdcAsset(chain) },
+	USDT: { resolve: (r, chain) => r.getUsdtAsset(chain) },
+	DAI: { resolve: (r, chain) => r.getDaiAsset(chain) },
+	CNGN: { resolve: (r, chain) => r.getCNgnAsset(chain) },
+}
+
+/**
+ * Symbols treated as worth exactly 1 USD for *risk sizing* (the `maxOrderUsd`
+ * cap and confirmation policies). Pairs quoted in one of these size directly
+ * off token0 notional; other quote assets are valued through the operator's own
+ * configured pair curves (see `FXFiller`). Trade pricing never uses this.
+ */
+export const USD_STABLE_SYMBOLS = new Set(["USDC", "USDT", "DAI"])
+
+/**
+ * Curated registry of additional stablecoin deployments on the supported
+ * mainnets, maintained here so operators reference assets purely by symbol —
+ * no address configuration required. Every address below was taken from the
+ * issuer's official documentation (Circle, ZARP Stablecoin, StraitsX, BiLira)
+ * and verified on-chain (`symbol()` + `decimals()`) before inclusion.
+ */
+export const KNOWN_ASSETS: Record<string, AssetDefinition> = {
+	// South African rand — same contract address on every EVM deployment.
+	ZARP: {
+		"EVM-1": "0xb755506531786C8aC63B756BaB1ac387bACB0C04",
+		"EVM-137": "0xb755506531786C8aC63B756BaB1ac387bACB0C04",
+		"EVM-8453": "0xb755506531786C8aC63B756BaB1ac387bACB0C04",
+	},
+	// Circle euro stablecoin.
+	EURC: {
+		"EVM-1": "0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c",
+		"EVM-8453": "0x60a3E35Cc302bFA44Cb288Bc5a4F316Fdb1adb42",
+	},
+	// StraitsX Singapore dollar stablecoin.
+	XSGD: {
+		"EVM-1": "0x70e8de73cE538DA2bEEd35d14187F6959a8ecA96",
+		"EVM-137": "0xDC3326e71D45186F113a2F448984CA0e8D201995",
+	},
+	// BiLira Turkish lira stablecoin.
+	TRYB: {
+		"EVM-1": "0x2C537E5624e4af88A7ae4060C022609376C8D0EB",
+	},
+}
+
+/** Normalises a symbol for lookups: trimmed, uppercased. "cNGN" ≡ "CNGN". */
+export function normalizeSymbol(symbol: string): string {
+	return symbol.trim().toUpperCase()
+}
+
+/** Every symbol the registry ships without user configuration. */
+export function registrySymbols(): string[] {
+	return [...new Set([...Object.keys(BUILTIN_ASSETS), ...Object.keys(KNOWN_ASSETS)])]
+}
+
+/** Whether `symbol` ships with the registry (built-in or curated). Pure — no chain resolution. */
+export function isRegistrySymbol(symbol: string): boolean {
+	const normalized = normalizeSymbol(symbol)
+	return normalized in BUILTIN_ASSETS || normalized in KNOWN_ASSETS
+}
+
+/**
+ * Validates the `[assets]` table; throws a descriptive error on the first
+ * invalid entry. Side-effect free — safe to call at config-parse time and again
+ * at registry construction.
+ */
+export function validateAssetDefinitions(assets: Record<string, AssetDefinition>): void {
+	const seen = new Set<string>()
+	for (const [symbol, definition] of Object.entries(assets)) {
+		const normalized = normalizeSymbol(symbol)
+		if (normalized.length === 0) {
+			throw new Error("assets: symbol must be a non-empty string")
+		}
+		if (seen.has(normalized)) {
+			throw new Error(`assets: symbol '${normalized}' is defined twice (symbols are case-insensitive)`)
+		}
+		seen.add(normalized)
+
+		const entries = Object.entries(definition ?? {})
+		if (entries.length === 0) {
+			throw new Error(`assets.${symbol}: entry must map at least one chain to a token address`)
+		}
+		for (const [chain, address] of entries) {
+			if (!isAddress(address)) {
+				throw new Error(`assets.${symbol}: invalid address '${address}' for chain '${chain}'`)
+			}
+		}
+	}
+}
+
+/**
+ * Symbol → contract address registry backing the `[[pairs]]` configuration.
+ *
+ * Resolution merges three layers, most specific winning:
+ *  1. the user's `[assets]` table — an *escape hatch* for assets the registry
+ *     doesn't ship (or per-deployment overrides), never required for shipped
+ *     symbols;
+ *  2. the curated {@link KNOWN_ASSETS} table maintained in this repository;
+ *  3. built-in symbols (USDC, USDT, DAI, CNGN) resolved per chain from the SDK
+ *     chain registry (which also covers testnets).
+ *
+ * Address lookups are per `(symbol, chain)` — a chain where no layer knows the
+ * asset simply doesn't trade pairs involving it. The registry holds addresses
+ * only; all pricing (including risk sizing) is derived from the pair curves.
+ */
+export class AssetRegistry {
+	private readonly resolver: BuiltinAssetResolver
+	private readonly userAssets: Map<string, AssetDefinition>
+	private readonly addressCache = new Map<string, HexString | null>()
+
+	constructor(resolver: BuiltinAssetResolver, userAssets?: Record<string, AssetDefinition>) {
+		this.resolver = resolver
+		if (userAssets) validateAssetDefinitions(userAssets)
+		this.userAssets = new Map(
+			Object.entries(userAssets ?? {}).map(([symbol, definition]) => [normalizeSymbol(symbol), definition]),
+		)
+	}
+
+	/** Whether `symbol` is known (user-defined, curated, or built-in). */
+	hasSymbol(symbol: string): boolean {
+		const normalized = normalizeSymbol(symbol)
+		return this.userAssets.has(normalized) || isRegistrySymbol(normalized)
+	}
+
+	/**
+	 * Contract address of `symbol` on `chain`, or `null` when the asset is not
+	 * deployed/known there. User `[assets]` addresses win over the curated
+	 * table, which wins over the built-in SDK registry, per chain.
+	 */
+	getAddress(symbol: string, chain: string): HexString | null {
+		const normalized = normalizeSymbol(symbol)
+		const cacheKey = `${normalized}:${chain}`
+		const cached = this.addressCache.get(cacheKey)
+		if (cached !== undefined) return cached
+
+		let address: HexString | undefined =
+			this.userAssets.get(normalized)?.[chain] ?? KNOWN_ASSETS[normalized]?.[chain]
+		if (!address) {
+			const builtin = BUILTIN_ASSETS[normalized]
+			if (builtin) {
+				try {
+					address = builtin.resolve(this.resolver, chain)
+				} catch {
+					// SDK registry has no entry for this chain — treat as absent.
+					address = undefined
+				}
+			}
+		}
+
+		const result = address ?? null
+		this.addressCache.set(cacheKey, result)
+		return result
+	}
+}

--- a/sdk/packages/simplex/src/config/pairs.ts
+++ b/sdk/packages/simplex/src/config/pairs.ts
@@ -1,0 +1,122 @@
+import { Decimal } from "decimal.js"
+import type { PriceCurvePoint } from "@/config/interpolated-curve"
+import { isRegistrySymbol, normalizeSymbol, registrySymbols, type AssetDefinition } from "@/config/asset-registry"
+
+/**
+ * One trading pair from the top-level `[[pairs]]` TOML array:
+ *
+ * ```toml
+ * [[pairs]]
+ * token0 = "USDC"        # quote side — any symbol in the asset registry
+ * token1 = "CNGN"        # base side — any symbol in the asset registry
+ * maxOrderSize = "5000"  # per-order cap, in token0 units
+ * bidPriceCurve = [ { amount = "1000", price = "1580" } ]
+ * askPriceCurve = [ { amount = "1000", price = "1550" } ]
+ * ```
+ *
+ * Curves are priced in **token1 per 1 token0** and keyed by the order's
+ * token0 notional — the same unit as `maxOrderSize`, so a pair is priced,
+ * capped, and sized entirely in its own quote asset with no external price
+ * feed. The bid curve prices the filler *buying* token1 (user sends token1,
+ * receives token0); the ask curve prices the filler *selling* token1.
+ * Omitting one curve disables that direction for this pair (one-sided LP);
+ * omitting both is only valid when Uniswap V4 venue pricing is configured.
+ *
+ * Users may declare any number of pairs; a single FX engine serves all of them.
+ */
+export interface PairConfig {
+	/** Quote-side symbol (e.g. "USDC", "USDT", "ZARP"). */
+	token0: string
+	/** Base-side symbol (e.g. "CNGN"). Any symbol in the registry. */
+	token1: string
+	/** Maximum token0 notional this pair fills per order. */
+	maxOrderSize: string
+	/** token1 per token0 when the filler buys token1. Omit for ask-only (one-sided) LP. */
+	bidPriceCurve?: PriceCurvePoint[]
+	/** token1 per token0 when the filler sells token1. Omit for bid-only (one-sided) LP. */
+	askPriceCurve?: PriceCurvePoint[]
+}
+
+function isKnownSymbol(symbol: string, userAssets?: Record<string, AssetDefinition>): boolean {
+	const normalized = normalizeSymbol(symbol)
+	if (isRegistrySymbol(normalized)) return true
+	return Object.keys(userAssets ?? {}).some((key) => normalizeSymbol(key) === normalized)
+}
+
+function validateCurve(pairLabel: string, name: string, curve: PriceCurvePoint[] | undefined): void {
+	if (curve === undefined) return
+	if (!Array.isArray(curve) || curve.length < 1) {
+		throw new Error(`pairs.${pairLabel}: '${name}' must be an array with at least 1 point`)
+	}
+	for (const point of curve) {
+		if (point.amount === undefined || point.price === undefined) {
+			throw new Error(`pairs.${pairLabel}: each ${name} point must have 'amount' and 'price'`)
+		}
+	}
+}
+
+/**
+ * Validates the `[[pairs]]` array against the `[assets]` table and built-in
+ * symbols. Pure — throws a descriptive error on the first invalid pair.
+ *
+ * @param hasVenuePricing whether Uniswap V4 venue pricing is configured; a pair
+ *   with no curves is only valid when it is.
+ */
+export function validatePairConfigs(
+	pairs: PairConfig[],
+	userAssets?: Record<string, AssetDefinition>,
+	hasVenuePricing = false,
+): void {
+	if (!Array.isArray(pairs) || pairs.length === 0) {
+		throw new Error("pairs: at least one [[pairs]] entry is required")
+	}
+
+	const seen = new Set<string>()
+	for (const pair of pairs) {
+		if (!pair.token0 || !pair.token1) {
+			throw new Error("pairs: each entry needs 'token0' and 'token1' symbols")
+		}
+		const token0 = normalizeSymbol(pair.token0)
+		const token1 = normalizeSymbol(pair.token1)
+		const label = `${token0}/${token1}`
+
+		if (token0 === token1) {
+			throw new Error(`pairs.${label}: token0 and token1 must differ`)
+		}
+		if (seen.has(label)) {
+			throw new Error(`pairs.${label}: pair is declared twice`)
+		}
+		seen.add(label)
+
+		for (const symbol of [token0, token1]) {
+			if (!isKnownSymbol(symbol, userAssets)) {
+				throw new Error(
+					`pairs.${label}: unknown symbol '${symbol}' — the registry ships ${registrySymbols().join(", ")}; anything else needs an [assets.${symbol}] entry`,
+				)
+			}
+		}
+
+		if (pair.maxOrderSize === undefined) {
+			throw new Error(`pairs.${label}: 'maxOrderSize' is required (per-order cap in ${token0} units)`)
+		}
+		let maxOrderSize: Decimal
+		try {
+			maxOrderSize = new Decimal(pair.maxOrderSize)
+		} catch {
+			throw new Error(`pairs.${label}: 'maxOrderSize' must be a decimal string, got '${pair.maxOrderSize}'`)
+		}
+		if (!maxOrderSize.isFinite() || maxOrderSize.lte(0)) {
+			throw new Error(`pairs.${label}: 'maxOrderSize' must be a positive number, got '${pair.maxOrderSize}'`)
+		}
+
+		validateCurve(label, "bidPriceCurve", pair.bidPriceCurve)
+		validateCurve(label, "askPriceCurve", pair.askPriceCurve)
+
+		const hasAnyCurve = (pair.bidPriceCurve?.length ?? 0) >= 1 || (pair.askPriceCurve?.length ?? 0) >= 1
+		if (!hasAnyCurve && !hasVenuePricing) {
+			throw new Error(
+				`pairs.${label}: provide a bid and/or ask price curve, or configure [strategies.vault.uniswapV4] positions for pool-based pricing`,
+			)
+		}
+	}
+}

--- a/sdk/packages/simplex/src/config/public-rpcs.ts
+++ b/sdk/packages/simplex/src/config/public-rpcs.ts
@@ -1,0 +1,64 @@
+/**
+ * Registry of well-known, keyless public JSON-RPC endpoints for the EVM networks
+ * Simplex supports. These are merged into the *quorum* provider set alongside the
+ * operator's own endpoints (see `FillerConfigService.getQuorumRpcUrls`) so that
+ * order detection and cross-chain confirmation counting never rest on a single
+ * provider's — or a single organisation's — view of the chain.
+ *
+ * Selection criteria: each chain lists endpoints operated by organisationally
+ * independent providers (the network's official gateway where one exists, plus
+ * PublicNode/Allnodes, dRPC and 1RPC), all reachable without an API key. The
+ * quorum threshold is `floor(2N/3) + 1`, so four public endpoints on top of a
+ * single operator endpoint (N=5, threshold 4) tolerate one faulty or lying
+ * provider; every additional operator endpoint raises the tolerance further.
+ *
+ * Public endpoints are only ever used for quorum-checked reads (`eth_getLogs`,
+ * `eth_blockNumber`, `eth_getTransactionReceipt`). Latency-sensitive and
+ * write paths (gas estimation, transaction submission, balance reads) stay on
+ * the operator's configured endpoints.
+ */
+export const PUBLIC_RPC_URLS: Record<number, readonly string[]> = {
+	// Ethereum Mainnet
+	1: [
+		"https://ethereum-rpc.publicnode.com",
+		"https://eth.drpc.org",
+		"https://1rpc.io/eth",
+		"https://eth.meowrpc.com",
+	],
+	// BNB Smart Chain
+	56: [
+		"https://bsc-dataseed.bnbchain.org",
+		"https://bsc-rpc.publicnode.com",
+		"https://bsc.drpc.org",
+		"https://1rpc.io/bnb",
+	],
+	// Polygon PoS
+	137: [
+		"https://polygon-bor-rpc.publicnode.com",
+		"https://polygon.drpc.org",
+		"https://1rpc.io/matic",
+		"https://polygon.gateway.tenderly.co",
+	],
+	// Base
+	8453: [
+		"https://mainnet.base.org",
+		"https://base-rpc.publicnode.com",
+		"https://base.drpc.org",
+		"https://1rpc.io/base",
+	],
+	// Arbitrum One
+	42161: [
+		"https://arb1.arbitrum.io/rpc",
+		"https://arbitrum-one-rpc.publicnode.com",
+		"https://arbitrum.drpc.org",
+		"https://1rpc.io/arb",
+	],
+}
+
+/**
+ * Public RPC endpoints for a chain, or an empty array for networks without a
+ * registry entry (testnets, chains Simplex does not curate endpoints for).
+ */
+export function getPublicRpcUrls(chainId: number): readonly string[] {
+	return PUBLIC_RPC_URLS[chainId] ?? []
+}

--- a/sdk/packages/simplex/src/core/event-monitor.ts
+++ b/sdk/packages/simplex/src/core/event-monitor.ts
@@ -139,11 +139,14 @@ export class EventMonitor extends EventEmitter {
 			this.chains.set(config.chainId, chain as IEvmChain)
 			this.scanningMutexes.set(config.chainId, new Mutex())
 
-			const rpcUrls = this.configService.getRpcUrls(chainName)
-			this.quorumClients.set(config.chainId, new QuorumPublicClient(config.chainId, rpcUrls))
-			if (rpcUrls.length > 1) {
+			// Shared quorum client: operator endpoints + the public RPC registry
+			// (see FillerConfigService.getQuorumRpcUrls), also used by the
+			// cross-chain confirmation waiter in the filler core.
+			const quorumClient = clientManager.getQuorumClient(chainName)
+			this.quorumClients.set(config.chainId, quorumClient)
+			if (quorumClient.size > 1) {
 				this.logger.info(
-					{ chainId: config.chainId, providerCount: rpcUrls.length },
+					{ chainId: config.chainId, providerCount: quorumClient.size, threshold: quorumClient.threshold },
 					"Quorum log scanning enabled",
 				)
 			}

--- a/sdk/packages/simplex/src/core/filler.ts
+++ b/sdk/packages/simplex/src/core/filler.ts
@@ -415,7 +415,11 @@ export class IntentFiller {
 					return
 				}
 
-				const sourceClient = this.chainClientManager.getPublicClient(order.source)
+				// Confirmations are counted with BFT-quorum semantics across the
+				// operator's endpoints plus the public RPC registry, so a single
+				// compromised or reorged provider cannot vouch for inclusion depth
+				// on cross-chain orders.
+				const sourceQuorumClient = this.chainClientManager.getQuorumClient(order.source)
 				// Base layer: stable-only USD value from ContractInteractionService
 				const baseInputUsd = await this.contractService.getInputUsdValue(order)
 
@@ -483,10 +487,14 @@ export class IntentFiller {
 				const abortController = new AbortController()
 				const confirmStartMs = Date.now()
 
+				// Single-provider setups keep the tight 300ms poll; quorum setups
+				// fan every poll out to all providers (including public endpoints),
+				// so poll less aggressively to stay within their rate limits.
+				const confirmationPollMs = sourceQuorumClient.size > 1 ? 1000 : 300
 				const waitForConfirmations = async (): Promise<void> => {
 					let currentConfirmations = await retryPromise(
 						() =>
-							sourceClient.getTransactionConfirmations({
+							sourceQuorumClient.getTransactionConfirmations({
 								hash: transactionHash as HexString,
 							}),
 						{
@@ -503,11 +511,11 @@ export class IntentFiller {
 
 					while (currentConfirmations < requiredConfirmations) {
 						if (abortController.signal.aborted) return
-						await new Promise((resolve) => setTimeout(resolve, 300)) // Wait 300ms
+						await new Promise((resolve) => setTimeout(resolve, confirmationPollMs))
 						if (abortController.signal.aborted) return
 						currentConfirmations = await retryPromise(
 							() =>
-								sourceClient.getTransactionConfirmations({
+								sourceQuorumClient.getTransactionConfirmations({
 									hash: transactionHash as HexString,
 								}),
 							{

--- a/sdk/packages/simplex/src/index.ts
+++ b/sdk/packages/simplex/src/index.ts
@@ -11,6 +11,20 @@ export { FXFiller } from "@/strategies/fx"
 // Configuration exports
 export { InterpolatedCurve, ConfirmationPolicy, FillerBpsPolicy } from "@/config/interpolated-curve"
 export type { CurvePoint, CurveConfig } from "@/config/interpolated-curve"
+export { PUBLIC_RPC_URLS, getPublicRpcUrls } from "@/config/public-rpcs"
+export {
+	AssetRegistry,
+	KNOWN_ASSETS,
+	USD_STABLE_SYMBOLS,
+	validateAssetDefinitions,
+	normalizeSymbol,
+	isRegistrySymbol,
+	registrySymbols,
+} from "@/config/asset-registry"
+export type { AssetDefinition, BuiltinAssetResolver } from "@/config/asset-registry"
+export { validatePairConfigs } from "@/config/pairs"
+export type { PairConfig } from "@/config/pairs"
+export type { TradingPair } from "@/strategies/fx"
 
 // Service exports
 export { ChainClientManager, ContractInteractionService } from "@/services"

--- a/sdk/packages/simplex/src/services/ChainClientManager.ts
+++ b/sdk/packages/simplex/src/services/ChainClientManager.ts
@@ -12,6 +12,7 @@ import { generatePrivateKey } from "viem/accounts"
 import { Order, ChainConfig, getViemChain } from "@hyperbridge/sdk"
 import type { Account } from "viem/accounts"
 import { FillerConfigService } from "./FillerConfigService"
+import { QuorumPublicClient } from "./QuorumPublicClient"
 import type { SigningAccount } from "./wallet"
 import { createPrivateKeySigningAccount } from "./wallet/accounts/privatekey"
 
@@ -96,6 +97,7 @@ export class ChainClientManager {
 	private signer: SigningAccount
 	private configService: FillerConfigService
 	private clientFactory: ViemClientFactoryImpl
+	private quorumClients: Map<number, QuorumPublicClient> = new Map()
 
 	constructor(configService: FillerConfigService, signer?: SigningAccount) {
 		this.configService = configService
@@ -107,6 +109,22 @@ export class ChainClientManager {
 		const config = this.configService.getChainConfig(chain)
 		const rpcUrls = this.configService.getRpcUrls(chain)
 		return this.clientFactory.getPublicClient(config, rpcUrls)
+	}
+
+	/**
+	 * Quorum client for consensus-critical reads (event scanning, cross-chain
+	 * confirmation counting). Built from the operator's endpoints plus the public
+	 * RPC registry (`FillerConfigService.getQuorumRpcUrls`) and cached per chain,
+	 * so the event monitor and the confirmation waiter share one provider set.
+	 */
+	getQuorumClient(chain: string): QuorumPublicClient {
+		const config = this.configService.getChainConfig(chain)
+		let client = this.quorumClients.get(config.chainId)
+		if (!client) {
+			client = new QuorumPublicClient(config.chainId, this.configService.getQuorumRpcUrls(chain))
+			this.quorumClients.set(config.chainId, client)
+		}
+		return client
 	}
 
 	getWalletClient(chain: string): WalletClient<Transport, Chain, Account> {

--- a/sdk/packages/simplex/src/services/FillerConfigService.ts
+++ b/sdk/packages/simplex/src/services/FillerConfigService.ts
@@ -1,5 +1,6 @@
 import type { ChainConfig, HexString } from "@hyperbridge/sdk"
 import { ChainConfigService, bytes32ToBytes20 } from "@hyperbridge/sdk"
+import { getPublicRpcUrls } from "@/config/public-rpcs"
 import { LogLevel } from "./Logger"
 
 export interface UserProvidedChainConfig {
@@ -13,6 +14,15 @@ export interface ResolvedChainConfig {
 	/** One or more RPC URLs for this chain. When multiple are provided, event scans use quorum consensus. */
 	rpcUrls: string[]
 	bundlerUrl?: string
+}
+
+/** Lowercased hostname of a URL, or null when the URL does not parse. */
+function hostnameOf(url: string): string | null {
+	try {
+		return new URL(url).hostname.toLowerCase()
+	} catch {
+		return null
+	}
 }
 
 /**
@@ -302,6 +312,34 @@ export class FillerConfigService {
 		}
 
 		return [this.chainConfigService.getRpcUrl(chain)]
+	}
+
+	/**
+	 * RPC URLs for quorum-checked reads (event scanning, cross-chain confirmation
+	 * counting): the operator's configured endpoints hardened with the public
+	 * registry for the chain. Public endpoints never replace operator endpoints —
+	 * they are appended, deduplicated by hostname with operator URLs taking
+	 * precedence — so adding them raises the quorum threshold instead of diluting
+	 * the operator's own providers. Chains without a registry entry return the
+	 * operator's URLs unchanged.
+	 */
+	getQuorumRpcUrls(chain: string): string[] {
+		const userUrls = this.getRpcUrls(chain)
+		const chainId = this.getChainIdFromStateMachineId(chain)
+
+		const merged = [...userUrls]
+		const seenHosts = new Set<string>()
+		for (const url of userUrls) {
+			const host = hostnameOf(url)
+			if (host) seenHosts.add(host)
+		}
+		for (const url of getPublicRpcUrls(chainId)) {
+			const host = hostnameOf(url)
+			if (!host || seenHosts.has(host)) continue
+			seenHosts.add(host)
+			merged.push(url)
+		}
+		return merged
 	}
 
 	private getChainIdFromStateMachineId(chain: string): number {

--- a/sdk/packages/simplex/src/services/QuorumPublicClient.ts
+++ b/sdk/packages/simplex/src/services/QuorumPublicClient.ts
@@ -7,6 +7,7 @@ import {
 	type Chain,
 	type GetLogsParameters,
 	type GetLogsReturnType,
+	type Hash,
 	type PublicClient,
 } from "viem"
 import { getViemChain } from "@hyperbridge/sdk"
@@ -112,6 +113,58 @@ export class QuorumPublicClient {
 	}
 
 	/**
+	 * Confirmation count for a transaction, counted with BFT-quorum semantics.
+	 *
+	 * Every provider is asked for the transaction receipt and its chain head in
+	 * parallel. At least {@link quorumThreshold} providers must agree on *where*
+	 * the transaction landed — the receipt's `(blockHash, blockNumber)` pair — so
+	 * a minority of providers serving a reorged or fabricated inclusion cannot
+	 * influence the count. The head used for counting is the highest block that
+	 * at least the threshold of *agreeing* providers have indexed, mirroring
+	 * {@link getBlockNumber}. Confirmations follow viem's convention:
+	 * `head - receiptBlock + 1`, floored at 0.
+	 *
+	 * Throws {@link QuorumError} when too few providers return an agreeing
+	 * receipt — including the window where the transaction is not yet mined on a
+	 * quorum of providers.
+	 */
+	async getTransactionConfirmations({ hash }: { hash: Hash }): Promise<bigint> {
+		const settled = await Promise.allSettled(
+			this.clients.map(async (client) => {
+				const [receipt, head] = await Promise.all([
+					client.getTransactionReceipt({ hash }),
+					client.getBlockNumber(),
+				])
+				return {
+					blockHash: receipt.blockHash,
+					blockNumber: receipt.blockNumber,
+					head,
+				} satisfies ProviderReceiptView
+			}),
+		)
+
+		const views: ProviderReceiptView[] = []
+		const failures: { idx: number; error: unknown }[] = []
+		for (let idx = 0; idx < settled.length; idx++) {
+			const outcome = settled[idx]
+			if (outcome.status === "fulfilled") {
+				views.push(outcome.value)
+			} else {
+				failures.push({ idx, error: outcome.reason })
+			}
+		}
+
+		const confirmations = aggregateConfirmations(views, this.threshold)
+		if (confirmations === null) {
+			throw new QuorumError(
+				`Quorum not reached for getTransactionConfirmations(${hash}): no receipt agreed on by ` +
+					`${this.threshold}/${this.clients.length} providers. ${this.formatFailures(failures)}`,
+			)
+		}
+		return confirmations
+	}
+
+	/**
 	 * Fetches logs from every provider in parallel and returns the result once a
 	 * quorum — {@link quorumThreshold} providers — agree. Fails with
 	 * {@link QuorumError} otherwise.
@@ -182,6 +235,52 @@ export class QuorumPublicClient {
 		})
 		return `Failures (${failures.length}): ${parts.join("; ")}`
 	}
+}
+
+/** One provider's answer to "where is this transaction, and how far is your head?". */
+export interface ProviderReceiptView {
+	blockHash: string
+	blockNumber: bigint
+	head: bigint
+}
+
+/**
+ * BFT aggregation for {@link QuorumPublicClient.getTransactionConfirmations}.
+ *
+ * Groups provider views by the receipt's `(blockHash, blockNumber)` identity and
+ * requires the largest group to reach `threshold`. The confirmation count is then
+ * derived from the threshold-th highest head *within the agreeing group*: at
+ * least `threshold` providers that agree on the inclusion block have indexed up
+ * to that head, so the count never advances on the say-so of fewer providers
+ * than the quorum bound.
+ *
+ * Returns `null` when no receipt identity reaches the threshold (the caller
+ * turns this into a {@link QuorumError}). Exported for unit testing.
+ */
+export function aggregateConfirmations(views: readonly ProviderReceiptView[], threshold: number): bigint | null {
+	const groups = new Map<string, ProviderReceiptView[]>()
+	for (const view of views) {
+		const key = `${view.blockHash}:${view.blockNumber}`
+		const group = groups.get(key)
+		if (group) {
+			group.push(view)
+		} else {
+			groups.set(key, [view])
+		}
+	}
+
+	let winner: ProviderReceiptView[] | undefined
+	for (const group of groups.values()) {
+		if (!winner || group.length > winner.length) winner = group
+	}
+	if (!winner || winner.length < threshold) return null
+
+	const headsDescending = winner.map((v) => v.head).sort((a, b) => (a > b ? -1 : a < b ? 1 : 0))
+	const quorumHead = headsDescending[threshold - 1]
+	const receiptBlock = winner[0].blockNumber
+
+	const confirmations = quorumHead - receiptBlock + 1n
+	return confirmations > 0n ? confirmations : 0n
 }
 
 /**

--- a/sdk/packages/simplex/src/strategies/fx.ts
+++ b/sdk/packages/simplex/src/strategies/fx.ts
@@ -5,7 +5,6 @@ import {
 	HexString,
 	bytes32ToBytes20,
 	type ERC7821Call,
-	FillOptions,
 	TokenInfo,
 	IntentsCoprocessor,
 	ADDRESS_ZERO,
@@ -15,6 +14,12 @@ import { FillerConfigService } from "@/services/FillerConfigService"
 import { formatUnits } from "viem"
 import { getLogger } from "@/services/Logger"
 import { ConfirmationPolicy, FillerPricePolicy } from "@/config/interpolated-curve"
+import {
+	AssetRegistry,
+	normalizeSymbol,
+	USD_STABLE_SYMBOLS,
+	type BuiltinAssetResolver,
+} from "@/config/asset-registry"
 import { type CachedPairClassification } from "@/services/CacheService"
 import { Decimal } from "decimal.js"
 import { ERC20_ABI } from "@/config/abis/ERC20"
@@ -22,46 +27,107 @@ import type { FundingVenue } from "@/funding/types"
 import type { SigningAccount } from "@/services/wallet"
 
 /**
- * Strategy for swaps between USD-pegged stablecoins (USDC/USDT) and a single
- * configurable exotic token priced via a `FillerPricePolicy`.
- * Supports both same-chain and cross-chain orders.
+ * A trading pair the FX engine serves. `token0` and `token1` are registry
+ * symbols (see `AssetRegistry`); the price policies quote **token1 per 1
+ * token0**, keyed by the order's token0 notional.
  *
- * The filler holds both the stablecoin(s) and the exotic token. When a user
- * places an order swapping between the two (on the same chain or across
- * different chains), this strategy:
- * 1. Evaluates profitability using the filler's price policy for the exotic token
- * 2. Calls fillOrder to deliver output tokens to the user on the destination chain
- * 3. Receives the user's escrowed input tokens from the source chain contract
+ * The bid policy prices the filler *buying* token1 (user sends token1, receives
+ * token0); the ask policy prices the filler *selling* token1. A missing policy
+ * disables that direction for this pair (one-sided LP). A pair with neither
+ * policy is priced from a Uniswap V4 venue (USD-stable `token0` only).
  *
- * For cross-chain orders, input tokens are resolved against the source chain's
- * stable/exotic addresses, and output tokens against the destination chain's.
- * The filler's output balance is checked on the destination chain.
+ * `maxOrderSize` caps the pair's exposure per order, denominated in token0 —
+ * every quantity that sizes this pair (curve amounts, the cap, confirmation
+ * sizing) shares that unit, so no external price feed is ever consulted.
+ */
+export interface TradingPair {
+	token0: string
+	token1: string
+	/** Maximum token0 notional this pair fills per order. */
+	maxOrderSize: Decimal
+	bidPricePolicy?: FillerPricePolicy
+	askPricePolicy?: FillerPricePolicy
+}
+
+/**
+ * Builds the pair set + registry for the legacy single-exotic configuration:
+ * the `token1` address map traded against USDC and USDT at par, both pairs
+ * sharing one bid/ask policy pair (curves in exotic-per-USD are identical to
+ * token1-per-token0 when token0 is a USD stablecoin) and one `maxOrderUsd`
+ * (identical to a token0-denominated cap for the same reason). Used by the
+ * CLI's deprecated config path and by tests.
+ */
+export function legacyExoticPairs(
+	resolver: BuiltinAssetResolver,
+	token1: Record<string, HexString>,
+	maxOrderUsd: number,
+	bidPricePolicy?: FillerPricePolicy,
+	askPricePolicy?: FillerPricePolicy,
+): { pairs: TradingPair[]; registry: AssetRegistry } {
+	const registry = new AssetRegistry(resolver, { EXOTIC: token1 })
+	const pairs: TradingPair[] = ["USDC", "USDT"].map((token0) => ({
+		token0,
+		token1: "EXOTIC",
+		maxOrderSize: new Decimal(maxOrderUsd),
+		bidPricePolicy,
+		askPricePolicy,
+	}))
+	return { pairs, registry }
+}
+
+/** A leg matched to a configured pair, with everything needed to price it. */
+interface ResolvedLeg {
+	pair: TradingPair
+	/** True when the leg's input is the pair's token0 (filler sells token1). */
+	inputIsToken0: boolean
+	/** token1 address on the chain where the exotic side of this leg settles. */
+	token1Address: string
+	/** Chain (state machine id) where the token1 side of this leg lives. */
+	token1Chain: string
+}
+
+/** Rate context resolved for a leg: pricing rate plus the opposite side for margin marking. */
+interface LegRates {
+	/** token1 per token0 used to price this leg's output. */
+	rate: Decimal
+	/** The opposite side's rate (bid for ask-legs, ask for bid-legs), when available. */
+	oppositeRate: Decimal | null
+	priceSource: "venue" | "policy"
+}
+
+/**
+ * Strategy for swaps across a configurable set of trading pairs, each priced
+ * and sized by its own bid/ask curves (or a Uniswap V4 venue). Supports both
+ * same-chain and cross-chain orders.
  *
- * The filler manages their own internal rebalancing/swaps outside of order execution.
+ * Pairs are declared as `token0`/`token1` registry symbols — e.g. USDC/CNGN,
+ * USDT/CNGN, ZARP/CNGN — and any number of pairs can run in one engine. Curves
+ * are quoted in **token1 per token0**; nothing assumes the quote side is a USD
+ * stablecoin and no external price feed is consulted. All sizing is pair-local
+ * in token0 units: the per-order `maxOrderSize` cap, the curve amount axis,
+ * and the order value reported for confirmation sizing.
  *
- * This implementation also enforces a per-order USD cap for risk management:
- * - A maximum order USD value is configured on the constructor.
- * - The price policy is always evaluated on the capped USD amount.
- * - The capped USD budget is then allocated across legs in order to determine
- *   how much the filler is willing to output.
- * - Actual outputs are further limited by the filler's real token balances.
+ * For each (input, output) leg the engine finds the configured pair matching
+ * the leg's direction:
+ *  - input = token0, output = token1 → the filler *sells* token1 at the ask.
+ *  - input = token1, output = token0 → the filler *buys* token1 at the bid.
  *
- * Because the IntentGateway releases inputs proportionally to the fraction of
- * outputs provided, this allows safe partial fills (and even overfills relative
- * to the user's requested outputs) without additional on-chain logic here.
+ * The filler holds inventory on both sides of its pairs. Profitability
+ * evaluation caps each pair's legs at the pair's `maxOrderSize`, prices each
+ * leg with its pair's curve (or venue), and bounds outputs by the filler's
+ * real balances plus funding-venue withdrawals. Because the IntentGateway
+ * releases inputs proportionally to the fraction of outputs provided, partial
+ * fills (and overfills) need no extra on-chain logic.
  */
 export class FXFiller implements FillerStrategy {
 	name = "FXFiller"
 	private clientManager: ChainClientManager
 	private contractService: ContractInteractionService
 	private configService: FillerConfigService
-	/** Bid price policy: exotic tokens per USD when the filler is *buying* exotic from a user */
-	private bidPricePolicy: FillerPricePolicy
-	/** Ask price policy: exotic tokens per USD when the filler is *selling* exotic to a user */
-	private askPricePolicy: FillerPricePolicy
-	/** Maps chain identifier → exotic token address (e.g. cNGN on each supported chain) */
-	private token1: Record<string, HexString>
-	private maxOrderUsd: Decimal
+	/** Trading pairs served by this engine; each with its own bid/ask policies and cap. */
+	private pairs: TradingPair[]
+	/** Symbol → per-chain address resolution (built-ins + curated + user `[assets]`). */
+	private registry: AssetRegistry
 	private signer: SigningAccount
 	private logger = getLogger("fx-simplex")
 	/** Consecutive orders where overfill clamp activated. */
@@ -78,51 +144,39 @@ export class FXFiller implements FillerStrategy {
 	/**
 	 * Optional Uniswap price guard, keyed by chain. When a chain has an entry, a
 	 * venue (pool) quote is only trusted if it stays within `maxDeviationBps` of the
-	 * static `reference` price (exotic per USD); a quote outside the band rejects the
+	 * static `reference` price (token1 per USD); a quote outside the band rejects the
 	 * order — defence against a manipulated, stale, or thin pool. Sourced from the
 	 * per-position config under `[strategies.vault.uniswapV4]`.
 	 */
 	private priceGuard?: Map<string, { reference: Decimal; maxDeviationBps: number }>
 	/**
-	 * Whether the filler buys exotic from users (exotic-in/stable-out legs), priced
-	 * with the bid curve. Disabled by omitting the bid curve — the basis for one-sided
-	 * LP: drop a side and the filler skips orders in that direction.
+	 * One-sided switch for venue-priced pairs (no static curves): "bid" only buys
+	 * token1, "ask" only sells it. Curve-priced pairs express one-sidedness by
+	 * omitting a curve instead.
 	 */
-	private bidEnabled: boolean
-	/** Whether the filler sells exotic to users (stable-in/exotic-out legs), priced with the ask curve. */
-	private askEnabled: boolean
+	private side?: "bid" | "ask"
 
 	/**
-	 * @param signer                 Filler's signing account for UserOp signatures.
-	 * @param configService          Network/config provider for addresses and decimals.
-	 * @param clientManager          Used to get viem PublicClients for chains.
-	 * @param contractService        Shared contract interaction service.
-	 * @param maxOrderUsd             Maximum USD value this filler is willing to fill per order.
-	 * @param token1   Map of chain identifier → exotic token address.
-	 * @param options.bidPricePolicy Optional price curve for buying exotic. Required if no fundingVenues.
-	 * @param options.askPricePolicy Optional price curve for selling exotic. Required if no fundingVenues.
+	 * @param signer          Filler's signing account for UserOp signatures.
+	 * @param configService   Network/config provider for addresses and decimals.
+	 * @param clientManager   Used to get viem PublicClients for chains.
+	 * @param contractService Shared contract interaction service.
+	 * @param pairs           Trading pairs with their bid/ask price policies and per-order caps.
+	 * @param registry        Asset symbol registry resolving pair symbols per chain.
 	 * @param options.confirmationPolicy Optional per-chain confirmation policy for cross-chain orders.
 	 * @param options.fundingVenues  Optional funding venues for on-chain liquidity sourcing and live pricing.
 	 * @param options.spreadBps      Spread in basis points applied when redeeming from the pool (default 50).
-	 *
-	 * One-sided LP, two ways depending on the pricing mode:
-	 * - Static curves: omit one of `bidPricePolicy`/`askPricePolicy` to fill only the other
-	 *   side. Providing both keeps both directions open.
-	 * - Venue (pool) pricing with no curves: set `side` to restrict to one direction.
-	 *   Omitting `side` keeps both directions open.
-	 * @param options.side Pool-pricing one-sided switch ("bid" buys exotic, "ask" sells exotic).
-	 *   Only valid with venue pricing and no static curves.
+	 * @param options.side    Venue-pricing one-sided switch ("bid" buys token1, "ask" sells token1).
+	 *   Only valid when no pair has static curves; curve-priced pairs go one-sided by omitting a curve.
 	 */
 	constructor(
 		signer: SigningAccount,
 		configService: FillerConfigService,
 		clientManager: ChainClientManager,
 		contractService: ContractInteractionService,
-		maxOrderUsd: number,
-		token1: Record<string, HexString>,
+		pairs: TradingPair[],
+		registry: AssetRegistry,
 		options?: {
-			bidPricePolicy?: FillerPricePolicy
-			askPricePolicy?: FillerPricePolicy
 			confirmationPolicy?: ConfirmationPolicy
 			fundingVenues?: FundingVenue[]
 			spreadBps?: number
@@ -130,38 +184,48 @@ export class FXFiller implements FillerStrategy {
 			side?: "bid" | "ask"
 		},
 	) {
-		const {
-			bidPricePolicy,
-			askPricePolicy,
-			confirmationPolicy,
-			fundingVenues = [],
-			spreadBps = 50,
-			priceGuard,
-			side,
-		} = options ?? {}
+		const { confirmationPolicy, fundingVenues = [], spreadBps = 50, priceGuard, side } = options ?? {}
 
-		const hasAnyPolicy = !!(bidPricePolicy || askPricePolicy)
+		if (pairs.length === 0) {
+			throw new Error("FXFiller requires at least one trading pair")
+		}
+		const hasAnyPolicy = pairs.some((p) => p.bidPricePolicy || p.askPricePolicy)
 		const hasVenues = fundingVenues.length > 0
 
 		if (!hasAnyPolicy && !hasVenues) {
-			throw new Error("FXFiller requires a bid and/or ask price policy, or funding venues")
+			throw new Error("FXFiller requires price curves on its pairs, or funding venues for pool pricing")
 		}
 		if (side && hasAnyPolicy) {
-			throw new Error("FXFiller 'side' only applies to venue (pool) pricing; omit bid/ask price policies")
+			throw new Error("FXFiller 'side' only applies to venue (pool) pricing; omit pair price curves")
 		}
-
-		// Direction enablement. With static curves, only the side(s) with a curve are filled
-		// (one-sided LP). With venue pricing (no curves), `side` optionally restricts to one
-		// direction; without it both sides are open.
-		this.bidEnabled = hasAnyPolicy ? !!bidPricePolicy : side ? side === "bid" : true
-		this.askEnabled = hasAnyPolicy ? !!askPricePolicy : side ? side === "ask" : true
+		for (const pair of pairs) {
+			if (!pair.maxOrderSize.isFinite() || pair.maxOrderSize.lte(0)) {
+				throw new Error(
+					`FXFiller pair ${pair.token0}/${pair.token1}: maxOrderSize must be a positive token0 amount`,
+				)
+			}
+			if (!pair.bidPricePolicy && !pair.askPricePolicy) {
+				if (!hasVenues) {
+					throw new Error(
+						`FXFiller pair ${pair.token0}/${pair.token1}: needs a bid and/or ask policy, or funding venues`,
+					)
+				}
+				if (!USD_STABLE_SYMBOLS.has(normalizeSymbol(pair.token0))) {
+					throw new Error(
+						`FXFiller pair ${pair.token0}/${pair.token1}: venue (pool) pricing requires a USD-stable token0 — add price curves instead`,
+					)
+				}
+			}
+		}
 
 		this.configService = configService
 		this.clientManager = clientManager
 		this.contractService = contractService
-		this.token1 = token1
+		this.pairs = pairs
+		this.registry = registry
 		this.fundingVenues = fundingVenues
 		this.spreadBps = spreadBps
+		this.side = side
 		if (priceGuard && Object.keys(priceGuard).length > 0) {
 			this.priceGuard = new Map()
 			for (const [chain, guard] of Object.entries(priceGuard)) {
@@ -172,15 +236,6 @@ export class FXFiller implements FillerStrategy {
 			}
 		}
 
-		// Absent policies get a placeholder flat curve. A side without a curve is either
-		// disabled (so never priced) or venue-priced at runtime, so the placeholder is unused.
-		this.bidPricePolicy = bidPricePolicy ?? new FillerPricePolicy({ points: [{ amount: "0", price: "1" }] })
-		this.askPricePolicy = askPricePolicy ?? new FillerPricePolicy({ points: [{ amount: "0", price: "1" }] })
-
-		this.maxOrderUsd = new Decimal(maxOrderUsd)
-		if (this.maxOrderUsd.lte(0)) {
-			throw new Error("FXFiller maxOrderUsd must be greater than 0")
-		}
 		this.signer = signer
 		this.maxOverfillBps = configService.getMaxOverfillBps()
 		this.maxConsecutiveClamps = configService.getMaxConsecutiveClamps()
@@ -198,7 +253,7 @@ export class FXFiller implements FillerStrategy {
 
 	/**
 	 * Call once at startup after construction.
-	 * Hydrates all funding venue state and derives initial bid/ask prices from venue data.
+	 * Hydrates all funding venue state so venue-priced pairs quote from live pool data.
 	 */
 	async initialise(): Promise<void> {
 		const solver = this.signer.account.address as HexString
@@ -206,48 +261,54 @@ export class FXFiller implements FillerStrategy {
 	}
 
 	/**
-	 * Queries funding venues for the exotic token's USD price on a given chain.
-	 * Uniswap V4 is preferred; falls back to other venues. Returns the raw
-	 * pool price as both bid and ask, or null if no venue has a price.
+	 * Queries funding venues for `token1Address`'s USD price on a chain.
+	 * Uniswap V4 is preferred; falls back to other venues. Returns null when no
+	 * venue can price the token there.
 	 */
-	private async getVenuePrice(chain: string): Promise<{ bid: Decimal; ask: Decimal } | null> {
-		const exoticAddr = this.token1[chain]
-		if (!exoticAddr) return null
+	private async getVenueUsdPrice(chain: string, token1Address: string): Promise<Decimal | null> {
+		if (this.fundingVenues.length === 0) return null
 
 		// Prefer V4, fall back to others
 		const v4 = this.fundingVenues.filter((v) => v.name === "UniswapV4")
 		const venues = v4.length > 0 ? v4 : this.fundingVenues
 
 		for (const venue of venues) {
-			const usdPrice = await venue.getExoticTokenPrice(chain, exoticAddr)
-			if (usdPrice && usdPrice.isPositive()) {
-				const exoticPerUsd = new Decimal(1).div(usdPrice)
-				return {
-					bid: exoticPerUsd,
-					ask: exoticPerUsd,
-				}
-			}
+			const usdPrice = await venue.getExoticTokenPrice(chain, token1Address)
+			if (usdPrice?.isPositive()) return usdPrice
 		}
 		return null
+	}
+
+	/** Per-evaluation memo over `getVenueUsdPrice`, keyed by (chain, token1). */
+	private venuePriceMemo(): (chain: string, token1Address: string) => Promise<Decimal | null> {
+		const cache = new Map<string, Decimal | null>()
+		return async (chain: string, token1Address: string) => {
+			const key = `${chain}:${token1Address}`
+			const cached = cache.get(key)
+			if (cached !== undefined) return cached
+			const price = await this.getVenueUsdPrice(chain, token1Address)
+			cache.set(key, price)
+			return price
+		}
 	}
 
 	/**
 	 * Validates a live venue quote against the static reference price for the chain.
 	 * Returns true (pass) when no guard is configured, or no reference exists for the
-	 * chain. Returns false when the quote (exotic per USD) deviates from the reference
+	 * chain. Returns false when the quote (token1 per USD) deviates from the reference
 	 * by more than `maxDeviationBps`, in which case the order must not be filled.
 	 */
-	private checkPriceGuard(orderId: string | undefined, chain: string, venueExoticPerUsd: Decimal): boolean {
+	private checkPriceGuard(orderId: string | undefined, chain: string, venueToken1PerUsd: Decimal): boolean {
 		const guard = this.priceGuard?.get(chain)
 		if (!guard || guard.reference.lte(0)) return true
 
-		const deviationBps = venueExoticPerUsd.minus(guard.reference).abs().div(guard.reference).mul(10000)
+		const deviationBps = venueToken1PerUsd.minus(guard.reference).abs().div(guard.reference).mul(10000)
 		if (deviationBps.gt(guard.maxDeviationBps)) {
 			this.logger.warn(
 				{
 					orderId,
 					chain,
-					venuePrice: venueExoticPerUsd.toString(),
+					venuePrice: venueToken1PerUsd.toString(),
 					referencePrice: guard.reference.toString(),
 					deviationBps: deviationBps.toFixed(2),
 					maxDeviationBps: guard.maxDeviationBps,
@@ -273,13 +334,12 @@ export class FXFiller implements FillerStrategy {
 				return false
 			}
 
-			const pairs = this.classifyAllPairs(order)
-			if (!pairs) {
-				this.logger.debug({ sourceChain: order.source, destChain: order.destination }, "Unsupported token pair")
-				return false
-			}
-
-			if (!this.isOrderDirectionEnabled(pairs, order.id)) {
+			const legs = this.resolveOrderLegs(order)
+			if (!legs) {
+				this.logger.debug(
+					{ sourceChain: order.source, destChain: order.destination },
+					"No configured pair matches the order's token legs",
+				)
 				return false
 			}
 
@@ -291,21 +351,22 @@ export class FXFiller implements FillerStrategy {
 	}
 
 	/**
-	 * Evaluates whether an order is profitable to fill under the configured
-	 * per-order USD cap and the filler's current token balances.
+	 * Evaluates whether an order is profitable to fill under the per-pair
+	 * `maxOrderSize` caps and the filler's current token balances.
 	 *
 	 * High-level flow:
-	 * - Compute the total USD value of the order based on the input side,
-	 *   pricing exotic inputs at the policy's minimum price.
-	 * - Cap this at `maxOrderUsd` to get a capped USD budget.
-	 * - Ask the price policy for an exotic token price at that capped USD.
-	 * - Walk each (input, output) leg in order, allocating from the capped USD
-	 *   budget and computing how much the filler is willing to output.
-	 * - Further cap each leg by the filler's current token balance.
+	 * - Resolve each (input, output) leg to a configured pair and direction.
+	 * - Estimate each pair's total token0 notional in the order and cap it at
+	 *   the pair's `maxOrderSize`; pair curves are evaluated at that capped
+	 *   notional.
+	 * - Walk the legs, allocating from each pair's capped token0 budget and
+	 *   pricing outputs at the pair's rate.
+	 * - Further cap each leg by the filler's current token balance plus
+	 *   funding-venue withdrawals.
 	 * - Cache the resulting outputs for later use in `executeOrder`.
 	 *
 	 * Note: we may intentionally overfill relative to the user's requested
-	 * outputs if the price policy makes that attractive. This is how we stay competitive.
+	 * outputs if the pair pricing makes that attractive. This is how we stay competitive.
 	 */
 	async calculateProfitability(order: Order): Promise<number> {
 		if (this.halted) {
@@ -321,66 +382,37 @@ export class FXFiller implements FillerStrategy {
 			const walletAddress = this.signer.account.address as HexString
 			const balanceCache = new Map<string, bigint>()
 
-			const pairs = this.classifyAllPairs(order)
-			if (!pairs) {
-				this.logger.info({ orderId: order.id }, "Skipping order: could not classify token pairs")
+			const legs = this.resolveOrderLegs(order)
+			if (!legs) {
+				this.logger.info({ orderId: order.id }, "Skipping order: no configured pair matches its legs")
 				return 0
 			}
 
-			if (!this.isOrderDirectionEnabled(pairs, order.id)) {
+			const venueUsdPrice = this.venuePriceMemo()
+
+			// Per-pair token0 notionals, capped at each pair's maxOrderSize. The
+			// capped notional is both the curve evaluation point and the budget
+			// legs of that pair draw from.
+			const sized = await this.sizeOrder(order, legs, venueUsdPrice)
+			if (!sized) {
+				this.logger.info({ orderId: order.id }, "Skipping order: could not size the order's legs")
 				return 0
 			}
+			const { legNotionals, cappedByPair, totalNotional } = sized
 
-			const usdResult = await this.getOrderUsdValue(order)
-			const totalInputUsd = usdResult?.inputUsd
+			const remainingByPair = new Map(cappedByPair)
 
-			if (!totalInputUsd || totalInputUsd.lte(0)) {
-				this.logger.info({ orderId: order.id }, "Skipping order: could not compute input USD value")
-				return 0
-			}
-
-			const cappedOrderUsd = Decimal.min(totalInputUsd, this.maxOrderUsd)
-			if (cappedOrderUsd.lte(0)) {
-				this.logger.info(
-					{
-						orderId: order.id,
-						orderValueUsdFull: totalInputUsd.toString(),
-						orderValueUsdCapped: cappedOrderUsd.toString(),
-						maxOrderUsd: this.maxOrderUsd.toString(),
-					},
-					"Skipping order: capped USD value is non-positive",
-				)
-				return 0
-			}
-
-			// Compute bid and ask prices at the capped order size once, then pick per leg.
-			// - askPrice: used when filler sells exotic (stable->exotic). Lower rate = fewer exotic sent.
-			// - bidPrice: used when filler buys exotic (exotic->stable). Higher rate = fewer USD paid out.
-			const policyBidPrice = this.bidPricePolicy.getPrice(cappedOrderUsd)
-			const policyAskPrice = this.askPricePolicy.getPrice(cappedOrderUsd)
 			const fillerOutputs: TokenInfo[] = []
 			// Original leg index for each entry in `fillerOutputs`. Legs can be skipped
 			// (insufficient balance, exhausted budget), so `fillerOutputs[k]` is the k-th
 			// *surviving* leg, not the k-th leg. The valuation pass below realigns to the
-			// original input/pair via this array rather than by position.
+			// original input/leg via this array rather than by position.
 			const fillerOutputLegs: number[] = []
-			let remainingUsd = cappedOrderUsd
+			// Rate context per original leg index, captured during the leg loop so the
+			// margin pass below prices with the same numbers.
+			const legRatesByIndex = new Map<number, LegRates>()
 
 			const fundingCalls: ERC7821Call[] = []
-
-			// Fetch venue prices once per chain (avoids redundant RPC per leg)
-			const sourceVenuePrice = this.fundingVenues.length > 0 ? await this.getVenuePrice(sourceChain) : null
-			const destVenuePrice = sourceChain !== destChain && this.fundingVenues.length > 0
-				? await this.getVenuePrice(destChain) : sourceVenuePrice
-
-			// Price guard: reject the whole order if a venue quote on any involved chain
-			// has drifted beyond the configured band from its static reference price.
-			if (sourceVenuePrice && !this.checkPriceGuard(order.id, sourceChain, sourceVenuePrice.bid)) {
-				return 0
-			}
-			if (sourceChain !== destChain && destVenuePrice && !this.checkPriceGuard(order.id, destChain, destVenuePrice.bid)) {
-				return 0
-			}
 
 			let deadlineTimestamp: bigint | undefined
 			try {
@@ -396,7 +428,7 @@ export class FXFiller implements FillerStrategy {
 			for (let i = 0; i < order.inputs.length; i++) {
 				const input = order.inputs[i]
 				const output = order.output.assets[i]
-				const pair = pairs[i]
+				const leg = legs[i]
 
 				const inputDecimals = await this.contractService.getTokenDecimals(
 					bytes32ToBytes20(input.token) as HexString,
@@ -407,28 +439,30 @@ export class FXFiller implements FillerStrategy {
 					destChain,
 				)
 
-				const stableDecimals = pair.inputIsStable ? inputDecimals : outputDecimals
-				const exoticTokenDecimals = pair.inputIsStable ? outputDecimals : inputDecimals
+				const token0Decimals = leg.inputIsToken0 ? inputDecimals : outputDecimals
+				const token1Decimals = leg.inputIsToken0 ? outputDecimals : inputDecimals
 
-				const venuePrice = pair.inputIsStable ? destVenuePrice : sourceVenuePrice
-				const bidPrice = venuePrice?.bid ?? policyBidPrice
-				const askPrice = venuePrice?.ask ?? policyAskPrice
+				const cappedNotional = cappedByPair.get(leg.pair) ?? leg.pair.maxOrderSize
+				const rates = await this.resolveLegRates(order.id, leg, cappedNotional, venueUsdPrice)
+				if (!rates) return 0
+				legRatesByIndex.set(i, rates)
 
+				const remaining = remainingByPair.get(leg.pair) ?? new Decimal(0)
 				const legResult = this.computeLegPolicyOutput(
 					input.amount,
-					pair.inputIsStable,
-					stableDecimals,
-					exoticTokenDecimals,
-					remainingUsd,
-					pair.inputIsStable ? askPrice : bidPrice,
+					leg.inputIsToken0,
+					token0Decimals,
+					token1Decimals,
+					remaining,
+					rates.rate,
 				)
 
 				if (!legResult) {
 					continue
 				}
 
-				const { usdUsed, policyMaxOutput: rawPolicyMaxOutput } = legResult
-				remainingUsd = remainingUsd.minus(usdUsed)
+				const { token0Used, policyMaxOutput: rawPolicyMaxOutput } = legResult
+				remainingByPair.set(leg.pair, remaining.minus(token0Used))
 
 				// Overfill detection is warn-only: the clamp is DISABLED, so the filler
 				// fills the full computed amount even when it exceeds
@@ -439,17 +473,17 @@ export class FXFiller implements FillerStrategy {
 				const overfillCeiling = (output.amount * (10000n + this.maxOverfillBps)) / 10000n
 				const policyMaxOutput = rawPolicyMaxOutput
 				if (rawPolicyMaxOutput > overfillCeiling) {
-					const priceSource = venuePrice ? "venue" : "policy"
 					this.logger.warn(
 						{
 							orderId: order.id,
 							leg: i,
+							pair: `${leg.pair.token0}/${leg.pair.token1}`,
 							token: output.token,
 							userRequested: output.amount.toString(),
 							unclamped: rawPolicyMaxOutput.toString(),
 							ceiling: overfillCeiling.toString(),
 							maxOverfillBps: this.maxOverfillBps.toString(),
-							priceSource,
+							priceSource: rates.priceSource,
 						},
 						"Overfill ceiling exceeded — clamp disabled, filling unclamped amount",
 					)
@@ -502,6 +536,7 @@ export class FXFiller implements FillerStrategy {
 					this.logger.info(
 						{
 							orderId: order.id,
+							pair: `${leg.pair.token0}/${leg.pair.token1}`,
 							token: output.token,
 							policyOutput: policyMaxOutput.toString(),
 							userRequested: output.amount.toString(),
@@ -532,21 +567,15 @@ export class FXFiller implements FillerStrategy {
 
 				fillerOutputs.push({ token: output.token, amount: finalOutputAmount })
 				fillerOutputLegs.push(i)
-
-				if (remainingUsd.lte(0)) {
-					break
-				}
 			}
 
 			if (fillerOutputs.length === 0) {
 				this.logger.info(
 					{
 						orderId: order.id,
-						orderValueUsdFull: totalInputUsd.toString(),
-						orderValueUsdCapped: cappedOrderUsd.toString(),
-						maxOrderUsd: this.maxOrderUsd.toString(),
+						orderNotional: totalNotional.toString(),
 					},
-					"Skipping order: no outputs after applying USD cap and balance constraints",
+					"Skipping order: no outputs after applying pair caps and balance constraints",
 				)
 				return 0
 			}
@@ -561,18 +590,21 @@ export class FXFiller implements FillerStrategy {
 				}
 			}
 
-			// Realized FX margin, report-only — never rejects an order. A single fill is half a
-			// round-trip, so the open leg is marked at the opposite side of the spread:
-			// - sells exotic (stable→exotic): value the exotic given at bid (rebuy cost).
-			// - buys exotic (exotic→stable): value the exotic received at ask (resale value).
-			// Positive by construction when bid ≥ ask. `fillerOutputs[i]` is the i-th *surviving*
-			// leg; realign to its original input/pair via `fillerOutputLegs`.
-			let fxMarginUsd = new Decimal(0)
+			// Realized FX margin, report-only — never rejects an order. A single fill is
+			// half a round-trip, so the open leg is marked at the opposite side of the
+			// spread: sells token1 → value the token1 given at bid (rebuy cost); buys
+			// token1 → value the token1 received at ask (resale value). Expressed in
+			// token0 units of each leg's pair (summed across legs). Positive by
+			// construction when bid ≥ ask. Legs whose opposite side is disabled
+			// (one-sided LP) are skipped — there is no curve to mark them against.
+			let fxMarginQuote = new Decimal(0)
 			for (let i = 0; i < fillerOutputs.length; i++) {
 				const legIndex = fillerOutputLegs[i]
 				const input = order.inputs[legIndex]
 				const output = fillerOutputs[i]
-				const pair = pairs[legIndex]
+				const leg = legs[legIndex]
+				const rates = legRatesByIndex.get(legIndex)
+				if (!rates?.oppositeRate) continue
 
 				const inputDecimals = await this.contractService.getTokenDecimals(
 					bytes32ToBytes20(input.token) as HexString,
@@ -582,23 +614,19 @@ export class FXFiller implements FillerStrategy {
 					bytes32ToBytes20(output.token) as HexString,
 					destChain,
 				)
-				const stableDecimals = pair.inputIsStable ? inputDecimals : outputDecimals
-				const exoticDecimalsLeg = pair.inputIsStable ? outputDecimals : inputDecimals
+				const token0Decimals = leg.inputIsToken0 ? inputDecimals : outputDecimals
+				const token1Decimals = leg.inputIsToken0 ? outputDecimals : inputDecimals
 
-				const venuePriceProfit = pair.inputIsStable ? destVenuePrice : sourceVenuePrice
-				const bidPrice = venuePriceProfit?.bid ?? policyBidPrice
-				const askPrice = venuePriceProfit?.ask ?? policyAskPrice
-
-				if (pair.inputIsStable) {
-					// Sells exotic: receives stable, gives exotic valued at bid (rebuy cost).
-					const inputUsd = new Decimal(formatUnits(input.amount, stableDecimals))
-					const outputExotic = new Decimal(formatUnits(output.amount, exoticDecimalsLeg))
-					fxMarginUsd = fxMarginUsd.plus(inputUsd.minus(outputExotic.div(bidPrice)))
+				if (leg.inputIsToken0) {
+					// Sells token1: receives token0, gives token1 valued at bid (rebuy cost).
+					const inputToken0 = new Decimal(formatUnits(input.amount, token0Decimals))
+					const outputToken1 = new Decimal(formatUnits(output.amount, token1Decimals))
+					fxMarginQuote = fxMarginQuote.plus(inputToken0.minus(outputToken1.div(rates.oppositeRate)))
 				} else {
-					// Buys exotic: gives stable, receives exotic valued at ask (resale value).
-					const inputExotic = new Decimal(formatUnits(input.amount, exoticDecimalsLeg))
-					const outputUsd = new Decimal(formatUnits(output.amount, stableDecimals))
-					fxMarginUsd = fxMarginUsd.plus(inputExotic.div(askPrice).minus(outputUsd))
+					// Buys token1: gives token0, receives token1 valued at ask (resale value).
+					const inputToken1 = new Decimal(formatUnits(input.amount, token1Decimals))
+					const outputToken0 = new Decimal(formatUnits(output.amount, token0Decimals))
+					fxMarginQuote = fxMarginQuote.plus(inputToken1.div(rates.oppositeRate).minus(outputToken0))
 				}
 			}
 
@@ -620,8 +648,9 @@ export class FXFiller implements FillerStrategy {
 				return 0
 			}
 			const feeProfit = order.fees - totalCostInSourceFeeToken
-			// FX bids are gated on fee profit only. fxMarginUsd is a theoretical mark-to-model
-			// value (open leg priced at the opposite curve) and is reported separately, never summed in.
+			// FX bids are gated on fee profit only. fxMarginQuote is a theoretical
+			// mark-to-model value (open leg priced at the opposite curve) and is
+			// reported separately, never summed in.
 			const totalProfit = parseFloat(formatUnits(feeProfit, feeTokenDecimals))
 
 			this.logger.info(
@@ -630,15 +659,16 @@ export class FXFiller implements FillerStrategy {
 					sourceChain,
 					destChain,
 					crossChain: sourceChain !== destChain,
-					orderValueUsdFull: totalInputUsd.toString(),
-					orderValueUsdCapped: cappedOrderUsd.toString(),
-					maxOrderUsd: this.maxOrderUsd.toString(),
-					bidPrice: policyBidPrice.toString(),
-					askPrice: policyAskPrice.toString(),
+					pairs: legs.map((leg) => `${leg.pair.token0}/${leg.pair.token1}`),
+					orderNotional: totalNotional.toString(),
+					legNotionals: legNotionals.map((n) => n.toString()),
+					pairCaps: [...cappedByPair].map(
+						([pair, cap]) => `${pair.token0}/${pair.token1}=${cap.toString()}`,
+					),
 					orderFees: formatUnits(order.fees, feeTokenDecimals),
 					estimatedFees: formatUnits(totalCostInSourceFeeToken, feeTokenDecimals),
 					feeProfit: formatUnits(feeProfit, feeTokenDecimals),
-					fxMarginUsd: fxMarginUsd.toString(),
+					fxMarginQuote: fxMarginQuote.toString(),
 					totalProfit,
 					profitable: totalProfit > 0,
 				},
@@ -737,19 +767,6 @@ export class FXFiller implements FillerStrategy {
 	// =========================================================================
 
 	/**
-	 * Given a single (input, output) leg and the remaining capped USD budget,
-	 * computes how much USD to allocate to this leg and the corresponding
-	 * maximum output amount according to the price policy.
-	 *
-	 * Uses `exoticPerUsd` (exotic tokens per 1 USD) consistently for both directions:
-	 * - Stable input → exotic output: USD × exoticPerUsd → exotic amount.
-	 * - Exotic input → stable output: exoticAmount / exoticPerUsd → USD.
-	 *
-	 * Returns `null` when this leg cannot consume any of the remaining USD
-	 * budget (e.g. the cap has already been exhausted).
-	 */
-
-	/**
 	 * Update consecutive-clamp counter after a successful order evaluation.
 	 * Only venue-priced legs feed this counter (see clamp site) — a streak of those
 	 * is the signal that a live market source has gone off (stale pool, manipulated
@@ -771,38 +788,160 @@ export class FXFiller implements FillerStrategy {
 		}
 	}
 
-	private computeLegPolicyOutput(
-		inputAmount: bigint,
-		inputIsStable: boolean,
-		stableDecimals: number,
-		exoticTokenDecimals: number,
-		remainingUsd: Decimal,
-		exoticPerUsd: Decimal,
-	): { usdUsed: Decimal; policyMaxOutput: bigint } | null {
-		let legMaxUsd: Decimal
-		if (inputIsStable) {
-			legMaxUsd = new Decimal(formatUnits(inputAmount, stableDecimals))
-		} else {
-			const normalizedExoticInput = new Decimal(formatUnits(inputAmount, exoticTokenDecimals))
-			legMaxUsd = normalizedExoticInput.div(exoticPerUsd)
+	/**
+	 * Estimates each leg's token0 notional and derives per-pair budgets.
+	 *
+	 * The estimate uses the leg's own price source at minimum size (curve at 0,
+	 * or the venue quote) to convert token1-input legs into token0 terms. Each
+	 * pair's total is capped at its `maxOrderSize` — that capped notional is
+	 * the point pair curves are evaluated at and the budget its legs draw from.
+	 *
+	 * Returns null when a leg cannot be estimated (no usable rate).
+	 */
+	private async sizeOrder(
+		order: Order,
+		legs: ResolvedLeg[],
+		venueUsdPrice: (chain: string, token1Address: string) => Promise<Decimal | null>,
+	): Promise<{ legNotionals: Decimal[]; cappedByPair: Map<TradingPair, Decimal>; totalNotional: Decimal } | null> {
+		const sourceChain = order.source
+		const legNotionals: Decimal[] = []
+		const totals = new Map<TradingPair, Decimal>()
+
+		for (let i = 0; i < order.inputs.length; i++) {
+			const leg = legs[i]
+			const decimals = await this.contractService.getTokenDecimals(
+				bytes32ToBytes20(order.inputs[i].token) as HexString,
+				sourceChain,
+			)
+			const amount = new Decimal(formatUnits(order.inputs[i].amount, decimals))
+
+			let notional: Decimal
+			if (leg.inputIsToken0) {
+				notional = amount
+			} else {
+				const rate = await this.referenceRate(leg, venueUsdPrice)
+				if (!rate) return null
+				notional = amount.div(rate)
+			}
+			legNotionals.push(notional)
+			totals.set(leg.pair, (totals.get(leg.pair) ?? new Decimal(0)).plus(notional))
 		}
 
-		const usdForLeg = Decimal.min(legMaxUsd, remainingUsd)
-		if (usdForLeg.lte(0)) {
+		const cappedByPair = new Map<TradingPair, Decimal>()
+		let totalNotional = new Decimal(0)
+		for (const [pair, total] of totals) {
+			cappedByPair.set(pair, Decimal.min(total, pair.maxOrderSize))
+			totalNotional = totalNotional.plus(total)
+		}
+
+		return { legNotionals, cappedByPair, totalNotional }
+	}
+
+	/**
+	 * Minimum-size reference rate (token1 per token0) for a leg's pair: the
+	 * bid curve at 0 (the side token1-input legs trade at), falling back to the
+	 * ask curve, then the live venue quote for venue-priced pairs.
+	 */
+	private async referenceRate(
+		leg: ResolvedLeg,
+		venueUsdPrice: (chain: string, token1Address: string) => Promise<Decimal | null>,
+	): Promise<Decimal | null> {
+		const policy = leg.pair.bidPricePolicy ?? leg.pair.askPricePolicy
+		if (policy) {
+			const rate = policy.getPrice(new Decimal(0))
+			return rate.gt(0) ? rate : null
+		}
+		// Venue-priced pair: token0 is USD-stable (constructor invariant), so the
+		// venue's USD-per-token1 quote inverts straight into token1-per-token0.
+		const venueUsd = await venueUsdPrice(leg.token1Chain, leg.token1Address)
+		return venueUsd ? new Decimal(1).div(venueUsd) : null
+	}
+
+	/**
+	 * Given a single (input, output) leg and the remaining token0 budget of its
+	 * pair, computes how much token0 notional to allocate to this leg and the
+	 * corresponding maximum output amount at the pair's rate.
+	 *
+	 * `rate` is **token1 per 1 token0**:
+	 * - token0 input → token1 output: token0 × rate → token1 amount.
+	 * - token1 input → token0 output: token1 ÷ rate → token0 amount.
+	 *
+	 * Returns `null` when this leg cannot consume any of the pair's remaining
+	 * budget (e.g. the cap has already been exhausted).
+	 */
+	private computeLegPolicyOutput(
+		inputAmount: bigint,
+		inputIsToken0: boolean,
+		token0Decimals: number,
+		token1Decimals: number,
+		remainingToken0: Decimal,
+		rate: Decimal,
+	): { token0Used: Decimal; policyMaxOutput: bigint } | null {
+		let legMaxToken0: Decimal
+		if (inputIsToken0) {
+			legMaxToken0 = new Decimal(formatUnits(inputAmount, token0Decimals))
+		} else {
+			legMaxToken0 = new Decimal(formatUnits(inputAmount, token1Decimals)).div(rate)
+		}
+
+		const token0ForLeg = Decimal.min(legMaxToken0, remainingToken0)
+		if (token0ForLeg.lte(0)) {
 			return null
 		}
 
 		let policyMaxOutput: bigint
-		if (inputIsStable) {
-			// Output is exotic: convert USD allocation to exotic tokens at the policy price
-			const exoticFromAlloc = usdForLeg.mul(exoticPerUsd)
-			policyMaxOutput = BigInt(exoticFromAlloc.mul(new Decimal(10).pow(exoticTokenDecimals)).floor().toFixed(0))
+		if (inputIsToken0) {
+			// Output is token1: convert the token0 allocation at the pair rate.
+			policyMaxOutput = BigInt(
+				token0ForLeg.mul(rate).mul(new Decimal(10).pow(token1Decimals)).floor().toFixed(0),
+			)
 		} else {
-			// Output is stable: the filler pays out the USD value of the exotic input
-			policyMaxOutput = BigInt(usdForLeg.mul(new Decimal(10).pow(stableDecimals)).floor().toFixed(0))
+			// Output is token0: pay out the token0 equivalent of the token1 input.
+			policyMaxOutput = BigInt(token0ForLeg.mul(new Decimal(10).pow(token0Decimals)).floor().toFixed(0))
 		}
 
-		return { usdUsed: usdForLeg, policyMaxOutput }
+		return { token0Used: token0ForLeg, policyMaxOutput }
+	}
+
+	/**
+	 * Resolves the pricing rate (token1 per token0) for a leg: the venue quote
+	 * when available (validated against the price guard; USD-stable token0
+	 * pairs only), otherwise the pair's curve for the leg's direction at the
+	 * pair's capped token0 notional. Returns null when the leg cannot be priced
+	 * (guard tripped, or direction disabled).
+	 */
+	private async resolveLegRates(
+		orderId: string | undefined,
+		leg: ResolvedLeg,
+		cappedPairNotional: Decimal,
+		venueUsdPrice: (chain: string, token1Address: string) => Promise<Decimal | null>,
+	): Promise<LegRates | null> {
+		if (USD_STABLE_SYMBOLS.has(normalizeSymbol(leg.pair.token0))) {
+			const venueUsd = await venueUsdPrice(leg.token1Chain, leg.token1Address)
+			if (venueUsd) {
+				// Guard compares the venue's token1-per-USD quote against the static reference.
+				if (!this.checkPriceGuard(orderId, leg.token1Chain, new Decimal(1).div(venueUsd))) {
+					return null
+				}
+				// The pool mid is used for both directions, mirroring the previous
+				// venue behaviour.
+				const venueRate = new Decimal(1).div(venueUsd)
+				return { rate: venueRate, oppositeRate: venueRate, priceSource: "venue" }
+			}
+		}
+
+		const askRate = leg.pair.askPricePolicy?.getPrice(cappedPairNotional) ?? null
+		const bidRate = leg.pair.bidPricePolicy?.getPrice(cappedPairNotional) ?? null
+
+		const rate = leg.inputIsToken0 ? askRate : bidRate
+		if (!rate) {
+			this.logger.debug(
+				{ orderId, pair: `${leg.pair.token0}/${leg.pair.token1}`, inputIsToken0: leg.inputIsToken0 },
+				"Rejecting leg: direction disabled for one-sided LP",
+			)
+			return null
+		}
+		return { rate, oppositeRate: leg.inputIsToken0 ? bidRate : askRate, priceSource: "policy" }
 	}
 
 	/**
@@ -816,6 +955,7 @@ export class FXFiller implements FillerStrategy {
 	private async getAndCacheBalance(
 		tokenAddressLower: string,
 		walletAddress: HexString,
+		// biome-ignore lint/suspicious/noExplicitAny: viem public client type varies per chain
 		destClient: any,
 		balanceCache: Map<string, bigint>,
 	): Promise<bigint> {
@@ -842,91 +982,117 @@ export class FXFiller implements FillerStrategy {
 	}
 
 	/**
-	 * Classifies all (input, output) legs of an order in one pass.
-	 * Returns null if any leg has an unsupported pair.
+	 * Matches an (input, output) leg to a configured pair on the order's chains.
+	 *
+	 * A leg matches when input = token0 on source and output = token1 on dest
+	 * (the filler sells token1 — ask direction), or input = token1 on source and
+	 * output = token0 on dest (the filler buys token1 — bid direction). The
+	 * direction must also be enabled for the pair (one-sided LP).
 	 */
-	private classifyAllPairs(order: Order): CachedPairClassification[] | null {
-		if (order.id) {
-			const cached = this.contractService.cacheService.getPairClassifications(order.id)
-			if (cached) return cached
-		}
+	private matchLeg(
+		sourceChain: string,
+		destChain: string,
+		inputAddress: string,
+		outputAddress: string,
+	): ResolvedLeg | null {
+		for (const pair of this.pairs) {
+			const token0Source = this.registry.getAddress(pair.token0, sourceChain)?.toLowerCase()
+			const token1Dest = this.registry.getAddress(pair.token1, destChain)?.toLowerCase()
+			if (token0Source && token1Dest && inputAddress === token0Source && outputAddress === token1Dest) {
+				if (!this.directionEnabled(pair, true)) continue
+				return {
+					pair,
+					inputIsToken0: true,
+					token1Address: token1Dest,
+					token1Chain: destChain,
+				}
+			}
 
-		const sourceChain = order.source
-		const destChain = order.destination
-		const sourceExotic = this.token1[sourceChain]
-		const destExotic = this.token1[destChain]
-		if (!sourceExotic && !destExotic) {
-			throw new Error(`Exotic token address not configured for chains ${sourceChain} / ${destChain}`)
-		}
-
-		const pairs: CachedPairClassification[] = []
-		for (let i = 0; i < order.inputs.length; i++) {
-			const normalizedInput = bytes32ToBytes20(order.inputs[i].token).toLowerCase()
-			const normalizedOutput = bytes32ToBytes20(order.output.assets[i].token).toLowerCase()
-
-			const inputStable = this.getStableType(normalizedInput, sourceChain)
-			const outputStable = this.getStableType(normalizedOutput, destChain)
-
-			if (inputStable && destExotic && normalizedOutput === destExotic.toLowerCase()) {
-				pairs.push({
-					inputIsStable: true,
-					stableToken: order.inputs[i].token,
-					exoticToken: order.output.assets[i].token,
-				})
-			} else if (sourceExotic && normalizedInput === sourceExotic.toLowerCase() && outputStable) {
-				pairs.push({
-					inputIsStable: false,
-					stableToken: order.output.assets[i].token,
-					exoticToken: order.inputs[i].token,
-				})
-			} else {
-				return null
+			const token1Source = this.registry.getAddress(pair.token1, sourceChain)?.toLowerCase()
+			const token0Dest = this.registry.getAddress(pair.token0, destChain)?.toLowerCase()
+			if (token1Source && token0Dest && inputAddress === token1Source && outputAddress === token0Dest) {
+				if (!this.directionEnabled(pair, false)) continue
+				return {
+					pair,
+					inputIsToken0: false,
+					token1Address: token1Source,
+					token1Chain: sourceChain,
+				}
 			}
 		}
-
-		if (order.id) {
-			this.contractService.cacheService.setPairClassifications(order.id, pairs)
-		}
-
-		return pairs
+		return null
 	}
 
 	/**
-	 * One-sided LP gate: returns false if any leg runs in a disabled direction
-	 * (curve omitted, or excluded by the venue `side`). A stable-in leg sells exotic
-	 * and needs the ask side; an exotic-in leg buys exotic and needs the bid side.
-	 * The IntentGateway settles all legs atomically, so a mixed-direction order can't
-	 * be partially honoured.
-	 *
-	 * Kept separate from `classifyAllPairs`: that result is cached and shared across
-	 * strategies, whereas enablement is per-strategy, so this must run on every
-	 * evaluation regardless of cache state.
+	 * Whether a pair fills legs in the given direction. Curve-priced pairs are
+	 * gated by the presence of the direction's curve; venue-priced pairs (no
+	 * curves) by the global `side` switch. The IntentGateway settles all legs
+	 * atomically, so a mixed-direction order is rejected as a whole when any
+	 * leg's direction is disabled.
 	 */
-	private isOrderDirectionEnabled(pairs: CachedPairClassification[], orderId: string | undefined): boolean {
-		for (let i = 0; i < pairs.length; i++) {
-			const leg = pairs[i]
-			if ((leg.inputIsStable && !this.askEnabled) || (!leg.inputIsStable && !this.bidEnabled)) {
-				this.logger.debug(
-					{
-						orderId,
-						leg: i,
-						inputIsStable: leg.inputIsStable,
-						bidEnabled: this.bidEnabled,
-						askEnabled: this.askEnabled,
-					},
-					"Rejecting order: leg direction disabled for one-sided LP",
-				)
-				return false
-			}
+	private directionEnabled(pair: TradingPair, inputIsToken0: boolean): boolean {
+		const hasCurves = !!(pair.bidPricePolicy || pair.askPricePolicy)
+		if (hasCurves) {
+			// input token0 → filler sells token1 → needs the ask curve; and vice versa.
+			return inputIsToken0 ? !!pair.askPricePolicy : !!pair.bidPricePolicy
+		}
+		if (this.side) {
+			return inputIsToken0 ? this.side === "ask" : this.side === "bid"
 		}
 		return true
 	}
 
-	private getStableType(normalizedAddress: string, chain: string): boolean {
-		return (
-			normalizedAddress === this.configService.getUsdcAsset(chain).toLowerCase() ||
-			normalizedAddress === this.configService.getUsdtAsset(chain).toLowerCase()
-		)
+	/**
+	 * Resolves every (input, output) leg of an order to a configured pair in one
+	 * pass. Returns null if any leg matches no pair (or a disabled direction).
+	 *
+	 * The address-level classification is cached per order id in the shared
+	 * cache (as `CachedPairClassification`, one entry per leg) so repeated
+	 * evaluations skip re-derivation; pair resolution itself is re-run per
+	 * strategy since pair sets differ between engine instances.
+	 */
+	private resolveOrderLegs(order: Order): ResolvedLeg[] | null {
+		const sourceChain = order.source
+		const destChain = order.destination
+
+		const cached = order.id ? this.contractService.cacheService.getPairClassifications(order.id) : null
+		if (cached) {
+			const legs: ResolvedLeg[] = []
+			for (const entry of cached) {
+				// Re-derive the leg's input/output addresses from the cached
+				// classification, then re-match against THIS engine's pairs.
+				const token0Address = bytes32ToBytes20(entry.stableToken).toLowerCase()
+				const token1Address = bytes32ToBytes20(entry.exoticToken).toLowerCase()
+				const inputAddress = entry.inputIsStable ? token0Address : token1Address
+				const outputAddress = entry.inputIsStable ? token1Address : token0Address
+				const leg = this.matchLeg(sourceChain, destChain, inputAddress, outputAddress)
+				if (!leg) return null
+				legs.push(leg)
+			}
+			return legs
+		}
+
+		const legs: ResolvedLeg[] = []
+		const classifications: CachedPairClassification[] = []
+		for (let i = 0; i < order.inputs.length; i++) {
+			const inputAddress = bytes32ToBytes20(order.inputs[i].token).toLowerCase()
+			const outputAddress = bytes32ToBytes20(order.output.assets[i].token).toLowerCase()
+
+			const leg = this.matchLeg(sourceChain, destChain, inputAddress, outputAddress)
+			if (!leg) return null
+			legs.push(leg)
+			classifications.push({
+				inputIsStable: leg.inputIsToken0,
+				stableToken: leg.inputIsToken0 ? order.inputs[i].token : order.output.assets[i].token,
+				exoticToken: leg.inputIsToken0 ? order.output.assets[i].token : order.inputs[i].token,
+			})
+		}
+
+		if (order.id) {
+			this.contractService.cacheService.setPairClassifications(order.id, classifications)
+		}
+
+		return legs
 	}
 
 	/**
@@ -934,33 +1100,28 @@ export class FXFiller implements FillerStrategy {
 	 * checking on-chain balance or estimating gas. Phantom orders are probes that
 	 * never execute; we only need the price signal.
 	 *
-	 * Returns `null` when the pair is not supported or the USD value cannot be
-	 * computed (e.g. venue price unavailable and no fallback).
+	 * Returns `null` when no pair matches or the legs cannot be sized (e.g.
+	 * venue price unavailable and no fallback).
 	 */
 	async quotePhantomFill(order: Order): Promise<TokenInfo[] | null> {
 		if (!(await this.canFill(order))) return null
 
-		const pairs = this.classifyAllPairs(order)
-		if (!pairs) return null
-
-		const usdResult = await this.getOrderUsdValue(order)
-		if (!usdResult || usdResult.inputUsd.lte(0)) return null
-
-		const cappedOrderUsd = Decimal.min(usdResult.inputUsd, this.maxOrderUsd)
-		if (cappedOrderUsd.lte(0)) return null
+		const legs = this.resolveOrderLegs(order)
+		if (!legs) return null
 
 		const chain = order.source
-		const venuePrice = this.fundingVenues.length > 0 ? await this.getVenuePrice(chain) : null
-		const policyBidPrice = this.bidPricePolicy.getPrice(cappedOrderUsd)
-		const policyAskPrice = this.askPricePolicy.getPrice(cappedOrderUsd)
+		const venueUsdPrice = this.venuePriceMemo()
+
+		const sized = await this.sizeOrder(order, legs, venueUsdPrice)
+		if (!sized) return null
+		const remainingByPair = new Map(sized.cappedByPair)
 
 		const outputs: TokenInfo[] = []
-		let remainingUsd = cappedOrderUsd
 
 		for (let i = 0; i < order.inputs.length; i++) {
 			const input = order.inputs[i]
 			const output = order.output.assets[i]
-			const pair = pairs[i]
+			const leg = legs[i]
 
 			const inputDecimals = await this.contractService.getTokenDecimals(
 				bytes32ToBytes20(input.token) as HexString,
@@ -971,29 +1132,30 @@ export class FXFiller implements FillerStrategy {
 				chain,
 			)
 
-			const stableDecimals = pair.inputIsStable ? inputDecimals : outputDecimals
-			const exoticDecimals = pair.inputIsStable ? outputDecimals : inputDecimals
-			const bidPrice = venuePrice?.bid ?? policyBidPrice
-			const askPrice = venuePrice?.ask ?? policyAskPrice
+			const token0Decimals = leg.inputIsToken0 ? inputDecimals : outputDecimals
+			const token1Decimals = leg.inputIsToken0 ? outputDecimals : inputDecimals
 
+			const cappedNotional = sized.cappedByPair.get(leg.pair) ?? leg.pair.maxOrderSize
+			const rates = await this.resolveLegRates(order.id, leg, cappedNotional, venueUsdPrice)
+			if (!rates) return null
+
+			const remaining = remainingByPair.get(leg.pair) ?? new Decimal(0)
 			const legResult = this.computeLegPolicyOutput(
 				input.amount,
-				pair.inputIsStable,
-				stableDecimals,
-				exoticDecimals,
-				remainingUsd,
-				pair.inputIsStable ? askPrice : bidPrice,
+				leg.inputIsToken0,
+				token0Decimals,
+				token1Decimals,
+				remaining,
+				rates.rate,
 			)
 
 			if (!legResult) continue
 
-			remainingUsd = remainingUsd.minus(legResult.usdUsed)
+			remainingByPair.set(leg.pair, remaining.minus(legResult.token0Used))
 
 			// Phantom orders only probe price (they request a zero output), so there is no
 			// user-requested amount to cap against — quote the full policy output.
 			outputs.push({ token: output.token, amount: legResult.policyMaxOutput })
-
-			if (remainingUsd.lte(0)) break
 		}
 
 		if (outputs.length === 0) return null
@@ -1006,38 +1168,22 @@ export class FXFiller implements FillerStrategy {
 	}
 
 	/**
-	 * Returns the USD value of the order's full input basket.
-	 * Stablecoin inputs are priced at face value; exotic inputs are converted
-	 * via the bid price policy at the minimum price point.
-	 * Returns `null` only when pair classification fails (genuine "can't price").
+	 * Returns the order's input basket sized in **token0 notional** — each leg
+	 * converted to its pair's token0 units via the pair's own reference rate
+	 * (curve at minimum size, or the venue quote), summed across legs.
+	 *
+	 * For pairs quoted in a USD stablecoin this is a USD value; for other quote
+	 * assets it is denominated in that asset. The core filler feeds it to the
+	 * per-chain confirmation curves, whose `amount` axis therefore shares the
+	 * same unit. Returns `null` when a leg matches no pair or cannot be sized
+	 * (genuine "can't price").
 	 */
 	async getOrderUsdValue(order: Order): Promise<{ inputUsd: Decimal } | null> {
-		const pairs = this.classifyAllPairs(order)
-		if (!pairs) return null
+		const legs = this.resolveOrderLegs(order)
+		if (!legs) return null
 
-		const sourceChain = order.source
-		let totalInputUsd = new Decimal(0)
-
-		for (let j = 0; j < order.inputs.length; j++) {
-			if (pairs[j].inputIsStable) {
-				const decimals = await this.contractService.getTokenDecimals(
-					bytes32ToBytes20(order.inputs[j].token) as HexString,
-					sourceChain,
-				)
-				totalInputUsd = totalInputUsd.plus(new Decimal(formatUnits(order.inputs[j].amount, decimals)))
-			} else {
-				const exoticDecimals = await this.contractService.getTokenDecimals(
-					this.token1[sourceChain],
-					sourceChain,
-				)
-				const normalized = new Decimal(formatUnits(order.inputs[j].amount, exoticDecimals))
-				const vp = this.fundingVenues.length > 0 ? await this.getVenuePrice(sourceChain) : null
-				const bidPriceForChain = vp?.bid ?? this.bidPricePolicy.getPrice(new Decimal(0))
-				totalInputUsd = totalInputUsd.plus(normalized.div(bidPriceForChain))
-			}
-		}
-
-		if (totalInputUsd.lte(0)) return null
-		return { inputUsd: totalInputUsd }
+		const sized = await this.sizeOrder(order, legs, this.venuePriceMemo())
+		if (!sized || sized.totalNotional.lte(0)) return null
+		return { inputUsd: sized.totalNotional }
 	}
 }

--- a/sdk/packages/simplex/src/tests/pairs.test.ts
+++ b/sdk/packages/simplex/src/tests/pairs.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect } from "vitest"
+import { Decimal } from "decimal.js"
+import { parseUnits } from "viem"
+import { bytes20ToBytes32, type HexString, type Order, type TokenInfo } from "@hyperbridge/sdk"
+import { AssetRegistry, validateAssetDefinitions, type BuiltinAssetResolver } from "@/config/asset-registry"
+import { validatePairConfigs } from "@/config/pairs"
+import { FXFiller, type TradingPair } from "@/strategies/fx"
+import { FillerPricePolicy } from "@/config/interpolated-curve"
+
+// Pure unit tests for the asset registry, [[pairs]] validation, and the
+// pairs-driven FX engine's leg math (via quotePhantomFill, mocked services).
+
+const CHAIN = "EVM-56"
+const OTHER_CHAIN = "EVM-8453"
+const USDC = "0x1111111111111111111111111111111111111111" as HexString
+const USDT = "0x4444444444444444444444444444444444444444" as HexString
+const CNGN = "0x2222222222222222222222222222222222222222" as HexString
+const ZARP = "0x5555555555555555555555555555555555555555" as HexString
+const SOLVER = "0x3333333333333333333333333333333333333333" as HexString
+
+const resolver: BuiltinAssetResolver = {
+	getUsdcAsset: (chain: string) => {
+		if (chain === OTHER_CHAIN) throw new Error("not configured")
+		return USDC
+	},
+	getUsdtAsset: () => USDT,
+	getDaiAsset: () => {
+		throw new Error("not configured")
+	},
+	getCNgnAsset: () => undefined,
+}
+
+describe("AssetRegistry", () => {
+	it("resolves built-in symbols per chain, case-insensitively", () => {
+		const registry = new AssetRegistry(resolver)
+		expect(registry.getAddress("USDC", CHAIN)).toBe(USDC)
+		expect(registry.getAddress("usdc", CHAIN)).toBe(USDC)
+		expect(registry.getAddress("USDT", CHAIN)).toBe(USDT)
+		// Resolver throws / returns undefined → absent, not an error.
+		expect(registry.getAddress("USDC", OTHER_CHAIN)).toBeNull()
+		expect(registry.getAddress("DAI", CHAIN)).toBeNull()
+		expect(registry.getAddress("CNGN", CHAIN)).toBeNull()
+	})
+
+	it("user [assets] entries extend and override built-ins per chain", () => {
+		const registry = new AssetRegistry(resolver, {
+			CNGN: { [CHAIN]: CNGN },
+			USDC: { [OTHER_CHAIN]: ZARP },
+		})
+		expect(registry.getAddress("CNGN", CHAIN)).toBe(CNGN)
+		expect(registry.getAddress("cNGN", CHAIN)).toBe(CNGN)
+		expect(registry.getAddress("CNGN", OTHER_CHAIN)).toBeNull()
+		// User address fills the chain the built-in resolver can't serve…
+		expect(registry.getAddress("USDC", OTHER_CHAIN)).toBe(ZARP)
+		// …while other chains still resolve from the built-in registry.
+		expect(registry.getAddress("USDC", CHAIN)).toBe(USDC)
+	})
+
+	it("ships curated assets with zero user configuration", () => {
+		const registry = new AssetRegistry(resolver)
+		// Addresses verified on-chain before inclusion in KNOWN_ASSETS.
+		expect(registry.getAddress("ZARP", "EVM-137")).toBe("0xb755506531786C8aC63B756BaB1ac387bACB0C04")
+		expect(registry.getAddress("zarp", "EVM-1")).toBe("0xb755506531786C8aC63B756BaB1ac387bACB0C04")
+		expect(registry.getAddress("EURC", "EVM-8453")).toBe("0x60a3E35Cc302bFA44Cb288Bc5a4F316Fdb1adb42")
+		expect(registry.getAddress("XSGD", "EVM-137")).toBe("0xDC3326e71D45186F113a2F448984CA0e8D201995")
+		// Not deployed there → absent, not an error.
+		expect(registry.getAddress("EURC", "EVM-56")).toBeNull()
+	})
+
+	it("rejects malformed definitions", () => {
+		expect(() => validateAssetDefinitions({ FOO: { [CHAIN]: "0xnope" as HexString } })).toThrow(/invalid address/)
+		expect(() => validateAssetDefinitions({ FOO: {} })).toThrow(/at least one chain/)
+		// Case-insensitive duplicate.
+		expect(() =>
+			validateAssetDefinitions({
+				foo: { [CHAIN]: ZARP },
+				FOO: { [CHAIN]: ZARP },
+			}),
+		).toThrow(/twice/)
+	})
+})
+
+describe("validatePairConfigs", () => {
+	const assets = { CNGN: { [CHAIN]: CNGN } }
+	const CURVE = [{ amount: "0", price: "1500" }]
+	const SIZE = "5000"
+
+	it("accepts arbitrary well-formed pairs", () => {
+		expect(() =>
+			validatePairConfigs(
+				[
+					{ token0: "USDC", token1: "CNGN", maxOrderSize: SIZE, bidPriceCurve: CURVE, askPriceCurve: CURVE },
+					{ token0: "USDT", token1: "CNGN", maxOrderSize: SIZE, askPriceCurve: CURVE },
+					{ token0: "ZARP", token1: "CNGN", maxOrderSize: "90000", bidPriceCurve: CURVE },
+				],
+				assets,
+			),
+		).not.toThrow()
+	})
+
+	it("accepts registry-shipped symbols with no [assets] config at all", () => {
+		expect(() =>
+			validatePairConfigs([
+				{ token0: "USDC", token1: "CNGN", maxOrderSize: SIZE, askPriceCurve: CURVE },
+				{ token0: "ZARP", token1: "CNGN", maxOrderSize: SIZE, askPriceCurve: CURVE },
+				{ token0: "EURC", token1: "XSGD", maxOrderSize: SIZE, bidPriceCurve: CURVE },
+			]),
+		).not.toThrow()
+	})
+
+	it("rejects unknown symbols, self-pairs, and duplicates", () => {
+		expect(() =>
+			validatePairConfigs([{ token0: "USDC", token1: "WAT", maxOrderSize: SIZE, askPriceCurve: CURVE }], assets),
+		).toThrow(/unknown symbol/)
+		expect(() =>
+			validatePairConfigs([{ token0: "USDC", token1: "usdc", maxOrderSize: SIZE, askPriceCurve: CURVE }], assets),
+		).toThrow(/must differ/)
+		expect(() =>
+			validatePairConfigs(
+				[
+					{ token0: "USDC", token1: "CNGN", maxOrderSize: SIZE, askPriceCurve: CURVE },
+					{ token0: "usdc", token1: "cngn", maxOrderSize: SIZE, bidPriceCurve: CURVE },
+				],
+				assets,
+			),
+		).toThrow(/declared twice/)
+	})
+
+	it("requires a positive maxOrderSize", () => {
+		expect(() => validatePairConfigs([{ token0: "USDC", token1: "CNGN", askPriceCurve: CURVE } as any])).toThrow(
+			/maxOrderSize' is required/,
+		)
+		expect(() =>
+			validatePairConfigs([{ token0: "USDC", token1: "CNGN", maxOrderSize: "0", askPriceCurve: CURVE }]),
+		).toThrow(/positive/)
+		expect(() =>
+			validatePairConfigs([{ token0: "USDC", token1: "CNGN", maxOrderSize: "abc", askPriceCurve: CURVE }]),
+		).toThrow(/decimal string/)
+	})
+
+	it("requires a curve unless venue pricing is available", () => {
+		expect(() => validatePairConfigs([{ token0: "USDC", token1: "CNGN", maxOrderSize: SIZE }], assets)).toThrow(
+			/price curve/,
+		)
+		expect(() =>
+			validatePairConfigs([{ token0: "USDC", token1: "CNGN", maxOrderSize: SIZE }], assets, true),
+		).not.toThrow()
+	})
+})
+
+// ---------------------------------------------------------------------------
+// FX engine leg math with pair-local rates and caps, via quotePhantomFill
+// ---------------------------------------------------------------------------
+
+function makeContractService(): any {
+	const cache = new Map<string, unknown>()
+	const decimals: Record<string, number> = {
+		[USDC.toLowerCase()]: 6,
+		[USDT.toLowerCase()]: 6,
+		[CNGN.toLowerCase()]: 18,
+		[ZARP.toLowerCase()]: 18,
+	}
+	return {
+		cacheService: {
+			getPairClassifications: (id: string) => cache.get(`pc:${id}`),
+			setPairClassifications: (id: string, pairs: unknown) => cache.set(`pc:${id}`, pairs),
+			setFillerOutputs: (id: string, outputs: unknown) => cache.set(`fo:${id}`, outputs),
+		},
+		getTokenDecimals: async (token: string) => decimals[token.toLowerCase()] ?? 18,
+	}
+}
+
+const flat = (price: string) => new FillerPricePolicy({ points: [{ amount: "0", price }] })
+
+function makeFiller(pairs: TradingPair[]) {
+	const configService = {
+		...resolver,
+		getMaxOverfillBps: () => 500n,
+		getMaxConsecutiveClamps: () => 3,
+	} as any
+	const registry = new AssetRegistry(configService, {
+		CNGN: { [CHAIN]: CNGN },
+		ZARP: { [CHAIN]: ZARP },
+	})
+	const signer = { account: { address: SOLVER } } as any
+	return new FXFiller(signer, configService, {} as any, makeContractService(), pairs, registry)
+}
+
+function makeOrder(id: string, input: TokenInfo, output: TokenInfo): Order {
+	return {
+		id,
+		user: bytes20ToBytes32(SOLVER),
+		source: CHAIN,
+		destination: CHAIN,
+		deadline: 0n,
+		nonce: 0n,
+		fees: 0n,
+		session: "0x0000000000000000000000000000000000000000" as HexString,
+		predispatch: { assets: [], call: "0x" as HexString },
+		inputs: [input],
+		output: { beneficiary: bytes20ToBytes32(SOLVER), assets: [output], call: "0x" as HexString },
+	} as unknown as Order
+}
+
+const size = (n: string) => new Decimal(n)
+
+describe("FXFiller pairs engine", () => {
+	it("prices the ask leg at the pair's rate (token1 per token0)", async () => {
+		const filler = makeFiller([
+			{ token0: "USDC", token1: "CNGN", maxOrderSize: size("5000"), askPricePolicy: flat("1500") },
+		])
+		const order = makeOrder(
+			"ask",
+			{ token: bytes20ToBytes32(USDC), amount: parseUnits("1000", 6) },
+			{ token: bytes20ToBytes32(CNGN), amount: 0n },
+		)
+		const outputs = await filler.quotePhantomFill(order)
+		// 1000 USDC × 1500 CNGN/USDC = 1,500,000 CNGN
+		expect(outputs?.[0].amount).toBe(parseUnits("1500000", 18))
+	})
+
+	it("prices the bid leg at the pair's rate", async () => {
+		const filler = makeFiller([
+			{ token0: "USDC", token1: "CNGN", maxOrderSize: size("5000"), bidPricePolicy: flat("1500") },
+		])
+		const order = makeOrder(
+			"bid",
+			{ token: bytes20ToBytes32(CNGN), amount: parseUnits("1500", 18) },
+			{ token: bytes20ToBytes32(USDC), amount: 0n },
+		)
+		const outputs = await filler.quotePhantomFill(order)
+		// 1500 CNGN ÷ 1500 CNGN/USDC = 1 USDC
+		expect(outputs?.[0].amount).toBe(parseUnits("1", 6))
+	})
+
+	it("routes each leg through its own pair's curve", async () => {
+		const filler = makeFiller([
+			{ token0: "USDC", token1: "CNGN", maxOrderSize: size("5000"), askPricePolicy: flat("1500") },
+			{ token0: "USDT", token1: "CNGN", maxOrderSize: size("5000"), askPricePolicy: flat("1000") },
+		])
+		const usdcLeg = makeOrder(
+			"multi-1",
+			{ token: bytes20ToBytes32(USDC), amount: parseUnits("100", 6) },
+			{ token: bytes20ToBytes32(CNGN), amount: 0n },
+		)
+		const usdtLeg = makeOrder(
+			"multi-2",
+			{ token: bytes20ToBytes32(USDT), amount: parseUnits("100", 6) },
+			{ token: bytes20ToBytes32(CNGN), amount: 0n },
+		)
+		expect((await filler.quotePhantomFill(usdcLeg))?.[0].amount).toBe(parseUnits("150000", 18))
+		expect((await filler.quotePhantomFill(usdtLeg))?.[0].amount).toBe(parseUnits("100000", 18))
+	})
+
+	it("caps each pair at its own maxOrderSize, in token0 units", async () => {
+		// ZARP-quoted pair: everything is denominated in ZARP — no USD anywhere.
+		const filler = makeFiller([
+			{ token0: "ZARP", token1: "CNGN", maxOrderSize: size("100000"), askPricePolicy: flat("100") },
+		])
+
+		const small = makeOrder(
+			"zarp-small",
+			{ token: bytes20ToBytes32(ZARP), amount: parseUnits("1000", 18) },
+			{ token: bytes20ToBytes32(CNGN), amount: 0n },
+		)
+		// 1000 ZARP (under the cap) × 100 CNGN/ZARP = 100,000 CNGN
+		expect((await filler.quotePhantomFill(small))?.[0].amount).toBe(parseUnits("100000", 18))
+		// Order sizing is the token0 notional — fed to confirmation curves as-is.
+		const sized = await filler.getOrderUsdValue(small)
+		expect(sized?.inputUsd.eq(new Decimal(1000))).toBe(true)
+
+		const large = makeOrder(
+			"zarp-large",
+			{ token: bytes20ToBytes32(ZARP), amount: parseUnits("200000", 18) },
+			{ token: bytes20ToBytes32(CNGN), amount: 0n },
+		)
+		// 200,000 ZARP → capped at maxOrderSize 100,000 ZARP → 10,000,000 CNGN
+		expect((await filler.quotePhantomFill(large))?.[0].amount).toBe(parseUnits("10000000", 18))
+	})
+
+	it("sizes bid legs through the pair's own curve", async () => {
+		const filler = makeFiller([
+			{ token0: "USDC", token1: "CNGN", maxOrderSize: size("5000"), bidPricePolicy: flat("1500") },
+		])
+		const order = makeOrder(
+			"bid-sizing",
+			{ token: bytes20ToBytes32(CNGN), amount: parseUnits("3000000", 18) },
+			{ token: bytes20ToBytes32(USDC), amount: 0n },
+		)
+		// 3,000,000 CNGN ÷ 1500 = 2000 USDC notional (under the 5000 cap)
+		const sized = await filler.getOrderUsdValue(order)
+		expect(sized?.inputUsd.eq(new Decimal(2000))).toBe(true)
+		expect((await filler.quotePhantomFill(order))?.[0].amount).toBe(parseUnits("2000", 6))
+
+		// 15,000,000 CNGN ÷ 1500 = 10,000 USDC notional → capped at 5000 USDC out.
+		const large = makeOrder(
+			"bid-sizing-large",
+			{ token: bytes20ToBytes32(CNGN), amount: parseUnits("15000000", 18) },
+			{ token: bytes20ToBytes32(USDC), amount: 0n },
+		)
+		expect((await filler.quotePhantomFill(large))?.[0].amount).toBe(parseUnits("5000", 6))
+	})
+
+	it("rejects orders whose legs match no configured pair", async () => {
+		const filler = makeFiller([
+			{ token0: "USDC", token1: "CNGN", maxOrderSize: size("5000"), askPricePolicy: flat("1500") },
+		])
+		const order = makeOrder(
+			"no-pair",
+			{ token: bytes20ToBytes32(USDT), amount: parseUnits("100", 6) },
+			{ token: bytes20ToBytes32(CNGN), amount: 0n },
+		)
+		expect(await filler.canFill(order)).toBe(false)
+		expect(await filler.quotePhantomFill(order)).toBeNull()
+	})
+})

--- a/sdk/packages/simplex/src/tests/phantom-filler.e2e.simnode.test.ts
+++ b/sdk/packages/simplex/src/tests/phantom-filler.e2e.simnode.test.ts
@@ -34,7 +34,7 @@ import {
 	type FillerConfig as FillerServiceConfig,
 } from "@/services"
 import { createSimplexSigner, SignerType } from "@/services/wallet"
-import { FXFiller } from "@/strategies/fx"
+import { FXFiller, legacyExoticPairs } from "@/strategies/fx"
 import { FillerPricePolicy } from "@/config/interpolated-curve"
 import {
 	ChainConfigService,
@@ -203,14 +203,14 @@ async function buildPhantomFiller(opts: {
 			{ amount: "10000", price: opts.cngnPerUsd },
 		],
 	})
+	const legacy = legacyExoticPairs(configService, { [BASE_STATE_MACHINE]: CNGN_BASE }, 5000, pricePolicy, pricePolicy)
 	const fxStrategy = new FXFiller(
 		signer,
 		configService,
 		chainClientManager,
 		contractService,
-		5000,
-		{ [BASE_STATE_MACHINE]: CNGN_BASE },
-		{ bidPricePolicy: pricePolicy, askPricePolicy: pricePolicy },
+		legacy.pairs,
+		legacy.registry,
 	)
 
 	const filler = new IntentFiller(

--- a/sdk/packages/simplex/src/tests/public-rpcs.test.ts
+++ b/sdk/packages/simplex/src/tests/public-rpcs.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest"
+import { PUBLIC_RPC_URLS, getPublicRpcUrls } from "@/config/public-rpcs"
+import { FillerConfigService, type ResolvedChainConfig } from "@/services/FillerConfigService"
+import { QuorumPublicClient } from "@/services/QuorumPublicClient"
+
+// Unit tests for the public RPC registry and how FillerConfigService merges it
+// into the quorum provider set. No network access required.
+
+const SUPPORTED_CHAIN_IDS = [1, 56, 137, 8453, 42161]
+
+describe("PUBLIC_RPC_URLS registry", () => {
+	it("covers every supported EVM mainnet", () => {
+		for (const chainId of SUPPORTED_CHAIN_IDS) {
+			expect(PUBLIC_RPC_URLS[chainId], `chain ${chainId}`).toBeDefined()
+			expect(PUBLIC_RPC_URLS[chainId].length).toBeGreaterThanOrEqual(3)
+		}
+	})
+
+	it("lists only well-formed https URLs with distinct hostnames per chain", () => {
+		for (const [chainId, urls] of Object.entries(PUBLIC_RPC_URLS)) {
+			const hosts = new Set<string>()
+			for (const url of urls) {
+				const parsed = new URL(url)
+				expect(parsed.protocol, `${chainId}: ${url}`).toBe("https:")
+				expect(hosts.has(parsed.hostname), `${chainId}: duplicate host ${parsed.hostname}`).toBe(false)
+				hosts.add(parsed.hostname)
+			}
+		}
+	})
+
+	it("returns an empty list for chains without a registry entry", () => {
+		expect(getPublicRpcUrls(130)).toEqual([])
+		expect(getPublicRpcUrls(11155111)).toEqual([])
+	})
+})
+
+describe("FillerConfigService.getQuorumRpcUrls", () => {
+	function makeService(chainId: number, rpcUrls: string[]): FillerConfigService {
+		const chains: ResolvedChainConfig[] = [{ chainId, rpcUrls }]
+		return new FillerConfigService(chains)
+	}
+
+	it("appends the public registry after the operator's endpoints", () => {
+		const userUrls = ["https://my-premium-node.example.com"]
+		const service = makeService(8453, userUrls)
+
+		const merged = service.getQuorumRpcUrls("EVM-8453")
+
+		// Operator endpoints come first, unchanged.
+		expect(merged[0]).toBe(userUrls[0])
+		// Every public endpoint for the chain is appended.
+		for (const url of getPublicRpcUrls(8453)) {
+			expect(merged).toContain(url)
+		}
+		expect(merged).toHaveLength(userUrls.length + getPublicRpcUrls(8453).length)
+	})
+
+	it("dedupes by hostname with operator endpoints taking precedence", () => {
+		// The operator already uses one of the public endpoints.
+		const userUrls = ["https://my-premium-node.example.com", "https://mainnet.base.org"]
+		const service = makeService(8453, userUrls)
+
+		const merged = service.getQuorumRpcUrls("EVM-8453")
+
+		expect(merged.slice(0, 2)).toEqual(userUrls)
+		expect(merged.filter((url) => new URL(url).hostname === "mainnet.base.org")).toHaveLength(1)
+		expect(merged).toHaveLength(userUrls.length + getPublicRpcUrls(8453).length - 1)
+	})
+
+	it("returns operator endpoints unchanged for chains without a registry entry", () => {
+		const userUrls = ["https://unichain.example.com"]
+		const service = makeService(130, userUrls)
+		expect(service.getQuorumRpcUrls("EVM-130")).toEqual(userUrls)
+	})
+
+	it("produces a set the QuorumPublicClient accepts (distinct hostnames)", () => {
+		const service = makeService(8453, ["https://my-premium-node.example.com", "https://mainnet.base.org"])
+		const merged = service.getQuorumRpcUrls("EVM-8453")
+
+		const client = new QuorumPublicClient(8453, merged)
+		expect(client.size).toBe(merged.length)
+		// 5 providers → BFT threshold 4: one faulty public endpoint is tolerated.
+		expect(client.threshold).toBe(Math.floor((2 * merged.length) / 3) + 1)
+	})
+})

--- a/sdk/packages/simplex/src/tests/quorum-public-client.test.ts
+++ b/sdk/packages/simplex/src/tests/quorum-public-client.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from "vitest"
 import { parseAbiItem } from "viem"
-import { QuorumPublicClient, QuorumError, quorumThreshold } from "@/services/QuorumPublicClient"
+import {
+	QuorumPublicClient,
+	QuorumError,
+	quorumThreshold,
+	aggregateConfirmations,
+	type ProviderReceiptView,
+} from "@/services/QuorumPublicClient"
 
 /**
  * Integration tests for QuorumPublicClient against a two-RPC quorum on Base mainnet.
@@ -171,4 +177,49 @@ describeIfNetwork("QuorumPublicClient.getBlockNumber — N=2 public + env Base R
 		])
 		await expect(client.getBlockNumber()).rejects.toBeInstanceOf(QuorumError)
 	}, 60_000)
+})
+
+describe("aggregateConfirmations — BFT receipt agreement", () => {
+	const RECEIPT_BLOCK = 100n
+	const HASH_A = "0xaaaa"
+	const HASH_B = "0xbbbb"
+
+	function view(head: bigint, blockHash = HASH_A, blockNumber = RECEIPT_BLOCK): ProviderReceiptView {
+		return { blockHash, blockNumber, head }
+	}
+
+	it("counts confirmations from the threshold-th highest head of the agreeing group", () => {
+		// 5 providers all agree on the receipt; heads diverge. threshold=4 →
+		// the 4th-highest head (115) backs the count: 115 - 100 + 1 = 16.
+		const views = [view(120n), view(118n), view(117n), view(115n), view(110n)]
+		expect(aggregateConfirmations(views, 4)).toBe(16n)
+	})
+
+	it("ignores a minority provider reporting a different inclusion block", () => {
+		// One provider serves a reorged/fabricated receipt. The agreeing four still
+		// form a quorum; the liar's head cannot influence the count.
+		const views = [view(120n), view(118n), view(117n), view(115n), view(999n, HASH_B, 90n)]
+		expect(aggregateConfirmations(views, 4)).toBe(16n)
+	})
+
+	it("returns null when no receipt identity reaches the threshold", () => {
+		const views = [view(120n), view(118n), view(999n, HASH_B), view(998n, HASH_B)]
+		expect(aggregateConfirmations(views, 3)).toBeNull()
+	})
+
+	it("returns null when there are no successful views", () => {
+		expect(aggregateConfirmations([], 1)).toBeNull()
+	})
+
+	it("floors at zero when the quorum head trails the inclusion block", () => {
+		// Providers agree on the receipt but their heads are behind it (possible
+		// mid-reorg or load-balanced lagging replicas). Never negative.
+		const views = [view(99n), view(98n), view(99n)]
+		expect(aggregateConfirmations(views, 3)).toBe(0n)
+	})
+
+	it("single provider degrades to plain confirmation counting", () => {
+		expect(aggregateConfirmations([view(100n)], 1)).toBe(1n)
+		expect(aggregateConfirmations([view(105n)], 1)).toBe(6n)
+	})
 })

--- a/sdk/packages/simplex/src/tests/strategies/fx.mainnet.test.ts
+++ b/sdk/packages/simplex/src/tests/strategies/fx.mainnet.test.ts
@@ -10,7 +10,7 @@ import {
 	type FillerConfig as FillerServiceConfig,
 } from "@/services"
 import { createSimplexSigner, SignerType, type SigningAccount } from "@/services/wallet"
-import { FXFiller } from "@/strategies/fx"
+import { FXFiller, legacyExoticPairs } from "@/strategies/fx"
 import { ConfirmationPolicy, FillerPricePolicy } from "@/config/interpolated-curve"
 import {
 	type ChainConfig,
@@ -851,9 +851,16 @@ describe.skip("Filler V2 FX - Base mainnet same-chain USDC→cNGN with V4 fundin
 
 		const token1: Record<string, HexString> = { [baseMainnetId]: cNGN }
 
-		const fxStrategy = new FXFiller(signer, chainConfigService, chainClientManager, contractService, 5000, token1, {
-			fundingVenues,
-		})
+		const legacy = legacyExoticPairs(chainConfigService, token1, 5000)
+		const fxStrategy = new FXFiller(
+			signer,
+			chainConfigService,
+			chainClientManager,
+			contractService,
+			legacy.pairs,
+			legacy.registry,
+			{ fundingVenues },
+		)
 		await fxStrategy.initialise()
 
 		const strategies = [fxStrategy]
@@ -1177,9 +1184,16 @@ describe.skip("Filler V2 FX - Base mainnet same-chain USDC→cNGN with V4 fundin
 
 		const token1: Record<string, HexString> = { [baseMainnetId]: cNGN }
 
-		const fxStrategy = new FXFiller(signer, chainConfigService, chainClientManager, contractService, 5000, token1, {
-			fundingVenues,
-		})
+		const legacy = legacyExoticPairs(chainConfigService, token1, 5000)
+		const fxStrategy = new FXFiller(
+			signer,
+			chainConfigService,
+			chainClientManager,
+			contractService,
+			legacy.pairs,
+			legacy.registry,
+			{ fundingVenues },
+		)
 		await fxStrategy.initialise()
 
 		const strategies = [fxStrategy]
@@ -2111,16 +2125,15 @@ async function createCrossChainFxIntentFiller(
 		},
 	})
 
+	const legacy = legacyExoticPairs(chainConfigService, token1, 5000, bidPricePolicy, askPricePolicy)
 	const fxStrategy = new FXFiller(
 		fillerSigner,
 		chainConfigService,
 		chainClientManager,
 		contractService,
-		5000,
-		token1,
+		legacy.pairs,
+		legacy.registry,
 		{
-			bidPricePolicy,
-			askPricePolicy,
 			confirmationPolicy,
 		},
 	)
@@ -2172,10 +2185,15 @@ async function createFxOnlyIntentFiller(
 	const extAsset = exoticTokenOverride ?? chainConfigService.getExtAsset(mainnetId)
 	const token1: Record<string, HexString> = extAsset ? { [mainnetId]: extAsset as HexString } : {}
 
-	const fxStrategy = new FXFiller(signer, chainConfigService, chainClientManager, contractService, 5000, token1, {
-		bidPricePolicy,
-		askPricePolicy,
-	})
+	const legacy = legacyExoticPairs(chainConfigService, token1, 5000, bidPricePolicy, askPricePolicy)
+	const fxStrategy = new FXFiller(
+		signer,
+		chainConfigService,
+		chainClientManager,
+		contractService,
+		legacy.pairs,
+		legacy.registry,
+	)
 
 	const strategies = [fxStrategy]
 	const bidStorage = new BidStorageService(chainConfigService.getDataDir())

--- a/sdk/packages/simplex/src/tests/strategies/fx.one-sided-lp.test.ts
+++ b/sdk/packages/simplex/src/tests/strategies/fx.one-sided-lp.test.ts
@@ -1,12 +1,15 @@
-import { FXFiller } from "@/strategies/fx"
+import { FXFiller, legacyExoticPairs, type TradingPair } from "@/strategies/fx"
 import { FillerPricePolicy } from "@/config/interpolated-curve"
+import { AssetRegistry } from "@/config/asset-registry"
 import { bytes20ToBytes32, type HexString, type Order, type TokenInfo } from "@hyperbridge/sdk"
 import { describe, it, expect } from "vitest"
+import { Decimal } from "decimal.js"
 import { parseUnits } from "viem"
 
-// Pure unit tests for one-sided LP on FXFiller. One-sided LP is expressed by omitting
-// a bid/ask price curve: a side without a curve is disabled, so the filler skips orders
-// in that direction. Exercises `canFill` with mocked services so no chain access is needed.
+// Pure unit tests for one-sided LP on FXFiller. One-sided LP is expressed per pair by
+// omitting a bid/ask price curve: a direction without a curve is disabled, so the filler
+// skips orders in that direction. Exercises `canFill` with mocked services so no chain
+// access is needed.
 
 const CHAIN = "EVM-97"
 const STABLE = "0x1111111111111111111111111111111111111111" as HexString
@@ -14,6 +17,15 @@ const EXOTIC = "0x2222222222222222222222222222222222222222" as HexString
 const SOLVER = "0x3333333333333333333333333333333333333333" as HexString
 
 const FLAT = new FillerPricePolicy({ points: [{ amount: "0", price: "1500" }] })
+
+const configService = {
+	getUsdcAsset: () => STABLE,
+	getUsdtAsset: () => "0x0000000000000000000000000000000000000000" as HexString,
+	getDaiAsset: () => "0x0000000000000000000000000000000000000000" as HexString,
+	getCNgnAsset: () => undefined,
+	getMaxOverfillBps: () => 500n,
+	getMaxConsecutiveClamps: () => 3,
+} as any
 
 // Mirrors how simplex.ts shares one contractService (and its classification cache)
 // across every strategy. Pass the same instance to two fillers to exercise that.
@@ -34,20 +46,12 @@ function makeFiller(options: {
 	side?: "bid" | "ask"
 	contractService?: any
 }): FXFiller {
-	const configService = {
-		getUsdcAsset: () => STABLE,
-		getUsdtAsset: () => "0x0000000000000000000000000000000000000000" as HexString,
-		getMaxOverfillBps: () => 500n,
-		getMaxConsecutiveClamps: () => 3,
-	} as any
-
-	const { contractService: provided, ...fillerOptions } = options
+	const { contractService: provided, bidPricePolicy, askPricePolicy, ...fillerOptions } = options
 	const contractService = provided ?? makeContractService()
-
 	const signer = { account: { address: SOLVER } } as any
-	const clientManager = {} as any
 
-	return new FXFiller(signer, configService, clientManager, contractService, 5000, { [CHAIN]: EXOTIC }, fillerOptions)
+	const { pairs, registry } = legacyExoticPairs(configService, { [CHAIN]: EXOTIC }, 5000, bidPricePolicy, askPricePolicy)
+	return new FXFiller(signer, configService, {} as any, contractService, pairs, registry, fillerOptions)
 }
 
 function makeOrder(id: string, input: HexString, output: HexString): Order {
@@ -112,6 +116,30 @@ describe("FXFiller one-sided LP", () => {
 
 	it("rejects 'side' combined with static curves", () => {
 		expect(() => makeFiller({ fundingVenues: VENUE, side: "ask", askPricePolicy: FLAT })).toThrow()
+	})
+
+	// One-sidedness is per pair: two pairs on the same engine can face opposite directions.
+	it("gates each pair independently", async () => {
+		const OTHER = "0x4444444444444444444444444444444444444444" as HexString
+		const registry = new AssetRegistry(configService, {
+			CNGN2: { [CHAIN]: EXOTIC },
+			ZARP: { [CHAIN]: OTHER },
+		})
+		const pairs: TradingPair[] = [
+			// ask-only: sells CNGN2 for USDC
+			{ token0: "USDC", token1: "CNGN2", maxOrderSize: new Decimal(5000), askPricePolicy: FLAT },
+			// bid-only: buys ZARP for USDC
+			{ token0: "USDC", token1: "ZARP", maxOrderSize: new Decimal(5000), bidPricePolicy: FLAT },
+		]
+		const signer = { account: { address: SOLVER } } as any
+		const filler = new FXFiller(signer, configService, {} as any, makeContractService(), pairs, registry)
+
+		// USDC→CNGN2 allowed (ask side), CNGN2→USDC rejected.
+		expect(await filler.canFill(makeOrder("m", STABLE, EXOTIC))).toBe(true)
+		expect(await filler.canFill(makeOrder("n", EXOTIC, STABLE))).toBe(false)
+		// ZARP→USDC allowed (bid side), USDC→ZARP rejected.
+		expect(await filler.canFill(makeOrder("o", OTHER, STABLE))).toBe(true)
+		expect(await filler.canFill(makeOrder("p", STABLE, OTHER))).toBe(false)
 	})
 
 	// Regression: the gate must run even when another strategy already cached the

--- a/sdk/packages/simplex/src/tests/strategies/fx.price-guard.test.ts
+++ b/sdk/packages/simplex/src/tests/strategies/fx.price-guard.test.ts
@@ -1,4 +1,4 @@
-import { FXFiller } from "@/strategies/fx"
+import { FXFiller, legacyExoticPairs } from "@/strategies/fx"
 import { FillerPricePolicy } from "@/config/interpolated-curve"
 import { type HexString } from "@hyperbridge/sdk"
 import { describe, it, expect } from "vitest"
@@ -13,6 +13,10 @@ const REFERENCE = "1575" // exotic per USD
 
 function makeFiller(priceGuard?: Record<string, { referencePrice: string; maxDeviationBps: number }>): FXFiller {
 	const configService = {
+		getUsdcAsset: () => "0x1111111111111111111111111111111111111111" as HexString,
+		getUsdtAsset: () => "0x0000000000000000000000000000000000000000" as HexString,
+		getDaiAsset: () => "0x0000000000000000000000000000000000000000" as HexString,
+		getCNgnAsset: () => undefined,
 		getMaxOverfillBps: () => 500n,
 		getMaxConsecutiveClamps: () => 3,
 	} as any
@@ -20,9 +24,14 @@ function makeFiller(priceGuard?: Record<string, { referencePrice: string; maxDev
 	const signer = { account: { address: "0x3333333333333333333333333333333333333333" } } as any
 	const clientManager = {} as any
 
-	return new FXFiller(signer, configService, clientManager, contractService, 5000, { [CHAIN]: EXOTIC }, {
-		bidPricePolicy: new FillerPricePolicy({ points: [{ amount: "0", price: REFERENCE }] }),
-		askPricePolicy: new FillerPricePolicy({ points: [{ amount: "0", price: REFERENCE }] }),
+	const { pairs, registry } = legacyExoticPairs(
+		configService,
+		{ [CHAIN]: EXOTIC },
+		5000,
+		new FillerPricePolicy({ points: [{ amount: "0", price: REFERENCE }] }),
+		new FillerPricePolicy({ points: [{ amount: "0", price: REFERENCE }] }),
+	)
+	return new FXFiller(signer, configService, clientManager, contractService, pairs, registry, {
 		priceGuard,
 	})
 }

--- a/sdk/packages/simplex/src/tests/strategies/fx.testnet.test.ts
+++ b/sdk/packages/simplex/src/tests/strategies/fx.testnet.test.ts
@@ -9,7 +9,7 @@ import {
 	type FillerConfig as FillerServiceConfig,
 } from "@/services"
 import { createSimplexSigner, SignerType } from "@/services/wallet"
-import { FXFiller } from "@/strategies/fx"
+import { FXFiller, legacyExoticPairs } from "@/strategies/fx"
 import {
 	type ChainConfig,
 	type FillerConfig,
@@ -385,10 +385,9 @@ async function createFxIntentFiller(
 		[exoticChainId]: chainConfigService.getUsdcAsset(exoticChainId),
 	}
 
+	const legacy = legacyExoticPairs(chainConfigService, token1, 5000, bidPricePolicy, askPricePolicy)
 	const strategies = [
-		new FXFiller(signer, chainConfigService, chainClientManager, contractService, 5000, token1, {
-			bidPricePolicy,
-			askPricePolicy,
+		new FXFiller(signer, chainConfigService, chainClientManager, contractService, legacy.pairs, legacy.registry, {
 			confirmationPolicy,
 		}),
 	]


### PR DESCRIPTION
## Trading pairs

HyperFX is now a pair-driven engine. Markets are declared as top-level `[[pairs]]` entries referencing assets by symbol; an LP can declare any number of them and one engine serves them all:

```toml
[[pairs]]
token0 = "USDC"
token1 = "CNGN"
maxOrderSize = "5000"       # per-order cap, in token0 units
bidPriceCurve = [ { amount = "0", price = "1580" } ]  # CNGN per USDC
askPriceCurve = [ { amount = "0", price = "1550" } ]

[[pairs]]
token0 = "ZARP"             # non-USD quote side — sized entirely in ZARP
token1 = "CNGN"
maxOrderSize = "90000"
askPriceCurve = [ { amount = "0", price = "84" } ]

[[strategies]]
type = "hyperfx"            # engine-level settings only
```

- Curves are quoted in **token1 per token0** and are the only price source — there are no USD reference prices anywhere. The curve amount axis, the per-pair `maxOrderSize` cap, and the order value fed to confirmation policies all share the pair's token0 unit.
- Every pair is priced, capped, and gated independently: per-pair one-sided LP via curve omission, and e.g. a USDT depeg is handled by editing one pair's curves (live via the admin server) instead of being silently absorbed.
- The pair list doubles as an allowlist — legs matching no configured pair are rejected.
- Venue (Uniswap V4) pricing is restricted to USD-stable `token0` pairs, matching what the V4 planner supports.
- The legacy `token1` + strategy-level curves + `maxOrderUsd` config still works (translated internally into USDC/exotic + USDT/exotic pairs) with a deprecation warning.

## In-repo asset registry

Pairs reference assets purely by symbol; the symbol → per-chain address registry is maintained in the repo, not in operator config:

- Built-ins USDC, USDT, DAI, cNGN resolve per chain from the SDK chain registry (testnets included).
- A curated `KNOWN_ASSETS` table adds mainnet deployments of **ZARP** (Ethereum/Polygon/Base), **EURC** (Ethereum/Base), **XSGD** (Ethereum/Polygon) and **TRYB** (Ethereum). Every address was taken from the issuer's official docs and verified on-chain (`symbol()`/`decimals()`) before inclusion.
- `[assets]` remains only as an escape hatch — a bare `symbol → chain → address` map for assets the registry doesn't ship or per-deployment overrides.

## Hardened RPC quorum

- New registry of keyless public RPC endpoints for Ethereum, Arbitrum, Base, Polygon and BNB Chain (official gateways + PublicNode, dRPC, 1RPC — all verified live). They are appended to the operator's endpoints for **quorum-checked reads only**, deduplicated by hostname with operator URLs taking precedence, so even a single-endpoint config gets a 5-provider BFT quorum tolerating one faulty/lying provider. Fills, gas estimation and balance reads stay on operator endpoints.
- Cross-chain **confirmation counting** now runs through the quorum: providers must agree on the receipt's inclusion block (blockHash + blockNumber) at the BFT threshold, and the count derives from the threshold-th highest head among agreeing providers — a minority provider can no longer vouch for inclusion depth on cross-chain orders.
- Quorum clients are shared between the event monitor and the confirmation waiter via `ChainClientManager.getQuorumClient`.

## Verification

- Build passes including the strict DTS build; changed files are Biome-clean.
- 122 offline tests pass, including new suites for the asset registry (curated resolution, overrides, validation), pair validation, per-pair cap/curve leg math, per-pair one-sided gating, RPC registry merging, and BFT confirmation aggregation (including a minority provider serving a fabricated receipt).
- All public RPC endpoints and curated token addresses were verified live on-chain before inclusion.