### PR TITLE
[sdk, simplex]: version bumps for the pair-engine release

### DIFF
--- a/sdk/packages/sdk/CHANGELOG.md
+++ b/sdk/packages/sdk/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Minor Changes
 
 - Cross-chain `order.fees` now attaches (fill gas + a `RELAYER_MESSAGE_GAS` (1M) settlement uplift) with a 5% buffer over the whole sum, while the solver-side requirement carries no padding — SDK-placed orders always clear a solver's fee gate, including expensive-source/cheap-destination routes that were previously refused. `RELAYER_MESSAGE_GAS` is exported.
-- The cross-chain dispatch is always paid in the fee token: `estimateFillOrder` fixes `fillOptions.nativeDispatchFee` at 0 (the native rail drew on a solver native balance nothing guaranteed) and returns a new `relayerFeeInSourceFeeToken` field for solver-side cost accounting.
+- The cross-chain dispatch is always paid in the fee token: `estimateFillOrder` no longer quotes the native payment rail and always sets `fillOptions.nativeDispatchFee = 0` (the field remains in the on-chain struct; the native rail drew on a solver native balance nothing guaranteed). The estimate gains a `relayerFeeInSourceFeeToken` field for solver-side cost accounting.
 - `ChainConfigService.getAssetBySymbol(chain, symbol)`: case-insensitive lookup into the per-chain asset table, which now ships curated mainnet deployments of ZARP, EURC, XSGD and TRYB (issuer-documented addresses, verified on-chain).
 
 

--- a/sdk/packages/sdk/CHANGELOG.md
+++ b/sdk/packages/sdk/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @hyperbridge/sdk
 
+## 2.6.0
+
+### Minor Changes
+
+- Cross-chain `order.fees` now attaches (fill gas + a `RELAYER_MESSAGE_GAS` (1M) settlement uplift) with a 5% buffer over the whole sum, while the solver-side requirement carries no padding — SDK-placed orders always clear a solver's fee gate, including expensive-source/cheap-destination routes that were previously refused. `RELAYER_MESSAGE_GAS` is exported.
+- The cross-chain dispatch is always paid in the fee token: `estimateFillOrder` fixes `fillOptions.nativeDispatchFee` at 0 (the native rail drew on a solver native balance nothing guaranteed) and returns a new `relayerFeeInSourceFeeToken` field for solver-side cost accounting.
+- `ChainConfigService.getAssetBySymbol(chain, symbol)`: case-insensitive lookup into the per-chain asset table, which now ships curated mainnet deployments of ZARP, EURC, XSGD and TRYB (issuer-documented addresses, verified on-chain).
+
+
 ## 2.5.0
 
 ### Minor Changes

--- a/sdk/packages/sdk/package.json
+++ b/sdk/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/sdk",
-	"version": "2.5.0",
+	"version": "2.6.0",
 	"description": "The hyperclient SDK provides utilities for querying proofs and statuses for cross-chain requests from HyperBridge.",
 	"type": "module",
 	"types": "./dist/node/index.d.ts",

--- a/sdk/packages/simplex/CHANGELOG.md
+++ b/sdk/packages/simplex/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @hyperbridge/filler
 
+## 0.8.0
+
+### Minor Changes
+
+- **Pair engine**: every market is a top-level `[[pairs]]` entry (cross-asset swaps and same-asset cross-chain transfers alike), priced by its own bid/ask curves in token1-per-token0. The `[[strategies]]` array and the stable strategy are removed — a config containing `[[strategies]]` fails at startup with a migration error.
+- **Two independent profit gates**: `order.fees` must cover fill gas + the relayer fee, and every leg must be independently profitable in its own quote asset (margins in different quote assets are never summed). Venue-priced and one-sided legs are directional (fee gate only), guarded by the Uniswap price band.
+- **USD-anchored confirmation sizing**: the operator's own curves are the price feed (USD stables at $1, curve mids as FX edges); every pair's token0 must be anchored or startup fails. `referenceOnly = true` pairs contribute their rate to the anchor graph without opening a market.
+- **Startup validation**: crossed or zero-spread books, same-token asks at or above par, unknown symbols, unanchored assets, malformed `EVM-` chain keys (confirmation policies, per-chain watchOnly, `[assets]`), and uncovered chains are all startup errors; admin live curve edits enforce the same book invariants.
+- **Hardened RPC quorum**: in-repo registry of public endpoints merged into a two-tier weighted quorum (operator BFT + two public witnesses); receipt-not-found counts as a valid no vote; reads resolve as soon as the quorum is met; same-chain orders skip the quorum entirely.
+- **Unified asset registry**: symbols resolve from the SDK chain registry (`chain.ts`) under the user `[assets]` escape hatch — the simplex-local curated table is removed.
+
+
 ## 0.1.0
 
 ### Patch Changes

--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/simplex",
-	"version": "0.7.2",
+	"version": "0.8.0",
 	"license": "Apache-2.0",
 	"description": "IntentGateway simplex package for hyperbridge",
 	"main": "dist/index.js",


### PR DESCRIPTION
Bumps `@hyperbridge/sdk` 2.5.0 → **2.6.0** and `@hyperbridge/simplex` 0.7.2 → **0.8.0**, with changelog entries covering #1058:

- **sdk 2.6.0 (minor)**: cross-chain `order.fees` model — `(fill gas + RELAYER_MESSAGE_GAS uplift) × 1.05` against an unpadded solver requirement; fee-token-only dispatch (`nativeDispatchFee` fixed at 0, new `relayerFeeInSourceFeeToken` estimate field); `ChainConfigService.getAssetBySymbol` and curated ZARP/EURC/XSGD/TRYB in `chain.ts`. Nothing exported was removed.
- **simplex 0.8.0 (minor, 0.x)**: the pair engine — a config-breaking release (`[[strategies]]` removed, fails at startup with a migration error), covered in detail in #1058's description.