### PR TITLE
feat(sdk): add available liquidity queries to IntentGateway

### DIFF
--- a/docs/content/developers/sdk/api/intent-gateway.mdx
+++ b/docs/content/developers/sdk/api/intent-gateway.mdx
@@ -227,6 +227,50 @@ The result includes `amountIn`, `amountOut`, and strategy-specific quote metadat
 
 For an exact-input Phantom quote, the SDK deducts the gateway fee and computes `floor(netInput × medianPrice / standardAmount)`. For an exact-output quote, it computes `ceil(amountOut × standardAmount / medianPrice)` and grosses that input up for the gateway fee. A missing indexer, missing snapshot, or invalid snapshot throws an explicit error; the SDK does not silently switch price sources.
 
+### queryAvailableLiquidity(params)
+
+Returns the total output-token liquidity measured in the latest directional
+Phantom snapshot. For `USDC → cNGN`, the result is the amount of cNGN held by
+eligible solvers for that snapshot at its measurement time.
+
+```typescript lineNumbers
+import { createQueryClient, IntentGateway } from "@hyperbridge/sdk"
+
+const gateway = (await IntentGateway.create(source, dest)).withQueryClient(
+  createQueryClient({ url: "https://nexus.indexer.polytope.technology" }),
+)
+
+const liquidity = await gateway.queryAvailableLiquidity({
+  tokenIn: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  tokenOut: "0x46C85152bFe9f96829aA94755D9f915F9B10EF5F",
+})
+
+if (liquidity) {
+  console.log(liquidity.totalLiquidity, "cNGN")
+  console.log("Providers:", liquidity.providerCount)
+  console.log("Liquidity by chain:", liquidity.liquidityByChain)
+  console.log("Measured at:", liquidity.snapshotTime)
+}
+```
+
+```typescript
+async queryAvailableLiquidity(params: {
+  tokenIn: HexString
+  tokenOut: HexString
+}): Promise<AvailableLiquiditySnapshot | undefined>
+```
+
+`totalLiquidity` is a decimal string formatted with the canonical Base output
+token decimals. `liquidityByChain` provides the corresponding `chain`,
+`tokenAddress`, formatted `totalLiquidity`, and `providerCount` for each
+indexed output-token balance group; each group uses its own chain/token
+decimals. The
+indexer aggregates raw ERC-20 balances plus
+redeemable ERC-4626 positions at the snapshot time. This is historical
+availability, not reserved liquidity or a guarantee that the same amount remains
+fillable. The method returns `undefined` when the directional pair has no indexed
+snapshot.
+
 ---
 
 ### executeBest(order, graffiti?, options)

--- a/sdk/packages/sdk/package.json
+++ b/sdk/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/sdk",
-	"version": "2.5.0",
+	"version": "2.5.1",
 	"description": "The hyperclient SDK provides utilities for querying proofs and statuses for cross-chain requests from HyperBridge.",
 	"type": "module",
 	"types": "./dist/node/index.d.ts",

--- a/sdk/packages/sdk/package.json
+++ b/sdk/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/sdk",
-	"version": "2.5.1",
+	"version": "2.5.0",
 	"description": "The hyperclient SDK provides utilities for querying proofs and statuses for cross-chain requests from HyperBridge.",
 	"type": "module",
 	"types": "./dist/node/index.d.ts",

