### PR TITLE
[indexer]: default EVM nodes to 3 block confirmations

### DIFF
--- a/sdk/packages/indexer/docker/docker-compose.local.yml
+++ b/sdk/packages/indexer/docker/docker-compose.local.yml
@@ -103,7 +103,7 @@ services:
             - --historical=timestamp
             - --unfinalized-blocks
             - --disable-multichain-rewind-lock
-            - --block-confirmations=0
+            - --block-confirmations=${SUBQL_BLOCK_CONFIRMATIONS:-3}
             - --store-cache-async=false
             - --store-cache-threshold=1
 
@@ -144,7 +144,7 @@ services:
             - --historical=timestamp
             - --unfinalized-blocks
             - --disable-multichain-rewind-lock
-            - --block-confirmations=0
+            - --block-confirmations=${SUBQL_BLOCK_CONFIRMATIONS:-3}
             - --store-cache-async=false
             - --store-cache-threshold=1
 

--- a/sdk/packages/indexer/scripts/templates/partials/docker-command.hbs
+++ b/sdk/packages/indexer/scripts/templates/partials/docker-command.hbs
@@ -13,7 +13,7 @@
 {{#if blockConfirmations}}
 - --block-confirmations={{blockConfirmations}}
 {{else}}
-- --block-confirmations=0
+- --block-confirmations=${SUBQL_BLOCK_CONFIRMATIONS:-3}
 {{/if}}
 - --unfinalized-blocks
 {{else}}


### PR DESCRIPTION
Closes: #1088

EVM indexer nodes ran with `--block-confirmations=0`, fetching logs the instant a block appears at head. A lagging RPC replica can answer with an empty log set for such a block, silently dropping events — this caused a missed vault Withdraw on Base that permanently skewed a filler's yield series. The generated node command now defaults to `--block-confirmations=${SUBQL_BLOCK_CONFIRMATIONS:-3}`, overridable per deployment; chains that set an explicit `blockConfirmations` in config are unchanged. Note: `generate-compose.ts` skips existing files, so already-generated per-chain compose files on deployment hosts must be deleted and regenerated to pick this up.