### PR TITLE
[indexer]: Track Base USDT in the LP balance sweep

### DIFF
--- a/sdk/packages/indexer/src/configs/config-mainnet.json
+++ b/sdk/packages/indexer/src/configs/config-mainnet.json
@@ -161,7 +161,7 @@
 			"solverAccount": "0xfCd233b937D7622AAc63ced3C9A1A12F4a6B64E3",
 			"yieldVaults": {
 				"0x833589fcd6edb6e08f4c7c32d4f71b54bda02913": {
-					"description": "USDC \u2192 stataUSDC (Aave v3 Base; no USDT market on Base)",
+					"description": "USDC \u2192 stataUSDC (Aave v3 Base)",
 					"vaults": [
 						"0xC768c589647798a6EE01A91FdE98EF2ed046DBD6"
 					]
@@ -171,6 +171,10 @@
 					"vaults": [
 						"0xa82a3531021317240fb32e67f9c7bc091f737d3b"
 					]
+				},
+				"0xfde4c96c8593536e31f229ea8f37b2ada2699bb2": {
+					"description": "USDT \u2014 no ERC-4626 market on Base; listed so the LP balance sweep tracks the raw ERC-20 balance",
+					"vaults": []
 				}
 			},
 			"tokenSlots": {


### PR DESCRIPTION
LP balances are swept per token from `yieldVaults`, not `tokenSlots`: `sweepSolverLiquidity` iterates `Object.keys(yieldVaults[chain])`, so that map doubles as the allowlist of tokens that ever get a LiquidityProviderBalance row.

Base USDT was only ever added to `tokenSlots` — there is no ERC-4626 market for it on Base, so it was never listed as a yield vault — and it was consequently never swept. It was the only token across the mainnet chains present in `tokenSlots` but absent from `yieldVaults`.

List it with an empty `vaults` array. `getTotalSolverBalance` reads the raw `balanceOf` first and reduces vault positions onto it, so an empty list yields exactly the raw ERC-20 balance; the datasource generator flat-maps over `vaults`, so no spurious datasource is emitted.