### PR TITLE
[simplex]: skip logs carry the leg input amount and name the actual limiter

### DIFF
--- a/sdk/packages/simplex/src/strategies/fx.ts
+++ b/sdk/packages/simplex/src/strategies/fx.ts
@@ -651,7 +651,9 @@ export class FXFiller implements FillerStrategy {
 					this.logger.info(
 						{
 							orderId: order.id,
+							pair: `${leg.pair.token0}/${leg.pair.token1}`,
 							token: output.token,
+							inputAmount: input.amount.toString(),
 							fillerBalance: balance.toString(),
 						},
 						"Skipping leg: no available balance for required output token",
@@ -663,15 +665,26 @@ export class FXFiller implements FillerStrategy {
 				}
 
 				if (policyMaxOutput < output.amount) {
+					// Name the actual limiter: a fair order capped by maxOrderSize
+					// reads very differently from one demanding a better-than-book
+					// rate, and the two have different operator fixes.
+					const capLimited = token0Used.lt(legNotionals[i])
 					this.logger.info(
 						{
 							orderId: order.id,
 							pair: `${leg.pair.token0}/${leg.pair.token1}`,
 							token: output.token,
+							inputAmount: input.amount.toString(),
+							legNotional: legNotionals[i].toString(),
+							pricedNotional: token0Used.toString(),
+							maxOrderSize: leg.pair.maxOrderSize.toString(),
 							policyOutput: policyMaxOutput.toString(),
 							userRequested: output.amount.toString(),
+							limiter: capLimited ? "maxOrderSize" : "price",
 						},
-						"Skipping order: filler price yields less than user's requested amount",
+						capLimited
+							? "Skipping order: maxOrderSize caps the leg below the user's requested amount"
+							: "Skipping order: filler price yields less than user's requested amount",
 					)
 					return 0
 				}
@@ -680,7 +693,9 @@ export class FXFiller implements FillerStrategy {
 					this.logger.info(
 						{
 							orderId: order.id,
+							pair: `${leg.pair.token0}/${leg.pair.token1}`,
 							token: output.token,
+							inputAmount: input.amount.toString(),
 							fillerBalance: balance.toString(),
 							userRequested: output.amount.toString(),
 						},


### PR DESCRIPTION
Production feedback: a market-fair ~$365 same-chain USDC→cNGN order was skipped with *"filler price yields less than user's requested amount"* when the real limiter was a 5-USDC `maxOrderSize` — diagnosing it required decoding the order on-chain because the logs carried neither the input amount nor the sized notionals.

- The price/cap skip now distinguishes **`limiter: "maxOrderSize"`** from **`limiter: "price"`** with distinct messages (the operator fixes differ: raise the cap vs ignore an off-market order).
- All three leg-skip logs (`price/cap`, `no balance`, `insufficient balance for full fill`) now carry the leg's **`inputAmount`**, and the price/cap skip adds `legNotional`, `pricedNotional`, and the pair's `maxOrderSize` so the diagnosis is one glance.