### PR TITLE
[simplex, docs]: self-funding testnet suite; document the current faucet generation

### DIFF
--- a/docs/content/developers/evm/contract-addresses/testnet.mdx
+++ b/docs/content/developers/evm/contract-addresses/testnet.mdx
@@ -43,8 +43,8 @@ The current testnet environment for the Hyperbridge network.
 | `HostManager` | [`0xb05fd51329b4dd28cf07e273efb496edd243dbee`](https://sepolia.etherscan.io/address/0xb05fd51329b4dd28cf07e273efb496edd243dbee) |
 | `CallDispatcher` | [`0x2b332088275bc9e3c26d81b2975de2483320c181`](https://sepolia.etherscan.io/address/0x2b332088275bc9e3c26d81b2975de2483320c181) |
 | `BandwidthManager` | [`0xFe6D81417CFe618aCaA34dF23376c738900290DE`](https://sepolia.etherscan.io/address/0xFe6D81417CFe618aCaA34dF23376c738900290DE) |
-| `TokenFaucet` | [`0xcb00f5b86aac5e2fdca9dc7f34d9bfe00b967c18`](https://sepolia.etherscan.io/address/0xcb00f5b86aac5e2fdca9dc7f34d9bfe00b967c18) |
-| `FeeToken (USD.h)` | [`0xBe97E73126d66188d72FBf99029126d0340a7f18`](https://sepolia.etherscan.io/address/0xBe97E73126d66188d72FBf99029126d0340a7f18) |
+| `TokenFaucet` | [`0x1794aB22388303ce9Cb798bE966eeEBeFe59C3a3`](https://sepolia.etherscan.io/address/0x1794aB22388303ce9Cb798bE966eeEBeFe59C3a3) |
+| `FeeToken (USD.h)` | [`0xA801da100bF16D07F668F4A49E1f71fc54D05177`](https://sepolia.etherscan.io/address/0xA801da100bF16D07F668F4A49E1f71fc54D05177) |
 | `ConsensusStateId` | `ETH0` |
 | `StateMachine` | `EVM-11155111` |
 
@@ -61,8 +61,8 @@ The current testnet environment for the Hyperbridge network.
 | `HostManager` | [`0xb05fd51329b4dd28cf07e273efb496edd243dbee`](https://sepolia.arbiscan.io/address/0xb05fd51329b4dd28cf07e273efb496edd243dbee) |
 | `CallDispatcher` | [`0x2b332088275bc9e3c26d81b2975de2483320c181`](https://sepolia.arbiscan.io/address/0x2b332088275bc9e3c26d81b2975de2483320c181) |
 | `BandwidthManager` | [`0xFe6D81417CFe618aCaA34dF23376c738900290DE`](https://sepolia.arbiscan.io/address/0xFe6D81417CFe618aCaA34dF23376c738900290DE) |
-| `TokenFaucet` | [`0xcb00f5b86aac5e2fdca9dc7f34d9bfe00b967c18`](https://sepolia.arbiscan.io/address/0xcb00f5b86aac5e2fdca9dc7f34d9bfe00b967c18) |
-| `FeeToken (USD.h)` | [`0xBe97E73126d66188d72FBf99029126d0340a7f18`](https://sepolia.arbiscan.io/address/0xBe97E73126d66188d72FBf99029126d0340a7f18) |
+| `TokenFaucet` | [`0x1794aB22388303ce9Cb798bE966eeEBeFe59C3a3`](https://sepolia.arbiscan.io/address/0x1794aB22388303ce9Cb798bE966eeEBeFe59C3a3) |
+| `FeeToken (USD.h)` | [`0xA801da100bF16D07F668F4A49E1f71fc54D05177`](https://sepolia.arbiscan.io/address/0xA801da100bF16D07F668F4A49E1f71fc54D05177) |
 | `ConsensusStateId` | Messaging: `ETH0` / Consensus: `ARB0` |
 | `StateMachine` | `EVM-421614` |
 
@@ -79,8 +79,8 @@ The current testnet environment for the Hyperbridge network.
 | `HostManager` | [`0xb05fd51329b4dd28cf07e273efb496edd243dbee`](https://sepolia-optimism.etherscan.io/address/0xb05fd51329b4dd28cf07e273efb496edd243dbee) |
 | `CallDispatcher` | [`0x2b332088275bc9e3c26d81b2975de2483320c181`](https://sepolia-optimism.etherscan.io/address/0x2b332088275bc9e3c26d81b2975de2483320c181) |
 | `BandwidthManager` | [`0xFe6D81417CFe618aCaA34dF23376c738900290DE`](https://sepolia-optimism.etherscan.io/address/0xFe6D81417CFe618aCaA34dF23376c738900290DE) |
-| `TokenFaucet` | [`0xcb00f5b86aac5e2fdca9dc7f34d9bfe00b967c18`](https://sepolia-optimism.etherscan.io/address/0xcb00f5b86aac5e2fdca9dc7f34d9bfe00b967c18) |
-| `FeeToken (USD.h)` | [`0xBe97E73126d66188d72FBf99029126d0340a7f18`](https://sepolia-optimism.etherscan.io/address/0xBe97E73126d66188d72FBf99029126d0340a7f18) |
+| `TokenFaucet` | [`0x1794aB22388303ce9Cb798bE966eeEBeFe59C3a3`](https://sepolia-optimism.etherscan.io/address/0x1794aB22388303ce9Cb798bE966eeEBeFe59C3a3) |
+| `FeeToken (USD.h)` | [`0xA801da100bF16D07F668F4A49E1f71fc54D05177`](https://sepolia-optimism.etherscan.io/address/0xA801da100bF16D07F668F4A49E1f71fc54D05177) |
 | `ConsensusStateId` | Messaging: `ETH0` / Consensus: `OPT0` |
 | `StateMachine` | `EVM-11155420` |
 
@@ -97,8 +97,8 @@ The current testnet environment for the Hyperbridge network.
 | `HostManager` | [`0xb05fd51329b4dd28cf07e273efb496edd243dbee`](https://sepolia.basescan.org/address/0xb05fd51329b4dd28cf07e273efb496edd243dbee) |
 | `CallDispatcher` | [`0x2b332088275bc9e3c26d81b2975de2483320c181`](https://sepolia.basescan.org/address/0x2b332088275bc9e3c26d81b2975de2483320c181) |
 | `BandwidthManager` | [`0xFe6D81417CFe618aCaA34dF23376c738900290DE`](https://sepolia.basescan.org/address/0xFe6D81417CFe618aCaA34dF23376c738900290DE) |
-| `TokenFaucet` | [`0xcb00f5b86aac5e2fdca9dc7f34d9bfe00b967c18`](https://sepolia.basescan.org/address/0xcb00f5b86aac5e2fdca9dc7f34d9bfe00b967c18) |
-| `FeeToken (USD.h)` | [`0xBe97E73126d66188d72FBf99029126d0340a7f18`](https://sepolia.basescan.org/address/0xBe97E73126d66188d72FBf99029126d0340a7f18) |
+| `TokenFaucet` | [`0x1794aB22388303ce9Cb798bE966eeEBeFe59C3a3`](https://sepolia.basescan.org/address/0x1794aB22388303ce9Cb798bE966eeEBeFe59C3a3) |
+| `FeeToken (USD.h)` | [`0xA801da100bF16D07F668F4A49E1f71fc54D05177`](https://sepolia.basescan.org/address/0xA801da100bF16D07F668F4A49E1f71fc54D05177) |
 | `ConsensusStateId` | Messaging: `ETH0` / Consensus: `BASE` |
 | `StateMachine` | `EVM-84532` |
 
@@ -115,8 +115,8 @@ The current testnet environment for the Hyperbridge network.
 | `HostManager` | [`0xb05fd51329b4dd28cf07e273efb496edd243dbee`](https://testnet.bscscan.com/address/0xb05fd51329b4dd28cf07e273efb496edd243dbee) |
 | `CallDispatcher` | [`0x2b332088275bc9e3c26d81b2975de2483320c181`](https://testnet.bscscan.com/address/0x2b332088275bc9e3c26d81b2975de2483320c181) |
 | `BandwidthManager` | [`0xFe6D81417CFe618aCaA34dF23376c738900290DE`](https://testnet.bscscan.com/address/0xFe6D81417CFe618aCaA34dF23376c738900290DE) |
-| `TokenFaucet` | [`0xcb00f5b86aac5e2fdca9dc7f34d9bfe00b967c18`](https://testnet.bscscan.com/address/0xcb00f5b86aac5e2fdca9dc7f34d9bfe00b967c18) |
-| `FeeToken (USD.h)` | [`0xBe97E73126d66188d72FBf99029126d0340a7f18`](https://testnet.bscscan.com/address/0xBe97E73126d66188d72FBf99029126d0340a7f18) |
+| `TokenFaucet` | [`0x1794aB22388303ce9Cb798bE966eeEBeFe59C3a3`](https://testnet.bscscan.com/address/0x1794aB22388303ce9Cb798bE966eeEBeFe59C3a3) |
+| `FeeToken (USD.h)` | [`0xA801da100bF16D07F668F4A49E1f71fc54D05177`](https://testnet.bscscan.com/address/0xA801da100bF16D07F668F4A49E1f71fc54D05177) |
 | `ConsensusStateId` | `BSC0` |
 | `StateMachine` | `EVM-97` |
 

--- a/docs/content/developers/evm/messaging/testnet-faucet.mdx
+++ b/docs/content/developers/evm/messaging/testnet-faucet.mdx
@@ -1,12 +1,12 @@
 ---
-title: Testnet Facucet
+title: Testnet Faucet
 description: This guide walks you through the process of requesting and receiving Hyper USD (the testnet token) for development and testing on the Hyperbridge network.
 ---
 
-# Testnet Fee Token Facucet
+# Testnet Fee Token Faucet
 
-[Hyper USD (USD.h)](https://sepolia.etherscan.io/address/0xBe97E73126d66188d72FBf99029126d0340a7f18) is the testnet-specific fee token required for dispatching messages through the Hyperbridge protocol on testnet. You'll need some USD.h to send [POST](/developers/evm/messaging/post-requests) and [GET Requests](/developers/evm/messaging/get-requests) across different testnet versions of blockchains.
-For development and testing on testnet environments, you can obtain free USD.h from the [faucet contract](https://sepolia.etherscan.io/address/0xcb00f5b86aac5e2fdca9dc7f34d9bfe00b967c18).
+[Hyper USD (USD.h)](https://sepolia.etherscan.io/address/0xA801da100bF16D07F668F4A49E1f71fc54D05177) is the testnet-specific fee token required for dispatching messages through the Hyperbridge protocol on testnet. You'll need some USD.h to send [POST](/developers/evm/messaging/post-requests) and [GET Requests](/developers/evm/messaging/get-requests) across different testnet versions of blockchains.
+For development and testing on testnet environments, you can obtain free USD.h from the [faucet contract](https://sepolia.etherscan.io/address/0x1794aB22388303ce9Cb798bE966eeEBeFe59C3a3).
 
 <Callout type="info">
 USD.h has the same contract address across most testnet EVM chains where Hyperbridge is deployed (Sepolia, BSC Testnet, etc.). For the addresses on differing EVM chains and other types of chains, please check [here](./contract-addresses/testnet.mdx). The same applies to the faucet.
@@ -23,7 +23,7 @@ Before you begin, ensure you have:
 
 ### Step 1: Access the Faucet Contract
 
-Navigate to the [faucet contract's "Write Contract" page](https://sepolia.etherscan.io/address/0xcb00f5b86aac5e2fdca9dc7f34d9bfe00b967c18#writeContract).
+Navigate to the [faucet contract's "Write Contract" page](https://sepolia.etherscan.io/address/0x1794aB22388303ce9Cb798bE966eeEBeFe59C3a3#writeContract).
 
 <Callout type="info">
 Like USD.h, the faucet contract also has the same address across most testnet EVM chains where Hyperbridge is deployed (Sepolia, BSC Testnet, etc.). For the addresses on differing EVM chains and other types of chains, please check [here](./contract-addresses/testnet.mdx).
@@ -41,9 +41,9 @@ Like USD.h, the faucet contract also has the same address across most testnet EV
 
 1. Scroll down to find the function labeled **"1. drip (0x67a5cd06)"**
 2. Click to expand the function tab
-3. In the **"token (address)"** field, enter the [USD.h fee token contract address](https://sepolia.etherscan.io/address/0xBe97E73126d66188d72FBf99029126d0340a7f18):
+3. In the **"token (address)"** field, enter the [USD.h fee token contract address](https://sepolia.etherscan.io/address/0xA801da100bF16D07F668F4A49E1f71fc54D05177):
    ```
-   0xBe97E73126d66188d72FBf99029126d0340a7f18
+   0xA801da100bF16D07F668F4A49E1f71fc54D05177
    ```
 4. Click the **"Write"** button
 5. Your wallet will prompt you to confirm the transaction. Approve it to proceed.
@@ -60,7 +60,7 @@ The faucet will automatically send **1000 USD.h tokens** to your connected walle
 
 - Ensure that you have not exceeded the faucet's limit of one request per day
 - Check that you have sufficient gas fee in the native token of the testnet chain (ETH for sepolia, testnet BNB for BNB Chain etc)
-- Make sure you are inputting the [USD.h](https://sepolia.etherscan.io/address/0xBe97E73126d66188d72FBf99029126d0340a7f18) and not something else (like your development wallet address) into the "token (address)" textbox
+- Make sure you are inputting the [USD.h](https://sepolia.etherscan.io/address/0xA801da100bF16D07F668F4A49E1f71fc54D05177) and not something else (like your development wallet address) into the "token (address)" textbox
 
 For additional support, visit the [Hyperbridge Discord](https://discord.gg/hyperbridge) or consult the [official documentation](https://docs.hyperbridge.network/).
 

--- a/sdk/packages/simplex/src/tests/strategies/fx.testnet.test.ts
+++ b/sdk/packages/simplex/src/tests/strategies/fx.testnet.test.ts
@@ -24,12 +24,18 @@ import {
 	IntentGateway,
 	IntentsCoprocessor,
 	DEFAULT_GRAFFITI,
+	ChainConfigService,
 } from "@hyperbridge/sdk"
-import { describe, it, expect } from "vitest"
+import { beforeAll, describe, it, expect } from "vitest"
 import { ConfirmationPolicy, FillerPricePolicy } from "@/config/interpolated-curve"
 import {
+	createPublicClient,
+	createWalletClient,
+	formatUnits,
 	getContract,
+	http,
 	maxUint256,
+	parseAbi,
 	parseUnits,
 	type PublicClient,
 	type WalletClient,
@@ -37,6 +43,7 @@ import {
 	keccak256,
 	toHex,
 } from "viem"
+import { bscTestnet } from "viem/chains"
 import { INTENT_GATEWAY_V2_ABI } from "@/config/abis/IntentGatewayV2"
 import { privateKeyToAccount } from "viem/accounts"
 import "../setup"
@@ -62,6 +69,63 @@ function exoticPairs(
 	return { pairs, registry }
 }
 
+
+// ── Self-funding ─────────────────────────────────────────────────────────────
+//
+// Each run burns ~0.1 USD.h from the CI wallet placing orders on BSC Chapel.
+// The current-generation TokenFaucet (CREATE2-deployed at the same address on
+// Sepolia, BSC Chapel, Base/Arbitrum/OP Sepolia and Gnosis Chiado) mints 1000
+// USD.h per address per day, so the suite tops itself up instead of dying at
+// placeOrder with an opaque "ERC20: transfer amount exceeds balance".
+const TOKEN_FAUCET = "0x1794aB22388303ce9Cb798bE966eeEBeFe59C3a3" as HexString
+const SOURCE_CHAIN_ID = "EVM-97"
+/** Refill when below ~100 runs' worth. */
+const MIN_SOURCE_BALANCE = parseUnits("10", 18)
+/** Below one run's worth, a failed drip is fatal — the suite cannot pass. */
+const MIN_RUNNABLE_BALANCE = parseUnits("1", 18)
+
+beforeAll(async () => {
+	const key = process.env.PRIVATE_KEY as HexString | undefined
+	const rpcUrl = process.env.BSC_CHAPEL
+	if (!key || !rpcUrl) return // env-less runs surface their own errors below
+
+	const account = privateKeyToAccount(key)
+	const feeToken = new ChainConfigService(process.env).getUsdcAsset(SOURCE_CHAIN_ID)
+	const transport = http(rpcUrl)
+	const publicClient = createPublicClient({ chain: bscTestnet, transport })
+	const balance = (await publicClient.readContract({
+		address: feeToken,
+		abi: ERC20_ABI,
+		functionName: "balanceOf",
+		args: [account.address],
+	})) as bigint
+	if (balance >= MIN_SOURCE_BALANCE) return
+
+	try {
+		const walletClient = createWalletClient({ chain: bscTestnet, transport, account })
+		const hash = await walletClient.writeContract({
+			chain: bscTestnet,
+			account,
+			address: TOKEN_FAUCET,
+			abi: parseAbi(["function drip(address token)"]),
+			functionName: "drip",
+			args: [feeToken],
+		})
+		await publicClient.waitForTransactionReceipt({ hash, timeout: 90_000 })
+		console.log(`[self-funding] dripped 1000 USD.h to ${account.address} on ${SOURCE_CHAIN_ID} (${hash})`)
+	} catch (err) {
+		// The faucet drips once per address per day — a cooldown revert is fine
+		// as long as the balance still covers this run.
+		if (balance < MIN_RUNNABLE_BALANCE) {
+			throw new Error(
+				`CI wallet ${account.address} holds ${formatUnits(balance, 18)} USD.h on ${SOURCE_CHAIN_ID} and the ` +
+					`faucet drip failed (daily cooldown?). Fund it manually: drip(${feeToken}) on TokenFaucet ` +
+					`${TOKEN_FAUCET}. Cause: ${err instanceof Error ? err.message : String(err)}`,
+			)
+		}
+		console.warn("[self-funding] drip unavailable; existing balance still covers this run")
+	}
+}, 120_000)
 
 // ============================================================================
 // Test Suites


### PR DESCRIPTION
The fx.testnet CI wallet ran dry on BSC Chapel (#1065's red `test` job) and the suite died at `placeOrder` with `ERC20: transfer amount exceeds balance`. Root-causing required on-chain archaeology because **every faucet in the docs is a dead generation**: the current ERC6160 USD.h (`0xA801da10…5177`) is mintable only by the undocumented third-generation TokenFaucet at `0x1794aB22…C3a3`, CREATE2-deployed at the same address on Sepolia, BSC Chapel, Base/Arbitrum/OP Sepolia and Gnosis Chiado (each verified on-chain).

**Self-funding suite**: `fx.testnet.test.ts` gains a `beforeAll` that drips 1000 USD.h from the faucet whenever the CI wallet's Chapel balance falls below ~100 runs' worth. The faucet's once-daily cooldown is tolerated while the balance still covers a run; when it can't, the failure names the wallet, faucet, and token — no more opaque ERC20 reverts. This class of CI outage is permanently closed.

**Docs**: the Gargantua V3 tables now carry the live TokenFaucet/FeeToken pair for the five verified chains (Amoy verifiably still runs the older generation and its rows stand; Paseo Asset Hub could not be verified and stands as-is), and `testnet-faucet.mdx` points at the working faucet + token with its typos fixed.