### PR TITLE
[runtime]: Validate ByteVector length when SCALE decoding

### DIFF
--- a/modules/utils/bls-utils/src/ssz/byte_vector.rs
+++ b/modules/utils/bls-utils/src/ssz/byte_vector.rs
@@ -23,11 +23,38 @@ use core::{
 };
 use ssz_rs::prelude::*;
 
-#[derive(Default, Clone, Eq, SimpleSerialize, codec::Encode, codec::Decode)]
+#[derive(Default, Clone, Eq, SimpleSerialize, codec::Encode)]
 #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub struct ByteVector<const N: usize>(
 	#[cfg_attr(feature = "serde", serde(with = "serde_hex_utils::as_hex"))] Vector<u8, N>,
 );
+
+/// Length-checked SCALE decoding.
+///
+/// A derived `Decode` here delegates to the inner `Vector`, which carries its own derive and
+/// so accepts any length — leaving a `ByteVector<N>` holding something other than `N` bytes.
+/// That matters because the SSZ hash root is not sensitive to trailing zero bytes: a value
+/// packs into `ceil(N / 32)` chunks with the tail already zero-padded, so appending zeros up
+/// to the next chunk boundary consumes padding that was already there and leaves the root
+/// unchanged. A consumer that authenticates only by `hash_tree_root` would therefore accept an
+/// over-length value and persist it, and the length would not be caught until some later
+/// operation — for a BLS key, a point decompression far away from this decode.
+///
+/// Reject at the boundary instead, reusing the same `deserialize` the byte-slice conversions
+/// above go through so there is one definition of the length rule.
+///
+/// The wire format is unchanged: `Vector`'s SCALE representation is just its inner `Vec`, as
+/// its merkle cache is `codec(skip)`.
+impl<const N: usize> codec::Decode for ByteVector<N> {
+	fn decode<I: codec::Input>(input: &mut I) -> Result<Self, codec::Error> {
+		let bytes = Vec::<u8>::decode(input)?;
+		if bytes.len() != N {
+			return Err(codec::Error::from("ByteVector: decoded length does not equal N"));
+		}
+		ByteVector::<N>::try_from(bytes)
+			.map_err(|_| codec::Error::from("ByteVector: SSZ deserialization failed"))
+	}
+}
 
 impl<const N: usize> TryFrom<&[u8]> for ByteVector<N> {
 	type Error = ssz_rs::DeserializeError;
@@ -105,5 +132,81 @@ impl<const N: usize> Deref for ByteVector<N> {
 impl<const N: usize> DerefMut for ByteVector<N> {
 	fn deref_mut(&mut self) -> &mut Self::Target {
 		&mut self.0
+	}
+}
+
+#[cfg(test)]
+mod decode_length_tests {
+	use super::*;
+	use codec::{Decode, Encode};
+
+	/// BLS public keys are the case that motivated this: 48 bytes, i.e. two SSZ chunks whose
+	/// second is half padding.
+	const N: usize = 48;
+
+	fn encoded(len: usize) -> Vec<u8> {
+		vec![7u8; len].encode()
+	}
+
+	#[test]
+	fn accepts_exactly_n_bytes_and_round_trips() {
+		let original = ByteVector::<N>::try_from(vec![7u8; N]).expect("N bytes is valid");
+		let decoded = ByteVector::<N>::decode(&mut &original.encode()[..]).expect("round trip");
+		assert_eq!(decoded, original);
+		assert_eq!(decoded.as_ref().len(), N);
+	}
+
+	/// The reported vector: one trailing byte past `N`. The SSZ root is unchanged by it, so the
+	/// decode boundary is the only place this can be caught.
+	#[test]
+	fn rejects_one_byte_over() {
+		assert!(ByteVector::<N>::decode(&mut &encoded(N + 1)[..]).is_err());
+	}
+
+	/// Every length up to the next chunk boundary shares the 48-byte root, so each one has to
+	/// be rejected — not just the first.
+	#[test]
+	fn rejects_every_length_sharing_the_hash_root() {
+		for len in (N + 1)..=64 {
+			assert!(
+				ByteVector::<N>::decode(&mut &encoded(len)[..]).is_err(),
+				"over-length value of {len} bytes was accepted",
+			);
+		}
+	}
+
+	#[test]
+	fn rejects_under_length() {
+		for len in [0usize, 1, N - 1] {
+			assert!(
+				ByteVector::<N>::decode(&mut &encoded(len)[..]).is_err(),
+				"under-length value of {len} bytes was accepted",
+			);
+		}
+	}
+
+	/// An over-length value must not survive as a field of a larger SCALE struct either, since
+	/// that is how it arrives in a consensus update.
+	#[test]
+	fn rejects_when_nested_in_a_struct() {
+		#[derive(Encode)]
+		struct Wire {
+			key: Vec<u8>,
+			tail: u32,
+		}
+
+		#[derive(Decode)]
+		struct Parsed {
+			#[allow(dead_code)]
+			key: ByteVector<N>,
+			#[allow(dead_code)]
+			tail: u32,
+		}
+
+		let good = Wire { key: vec![7u8; N], tail: 1 }.encode();
+		assert!(Parsed::decode(&mut &good[..]).is_ok());
+
+		let bad = Wire { key: vec![7u8; N + 1], tail: 1 }.encode();
+		assert!(Parsed::decode(&mut &bad[..]).is_err());
 	}
 }


### PR DESCRIPTION
The derived `Decode` on `ByteVector<N>` delegates to the inner ssz-rs `Vector`, which carries its own derive and accepts any length, so a `ByteVector<48>` could hold something other than 48 bytes. The byte-slice conversions right beside it go through `deserialize` and do enforce `N`, so the same type validated on one path and not the other.

That gap is reachable because the SSZ hash root does not distinguish the two. A 48-byte value packs into two chunks whose second is half padding, so appending zero bytes up to the next chunk boundary consumes padding that was already zero and leaves `hash_tree_root` unchanged. The sync-committee verifier authenticates `next_sync_committee` solely by that root against the attested beacon state root and then persists the value it received, so an over-length aggregate public key verifies against a genuine state root and is stored. A period later it is promoted to the current committee and every subsequent update fails inside point decompression, far from the decode that admitted it.

Replace the derive with a length-checked impl that reuses the same `deserialize` the byte-slice conversions use, so there is one definition of the rule. The wire format is unchanged: `Vector`'s SCALE representation is just its inner `Vec`, since its merkle cache is `codec(skip)`.

Tests cover the exact-length round trip, one byte over, every length up to the next chunk boundary that shares the 48-byte root, under-length values, and an over-length value nested in a larger SCALE struct — which is how it would arrive in a consensus update.