--- a/sdk/packages/sdk/src/index.ts
+++ b/sdk/packages/sdk/src/index.ts
@@ -10,6 +10,7 @@ export {
 	bytes32ToBytes20,
 	bytes20ToBytes32,
 	normalizeAddressForEvmBytes32,
+	normalizeEvmAddress,
 	normalizeAddressForStateMachine,
 	hexToString,
 	normalizeEvmChainId,

--- a/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
+++ b/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
@@ -10,6 +10,7 @@ import type {
 	IndexerQueryClient,
 	OrderStatus,
 	OrderWithStatus,
+	AvailableLiquiditySnapshot,
 } from "@/types"
 import type {
 	PackedUserOperation,
@@ -35,14 +36,17 @@ import { OrderCanceller } from "./OrderCanceller"
 import { BidManager } from "./BidManager"
 import { GasEstimator } from "./GasEstimator"
 import { OrderStatusChecker } from "./OrderStatusChecker"
+import { LiquidityEngine } from "./LiquidityEngine"
 import {
 	type IntentQuoteStrategyHandler,
 	type QuoteIntentParams,
 	type QuoteIntentResult,
 	PhantomSnapshotIntentQuoteStrategy,
 	UniswapV4IntentQuoteStrategy,
+	UnsupportedIntentQuotePairError,
 	UnsupportedIntentQuoteStrategyError,
 } from "./quote"
+import { PhantomSnapshotPairResolver } from "./quote/phantomSnapshot"
 import type { ERC7821Call } from "@/types"
 import { DEFAULT_GRAFFITI, DEFAULT_POLL_INTERVAL, ADDRESS_ZERO, sleep } from "@/utils"
 import { convertGasToFeeToken } from "./utils"
@@ -100,6 +104,8 @@ export class IntentGateway {
 	private readonly gasEstimator: GasEstimator
 	/** Quote strategies for pricing orders before placement, keyed by strategy name. */
 	private readonly quoteStrategies: Record<string, IntentQuoteStrategyHandler>
+	/** Resolves order tokens to canonical Phantom snapshot market pairs. */
+	private readonly phantomSnapshotPairResolver: PhantomSnapshotPairResolver
 
 	/**
 	 * Private constructor — use {@link IntentGateway.create} instead.
@@ -148,6 +154,7 @@ export class IntentGateway {
 		this.bidManager = bidManager
 		this.gasEstimator = gasEstimator
 		this._crypto = crypto
+		this.phantomSnapshotPairResolver = new PhantomSnapshotPairResolver(dest.configService)
 		this.quoteStrategies = {
 			phantom_snapshot: new PhantomSnapshotIntentQuoteStrategy(
 				dest.configService,
@@ -238,6 +245,40 @@ export class IntentGateway {
 	}
 
 	/**
+	 * Returns the output-token liquidity measured in the latest directional
+	 * Phantom snapshot for this gateway's source and destination.
+	 *
+	 * Pair resolution uses the same canonical Base market as {@link quoteIntent}.
+	 * The snapshot itself determines the output token and chain to aggregate. The
+	 * amount is in the token's smallest unit and reflects the indexer's
+	 * `snapshotTime`; it is not a live reservation or fill guarantee.
+	 *
+	 * Requires a prior call to {@link withQueryClient}.
+	 */
+	async queryAvailableLiquidity(
+		params: Pick<QuoteIntentParams, "tokenIn" | "tokenOut">,
+	): Promise<AvailableLiquiditySnapshot | undefined> {
+		const { queryClient } = this.requireIndexer()
+		const sourceStateMachineId = this.source.config.stateMachineId
+		const destinationStateMachineId = this.dest.config.stateMachineId
+		const pair = this.phantomSnapshotPairResolver.resolve(params, sourceStateMachineId, destinationStateMachineId)
+		if (!pair) {
+			throw new UnsupportedIntentQuotePairError({
+				source: sourceStateMachineId,
+				destination: destinationStateMachineId,
+				tokenIn: params.tokenIn,
+				tokenOut: params.tokenOut,
+				quoteSource: "Phantom snapshot pair",
+			})
+		}
+
+		return new LiquidityEngine(queryClient, this.dest.configService).getAvailableLiquiditySnapshot({
+			tokenIn: pair.tokenA,
+			tokenOut: pair.tokenB,
+		})
+	}
+
+	/**
 	 * Bidirectional async generator that orchestrates the full order lifecycle:
 	 * placement, fee estimation, bid collection, and execution.
 	 *
@@ -306,8 +347,7 @@ export class IntentGateway {
 			// unchanged for Simplex, and apply the user-order fee uplift only at placement.
 			executionOrder.fees = isSameChain
 				? estimate.totalGasInFeeToken * 2n
-				: estimate.totalGasInFeeToken +
-					(crossChainFeeBump + (estimate.totalGasInFeeToken * 1n) / 100n)
+				: estimate.totalGasInFeeToken + (crossChainFeeBump + (estimate.totalGasInFeeToken * 1n) / 100n)
 		}
 
 		const placeOrderGen = this.orderPlacer.placeOrder(executionOrder, graffiti)

--- a/sdk/packages/sdk/src/protocols/intents/LiquidityEngine.ts
+++ b/sdk/packages/sdk/src/protocols/intents/LiquidityEngine.ts
@@ -1,0 +1,237 @@
+import { LATEST_PHANTOM_ORDER_LIQUIDITY_SNAPSHOT, LIQUIDITY_PROVIDER_BALANCES } from "@/queries"
+import { Chains } from "@/configs/chain"
+import type { ChainConfigService } from "@/configs/ChainConfigService"
+import type { AvailableLiquidityByChain, AvailableLiquiditySnapshot, HexString, IndexerQueryClient } from "@/types"
+import { dateStringtoTimestamp, normalizeEvmAddress } from "@/utils"
+import { formatUnits } from "viem"
+
+interface LiquidityProviderBalancesResponse {
+	liquidityProviderBalances: {
+		aggregates: {
+			sum: { balance: string | null }
+			distinctCount: { providerId: string }
+		} | null
+		groupedAggregates: Array<{
+			keys: string[]
+			sum: { balance: string | null }
+			distinctCount: { providerId: string }
+		}>
+	}
+}
+
+interface PhantomOrderLiquiditySnapshotsResponse {
+	phantomOrderPriceSnapshots: {
+		nodes: Array<{
+			commitment: string
+			tokenA: string
+			tokenB: string
+			snapshotTime: string
+		}>
+	}
+}
+
+const COMMITMENT_PATTERN = /^0x[0-9a-f]{64}$/i
+
+/**
+ * Owns Phantom liquidity snapshot retrieval and aggregation from Nexus.
+ *
+ * The indexer performs balance and distinct-provider aggregation; this class
+ * validates and maps those aggregate results into the SDK response shape.
+ */
+export class LiquidityEngine {
+	/**
+	 * @param queryClient - Nexus GraphQL client attached to the gateway.
+	 * @param chainConfigService - Resolves token decimals for formatted results.
+	 */
+	constructor(
+		private readonly queryClient: IndexerQueryClient,
+		private readonly chainConfigService: ChainConfigService,
+	) {}
+
+	/**
+	 * Retrieves the newest directional Phantom snapshot for a pair and its
+	 * indexed output-token liquidity.
+	 *
+	 * Nexus filters balances to the canonical output token, then aggregates them
+	 * overall and by chain. The returned amounts are decimal strings: the total
+	 * uses the canonical Base output-token decimals, while each chain group uses
+	 * that chain's token decimals. They describe `snapshotTime`, not live
+	 * reservations or fill guarantees.
+	 *
+	 * @param params - Canonical Phantom-market input and output token addresses.
+	 * @returns The latest snapshot, or `undefined` if Nexus has no snapshot for
+	 * the directional pair.
+	 * @throws {InvalidAvailableLiquiditySnapshotError} If Nexus returns malformed
+	 * or internally inconsistent snapshot data.
+	 */
+	async getAvailableLiquiditySnapshot(params: {
+		tokenIn: HexString
+		tokenOut: HexString
+	}): Promise<AvailableLiquiditySnapshot | undefined> {
+		const tokenIn = normalizeEvmAddress(params.tokenIn, "tokenIn")
+		const tokenOut = normalizeEvmAddress(params.tokenOut, "tokenOut")
+		const response = await this.queryClient.request<PhantomOrderLiquiditySnapshotsResponse>(
+			LATEST_PHANTOM_ORDER_LIQUIDITY_SNAPSHOT,
+			{ tokenA: tokenIn, tokenB: tokenOut },
+		)
+		const node = response?.phantomOrderPriceSnapshots?.nodes?.[0]
+		if (!node) return
+
+		const commitment = node.commitment.toLowerCase()
+		if (!COMMITMENT_PATTERN.test(commitment)) {
+			throw new InvalidAvailableLiquiditySnapshotError(commitment || "<missing>", "commitment is not bytes32 hex")
+		}
+		if (node.tokenA.toLowerCase() !== tokenIn || node.tokenB.toLowerCase() !== tokenOut) {
+			throw new InvalidAvailableLiquiditySnapshotError(commitment, "snapshot token pair does not match the query")
+		}
+
+		const snapshotTime = new Date(dateStringtoTimestamp(node.snapshotTime))
+		if (Number.isNaN(snapshotTime.getTime())) {
+			throw new InvalidAvailableLiquiditySnapshotError(commitment, "snapshotTime is invalid")
+		}
+
+		const { totalLiquidity, providerCount, liquidityByChain } = await this.querySnapshotLiquidityAggregates({
+			commitment,
+			tokenAddress: tokenOut,
+		})
+
+		return {
+			totalLiquidity: this.formatLiquidity(totalLiquidity, Chains.BASE_MAINNET, tokenOut, commitment),
+			providerCount,
+			tokenAddress: tokenOut,
+			snapshotTime,
+			liquidityByChain: liquidityByChain.map((group) => ({
+				...group,
+				totalLiquidity: this.formatLiquidity(group.totalLiquidity, group.chain, group.tokenAddress, commitment),
+			})),
+		}
+	}
+
+	/**
+	 * Requests server-side sums and distinct provider counts for one immutable
+	 * snapshot/output-token pair, including chain-level aggregate groups.
+	 *
+	 * `commitment` uniquely identifies the selected snapshot
+	 */
+	private async querySnapshotLiquidityAggregates(params: { commitment: string; tokenAddress: HexString }): Promise<{
+		totalLiquidity: bigint
+		providerCount: number
+		liquidityByChain: RawAvailableLiquidityByChain[]
+	}> {
+		const response = await this.queryClient.request<LiquidityProviderBalancesResponse>(
+			LIQUIDITY_PROVIDER_BALANCES,
+			{ commitment: params.commitment, tokenAddress: params.tokenAddress },
+		)
+		const connection = response?.liquidityProviderBalances
+		const aggregates = connection?.aggregates
+		if (!connection || !aggregates) {
+			throw new InvalidAvailableLiquiditySnapshotError(
+				params.commitment,
+				"liquidityProviderBalances aggregates are missing",
+			)
+		}
+
+		const totalLiquidity = parseSnapshotBigInt(aggregates.sum.balance ?? "0", params.commitment, "total balance")
+		const providerCount = parseProviderCount(aggregates.distinctCount.providerId, params.commitment, "total")
+		const liquidityByChain = connection.groupedAggregates.map((group, index) => {
+			const [chain, tokenAddress] = group.keys
+			if (!chain?.trim() || !tokenAddress) {
+				throw new InvalidAvailableLiquiditySnapshotError(
+					params.commitment,
+					`liquidity group ${index} has invalid keys`,
+				)
+			}
+			const normalizedTokenAddress = normalizeIndexedLiquidityAddress(
+				tokenAddress,
+				params.commitment,
+				`liquidity group ${index} tokenAddress`,
+			)
+			if (normalizedTokenAddress !== params.tokenAddress) {
+				throw new InvalidAvailableLiquiditySnapshotError(
+					params.commitment,
+					`liquidity group ${index} tokenAddress does not match the snapshot output token`,
+				)
+			}
+
+			return {
+				chain: chain.trim(),
+				tokenAddress: normalizedTokenAddress,
+				totalLiquidity: parseSnapshotBigInt(
+					group.sum.balance ?? "0",
+					params.commitment,
+					`liquidity group ${index} balance`,
+				),
+				providerCount: parseProviderCount(
+					group.distinctCount.providerId,
+					params.commitment,
+					`liquidity group ${index}`,
+				),
+			}
+		})
+		const groupedTotal = liquidityByChain.reduce((sum, group) => sum + group.totalLiquidity, 0n)
+		if (groupedTotal !== totalLiquidity) {
+			throw new InvalidAvailableLiquiditySnapshotError(
+				params.commitment,
+				"grouped liquidity does not match the total liquidity",
+			)
+		}
+
+		return { totalLiquidity, providerCount, liquidityByChain }
+	}
+
+	/** Formats a raw amount using the configured decimals for its chain/token. */
+	private formatLiquidity(amount: bigint, chain: string, tokenAddress: HexString, commitment: string): string {
+		const decimals = this.chainConfigService.getAssetMetadataByAddress(chain, tokenAddress)?.decimals
+		if (decimals === undefined) {
+			throw new InvalidAvailableLiquiditySnapshotError(
+				commitment,
+				`token decimals are not configured for ${tokenAddress} on ${chain}`,
+			)
+		}
+		return formatUnits(amount, decimals)
+	}
+}
+
+type RawAvailableLiquidityByChain = Omit<AvailableLiquidityByChain, "totalLiquidity"> & {
+	totalLiquidity: bigint
+}
+
+class InvalidAvailableLiquiditySnapshotError extends Error {
+	/** Creates an error that identifies the invalid snapshot and field/reason. */
+	constructor(commitment: string, reason: string) {
+		super(`Invalid available-liquidity snapshot ${commitment}: ${reason}`)
+		this.name = "InvalidAvailableLiquiditySnapshotError"
+	}
+}
+
+/** Parses a non-negative smallest-unit amount returned by the indexer. */
+function parseSnapshotBigInt(value: string, commitment: string, field: string): bigint {
+	try {
+		const amount = BigInt(value)
+		if (amount < 0n) {
+			throw new InvalidAvailableLiquiditySnapshotError(commitment, `${field} cannot be negative`)
+		}
+		return amount
+	} catch (error) {
+		if (error instanceof InvalidAvailableLiquiditySnapshotError) throw error
+		throw new InvalidAvailableLiquiditySnapshotError(commitment, `${field} is not an integer`)
+	}
+}
+
+/** Parses a safe, non-negative distinct-provider count returned by the indexer. */
+function parseProviderCount(value: string, commitment: string, field: string): number {
+	const count = Number(value)
+	if (!Number.isSafeInteger(count) || count < 0) {
+		throw new InvalidAvailableLiquiditySnapshotError(commitment, `${field} provider count is invalid`)
+	}
+	return count
+}
+
+/** Validates and canonicalizes an EVM address from a Nexus aggregate group. */
+function normalizeIndexedLiquidityAddress(address: string, commitment: string, field: string): HexString {
+	try {
+		return normalizeEvmAddress(address, field)
+	} catch {
+		throw new InvalidAvailableLiquiditySnapshotError(commitment, `${field} is not a valid EVM address`)
+	}
+}

--- a/sdk/packages/sdk/src/protocols/intents/quote/phantomSnapshot.ts
+++ b/sdk/packages/sdk/src/protocols/intents/quote/phantomSnapshot.ts
@@ -16,7 +16,7 @@ import { deductProtocolFee, divCeil, grossUpForProtocolFee, readProtocolFeeBps, 
 
 export const PHANTOM_INTENT_QUOTE_CHAIN = Chains.BASE_MAINNET
 
-interface ResolvedPhantomPair {
+export interface ResolvedPhantomPair {
 	tokenA: HexString
 	tokenB: HexString
 }
@@ -40,10 +40,14 @@ const BASE_SNAPSHOT_ASSET_BY_ORDER_ASSET: Partial<Record<ConfiguredAssetSymbol, 
 const SUPPORTED_BASE_SNAPSHOT_PAIRS = new Set(["USDC:cNGN", "cNGN:USDC"])
 
 export class PhantomSnapshotIntentQuoteStrategy implements IntentQuoteStrategyHandler {
+	private readonly pairResolver: PhantomSnapshotPairResolver
+
 	constructor(
 		private readonly chainConfigService: ChainConfigService,
 		private readonly getQueryClient: () => IndexerQueryClient,
-	) {}
+	) {
+		this.pairResolver = new PhantomSnapshotPairResolver(chainConfigService)
+	}
 
 	async quote(
 		params: QuoteIntentParams,
@@ -51,7 +55,7 @@ export class PhantomSnapshotIntentQuoteStrategy implements IntentQuoteStrategyHa
 		destination: IntentQuoteChainContext,
 	): Promise<QuoteIntentResult> {
 		validateQuoteParams(params)
-		const pair = this.resolveBaseSnapshotPair(params, source.stateMachineId, destination.stateMachineId)
+		const pair = this.pairResolver.resolve(params, source.stateMachineId, destination.stateMachineId)
 		if (!pair) {
 			throw new UnsupportedIntentQuotePairError({
 				source: source.stateMachineId,
@@ -139,8 +143,13 @@ export class PhantomSnapshotIntentQuoteStrategy implements IntentQuoteStrategyHa
 			throw new InvalidPhantomSnapshotError(snapshot.commitment, "snapshotTime is invalid")
 		}
 	}
+}
 
-	private resolveBaseSnapshotPair(
+/** Resolves order-chain tokens to the canonical Base Phantom snapshot market. */
+export class PhantomSnapshotPairResolver {
+	constructor(private readonly chainConfigService: ChainConfigService) {}
+
+	resolve(
 		params: Pick<QuoteIntentParams, "tokenIn" | "tokenOut">,
 		sourceStateMachineId: string,
 		destinationStateMachineId: string,

--- a/sdk/packages/sdk/src/queries.ts
+++ b/sdk/packages/sdk/src/queries.ts
@@ -265,6 +265,57 @@ query LatestPhantomOrderPriceSnapshot($tokenA: String!, $tokenB: String!) {
   }
 }`
 
+export const LATEST_PHANTOM_ORDER_LIQUIDITY_SNAPSHOT = `
+query LatestPhantomOrderLiquiditySnapshot($tokenA: String!, $tokenB: String!) {
+  phantomOrderPriceSnapshots(
+    filter: {
+      and: [
+        { tokenA: { equalTo: $tokenA } }
+        { tokenB: { equalTo: $tokenB } }
+      ]
+    }
+    orderBy: SNAPSHOT_TIME_DESC
+    first: 1
+  ) {
+    nodes {
+      commitment
+      tokenA
+      tokenB
+      snapshotTime
+    }
+  }
+}`
+
+export const LIQUIDITY_PROVIDER_BALANCES = `
+query LiquidityProviderBalanceAggregates($commitment: String!, $tokenAddress: String!) {
+  liquidityProviderBalances(
+    filter: {
+      and: [
+        { commitment: { equalTo: $commitment } }
+        { tokenAddress: { equalTo: $tokenAddress } }
+      ]
+    }
+  ) {
+    aggregates {
+      sum {
+        balance
+      }
+      distinctCount {
+        providerId
+      }
+    }
+    groupedAggregates(groupBy: [CHAIN, TOKEN_ADDRESS]) {
+      keys
+      sum {
+        balance
+      }
+      distinctCount {
+        providerId
+      }
+    }
+  }
+}`
+
 export const TOKEN_GATEWAY_ASSET_TELEPORTED_STATUS = `
 query TokenGatewayAssetTeleportedStatus($commitment: String!) {
   tokenGatewayAssetTeleportedV2s(

--- a/sdk/packages/sdk/src/tests/sequential/intentGateway.test.ts
+++ b/sdk/packages/sdk/src/tests/sequential/intentGateway.test.ts
@@ -2,7 +2,7 @@ import "log-timestamp"
 
 import { strict as assert } from "node:assert"
 import type { PublicClient } from "viem"
-import type { HexString, Order, TokenInfo } from "@/types"
+import type { AvailableLiquiditySnapshot, HexString, Order, TokenInfo } from "@/types"
 import { EvmChain } from "@/chain"
 import { IntentGateway } from "@/protocols/intents/IntentGateway"
 import { createQueryClient } from "@/queryClient"
@@ -81,6 +81,51 @@ describe("Intent quote helper", () => {
 		assert.equal(deductProtocolFee(1_000_000n, 0n), 1_000_000n)
 		assert.equal(grossUpForProtocolFee(1_000_000n, 0n), 1_000_000n)
 	})
+
+	it("queries live USDC to cNGN liquidity", async () => {
+		const configService = new ChainConfigService()
+		const cNgnAddress = configService.getCNgnAsset(BASE_CHAIN)
+
+		assert(cNgnAddress, "Expected cNGN to be configured on Base")
+
+		const intentGateway = await createLiveBaseIntentGateway(configService)
+
+		const liquidity = await intentGateway.queryAvailableLiquidity({
+			tokenIn: configService.getUsdcAsset(BASE_CHAIN),
+			tokenOut: cNgnAddress,
+		})
+
+		assertAndLogLiquidity("USDC → cNGN", liquidity, cNgnAddress)
+	}, 120_000)
+
+	it("queries live cNGN to USDC liquidity", async () => {
+		const configService = new ChainConfigService()
+		const cNgnAddress = configService.getCNgnAsset(BASE_CHAIN)
+		const usdcAddress = configService.getUsdcAsset(BASE_CHAIN)
+
+		assert(cNgnAddress, "Expected cNGN to be configured on Base")
+		const intentGateway = await createLiveBaseIntentGateway(configService)
+		const liquidity = await intentGateway.queryAvailableLiquidity({
+			tokenIn: cNgnAddress,
+			tokenOut: usdcAddress,
+		})
+
+		assertAndLogLiquidity("cNGN → USDC", liquidity, usdcAddress)
+	}, 120_000)
+
+	it("resolves Base USDT to the canonical USDC to cNGN liquidity snapshot", async () => {
+		const configService = new ChainConfigService()
+		const cNgnAddress = configService.getCNgnAsset(BASE_CHAIN)
+
+		assert(cNgnAddress, "Expected cNGN to be configured on Base")
+		const intentGateway = await createLiveBaseIntentGateway(configService)
+		const liquidity = await intentGateway.queryAvailableLiquidity({
+			tokenIn: configService.getUsdtAsset(BASE_CHAIN),
+			tokenOut: cNgnAddress,
+		})
+
+		assertAndLogLiquidity("USDT → cNGN (canonical USDC snapshot)", liquidity, cNgnAddress)
+	}, 120_000)
 
 	it("quotes USDT through the Base USDC Phantom snapshot", async () => {
 		const configService = new ChainConfigService()
@@ -247,6 +292,41 @@ function makeEvmChain(chain: ChainDef, configService: ChainConfigService, bundle
 		rpcUrl: process.env[chain.rpcEnvVar] ?? configService.getRpcUrl(chain.id),
 		bundlerUrl,
 	})
+}
+
+async function createLiveBaseIntentGateway(configService: ChainConfigService): Promise<IntentGateway> {
+	const baseChain = makeEvmChain(CHAINS.base, configService)
+	return (await IntentGateway.create(baseChain, baseChain)).withQueryClient(
+		createQueryClient({ url: "https://nexus.indexer.polytope.technology/" }),
+	)
+}
+
+function assertAndLogLiquidity(
+	pair: string,
+	liquidity: AvailableLiquiditySnapshot | undefined,
+	expectedTokenAddress: HexString,
+): asserts liquidity is AvailableLiquiditySnapshot {
+	assert(liquidity, `Expected a live ${pair} Phantom liquidity snapshot from Nexus`)
+	console.log(`Live ${pair} liquidity snapshot from Nexus`)
+	console.log({
+		totalLiquidity: liquidity.totalLiquidity,
+		providerCount: liquidity.providerCount,
+		tokenAddress: liquidity.tokenAddress,
+		snapshotTime: liquidity.snapshotTime.toISOString(),
+		liquidityByChain: liquidity.liquidityByChain,
+	})
+	assert.notEqual(liquidity.totalLiquidity, "0")
+	assert(liquidity.providerCount > 0)
+	assert.equal(liquidity.tokenAddress.toLowerCase(), expectedTokenAddress.toLowerCase())
+	assert(!Number.isNaN(liquidity.snapshotTime.getTime()))
+	assert(liquidity.liquidityByChain.length > 0)
+	assert(
+		liquidity.liquidityByChain.some(
+			(group) =>
+				group.chain === CHAINS.base.id &&
+				group.tokenAddress.toLowerCase() === expectedTokenAddress.toLowerCase(),
+		),
+	)
 }
 
 function buildOrder(

--- a/sdk/packages/sdk/src/types/index.ts
+++ b/sdk/packages/sdk/src/types/index.ts
@@ -1118,6 +1118,28 @@ export interface PhantomOrderPriceSnapshotsResponse {
 	}
 }
 
+/**
+ * Total solver liquidity measured at one immutable Phantom price snapshot.
+ *
+ * Liquidity amounts are decimal strings formatted with the configured decimals
+ * for their respective `tokenAddress` and chain.
+ */
+export interface AvailableLiquiditySnapshot {
+	totalLiquidity: string
+	providerCount: number
+	tokenAddress: HexString
+	snapshotTime: Date
+	liquidityByChain: AvailableLiquidityByChain[]
+}
+
+/** Liquidity for one chain/token balance group in an availability snapshot. */
+export interface AvailableLiquidityByChain {
+	chain: string
+	tokenAddress: HexString
+	totalLiquidity: string
+	providerCount: number
+}
+
 export interface TokenPrice {
 	symbol: string
 	address?: string

--- a/sdk/packages/sdk/src/utils.ts
+++ b/sdk/packages/sdk/src/utils.ts
@@ -18,6 +18,7 @@ import {
 	encodePacked,
 	isHex,
 	hexToBytes,
+	isAddress,
 	keccak256,
 	toHex,
 } from "viem"
@@ -306,6 +307,14 @@ export function encodeStateMachineId(stateMachineId: string): HexString {
 export function normalizeAddressForEvmBytes32(address: string): HexString {
 	if (address.length === 66) return address as HexString
 	return bytes20ToBytes32(address)
+}
+
+/**
+ * Validates an EVM address and returns its canonical lowercase representation.
+ */
+export function normalizeEvmAddress(address: string, field = "address"): HexString {
+	if (!isAddress(address)) throw new TypeError(`${field} must be a valid EVM address`)
+	return address.toLowerCase() as HexString
 }
 
 export function normalizeAddressForStateMachine(address: string, stateMachineId: string): HexString {


### PR DESCRIPTION
## Summary

Adds `IntentGateway.queryAvailableLiquidity()` to show how much liquidity is available for a token direction, such as USDC → cNGN.

The result includes:

- Total available liquidity
- Number of providers
- Snapshot time
- Output token address
- Liquidity grouped by chain

Amounts are formatted using the token decimals for their chain.

## Testing

- Added live tests for:
  - USDC → cNGN
  - cNGN → USDC
  - USDT → cNGN, using the canonical USDC snapshot