### PR TITLE
[runtime, tesseract]: give mandatory proofs their own offchain namespace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,7 +415,7 @@ jobs:
             - name: Run Simnet Tests
               run: |
                   cargo build -p hyperbridge --release
-                  ./target/release/hyperbridge simnode --chain=gargantua-4009 --name=alice --tmp  --state-pruning=archive --blocks-pruning=archive --rpc-port=9990 --port 40337 --log="mmr=trace" --rpc-cors=all --unsafe-rpc-external --rpc-methods=unsafe --pool-type=single-state &
+                  ./target/release/hyperbridge simnode --chain=gargantua-4009 --name=alice --tmp  --state-pruning=archive --blocks-pruning=archive --rpc-port=9990 --port 40337 --log="mmr=trace" --rpc-cors=all --unsafe-rpc-external --rpc-methods=unsafe --pool-type=single-state --enable-offchain-indexing true &
                   ./scripts/wait_for_tcp_port_opening.sh localhost 9990
                   cargo test -p simtests -- --nocapture --ignored --test-threads=1 --skip test_runtime_upgrade_and_fee_migration --skip legacy_storage_items_state_drain_test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,7 +415,7 @@ jobs:
             - name: Run Simnet Tests
               run: |
                   cargo build -p hyperbridge --release
-                  ./target/release/hyperbridge simnode --chain=gargantua-4009 --name=alice --tmp  --state-pruning=archive --blocks-pruning=archive --rpc-port=9990 --port 40337 --log="mmr=trace" --rpc-cors=all --unsafe-rpc-external --rpc-methods=unsafe --pool-type=single-state --enable-offchain-indexing true &
+                  ./target/release/hyperbridge simnode --chain=gargantua-4009 --name=alice --tmp  --state-pruning=archive --blocks-pruning=archive --rpc-port=9990 --port 40337 --log="mmr=trace" --rpc-cors=all --unsafe-rpc-external --rpc-methods=unsafe --pool-type=single-state &
                   ./scripts/wait_for_tcp_port_opening.sh localhost 9990
                   cargo test -p simtests -- --nocapture --ignored --test-threads=1 --skip test_runtime_upgrade_and_fee_migration --skip legacy_storage_items_state_drain_test
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24437,6 +24437,7 @@ dependencies = [
  "mmr-primitives",
  "mockito",
  "nexus-runtime",
+ "pallet-beefy-consensus-proofs",
  "pallet-intents-coprocessor",
  "pallet-intents-rpc",
  "pallet-ismp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15589,6 +15589,7 @@ dependencies = [
  "log",
  "mmr-primitives",
  "pallet-bandwidth",
+ "pallet-beefy-consensus-proofs",
  "pallet-call-decompressor",
  "pallet-collator-manager",
  "pallet-consensus-incentives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28392,7 +28392,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tesseract"
-version = "2.4.9"
+version = "2.4.10"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/modules/pallets/beefy-consensus-proofs/src/lib.rs
+++ b/modules/pallets/beefy-consensus-proofs/src/lib.rs
@@ -185,7 +185,7 @@ pub mod pallet {
 	/// EVM destination up across multiple epochs: given the last-known authority set id,
 	/// walk entries forward, fetching each rotation proof from offchain storage under
 	/// [`rotation_offchain_key(set_id)`](types::rotation_offchain_key). BEEFY set ids are
-	/// monotone, so `iter().next()` gives FIFO eviction on overflow.
+	/// monotone, so `keys().next()` gives FIFO eviction on overflow.
 	#[pallet::storage]
 	pub type RotationProofs<T: Config> =
 		StorageValue<_, BoundedBTreeMap<u64, u64, T::MaxStoredProofs>, ValueQuery>;
@@ -521,7 +521,11 @@ pub mod pallet {
 		///
 		/// `account` is the committed nonce (== signer) for SP1 proofs, and `None` for naive
 		/// proofs (which are ineligible for uncle rewards).
-		fn settle_first_proof(
+		///
+		/// Public so tests can drive the settlement paths with a synthetic [`VerifyOutcome`],
+		/// which is the only way to construct a rotation and a messaging proof at one height
+		/// without minting real BEEFY proofs.
+		pub fn settle_first_proof(
 			submitter: T::AccountId,
 			proof: Vec<u8>,
 			account: Option<H256>,
@@ -534,9 +538,26 @@ pub mod pallet {
 			}
 
 			// Record uncle metadata for SP1 proofs only. Naive proofs are ineligible.
+			//
+			// A rotation may land on a height a messaging proof already filled, and the slots
+			// are bounded, so this can fail. Uncle bookkeeping only decides who gets paid,
+			// while the caller has already applied the authority-set rotation, so a hard error
+			// here would roll that rotation back. The mandatory justification is the only one
+			// obtainable for that session, so every retry would fail identically and the
+			// consensus state would sit on the old set forever. Log and carry on instead.
+			// Skipping the record cannot mint a second reward: `ProverCount` is already at the
+			// cap, so `settle_uncle_proof` rejects on position before it reads `AcceptedProvers`.
 			if proof_type == types::PROOF_TYPE_SP1 {
 				let account = account.ok_or(Error::<T>::UnknownProofType)?;
-				Self::record_uncle_metadata(outcome.latest_height, prev_state_bytes, account)?;
+				if let Err(e) =
+					Self::record_uncle_metadata(outcome.latest_height, prev_state_bytes, account)
+				{
+					log::warn!(
+						target: "ismp",
+						"[beefy-consensus-proofs] uncle metadata skipped at height {}: {e:?}",
+						outcome.latest_height,
+					);
+				}
 			}
 
 			let reward_paid = Self::pay_position_reward(&submitter, 0)?;

--- a/modules/pallets/beefy-consensus-proofs/src/lib.rs
+++ b/modules/pallets/beefy-consensus-proofs/src/lib.rs
@@ -560,7 +560,25 @@ pub mod pallet {
 				}
 			}
 
-			let reward_paid = Self::pay_position_reward(&submitter, 0)?;
+			// Same reasoning as the uncle bookkeeping above: the caller has already applied the
+			// authority-set rotation, so a hard error here rolls it back, and since the mandatory
+			// justification is the only one obtainable for that session every retry fails
+			// identically until someone tops the treasury up — leaving the consensus state on the
+			// old set in the meantime. A missed reward is the cheaper loss, so log and carry on.
+			// Messaging proofs keep the hard error: reverting one is recoverable, because the work
+			// is re-attempted by the next proof once the treasury can pay.
+			let reward_paid = match Self::pay_position_reward(&submitter, 0) {
+				Ok(reward) => reward,
+				Err(e) if outcome.rotated => {
+					log::warn!(
+						target: "ismp",
+						"[beefy-consensus-proofs] reward skipped for rotation to set {}: {e:?}",
+						outcome.current_set_id,
+					);
+					BalanceOf::<T>::default()
+				},
+				Err(e) => Err(e)?,
+			};
 
 			// Mandatory proofs are keyed by the set id they rotated to, messaging proofs by the
 			// height they advanced to, so the two never write over each other even when a

--- a/modules/pallets/beefy-consensus-proofs/src/lib.rs
+++ b/modules/pallets/beefy-consensus-proofs/src/lib.rs
@@ -176,7 +176,7 @@ pub mod pallet {
 	/// strictly increasing because every accepted proof advances the proven height,
 	/// so `vec[0]` is always the oldest — FIFO eviction via `remove(0)` when full.
 	/// The proof bytes live in offchain storage under
-	/// [`offchain_key(latest_height)`](types::offchain_key).
+	/// [`messaging_offchain_key(latest_height)`](types::messaging_offchain_key).
 	#[pallet::storage]
 	pub type MessagingProofs<T: Config> =
 		StorageValue<_, BoundedVec<u64, T::MaxStoredProofs>, ValueQuery>;
@@ -184,8 +184,8 @@ pub mod pallet {
 	/// Map of `set_id → latest_height` for rotation proofs. Lets relayers catch a lagging
 	/// EVM destination up across multiple epochs: given the last-known authority set id,
 	/// walk entries forward, fetching each rotation proof from offchain storage under
-	/// [`offchain_key(latest_height)`](types::offchain_key). BEEFY set ids are monotone,
-	/// so `iter().next()` gives FIFO eviction on overflow.
+	/// [`rotation_offchain_key(set_id)`](types::rotation_offchain_key). BEEFY set ids are
+	/// monotone, so `iter().next()` gives FIFO eviction on overflow.
 	#[pallet::storage]
 	pub type RotationProofs<T: Config> =
 		StorageValue<_, BoundedBTreeMap<u64, u64, T::MaxStoredProofs>, ValueQuery>;
@@ -541,27 +541,41 @@ pub mod pallet {
 
 			let reward_paid = Self::pay_position_reward(&submitter, 0)?;
 
-			sp_io::offchain_index::set(&types::offchain_key(outcome.latest_height), &proof);
-			let evicted_height = if outcome.rotated {
+			// Mandatory proofs are keyed by the set id they rotated to, messaging proofs by the
+			// height they advanced to, so the two never write over each other even when a
+			// rotation lands on a head an earlier messaging proof already finalized.
+			let evicted = if outcome.rotated {
+				sp_io::offchain_index::set(
+					&types::rotation_offchain_key(outcome.current_set_id),
+					&proof,
+				);
 				RotationProofs::<T>::mutate(|map| {
 					let evicted = (map.len() as u32 == T::MaxStoredProofs::get())
-						.then(|| map.iter().next().map(|(k, _)| *k))
+						.then(|| map.keys().next().copied())
 						.flatten()
-						.and_then(|set_id| map.remove(&set_id));
+						.and_then(|set_id| {
+							map.remove(&set_id)
+								.map(|height| (types::rotation_offchain_key(set_id), height))
+						});
 					let _ = map.try_insert(outcome.current_set_id, outcome.latest_height);
 					evicted
 				})
 			} else {
+				sp_io::offchain_index::set(
+					&types::messaging_offchain_key(outcome.latest_height),
+					&proof,
+				);
 				MessagingProofs::<T>::mutate(|vec| {
-					let evicted =
-						(vec.len() as u32 == T::MaxStoredProofs::get()).then(|| vec.remove(0));
+					let evicted = (vec.len() as u32 == T::MaxStoredProofs::get())
+						.then(|| vec.remove(0))
+						.map(|height| (types::messaging_offchain_key(height), height));
 					let _ = vec.try_push(outcome.latest_height);
 					evicted
 				})
 			};
 
-			if let Some(height) = evicted_height {
-				sp_io::offchain_index::clear(&types::offchain_key(height));
+			if let Some((key, height)) = evicted {
+				sp_io::offchain_index::clear(&key);
 				ProofContext::<T>::remove(height);
 				ProverCount::<T>::remove(height);
 				AcceptedProvers::<T>::remove(height);

--- a/modules/pallets/beefy-consensus-proofs/src/types.rs
+++ b/modules/pallets/beefy-consensus-proofs/src/types.rs
@@ -15,28 +15,74 @@
 
 //! Types for `pallet-beefy-consensus-proofs`.
 
-/// Offchain-storage prefix for raw verified proof bytes written by `submit_proof`.
-/// Combined with the `proven_height` (`u64`, big-endian) to form the actual offchain key.
-/// All proofs — rotation and messaging alike — share this single namespace since both
-/// advance parachain height monotonically.
-pub const OFFCHAIN_PREFIX: &[u8] = b"beefy_consensus_proofs::";
+use alloc::vec::Vec;
+
+/// Offchain-storage prefix for messaging proof bytes, combined with the proven parachain
+/// height.
+pub const MESSAGING_OFFCHAIN_PREFIX: &[u8] = b"beefy_consensus_proofs::";
+
+/// Offchain-storage prefix for mandatory proof bytes, combined with the authority set id
+/// the proof rotated to.
+///
+/// Mandatory proofs need their own namespace because parachain height doesn't identify them
+/// uniquely. A rotation proof carries whatever head the relay chain held at the session
+/// boundary, which can be a head an earlier messaging proof already finalized, so under one
+/// shared namespace the two blobs land on the same key and the later write wins.
+pub const ROTATION_OFFCHAIN_PREFIX: &[u8] = b"beefy_consensus_proofs::rotation::";
 
 /// Proof type byte: naive BEEFY proof.
 pub const PROOF_TYPE_NAIVE: u8 = 0x00;
 /// Proof type byte: SP1 ZK BEEFY proof.
 pub const PROOF_TYPE_SP1: u8 = 0x01;
 
-/// Offchain-storage key for a verified consensus proof keyed by `proven_height`.
-/// Relayers reconstruct this key off of a [`MessagingProofs`](crate::pallet::MessagingProofs)
-/// or [`RotationProofs`](crate::pallet::RotationProofs) entry and read the raw
-/// ABI-encoded proof bytes from node-local offchain storage. A single namespace
-/// covers both rotation and messaging proofs since both advance parachain height
-/// monotonically.
-pub fn offchain_key(proven_height: u64) -> alloc::vec::Vec<u8> {
-	let mut key = alloc::vec::Vec::with_capacity(OFFCHAIN_PREFIX.len() + 8);
-	key.extend_from_slice(OFFCHAIN_PREFIX);
-	key.extend_from_slice(&proven_height.to_be_bytes());
+fn offchain_key(prefix: &[u8], id: u64) -> Vec<u8> {
+	let mut key = Vec::with_capacity(prefix.len() + 8);
+	key.extend_from_slice(prefix);
+	key.extend_from_slice(&id.to_be_bytes());
 	key
+}
+
+/// Offchain key for a messaging proof, keyed by the parachain height it advanced to.
+/// Relayers rebuild this off a [`MessagingProofs`](crate::pallet::MessagingProofs) entry.
+/// Messaging proofs must advance the proven height, so the height is unique here.
+pub fn messaging_offchain_key(proven_height: u64) -> Vec<u8> {
+	offchain_key(MESSAGING_OFFCHAIN_PREFIX, proven_height)
+}
+
+/// Offchain key for a mandatory proof, keyed by the authority set id it rotated to. This is
+/// the same key [`RotationProofs`](crate::pallet::RotationProofs) is indexed by, so a relayer
+/// walking that map across epochs builds the key from the map key rather than the height.
+pub fn rotation_offchain_key(set_id: u64) -> Vec<u8> {
+	offchain_key(ROTATION_OFFCHAIN_PREFIX, set_id)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// The rotation prefix extends the messaging one, so what actually keeps a rotation blob
+	/// off a messaging key is the length, not the leading bytes. Offchain lookups are exact
+	/// key, so no height and set id can ever alias.
+	#[test]
+	fn messaging_and_rotation_keys_cannot_alias() {
+		assert!(ROTATION_OFFCHAIN_PREFIX.starts_with(MESSAGING_OFFCHAIN_PREFIX));
+		assert_eq!(messaging_offchain_key(u64::MAX).len(), MESSAGING_OFFCHAIN_PREFIX.len() + 8);
+		assert_eq!(rotation_offchain_key(u64::MAX).len(), ROTATION_OFFCHAIN_PREFIX.len() + 8);
+	}
+
+	/// The SDK rebuilds both keys from hardcoded strings and big-endian ids, so pin the
+	/// encoding here to catch a change on this side that isn't mirrored there.
+	#[test]
+	fn keys_match_the_sdk_encoding() {
+		assert_eq!(
+			messaging_offchain_key(1),
+			[b"beefy_consensus_proofs::".as_slice(), &1u64.to_be_bytes()].concat(),
+		);
+		assert_eq!(
+			rotation_offchain_key(7),
+			[b"beefy_consensus_proofs::rotation::".as_slice(), &7u64.to_be_bytes()].concat(),
+		);
+	}
 }
 
 /// BEEFY host-function backed crypto used by `beefy-verifier`.

--- a/modules/pallets/beefy-consensus-proofs/src/types.rs
+++ b/modules/pallets/beefy-consensus-proofs/src/types.rs
@@ -60,14 +60,21 @@ pub fn rotation_offchain_key(set_id: u64) -> Vec<u8> {
 mod tests {
 	use super::*;
 
-	/// The rotation prefix extends the messaging one, so what actually keeps a rotation blob
-	/// off a messaging key is the length, not the leading bytes. Offchain lookups are exact
-	/// key, so no height and set id can ever alias.
+	/// No height and set id may ever produce the same key, whatever the two ids are. Compare
+	/// the built keys across a spread of pairs rather than asserting anything about the
+	/// prefixes, so that making the two namespaces identical fails this outright.
 	#[test]
 	fn messaging_and_rotation_keys_cannot_alias() {
-		assert!(ROTATION_OFFCHAIN_PREFIX.starts_with(MESSAGING_OFFCHAIN_PREFIX));
-		assert_eq!(messaging_offchain_key(u64::MAX).len(), MESSAGING_OFFCHAIN_PREFIX.len() + 8);
-		assert_eq!(rotation_offchain_key(u64::MAX).len(), ROTATION_OFFCHAIN_PREFIX.len() + 8);
+		let ids = [0u64, 1, 2, 512, 9_812_059, u64::MAX];
+		for height in ids {
+			for set_id in ids {
+				assert_ne!(
+					messaging_offchain_key(height),
+					rotation_offchain_key(set_id),
+					"messaging height {height} aliased rotation set {set_id}",
+				);
+			}
+		}
 	}
 
 	/// The SDK rebuilds both keys from hardcoded strings and big-endian ids, so pin the

--- a/modules/pallets/testsuite/Cargo.toml
+++ b/modules/pallets/testsuite/Cargo.toml
@@ -34,6 +34,7 @@ pallet-ismp = { workspace = true, default-features = true, features = [
 ] }
 pallet-bandwidth = { workspace = true, default-features = true }
 pallet-state-coprocessor = { workspace = true, default-features = true }
+pallet-beefy-consensus-proofs = { workspace = true, default-features = true }
 ethereum-triedb = { workspace = true, default-features = true }
 substrate-state-machine = { workspace = true, default-features = true }
 pallet-ismp-relayer = { workspace = true, default-features = true }

--- a/modules/pallets/testsuite/src/runtime.rs
+++ b/modules/pallets/testsuite/src/runtime.rs
@@ -103,6 +103,7 @@ frame_support::construct_runtime!(
 		IsmpParachain: ismp_parachain,
 		Bandwidth: pallet_bandwidth,
 		StateCoprocessor: pallet_state_coprocessor,
+		BeefyConsensusProofs: pallet_beefy_consensus_proofs,
 	}
 );
 
@@ -497,6 +498,27 @@ impl pallet_consensus_incentives::Config for Test {
 impl pallet_messaging_incentives::Config for Test {
 	type ReputationAsset = ReputationAsset;
 	type AdminOrigin = EnsureRoot<AccountId32>;
+}
+
+parameter_types! {
+	pub const BeefyProofsTreasury: PalletId = PalletId(*b"bf/proof");
+	pub const BeefyConsensusStateId: ismp::consensus::ConsensusStateId = *b"BEEF";
+	/// Deliberately small so a test can fill the ring and drive eviction without
+	/// authoring hundreds of proofs.
+	pub const MaxStoredBeefyProofs: u32 = 4;
+}
+
+impl pallet_beefy_consensus_proofs::Config for Test {
+	type AdminOrigin = EnsureRoot<AccountId32>;
+	type Currency = Balances;
+	type TreasuryPalletId = BeefyProofsTreasury;
+	type MaxProofSize = ConstU32<1024>;
+	type MaxStoredProofs = MaxStoredBeefyProofs;
+	type ConsensusStateId = BeefyConsensusStateId;
+	type UnbondingPeriod = ConstU64<10>;
+	type MaxUncleProvers = ConstU32<5>;
+	type ReputationAsset = ReputationAsset;
+	type WeightInfo = ();
 }
 
 parameter_types! {

--- a/modules/pallets/testsuite/src/tests/mod.rs
+++ b/modules/pallets/testsuite/src/tests/mod.rs
@@ -1,5 +1,6 @@
 mod child_trie_proof_check;
 mod pallet_bandwidth;
+mod pallet_beefy_consensus_proofs;
 mod pallet_call_decompressor;
 mod pallet_fishermen;
 mod pallet_ismp;

--- a/modules/pallets/testsuite/src/tests/pallet_beefy_consensus_proofs.rs
+++ b/modules/pallets/testsuite/src/tests/pallet_beefy_consensus_proofs.rs
@@ -1,0 +1,235 @@
+// Copyright (C) Polytope Labs Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Settlement tests for `pallet-beefy-consensus-proofs`.
+//!
+//! These drive `settle_first_proof` with a synthetic `VerifyOutcome` rather than a real BEEFY
+//! proof. Minting a proof that rotates the authority set without advancing the parachain head
+//! isn't something a test can do against live data, so the outcome is constructed directly.
+//! That's the whole point: the collision these guard against needs a mandatory proof landing
+//! on a height a messaging proof already used, which on a live chain only happens when the
+//! parachain stalls across a session boundary.
+
+use crate::runtime::{new_test_ext, Test};
+use pallet_beefy_consensus_proofs::{
+	pallet::VerifyOutcome,
+	types::{messaging_offchain_key, rotation_offchain_key, PROOF_TYPE_NAIVE, PROOF_TYPE_SP1},
+	AcceptedProvers, MessagingProofs, ProverCount, RotationProofs,
+};
+use polkadot_sdk::*;
+use primitive_types::H256;
+use sp_core::offchain::StorageKind;
+use sp_runtime::AccountId32;
+
+fn submitter(seed: u8) -> AccountId32 {
+	AccountId32::new([seed; 32])
+}
+
+fn messaging_outcome(height: u64, set_id: u64) -> VerifyOutcome {
+	VerifyOutcome {
+		latest_height: height,
+		current_set_id: set_id,
+		rotated: false,
+		has_new_messages: true,
+		child_trie_root: H256::repeat_byte(height as u8),
+	}
+}
+
+/// A mandatory proof that finalizes the same head an earlier messaging proof already covered,
+/// which is exactly what #1067 made possible.
+fn rotation_outcome(height: u64, set_id: u64) -> VerifyOutcome {
+	VerifyOutcome {
+		latest_height: height,
+		current_set_id: set_id,
+		rotated: true,
+		has_new_messages: false,
+		child_trie_root: H256::repeat_byte(height as u8),
+	}
+}
+
+fn read_offchain(key: &[u8]) -> Option<Vec<u8>> {
+	sp_io::offchain::local_storage_get(StorageKind::PERSISTENT, key)
+}
+
+/// The regression this PR exists to prevent: a mandatory proof landing on a height a messaging
+/// proof already wrote must not replace it. Under the old shared namespace the second write
+/// silently clobbered the first.
+#[test]
+fn rotation_at_a_used_height_does_not_overwrite_the_messaging_blob() {
+	let mut ext = new_test_ext();
+	let height = 500u64;
+	let messaging_blob = vec![PROOF_TYPE_NAIVE, 0xaa, 0xaa];
+	let rotation_blob = vec![PROOF_TYPE_NAIVE, 0xbb, 0xbb];
+
+	ext.execute_with(|| {
+		pallet_beefy_consensus_proofs::Pallet::<Test>::settle_first_proof(
+			submitter(1),
+			messaging_blob.clone(),
+			None,
+			PROOF_TYPE_NAIVE,
+			Vec::new(),
+			messaging_outcome(height, 7),
+		)
+		.expect("messaging proof settles");
+
+		pallet_beefy_consensus_proofs::Pallet::<Test>::settle_first_proof(
+			submitter(2),
+			rotation_blob.clone(),
+			None,
+			PROOF_TYPE_NAIVE,
+			Vec::new(),
+			rotation_outcome(height, 8),
+		)
+		.expect("rotation at the same height settles");
+	});
+	ext.persist_offchain_overlay();
+
+	ext.execute_with(|| {
+		assert_eq!(
+			read_offchain(&messaging_offchain_key(height)),
+			Some(messaging_blob),
+			"the messaging blob must survive a rotation landing on its height",
+		);
+		assert_eq!(
+			read_offchain(&rotation_offchain_key(8)),
+			Some(rotation_blob),
+			"the rotation blob must be readable under its set id",
+		);
+	});
+}
+
+/// A rotation writes nothing to the messaging namespace even though it advances the proven
+/// height, which is the hole `OffchainProofSource::fetch` resolves through `RotationProofs`.
+/// Pinned here so the index a reader needs for that lookup stays populated.
+#[test]
+fn a_rotation_is_only_discoverable_through_the_rotation_index() {
+	let mut ext = new_test_ext();
+	let height = 900u64;
+
+	ext.execute_with(|| {
+		pallet_beefy_consensus_proofs::Pallet::<Test>::settle_first_proof(
+			submitter(1),
+			vec![PROOF_TYPE_NAIVE, 0xcc],
+			None,
+			PROOF_TYPE_NAIVE,
+			Vec::new(),
+			rotation_outcome(height, 12),
+		)
+		.expect("rotation settles");
+
+		assert!(
+			!MessagingProofs::<Test>::get().contains(&height),
+			"a rotation must not be recorded as a messaging proof",
+		);
+		assert_eq!(
+			RotationProofs::<Test>::get().get(&12).copied(),
+			Some(height),
+			"the rotation index must map the set id to the height a reader would hold",
+		);
+	});
+	ext.persist_offchain_overlay();
+
+	ext.execute_with(|| {
+		assert!(
+			read_offchain(&messaging_offchain_key(height)).is_none(),
+			"nothing is written to the messaging namespace for a rotation",
+		);
+		assert!(read_offchain(&rotation_offchain_key(12)).is_some());
+	});
+}
+
+/// A rotation must still settle when the height it lands on has already handed out every uncle
+/// slot. `record_uncle_metadata` fails there, and treating that as a dispatch error would roll
+/// back the authority-set rotation, pinning consensus on the old set forever.
+#[test]
+fn a_full_uncle_slate_cannot_block_a_rotation() {
+	let mut ext = new_test_ext();
+	let height = 700u64;
+
+	ext.execute_with(|| {
+		// Fill every slot: one first prover plus MaxUncleProvers.
+		let full = (0..=5u8).map(|i| H256::repeat_byte(i)).collect::<Vec<_>>();
+		AcceptedProvers::<Test>::insert(
+			height,
+			sp_runtime::BoundedVec::truncate_from(full.clone()),
+		);
+		ProverCount::<Test>::insert(height, full.len() as u32);
+
+		pallet_beefy_consensus_proofs::Pallet::<Test>::settle_first_proof(
+			submitter(9),
+			vec![PROOF_TYPE_SP1, 0xdd],
+			Some(H256::repeat_byte(9)),
+			PROOF_TYPE_SP1,
+			Vec::new(),
+			rotation_outcome(height, 20),
+		)
+		.expect("a full uncle slate must not reject the rotation");
+
+		assert_eq!(
+			RotationProofs::<Test>::get().get(&20).copied(),
+			Some(height),
+			"the rotation must be recorded despite the uncle bookkeeping being full",
+		);
+	});
+}
+
+/// Eviction clears the namespace the departing entry actually lived in. Previously an expiring
+/// rotation computed a height key, which could delete a live messaging blob.
+#[test]
+fn eviction_clears_only_the_departing_namespace() {
+	let mut ext = new_test_ext();
+	// MaxStoredProofs is 4 in the test runtime, so the fifth rotation evicts the first.
+	let heights = [10u64, 20, 30, 40, 50];
+
+	ext.execute_with(|| {
+		pallet_beefy_consensus_proofs::Pallet::<Test>::settle_first_proof(
+			submitter(1),
+			vec![PROOF_TYPE_NAIVE, 0xee],
+			None,
+			PROOF_TYPE_NAIVE,
+			Vec::new(),
+			messaging_outcome(heights[0], 1),
+		)
+		.expect("messaging proof settles");
+
+		for (i, height) in heights.iter().enumerate() {
+			pallet_beefy_consensus_proofs::Pallet::<Test>::settle_first_proof(
+				submitter(2),
+				vec![PROOF_TYPE_NAIVE, *height as u8],
+				None,
+				PROOF_TYPE_NAIVE,
+				Vec::new(),
+				rotation_outcome(*height, 100 + i as u64),
+			)
+			.expect("rotation settles");
+		}
+	});
+	ext.persist_offchain_overlay();
+
+	ext.execute_with(|| {
+		assert!(
+			read_offchain(&rotation_offchain_key(100)).is_none(),
+			"the oldest rotation should have been evicted",
+		);
+		assert!(
+			read_offchain(&rotation_offchain_key(104)).is_some(),
+			"the newest rotation should still be present",
+		);
+		assert!(
+			read_offchain(&messaging_offchain_key(heights[0])).is_some(),
+			"evicting a rotation must not delete the messaging blob at the same height",
+		);
+	});
+}

--- a/modules/pallets/testsuite/src/tests/pallet_beefy_consensus_proofs.rs
+++ b/modules/pallets/testsuite/src/tests/pallet_beefy_consensus_proofs.rs
@@ -26,7 +26,7 @@ use crate::runtime::{new_test_ext, Test};
 use pallet_beefy_consensus_proofs::{
 	pallet::VerifyOutcome,
 	types::{messaging_offchain_key, rotation_offchain_key, PROOF_TYPE_NAIVE, PROOF_TYPE_SP1},
-	AcceptedProvers, MessagingProofs, ProverCount, RotationProofs,
+	AcceptedProvers, MessagingProofs, ProofReward, ProverCount, RotationProofs,
 };
 use polkadot_sdk::*;
 use primitive_types::H256;
@@ -181,6 +181,62 @@ fn a_full_uncle_slate_cannot_block_a_rotation() {
 			RotationProofs::<Test>::get().get(&20).copied(),
 			Some(height),
 			"the rotation must be recorded despite the uncle bookkeeping being full",
+		);
+	});
+}
+
+/// Same hazard, different source: an unpayable reward. `pay_position_reward` runs after the
+/// caller has applied the rotation, so propagating `RewardTransferFailed` rolls it back — and
+/// since the mandatory justification is the only one obtainable for that session, every retry
+/// fails identically until the treasury is topped up, leaving consensus on the old set. The
+/// reward is the cheaper thing to drop. Messaging proofs deliberately keep the hard error.
+#[test]
+fn an_unpayable_reward_cannot_block_a_rotation() {
+	let mut ext = new_test_ext();
+	let height = 800u64;
+
+	ext.execute_with(|| {
+		// The BEEFY proofs treasury holds nothing in genesis, so any non-zero reward makes the
+		// transfer fail with `RewardTransferFailed`.
+		ProofReward::<Test>::put(1_000_000u128);
+
+		pallet_beefy_consensus_proofs::Pallet::<Test>::settle_first_proof(
+			submitter(11),
+			vec![PROOF_TYPE_SP1, 0xab],
+			Some(H256::repeat_byte(11)),
+			PROOF_TYPE_SP1,
+			Vec::new(),
+			rotation_outcome(height, 30),
+		)
+		.expect("an unpayable reward must not reject the rotation");
+
+		assert_eq!(
+			RotationProofs::<Test>::get().get(&30).copied(),
+			Some(height),
+			"the rotation must be recorded even though the reward could not be paid",
+		);
+
+		// The asymmetry is deliberate: reverting a messaging proof is recoverable, because the
+		// next proof re-attempts the same work once the treasury can pay.
+		assert!(
+			pallet_beefy_consensus_proofs::Pallet::<Test>::settle_first_proof(
+				submitter(12),
+				vec![PROOF_TYPE_SP1, 0xac],
+				Some(H256::repeat_byte(12)),
+				PROOF_TYPE_SP1,
+				Vec::new(),
+				messaging_outcome(height + 1, 30),
+			)
+			.is_err(),
+			"a messaging proof must still fail hard when the reward cannot be paid",
+		);
+	});
+	ext.persist_offchain_overlay();
+
+	ext.execute_with(|| {
+		assert!(
+			read_offchain(&rotation_offchain_key(30)).is_some(),
+			"the rotation blob must still be written",
 		);
 	});
 }

--- a/parachain/simtests/Cargo.toml
+++ b/parachain/simtests/Cargo.toml
@@ -34,6 +34,7 @@ pallet-ismp-rpc = { workspace = true }
 pallet-intents-rpc = { workspace = true }
 pallet-intents-coprocessor = { workspace = true, default-features = true }
 ismp-parachain = { workspace = true, default-features = true }
+pallet-beefy-consensus-proofs = { workspace = true, default-features = true }
 beefy-prover = { workspace = true }
 beefy-verifier-primitives = { workspace = true, default-features = true }
 ismp-abi = { workspace = true, default-features = true }

--- a/parachain/simtests/src/pallet_beefy_consensus_proofs.rs
+++ b/parachain/simtests/src/pallet_beefy_consensus_proofs.rs
@@ -656,9 +656,9 @@ async fn test_naive_proof_happy_path() -> Result<(), anyhow::Error> {
 	};
 
 	eprintln!("[stage] proof stored in the {bucket} namespace at height {height}");
-	let stored = fetch_offchain(&rpc_client, &proof_key).await?.ok_or_else(|| {
-		anyhow!("proof blob missing under the {bucket} key at height {height}")
-	})?;
+	let stored = fetch_offchain(&rpc_client, &proof_key)
+		.await?
+		.ok_or_else(|| anyhow!("proof blob missing under the {bucket} key at height {height}"))?;
 	assert_eq!(stored, wire_proof, "blob under the {bucket} key must be the submitted proof");
 
 	// A mandatory proof may finalize a head a messaging proof already covered, so the thing
@@ -682,8 +682,9 @@ async fn fetch_offchain(
 	key: &[u8],
 ) -> Result<Option<Vec<u8>>, anyhow::Error> {
 	let hex_key = format!("0x{}", hex::encode(key));
-	let raw: Option<String> =
-		rpc_client.request("offchain_localStorageGet", rpc_params!["PERSISTENT", hex_key]).await?;
+	let raw: Option<String> = rpc_client
+		.request("offchain_localStorageGet", rpc_params!["PERSISTENT", hex_key])
+		.await?;
 	raw.map(|value| hex::decode(value.strip_prefix("0x").unwrap_or(&value)).map_err(Into::into))
 		.transpose()
 }

--- a/parachain/simtests/src/pallet_beefy_consensus_proofs.rs
+++ b/parachain/simtests/src/pallet_beefy_consensus_proofs.rs
@@ -66,6 +66,7 @@ use beefy_verifier_primitives::{
 use ismp_abi::ecdsa_beefy::{
 	BeefyConsensusProof as SolBeefyConsensusProof, BeefyConsensusState as SolBeefyConsensusState,
 };
+use pallet_beefy_consensus_proofs::types::{messaging_offchain_key, rotation_offchain_key};
 use primitive_types::H256;
 
 const PROOF_TYPE_NAIVE: u8 = 0;
@@ -630,25 +631,64 @@ async fn test_naive_proof_happy_path() -> Result<(), anyhow::Error> {
 	// a parachain commitment, and ran ring-buffer eviction. Combined with
 	// `wait_for_finalized_success` having returned ok, that's sufficient
 	// evidence the naive happy path works end-to-end.
-	if will_rotate {
+	//
+	// The proof bytes themselves land in offchain storage under a key that depends on the
+	// kind, so also read the blob back under the key its kind implies and check that the
+	// other namespace didn't receive it.
+	let (proof_key, height, bucket) = if will_rotate {
 		let rotation_proofs: BTreeMap<u64, u64> =
 			fetch_storage::<BTreeMap<u64, u64>>(&client, "RotationProofs")
 				.await?
 				.unwrap_or_default();
-		assert!(
-			!rotation_proofs.is_empty(),
-			"RotationProofs must contain the rotation height after a successful rotating proof",
-		);
+		let (set_id, height) = rotation_proofs
+			.into_iter()
+			.next_back()
+			.ok_or_else(|| anyhow!("RotationProofs empty after a successful rotating proof"))?;
+		(rotation_offchain_key(set_id), height, "rotation")
 	} else {
 		let messaging_proofs: Vec<u64> =
 			fetch_storage::<Vec<u64>>(&client, "MessagingProofs").await?.unwrap_or_default();
-		assert!(
-			!messaging_proofs.is_empty(),
-			"MessagingProofs must contain the proven height after a successful first proof",
+		let height = messaging_proofs
+			.last()
+			.copied()
+			.ok_or_else(|| anyhow!("MessagingProofs empty after a successful first proof"))?;
+		(messaging_offchain_key(height), height, "messaging")
+	};
+
+	eprintln!("[stage] proof stored in the {bucket} namespace at height {height}");
+	let stored = fetch_offchain(&rpc_client, &proof_key).await?.ok_or_else(|| {
+		anyhow!(
+			"proof blob missing under the {bucket} key; \
+			 is the node running with --enable-offchain-indexing true?"
+		)
+	})?;
+	assert_eq!(stored, wire_proof, "blob under the {bucket} key must be the submitted proof");
+
+	// A mandatory proof may finalize a head a messaging proof already covered, so the thing
+	// worth pinning is that it stays out of the messaging namespace at that height.
+	if will_rotate {
+		let aliased = fetch_offchain(&rpc_client, &messaging_offchain_key(height)).await?;
+		assert_ne!(
+			aliased.as_ref(),
+			Some(&wire_proof),
+			"rotation proof must not be reachable under the messaging key for height {height}",
 		);
 	}
 
 	Ok(())
+}
+
+/// Read a raw value out of the node's persistent offchain store. Returns `None` when the key
+/// was never written, which on a node without offchain indexing is every key.
+async fn fetch_offchain(
+	rpc_client: &RpcClient,
+	key: &[u8],
+) -> Result<Option<Vec<u8>>, anyhow::Error> {
+	let hex_key = format!("0x{}", hex::encode(key));
+	let raw: Option<String> =
+		rpc_client.request("offchain_localStorageGet", rpc_params!["PERSISTENT", hex_key]).await?;
+	raw.map(|value| hex::decode(value.strip_prefix("0x").unwrap_or(&value)).map_err(Into::into))
+		.transpose()
 }
 
 /// Tier-3 SP1 uncle dispatch path. Mirrors the bench in

--- a/parachain/simtests/src/pallet_beefy_consensus_proofs.rs
+++ b/parachain/simtests/src/pallet_beefy_consensus_proofs.rs
@@ -657,10 +657,7 @@ async fn test_naive_proof_happy_path() -> Result<(), anyhow::Error> {
 
 	eprintln!("[stage] proof stored in the {bucket} namespace at height {height}");
 	let stored = fetch_offchain(&rpc_client, &proof_key).await?.ok_or_else(|| {
-		anyhow!(
-			"proof blob missing under the {bucket} key; \
-			 is the node running with --enable-offchain-indexing true?"
-		)
+		anyhow!("proof blob missing under the {bucket} key at height {height}")
 	})?;
 	assert_eq!(stored, wire_proof, "blob under the {bucket} key must be the submitted proof");
 

--- a/sdk/packages/sdk/CHANGELOG.md
+++ b/sdk/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @hyperbridge/sdk
 
+## 2.6.2
+
+### Patch Changes
+
+- Mandatory (rotation) BEEFY proofs are read from their own offchain namespace, keyed by the authority set the proof rotated to rather than by parachain height. A rotation that finalizes a head an earlier messaging proof already covered no longer resolves to the wrong blob. The rotation walk now starts at the destination's current authority set id + 1 (it previously started two epochs low), and a proven height produced by a rotation is resolved through the rotation index instead of returning no proof. Proofs written under the previous shared key are still readable via a legacy fallback, so this requires no coordinated upgrade.
+
 ## 2.6.1
 
 ### Patch Changes

--- a/sdk/packages/sdk/package.json
+++ b/sdk/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/sdk",
-	"version": "2.6.1",
+	"version": "2.6.2",
 	"description": "The hyperclient SDK provides utilities for querying proofs and statuses for cross-chain requests from HyperBridge.",
 	"type": "module",
 	"types": "./dist/node/index.d.ts",

--- a/sdk/packages/sdk/src/chains/substrate.ts
+++ b/sdk/packages/sdk/src/chains/substrate.ts
@@ -487,23 +487,40 @@ export class SubstrateChain implements IChain {
 
 		const proofs: HexString[] = []
 
-		// The rotation map is keyed by the epoch that was current when the proof
-		// was generated — the proof itself is signed by set (key + 1). The handler's
-		// currentEpoch equals the destination's nextAuthoritySet.id. We start from
-		// currentEpoch - 1 (the destination's currentAuthoritySet.id) so the first
-		// proof is signed by a set the destination already knows.
-		let epoch = currentEpoch - 1n
+		// The map is keyed by the set each proof rotated *to*, and HandlerV2 records
+		// `nextAuthoritySetId - 1`, so `currentEpoch` is the destination's current set. The
+		// first proof it still needs is therefore the one rotating to currentEpoch + 1. This
+		// matches `rotation_proofs_from`, which walks from `from_set_id + 1`.
+		let epoch = currentEpoch + 1n
 		while (rotationMap.has(epoch)) {
 			const key = rotationOffchainKey(epoch)
-			const proof = await this.rpcClient.call("offchain_localStorageGet", ["PERSISTENT", key])
+			let proof = await this.rpcClient.call("offchain_localStorageGet", ["PERSISTENT", key])
+			if (!proof) {
+				// Rotations recorded before the namespace split are still under the messaging
+				// key at their height. Drop this once every destination is past the upgrade.
+				const legacyKey = messagingOffchainKey(rotationMap.get(epoch)!)
+				proof = await this.rpcClient.call("offchain_localStorageGet", ["PERSISTENT", legacyKey])
+			}
 			if (!proof) return undefined
 			proofs.push(proof as HexString)
 			epoch++
 		}
 
-		// Fetch the final messaging proof at lastProvenHeight
+		// Fetch the final messaging proof at lastProvenHeight. A rotation advances the proven
+		// height without writing a messaging blob, so when nothing is there, resolve the
+		// height through the rotation index instead.
 		const messagingKey = messagingOffchainKey(lastProvenHeight)
-		const messagingProof = await this.rpcClient.call("offchain_localStorageGet", ["PERSISTENT", messagingKey])
+		let messagingProof = await this.rpcClient.call("offchain_localStorageGet", ["PERSISTENT", messagingKey])
+		if (!messagingProof) {
+			for (const [setId, height] of rotationMap) {
+				if (height !== lastProvenHeight) continue
+				messagingProof = await this.rpcClient.call("offchain_localStorageGet", [
+					"PERSISTENT",
+					rotationOffchainKey(setId),
+				])
+				break
+			}
+		}
 		if (!messagingProof) return undefined
 		proofs.push(messagingProof as HexString)
 

--- a/sdk/packages/sdk/src/chains/substrate.ts
+++ b/sdk/packages/sdk/src/chains/substrate.ts
@@ -494,8 +494,7 @@ export class SubstrateChain implements IChain {
 		// proof is signed by a set the destination already knows.
 		let epoch = currentEpoch - 1n
 		while (rotationMap.has(epoch)) {
-			const height = rotationMap.get(epoch)!
-			const key = beefyOffchainKey(height)
+			const key = rotationOffchainKey(epoch)
 			const proof = await this.rpcClient.call("offchain_localStorageGet", ["PERSISTENT", key])
 			if (!proof) return undefined
 			proofs.push(proof as HexString)
@@ -503,7 +502,7 @@ export class SubstrateChain implements IChain {
 		}
 
 		// Fetch the final messaging proof at lastProvenHeight
-		const messagingKey = beefyOffchainKey(lastProvenHeight)
+		const messagingKey = messagingOffchainKey(lastProvenHeight)
 		const messagingProof = await this.rpcClient.call("offchain_localStorageGet", ["PERSISTENT", messagingKey])
 		if (!messagingProof) return undefined
 		proofs.push(messagingProof as HexString)
@@ -527,16 +526,29 @@ export class SubstrateChain implements IChain {
 	}
 }
 
+function beefyOffchainKey(prefix: string, id: bigint): HexString {
+	const prefixBytes = new TextEncoder().encode(prefix)
+	const idBytes = new Uint8Array(8)
+	new DataView(idBytes.buffer).setBigUint64(0, id, false)
+	return toHex(new Uint8Array([...prefixBytes, ...idBytes]))
+}
+
 /**
- * Constructs the offchain storage key for a verified consensus proof keyed by
- * proven parachain height. Matches Rust's `offchain_key(proven_height)` in
- * pallet-beefy-consensus-proofs: `OFFCHAIN_PREFIX || u64_be(proven_height)`.
+ * Offchain key for a messaging proof, keyed by the parachain height it advanced to.
+ * Mirrors `messaging_offchain_key` in pallet-beefy-consensus-proofs.
  */
-function beefyOffchainKey(provenHeight: bigint): HexString {
-	const prefix = new TextEncoder().encode("beefy_consensus_proofs::")
-	const heightBytes = new Uint8Array(8)
-	new DataView(heightBytes.buffer).setBigUint64(0, provenHeight, false)
-	return toHex(new Uint8Array([...prefix, ...heightBytes]))
+function messagingOffchainKey(provenHeight: bigint): HexString {
+	return beefyOffchainKey("beefy_consensus_proofs::", provenHeight)
+}
+
+/**
+ * Offchain key for a mandatory proof, keyed by the authority set id it rotated to.
+ * Mirrors `rotation_offchain_key` in pallet-beefy-consensus-proofs. Mandatory proofs sit in
+ * their own namespace because a rotation can finalize a head a messaging proof already
+ * covered, so height alone would let one overwrite the other.
+ */
+function rotationOffchainKey(setId: bigint): HexString {
+	return beefyOffchainKey("beefy_consensus_proofs::rotation::", setId)
 }
 
 function requestCommitmentStorageKey(key: HexString): number[] {

--- a/tesseract/messaging/messaging/src/fees.rs
+++ b/tesseract/messaging/messaging/src/fees.rs
@@ -27,7 +27,7 @@ use sp_core::U256;
 use std::{collections::HashMap, sync::Arc, time::Duration};
 use tesseract_primitives::{
 	config::RelayerConfig, ConsensusProofSource, Cost, Hasher, HyperbridgeClaim, IsmpProvider,
-	Query, WithdrawFundsResult, BEEFY_CONSENSUS_STATE_ID,
+	ProofKey, Query, WithdrawFundsResult, BEEFY_CONSENSUS_STATE_ID,
 };
 use tokio_stream::wrappers::IntervalStream;
 use tracing::{instrument, Instrument};
@@ -273,6 +273,7 @@ async fn deliver_post_request_evm<D: IsmpProvider>(
 				None => {
 					let mut latest_height =
 						hyperbridge.query_latest_height(hb_state_machine_id).await? as u64;
+					let mut proof_key = ProofKey::Messaging(latest_height);
 
 					if max_block > latest_height {
 						tracing::info!(
@@ -282,7 +283,7 @@ async fn deliver_post_request_evm<D: IsmpProvider>(
 						);
 						let mut stream = hyperbridge.proof_accepted_notification().await?;
 
-						latest_height = loop {
+						(latest_height, proof_key) = loop {
 							match stream.next().await {
 								Some(Ok(event)) =>
 									if event.height < max_block {
@@ -293,7 +294,11 @@ async fn deliver_post_request_evm<D: IsmpProvider>(
 											height = event.height,
 											"proof accepted",
 										);
-										break event.height;
+										let key = event.new_set_id.map_or(
+											ProofKey::Messaging(event.height),
+											ProofKey::Rotation,
+										);
+										break (event.height, key);
 									},
 								Some(Err(_)) => {
 									tracing::error!(
@@ -307,7 +312,7 @@ async fn deliver_post_request_evm<D: IsmpProvider>(
 						};
 					}
 
-					let consensus_proof = proof_source.fetch(latest_height).await?;
+					let consensus_proof = proof_source.fetch(proof_key).await?;
 					let msg = ConsensusMessage {
 						consensus_proof,
 						consensus_state_id: BEEFY_CONSENSUS_STATE_ID,

--- a/tesseract/messaging/messaging/src/outbound.rs
+++ b/tesseract/messaging/messaging/src/outbound.rs
@@ -31,8 +31,8 @@ use ismp::{
 use primitive_types::H256;
 use tesseract_primitives::{
 	config::RelayerConfig, ConsensusProofSource, Hasher, IsmpHost, IsmpProvider, NewEpochEvent,
-	PendingRequestDeliveryClaim, ProofAccepted, RotationProof, StateMachineUpdated, TxReceipt,
-	BEEFY_CONSENSUS_STATE_ID,
+	PendingRequestDeliveryClaim, ProofAccepted, ProofKey, RotationProof, StateMachineUpdated,
+	TxReceipt, BEEFY_CONSENSUS_STATE_ID,
 };
 use tesseract_substrate::{config::KeccakSubstrateChain, SubstrateClient};
 use tokio::sync::mpsc::Sender;
@@ -169,7 +169,8 @@ pub async fn run(
 			},
 		};
 
-		let proof_bytes = match proof_source.fetch(new_height).await {
+		let proof_key = new_set_id.map_or(ProofKey::Messaging(new_height), ProofKey::Rotation);
+		let proof_bytes = match proof_source.fetch(proof_key).await {
 			Ok(bytes) => bytes,
 			Err(err) => {
 				tracing::error!(
@@ -994,7 +995,7 @@ mod tests {
 	struct NoopProofSource;
 	#[async_trait::async_trait]
 	impl ConsensusProofSource for NoopProofSource {
-		async fn fetch(&self, _height: u64) -> Result<Vec<u8>, anyhow::Error> {
+		async fn fetch(&self, _key: ProofKey) -> Result<Vec<u8>, anyhow::Error> {
 			Ok(vec![0xcc])
 		}
 	}

--- a/tesseract/messaging/primitives/src/lib.rs
+++ b/tesseract/messaging/primitives/src/lib.rs
@@ -36,15 +36,25 @@ pub struct ProofAccepted {
 	pub new_set_id: Option<u64>,
 }
 
-/// Pulls the raw `payload.proof` bytes for an accepted BEEFY consensus proof
-/// (keyed by the parachain height it advanced HB to). Implementations live
-/// downstream — the relayer binary reads from HB's offchain storage via RPC,
-/// but tests mock it. Callers wrap the returned bytes in a
+/// Names the slot an accepted BEEFY proof was stored under. The pallet keeps mandatory
+/// and messaging proofs in separate offchain namespaces because a rotation may finalize a
+/// head an earlier messaging proof already covered, so height alone is ambiguous.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProofKey {
+	/// A messaging proof, keyed by the parachain height it advanced Hyperbridge to.
+	Messaging(u64),
+	/// A mandatory proof, keyed by the authority set id it rotated to.
+	Rotation(u64),
+}
+
+/// Pulls the raw `payload.proof` bytes for an accepted BEEFY consensus proof.
+/// Implementations live downstream: the relayer binary reads from HB's offchain
+/// storage via RPC, but tests mock it. Callers wrap the returned bytes in a
 /// [`ConsensusMessage`](ismp::messaging::ConsensusMessage).
 #[async_trait::async_trait]
 pub trait ConsensusProofSource: Send + Sync {
-	/// Fetch the proof bytes that advanced the parachain to `height`.
-	async fn fetch(&self, height: u64) -> Result<Vec<u8>, anyhow::Error>;
+	/// Fetch the proof bytes stored under `key`.
+	async fn fetch(&self, key: ProofKey) -> Result<Vec<u8>, anyhow::Error>;
 
 	/// Return every stored rotation proof with `set_id > from_set_id`,
 	/// ordered ascending by set_id. Used by outbound to catch a lagging EVM

--- a/tesseract/relayer/Cargo.toml
+++ b/tesseract/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tesseract"
-version = "2.4.9"
+version = "2.4.10"
 edition = "2021"
 description = "Consolidated Hyperbridge relayer — inbound and outbound consensus + messaging"
 authors = ["Polytope Labs <hello@polytope.technology>"]

--- a/tesseract/relayer/src/provider.rs
+++ b/tesseract/relayer/src/provider.rs
@@ -37,14 +37,54 @@ impl OffchainProofSource {
 	}
 }
 
-/// SCALE storage key for `pallet_beefy_consensus_proofs::RotationProofs`
-/// (`twox_128("BeefyConsensusProofs") ++ twox_128("RotationProofs")`). Computed
-/// at call time rather than once-at-startup because it's only used on the
-/// rotation-catch-up path, which runs at most once per accepted proof.
-fn rotation_proofs_storage_key() -> Vec<u8> {
+/// SCALE storage key for a `pallet_beefy_consensus_proofs` item
+/// (`twox_128("BeefyConsensusProofs") ++ twox_128(item)`). Computed at call time rather
+/// than once-at-startup because it's only used on the rotation-catch-up path, which runs
+/// at most once per accepted proof.
+fn storage_key(item: &[u8]) -> Vec<u8> {
 	let mut key = twox_128(b"BeefyConsensusProofs").to_vec();
-	key.extend_from_slice(&twox_128(b"RotationProofs"));
+	key.extend_from_slice(&twox_128(item));
 	key
+}
+
+impl OffchainProofSource {
+	/// Raw read from the node's persistent offchain store. `None` when nothing was ever
+	/// written under `storage_key` on this node.
+	async fn read_offchain(&self, storage_key: &[u8]) -> Result<Option<Vec<u8>>, anyhow::Error> {
+		let hex_key = format!("0x{}", hex::encode(storage_key));
+		let result: Option<String> = self
+			.rpc_client
+			.request("offchain_localStorageGet", rpc_params!["PERSISTENT", hex_key])
+			.await
+			.map_err(|err| anyhow!("offchain_localStorageGet failed: {err:?}"))?;
+
+		result
+			.map(|hex_bytes| {
+				let stripped = hex_bytes.strip_prefix("0x").unwrap_or(hex_bytes.as_str());
+				hex::decode(stripped)
+					.map_err(|err| anyhow!("offchain proof not valid hex: {err:?}"))
+			})
+			.transpose()
+	}
+
+	/// The pallet's `set_id → parachain height` rotation index. Empty when the storage item
+	/// was never written, which is normal on a fresh chain.
+	async fn rotation_proofs(&self) -> Result<BTreeMap<u64, u64>, anyhow::Error> {
+		let hex_key = format!("0x{}", hex::encode(storage_key(b"RotationProofs")));
+		let raw: Option<String> = self
+			.rpc_client
+			.request("state_getStorage", rpc_params![hex_key])
+			.await
+			.map_err(|err| anyhow!("state_getStorage(RotationProofs) failed: {err:?}"))?;
+
+		let Some(hex_value) = raw else { return Ok(BTreeMap::new()) };
+		let stripped = hex_value.strip_prefix("0x").unwrap_or(hex_value.as_str());
+		let bytes = hex::decode(stripped)
+			.map_err(|err| anyhow!("RotationProofs storage not valid hex: {err:?}"))?;
+		// `BoundedBTreeMap` encodes exactly like `BTreeMap`, so we skip the bound generic.
+		Decode::decode(&mut &bytes[..])
+			.map_err(|err| anyhow!("decode RotationProofs BTreeMap: {err:?}"))
+	}
 }
 
 #[async_trait::async_trait]
@@ -54,59 +94,52 @@ impl ConsensusProofSource for OffchainProofSource {
 			ProofKey::Messaging(height) => messaging_offchain_key(height),
 			ProofKey::Rotation(set_id) => rotation_offchain_key(set_id),
 		};
-		let hex_key = format!("0x{}", hex::encode(&storage_key));
-		tracing::debug!(target: crate::LOG_TARGET, ?key, storage_key = %hex_key, "offchain proof fetch");
-		let params = rpc_params!["PERSISTENT", hex_key];
+		tracing::debug!(target: crate::LOG_TARGET, ?key, "offchain proof fetch");
 
-		let result: Option<String> = self
-			.rpc_client
-			.request("offchain_localStorageGet", params)
-			.await
-			.map_err(|err| anyhow!("offchain_localStorageGet failed: {err:?}"))?;
+		if let Some(bytes) = self.read_offchain(&storage_key).await? {
+			tracing::debug!(target: crate::LOG_TARGET, ?key, bytes = bytes.len(), "proof fetched");
+			return Ok(bytes);
+		}
 
-		let hex_bytes = result.ok_or_else(|| {
-			tracing::warn!(target: crate::LOG_TARGET, ?key, "proof missing from HB offchain storage");
-			anyhow!(
-				"proof missing from HB offchain storage ({key:?}). \
-				 Ensure the HB node exposes unsafe RPCs and was up when the proof was submitted."
-			)
-		})?;
+		// A mandatory proof advances the proven height but writes no messaging blob, so a
+		// caller holding only that height finds nothing here. Resolve the height through the
+		// rotation index and read it out of the namespace it actually landed in.
+		if let ProofKey::Messaging(height) = key {
+			let rotated = self
+				.rotation_proofs()
+				.await?
+				.into_iter()
+				.find_map(|(set_id, at)| (at == height).then_some(set_id));
 
-		let stripped = hex_bytes.strip_prefix("0x").unwrap_or(hex_bytes.as_str());
-		let bytes = hex::decode(stripped)
-			.map_err(|err| anyhow!("offchain proof not valid hex: {err:?}"))?;
-		tracing::debug!(target: crate::LOG_TARGET, ?key, bytes = bytes.len(), "proof fetched");
-		Ok(bytes)
+			if let Some(set_id) = rotated {
+				if let Some(bytes) = self.read_offchain(&rotation_offchain_key(set_id)).await? {
+					tracing::debug!(
+						target: crate::LOG_TARGET,
+						height,
+						set_id,
+						"height belongs to a rotation proof",
+					);
+					return Ok(bytes);
+				}
+			}
+		}
+
+		tracing::warn!(target: crate::LOG_TARGET, ?key, "proof missing from HB offchain storage");
+		Err(anyhow!(
+			"proof missing from HB offchain storage ({key:?}). \
+			 Ensure the HB node exposes unsafe RPCs and was up when the proof was submitted."
+		))
 	}
 
 	async fn rotation_proofs_from(
 		&self,
 		from_set_id: u64,
 	) -> Result<Vec<RotationProof>, anyhow::Error> {
-		// Read the `BoundedBTreeMap<u64, u64, MaxStoredProofs>` storage value
-		// via `state_getStorage`. SCALE encoding for `BoundedBTreeMap` is the
-		// same as `BTreeMap` (a length-prefixed sequence of `(K, V)`), so we
-		// decode straight into `BTreeMap<u64, u64>` and avoid bringing the
-		// `MaxStoredProofs` generic into scope here.
-		let hex_key = format!("0x{}", hex::encode(rotation_proofs_storage_key()));
-		let params = rpc_params![hex_key];
-		let raw: Option<String> = self
-			.rpc_client
-			.request("state_getStorage", params)
-			.await
-			.map_err(|err| anyhow!("state_getStorage(RotationProofs) failed: {err:?}"))?;
-
-		let Some(hex_value) = raw else {
-			// Storage not yet written → no rotations recorded yet. Normal on
-			// a fresh HB — nothing to catch up to.
+		// An empty map means no rotations are recorded yet, which is normal on a fresh HB.
+		let map = self.rotation_proofs().await?;
+		if map.is_empty() {
 			return Ok(Vec::new());
-		};
-
-		let stripped = hex_value.strip_prefix("0x").unwrap_or(hex_value.as_str());
-		let bytes = hex::decode(stripped)
-			.map_err(|err| anyhow!("RotationProofs storage not valid hex: {err:?}"))?;
-		let map: BTreeMap<u64, u64> = Decode::decode(&mut &bytes[..])
-			.map_err(|err| anyhow!("decode RotationProofs BTreeMap: {err:?}"))?;
+		}
 
 		let next_set_id = from_set_id + 1;
 		if !map.contains_key(&next_set_id) {

--- a/tesseract/relayer/src/provider.rs
+++ b/tesseract/relayer/src/provider.rs
@@ -21,11 +21,11 @@
 
 use anyhow::anyhow;
 use codec::Decode;
-use pallet_beefy_consensus_proofs::types::offchain_key;
+use pallet_beefy_consensus_proofs::types::{messaging_offchain_key, rotation_offchain_key};
 use sp_crypto_hashing::twox_128;
 use std::collections::BTreeMap;
 use subxt::ext::subxt_rpcs::{rpc_params, RpcClient};
-pub use tesseract_primitives::{ConsensusProofSource, RotationProof};
+pub use tesseract_primitives::{ConsensusProofSource, ProofKey, RotationProof};
 
 pub struct OffchainProofSource {
 	rpc_client: RpcClient,
@@ -49,10 +49,13 @@ fn rotation_proofs_storage_key() -> Vec<u8> {
 
 #[async_trait::async_trait]
 impl ConsensusProofSource for OffchainProofSource {
-	async fn fetch(&self, height: u64) -> Result<Vec<u8>, anyhow::Error> {
-		let key = offchain_key(height);
-		let hex_key = format!("0x{}", hex::encode(&key));
-		tracing::debug!(target: crate::LOG_TARGET, height, key = %hex_key, "offchain proof fetch");
+	async fn fetch(&self, key: ProofKey) -> Result<Vec<u8>, anyhow::Error> {
+		let storage_key = match key {
+			ProofKey::Messaging(height) => messaging_offchain_key(height),
+			ProofKey::Rotation(set_id) => rotation_offchain_key(set_id),
+		};
+		let hex_key = format!("0x{}", hex::encode(&storage_key));
+		tracing::debug!(target: crate::LOG_TARGET, ?key, storage_key = %hex_key, "offchain proof fetch");
 		let params = rpc_params!["PERSISTENT", hex_key];
 
 		let result: Option<String> = self
@@ -62,9 +65,9 @@ impl ConsensusProofSource for OffchainProofSource {
 			.map_err(|err| anyhow!("offchain_localStorageGet failed: {err:?}"))?;
 
 		let hex_bytes = result.ok_or_else(|| {
-			tracing::warn!(target: crate::LOG_TARGET, height, "proof missing from HB offchain storage");
+			tracing::warn!(target: crate::LOG_TARGET, ?key, "proof missing from HB offchain storage");
 			anyhow!(
-				"proof missing from HB offchain storage (h={height}). \
+				"proof missing from HB offchain storage ({key:?}). \
 				 Ensure the HB node exposes unsafe RPCs and was up when the proof was submitted."
 			)
 		})?;
@@ -72,7 +75,7 @@ impl ConsensusProofSource for OffchainProofSource {
 		let stripped = hex_bytes.strip_prefix("0x").unwrap_or(hex_bytes.as_str());
 		let bytes = hex::decode(stripped)
 			.map_err(|err| anyhow!("offchain proof not valid hex: {err:?}"))?;
-		tracing::debug!(target: crate::LOG_TARGET, height, bytes = bytes.len(), "proof fetched");
+		tracing::debug!(target: crate::LOG_TARGET, ?key, bytes = bytes.len(), "proof fetched");
 		Ok(bytes)
 	}
 
@@ -112,12 +115,19 @@ impl ConsensusProofSource for OffchainProofSource {
 			));
 		}
 
-		// Walk ascending so the caller can submit rotations in order.
+		// Walk ascending so the caller can submit rotations in order. The blob for each
+		// rotation lives under its set id, which is the key we are already iterating.
+		// Rotations recorded before the namespace split still sit under the messaging key at
+		// their recorded height, so fall back there rather than strand a lagging destination.
+		// Drop the fallback once every live destination is past the upgrade.
 		let mut out = Vec::new();
 		for (set_id, height) in map.into_iter().filter(|(set_id, _)| *set_id > from_set_id) {
-			let proof = self.fetch(height).await.map_err(|err| {
-				anyhow!("rotation proof missing from offchain storage (set_id={set_id}, height={height}): {err:?}")
-			})?;
+			let proof = match self.fetch(ProofKey::Rotation(set_id)).await {
+				Ok(proof) => proof,
+				Err(_) => self.fetch(ProofKey::Messaging(height)).await.map_err(|err| {
+					anyhow!("rotation proof missing from offchain storage (set_id={set_id}, height={height}): {err:?}")
+				})?,
+			};
 			out.push(RotationProof { set_id, height, proof });
 		}
 		Ok(out)


### PR DESCRIPTION
Mandatory proofs shared an offchain key with messaging proofs, they now sit under a rotation prefix keyed by the set id they rotated to, and the relayer and SDK pick the namespace from the accepted proof's set  id rather than always deriving it from height.
