### PR TITLE
[runtime]: Turn off dispatchable xcm execute on both runtimes

### DIFF
--- a/parachain/runtimes/gargantua/src/xcm.rs
+++ b/parachain/runtimes/gargantua/src/xcm.rs
@@ -221,9 +221,9 @@ impl pallet_xcm::Config for Runtime {
 	type SendXcmOrigin = EnsureXcmOrigin<RuntimeOrigin, LocalOriginToLocation>;
 	type XcmRouter = XcmRouter;
 	type ExecuteXcmOrigin = EnsureXcmOrigin<RuntimeOrigin, LocalOriginToLocation>;
-	type XcmExecuteFilter = Everything;
-	// ^ Disable dispatchable execute on the XCM pallet.
-	// Needs to be `Everything` for local testing.
+	// Origins lose any filter attached to them once reduced to a location, so `Transact` would
+	// come back with more authority than the caller had.
+	type XcmExecuteFilter = Nothing;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 	type XcmTeleportFilter = Everything;
 	type XcmReserveTransferFilter = Nothing;

--- a/parachain/runtimes/nexus/src/xcm.rs
+++ b/parachain/runtimes/nexus/src/xcm.rs
@@ -193,9 +193,9 @@ impl pallet_xcm::Config for Runtime {
 	type SendXcmOrigin = EnsureXcmOrigin<RuntimeOrigin, LocalOriginToLocation>;
 	type XcmRouter = XcmRouter;
 	type ExecuteXcmOrigin = EnsureXcmOrigin<RuntimeOrigin, LocalOriginToLocation>;
-	type XcmExecuteFilter = Everything;
-	// ^ Disable dispatchable execute on the XCM pallet.
-	// Needs to be `Everything` for local testing.
+	// Origins lose any filter attached to them once reduced to a location, so `Transact` would
+	// come back with more authority than the caller had.
+	type XcmExecuteFilter = Nothing;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 	type XcmTeleportFilter = Everything;
 	type XcmReserveTransferFilter = Nothing;


### PR DESCRIPTION
`XcmExecuteFilter` was set to `Everything` on nexus and gargantua, which let any signed account run a local XCM program. That is not safe for restricted origins, because a filter attached to an origin is dropped once the origin is reduced to a location and `Transact` rebuilds a plain signed origin from it. Both runtimes now set `Nothing`

Nothing depends on it, no `Transact` instruction is constructed anywhere in the workspace.
