### PR TITLE
[sdk]: Read substrate state machine update time from storage

### DIFF
--- a/sdk/packages/sdk/CHANGELOG.md
+++ b/sdk/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @hyperbridge/sdk
 
+## 2.6.1
+
+### Patch Changes
+
+- `SubstrateChain.stateMachineUpdateTime` reads pallet-ismp's `BoundedStateMachineUpdateTime` storage map directly instead of the `ismp_queryStateMachineUpdateTime` RPC. An evicted height now surfaces as a `MissingConsensusUpdateTimeError` from the absent storage entry rather than from matching an RPC error message.
+
 ## 2.6.0
 
 ### Minor Changes

--- a/sdk/packages/sdk/package.json
+++ b/sdk/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/sdk",
-	"version": "2.6.0",
+	"version": "2.6.1",
 	"description": "The hyperclient SDK provides utilities for querying proofs and statuses for cross-chain requests from HyperBridge.",
 	"type": "module",
 	"types": "./dist/node/index.d.ts",

--- a/sdk/packages/sdk/src/chains/substrate.ts
+++ b/sdk/packages/sdk/src/chains/substrate.ts
@@ -391,32 +391,32 @@ export class SubstrateChain implements IChain {
 	}
 
 	/**
-	 * Get the state machine update time for a given state machine height.
+	 * Get the state machine update time for a given state machine height. Reads the
+	 * `BoundedStateMachineUpdateTime` map in pallet-ismp directly, so the height is either
+	 * still retained on-chain or it has been evicted — there's no intermediate RPC to
+	 * reinterpret the absence.
 	 * @param {StateMachineHeight} stateMachineHeight - The state machine height.
 	 * @returns {Promise<bigint>} The statemachine update time in seconds.
 	 */
 	async stateMachineUpdateTime(stateMachineHeight: StateMachineHeight): Promise<bigint> {
-		const state_id = convertStateIdToStateMachineId(stateMachineHeight.id.stateId)
+		if (!this.api) throw new Error("API not initialized")
 
-		const stateMachineId = {
-			state_id,
-			consensus_state_id: stateMachineHeight.id.consensusStateId,
+		const id = {
+			stateId: stateMachineHeight.id.stateId,
+			// on-chain StateMachineId encodes consensusStateId as [u8; 4]
+			consensusStateId: toHex(toBytes(stateMachineHeight.id.consensusStateId)),
 		}
 
-		const payload = {
-			id: stateMachineId,
-			height: Number(stateMachineHeight.height),
+		const updateTime = await this.api.query.ismp.boundedStateMachineUpdateTime(
+			id,
+			Number(stateMachineHeight.height),
+		)
+
+		if ((updateTime as any).isNone) {
+			throw new MissingConsensusUpdateTimeError(MISSING_CONSENSUS_UPDATE_TIME_MESSAGE)
 		}
 
-		try {
-			const updateTime: number = await this.rpcClient.call("ismp_queryStateMachineUpdateTime", [payload])
-			return BigInt(updateTime)
-		} catch (error) {
-			if (MissingConsensusUpdateTimeError.isError(error)) {
-				throw new MissingConsensusUpdateTimeError(MISSING_CONSENSUS_UPDATE_TIME_MESSAGE, { cause: error })
-			}
-			throw error
-		}
+		return BigInt((updateTime as any).unwrap().toString())
 	}
 
 	/**


### PR DESCRIPTION
Query pallet-ismp's BoundedStateMachineUpdateTime map directly instead of the ismp_queryStateMachineUpdateTime RPC. An evicted height now surfaces as a MissingConsensusUpdateTimeError from the absent storage entry rather than from string-matching an RPC error message.