### PR TITLE
[simplex]: circle paymaster keeps its 200k default when a permit executes during validation

### DIFF
--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/simplex",
-	"version": "0.8.4",
+	"version": "0.8.5",
 	"license": "Apache-2.0",
 	"description": "IntentGateway simplex package for hyperbridge",
 	"main": "dist/index.js",

--- a/sdk/packages/simplex/src/services/DelegationService.ts
+++ b/sdk/packages/simplex/src/services/DelegationService.ts
@@ -185,6 +185,12 @@ export class DelegationService {
 			// reused) — actual ~96k — so those loose limits fall below the 0.4 floor
 			// (`actual / (accountVerif + paymasterVerif)`). Tighten both verification
 			// limits for that case so the ratio clears 0.4 while still covering usage.
+			//
+			// The tightened paymaster limit assumes the allowance is still in place. When
+			// it has been depleted (or was never set on this chain — e.g. re-delegating
+			// from an older SolverAccount), the Circle builder ignores the override and
+			// keeps its 200k default: the permit executed during validation needs ~113k
+			// on its own and would OOG the paymaster frame (bundler AA33) at 110k.
 			const code = await this.clientManager.getPublicClient(chain).getCode({
 				address: this.signer.account.address as HexString,
 			})

--- a/sdk/packages/simplex/src/services/UserOpSender.ts
+++ b/sdk/packages/simplex/src/services/UserOpSender.ts
@@ -44,8 +44,10 @@ export interface SponsoredUserOpRequest {
 	 * Override for the Circle paymaster verification gas limit (default 200k).
 	 * Lower it for a known cheap op so rundler's verification-gas-limit efficiency
 	 * policy — which divides actual usage by `accountVerif + paymasterVerif` —
-	 * accepts the op (e.g. re-delegation). Ignored when the Simplex paymaster is
-	 * selected; its limits are mode-specific.
+	 * accepts the op (e.g. re-delegation). Only honored when the paymaster allowance
+	 * is already in place — a permit executed during validation needs the full
+	 * default. Ignored when the Simplex paymaster is selected; its limits are
+	 * mode-specific.
 	 */
 	paymasterVerificationGasLimit?: bigint
 	/**

--- a/sdk/packages/simplex/src/services/paymaster/provider/circle.ts
+++ b/sdk/packages/simplex/src/services/paymaster/provider/circle.ts
@@ -29,6 +29,12 @@ export async function buildCirclePaymasterData(
 	 * Circle-recommended {@link VERIFICATION_GAS_LIMIT_CIRCLE}. A caller can pass a
 	 * tighter value for a known, cheap op (e.g. a re-delegation) so the bundler's
 	 * verification-gas-limit efficiency policy accepts it — see the delegation path.
+	 *
+	 * Only honored when the existing allowance covers the threshold. The permit path
+	 * alone burns ~113k gas during validation (EIP-2612 permit resolved via ERC-1271
+	 * through the delegated account, plus the upfront transferFrom), so a tightened
+	 * limit would make the paymaster frame run out of gas and the bundler reject the
+	 * op with AA33.
 	 */
 	paymasterVerificationGasLimit: bigint = VERIFICATION_GAS_LIMIT_CIRCLE,
 ): Promise<PaymasterResult> {
@@ -78,7 +84,9 @@ export async function buildCirclePaymasterData(
 	return {
 		paymaster: paymasterAddress,
 		paymasterData,
-		paymasterVerificationGasLimit,
+		// Executing the permit needs the full Circle default — a caller's tightened
+		// limit only applies to the cheap allowance-reuse branch above.
+		paymasterVerificationGasLimit: VERIFICATION_GAS_LIMIT_CIRCLE,
 		paymasterPostOpGasLimit: POST_OP_GAS_LIMIT,
 	}
 }

--- a/sdk/packages/simplex/src/services/paymaster/types.ts
+++ b/sdk/packages/simplex/src/services/paymaster/types.ts
@@ -22,7 +22,9 @@ export interface PaymasterOptions {
 	configService: FillerConfigService
 	/**
 	 * Override for the Circle paymaster verification gas limit (default 200k).
-	 * Ignored when the Simplex paymaster is selected — its limits are mode-specific
+	 * Only honored when the paymaster allowance is already in place — a permit
+	 * executed during validation needs the full default. Ignored when the Simplex
+	 * paymaster is selected — its limits are mode-specific
 	 * ({@link VERIFICATION_GAS_LIMIT_PERMIT} / {@link VERIFICATION_GAS_LIMIT_APPROVE}).
 	 */
 	paymasterVerificationGasLimit?: bigint

--- a/sdk/packages/simplex/src/tests/services/CirclePaymaster.test.ts
+++ b/sdk/packages/simplex/src/tests/services/CirclePaymaster.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest"
+import type { PublicClient } from "viem"
+import type { HexString } from "@hyperbridge/sdk"
+
+import { buildCirclePaymasterData } from "@/services/paymaster/provider/circle"
+import { VERIFICATION_GAS_LIMIT_CIRCLE } from "@/services/paymaster/types"
+import type { FillerConfigService } from "@/services/FillerConfigService"
+
+/**
+ * Regression test for the Polygon AA33 delegation failure: a re-delegation passes a
+ * tightened paymasterVerificationGasLimit (110k) on the assumption that the Circle
+ * paymaster allowance is already in place. When the allowance is depleted (or never
+ * set), the paymasterData carries a full EIP-2612 permit that executes during
+ * validation and needs ~113k on its own — so the tightened override must only be
+ * honored on the allowance-reuse branch, never on the permit branch.
+ */
+
+const USDC = "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359" as HexString
+const PAYMASTER = "0x0578cFB241215b77442a541325d6A4E6dFE700Ec" as HexString
+const SOLVER = "0x13E41CdE1D55880cbe031c69f206C2E9BC3c94C2" as HexString
+const CHAIN = "EVM-137"
+const TIGHTENED_LIMIT = 110_000n
+
+const configService = {
+	getUsdcAsset: () => USDC,
+	getUsdcDecimals: () => 6,
+	getChainId: () => 137,
+} as unknown as FillerConfigService
+
+function mockClient(allowance: bigint): PublicClient {
+	return {
+		readContract: async ({ functionName }: { functionName: string }) => {
+			switch (functionName) {
+				case "allowance":
+					return allowance
+				case "name":
+					return "USD Coin"
+				case "version":
+					return "2"
+				case "nonces":
+					return 0n
+				default:
+					throw new Error(`unexpected readContract: ${functionName}`)
+			}
+		},
+	} as unknown as PublicClient
+}
+
+const signer = {
+	signTypedData: async () => ("0x" + "11".repeat(65)) as HexString,
+}
+
+describe("buildCirclePaymasterData verification gas limit", () => {
+	it("honors a tightened limit when the existing allowance covers the threshold", async () => {
+		const pm = await buildCirclePaymasterData(
+			mockClient(5_000_000n),
+			signer,
+			SOLVER,
+			PAYMASTER,
+			CHAIN,
+			configService,
+			TIGHTENED_LIMIT,
+		)
+
+		// Allowance-reuse branch: no permit, single mode byte
+		expect(pm.paymasterData).toBe("0x00")
+		expect(pm.paymasterVerificationGasLimit).toBe(TIGHTENED_LIMIT)
+	})
+
+	it("restores the Circle default when a permit must execute during validation", async () => {
+		const pm = await buildCirclePaymasterData(
+			mockClient(0n),
+			signer,
+			SOLVER,
+			PAYMASTER,
+			CHAIN,
+			configService,
+			TIGHTENED_LIMIT,
+		)
+
+		// Permit branch: mode byte + token + amount + signature
+		expect(pm.paymasterData.length).toBeGreaterThan(4)
+		expect(pm.paymasterVerificationGasLimit).toBe(VERIFICATION_GAS_LIMIT_CIRCLE)
+	})
+})


### PR DESCRIPTION
## Problem

Delegating to SolverAccount on Polygon failed with `AA33 reverted` from the bundler, then fell back to a direct EIP-7702 tx and died on zero native balance.

AA33 is the paymaster's `validatePaymasterUserOp` reverting — in this case an out-of-gas inside the Circle paymaster's validation frame:

1. On Polygon the filler EOA is already delegated, but to an **old** SolverAccount — so `DelegationService` takes the re-delegation branch and tightens `paymasterVerificationGasLimit` to 110k, assuming the paymaster allowance is still in place.
2. On Polygon the USDC allowance to the Circle paymaster is **0** (never permitted there — unlike Base, which holds a live allowance from an earlier permit). With no allowance, the paymasterData carries a full EIP-2612 permit that executes during validation: USDC's `permit(…bytes)` overload resolves the signature via ERC-1271 through the delegated account, and the paymaster also does an upfront `transferFrom`.
3. Measured on a Polygon fork (real paymaster + USDC, synthetic 7702-delegated EOA): the permit path needs **~113,063 gas**. At 110k it OOGs → `AA33 reverted`; at the 200k Circle default it succeeds — a 3k miss.

Ruled out along the way: paymaster EntryPoint deposit (18.8k POL), permit signature/domain issues (the same signing code produced Base's live allowance), and missing ERC-1271 on either SolverAccount version.

## Fix

`buildCirclePaymasterData` already knows which branch it's on, so the decision moves there: the tightened override is only honored on the allowance-reuse branch, and the permit branch always uses `VERIFICATION_GAS_LIMIT_CIRCLE` (200k). rundler's verification-efficiency policy still clears: ~148k actual over 80k + 200k limits ≈ 0.53 > 0.4.

- `circle.ts`: permit branch ignores the caller override
- `DelegationService.ts` / `UserOpSender.ts` / `types.ts`: comments state the real invariant
- New unit test pinning both branches (`CirclePaymaster.test.ts`)
- `@hyperbridge/simplex` 0.8.4 → 0.8.5 (0.8.4 was already released from #1096)
