### PR TITLE
[simplex]: Contain phantom bid errors and cover one-sided LP probes

### DIFF
--- a/sdk/packages/simplex/src/core/filler.ts
+++ b/sdk/packages/simplex/src/core/filler.ts
@@ -837,7 +837,17 @@ export class IntentFiller {
 			.then((coprocessor) => {
 				this.stopPhantomPolling = coprocessor.pollPhantomOrders(
 					(order) => {
-						this.globalQueue.add(() => this.handlePhantomOrder(order, coprocessor))
+						// The queued promise is nobody's return value, so an escaping throw would be an
+						// unhandled rejection — which this process has no handler for and Node turns into
+						// an exit. Contain it here so a bad phantom order can never take the filler down.
+						void this.globalQueue
+							.add(() => this.handlePhantomOrder(order, coprocessor))
+							.catch((err) =>
+								this.logger.error(
+									{ err, chain: order.chain, commitment: order.commitment },
+									"Unhandled error while processing a phantom order",
+								),
+							)
 					},
 					{ onError: (err) => this.logger.warn({ err }, "Phantom order poll failed, will retry") },
 				)
@@ -855,8 +865,20 @@ export class IntentFiller {
 			return
 		}
 
-		// Fetch the exact ABI-encoded order the pallet committed to from offchain storage.
-		const phantomOrder = await coprocessor.fetchPhantomOrder(event.commitment)
+		// Fetch the exact ABI-encoded order the pallet committed to from offchain storage. The read
+		// throws rather than returning empty when the node does not serve the offchain RPC at all,
+		// which is the common misconfiguration — a public endpoint runs safe methods only.
+		let phantomOrder: Order | null
+		try {
+			phantomOrder = await coprocessor.fetchPhantomOrder(event.commitment)
+		} catch (err) {
+			this.logger.error(
+				{ err, commitment: event.commitment, chain: event.chain },
+				"Could not read the phantom order from offchain storage — the Hyperbridge node must run with " +
+					"--enable-offchain-indexing=true and expose offchain_localStorageGet (--rpc-methods=unsafe)",
+			)
+			return
+		}
 		if (!phantomOrder) {
 			this.logger.warn(
 				{ commitment: event.commitment, chain: event.chain },

--- a/sdk/packages/simplex/src/tests/strategies/fx.one-sided-lp.test.ts
+++ b/sdk/packages/simplex/src/tests/strategies/fx.one-sided-lp.test.ts
@@ -51,12 +51,18 @@ const configService = {
 
 // Mirrors how simplex.ts shares one contractService (and its classification cache)
 // across every strategy. Pass the same instance to two fillers to exercise that.
+// `getTokenDecimals` and the filler-output cache are what `quotePhantomFill` needs on
+// top of `canFill`; both test tokens are 18-decimal.
 function makeContractService(): any {
 	const cache = new Map<string, unknown>()
+	const outputs = new Map<string, unknown>()
 	return {
+		getTokenDecimals: async () => 18,
 		cacheService: {
 			getPairClassifications: (id: string) => cache.get(id),
 			setPairClassifications: (id: string, pairs: unknown) => cache.set(id, pairs),
+			getFillerOutputs: (id: string) => outputs.get(id),
+			setFillerOutputs: (id: string, value: unknown) => outputs.set(id, value),
 		},
 	}
 }
@@ -92,6 +98,17 @@ function makeOrder(id: string, input: HexString, output: HexString): Order {
 		inputs,
 		output: { beneficiary: bytes20ToBytes32(SOLVER), assets: outputs, call: "0x" as HexString },
 	} as unknown as Order
+}
+
+/**
+ * Mirrors a phantom probe as `pallet-intents-coprocessor` builds it: same chain on both sides,
+ * a standard input amount, and an output whose requested amount is zero — the probe asks what
+ * the filler would pay for the input, and never executes.
+ */
+function makePhantomOrder(id: string, input: HexString, output: HexString): Order {
+	const order = makeOrder(id, input, output)
+	order.output.assets[0].amount = 0n
+	return order
 }
 
 describe("FXFiller one-sided LP", () => {
@@ -162,6 +179,82 @@ describe("FXFiller one-sided LP", () => {
 		// ZARP→USDC allowed (bid side), USDC→ZARP rejected.
 		expect(await filler.canFill(makeOrder("o", OTHER, STABLE))).toBe(true)
 		expect(await filler.canFill(makeOrder("p", STABLE, OTHER))).toBe(false)
+	})
+
+	// The pallet fixes each probe's direction (token_a in, token_b out), so a one-sided LP only
+	// ever sees some probes facing its enabled side — and it has to bid on those. Quoting is the
+	// whole of the phantom bid: the filler feeds these outputs straight into the UserOp, with no
+	// balance check or gas estimation in the way.
+	describe("phantom probes", () => {
+		it("ask-only quotes a probe in its enabled (sell exotic) direction", async () => {
+			const filler = makeFiller({ askPricePolicy: FLAT })
+			const outputs = await filler.quotePhantomFill(makePhantomOrder("ph-a", STABLE, EXOTIC))
+
+			expect(outputs).not.toBeNull()
+			expect(outputs).toHaveLength(1)
+			expect(outputs?.[0].token).toBe(bytes20ToBytes32(EXOTIC))
+			// 100 token0 at a flat ask of 1500 token1/token0 — quoted in full despite the probe
+			// requesting zero, which is the point: a zero-output probe must not yield a zero quote.
+			expect(outputs?.[0].amount).toBe(parseUnits("150000", 18))
+		})
+
+		it("bid-only quotes a probe in its enabled (buy exotic) direction", async () => {
+			const filler = makeFiller({ bidPricePolicy: FLAT })
+			const outputs = await filler.quotePhantomFill(makePhantomOrder("ph-b", EXOTIC, STABLE))
+
+			expect(outputs).not.toBeNull()
+			expect(outputs).toHaveLength(1)
+			expect(outputs?.[0].token).toBe(bytes20ToBytes32(STABLE))
+			// 100 token1 back through the same flat rate: 100/1500 token0.
+			expect(outputs?.[0].amount).toBeGreaterThan(0n)
+		})
+
+		it("two-sided quotes probes in both directions", async () => {
+			const filler = makeFiller({ bidPricePolicy: FLAT_BID, askPricePolicy: FLAT })
+			expect(await filler.quotePhantomFill(makePhantomOrder("ph-c", STABLE, EXOTIC))).not.toBeNull()
+			expect(await filler.quotePhantomFill(makePhantomOrder("ph-d", EXOTIC, STABLE))).not.toBeNull()
+		})
+
+		// The other half of one-sidedness: a probe facing the disabled side gets no quote at all.
+		// Pricing it off the curve we *do* have would publish an offer the filler would not honour,
+		// and every accepted quote moves the median the protocol prices intents against.
+		it("declines a probe facing its disabled side", async () => {
+			const askOnly = makeFiller({ askPricePolicy: FLAT })
+			expect(await askOnly.quotePhantomFill(makePhantomOrder("ph-e", EXOTIC, STABLE))).toBeNull()
+
+			const bidOnly = makeFiller({ bidPricePolicy: FLAT })
+			expect(await bidOnly.quotePhantomFill(makePhantomOrder("ph-f", STABLE, EXOTIC))).toBeNull()
+		})
+
+		// Per pair, not per engine: one pair being unquotable in the probe's direction must not
+		// stop another pair's probe from being quoted.
+		it("quotes each pair's probe on that pair's own enabled side", async () => {
+			const OTHER = "0x4444444444444444444444444444444444444444" as HexString
+			const registry = new AssetRegistry(configService, {
+				CNGN2: { [CHAIN]: EXOTIC },
+				ZARP: { [CHAIN]: OTHER },
+			})
+			const pairs: TradingPair[] = [
+				{ token0: "USDC", token1: "CNGN2", maxOrderSize: new Decimal(5000), askPricePolicy: FLAT },
+				{ token0: "USDC", token1: "ZARP", maxOrderSize: new Decimal(5000), bidPricePolicy: FLAT },
+			]
+			const signer = { account: { address: SOLVER } } as any
+			const filler = new FXFiller(signer, configService, {} as any, makeContractService(), pairs, registry)
+
+			// CNGN2 is ask-only: quotes USDC→CNGN2, declines the reverse.
+			expect(await filler.quotePhantomFill(makePhantomOrder("ph-g", STABLE, EXOTIC))).not.toBeNull()
+			expect(await filler.quotePhantomFill(makePhantomOrder("ph-h", EXOTIC, STABLE))).toBeNull()
+			// ZARP is bid-only: the opposite pattern, on the same engine.
+			expect(await filler.quotePhantomFill(makePhantomOrder("ph-i", OTHER, STABLE))).not.toBeNull()
+			expect(await filler.quotePhantomFill(makePhantomOrder("ph-j", STABLE, OTHER))).toBeNull()
+		})
+
+		it("declines every probe once halted", async () => {
+			const filler = makeFiller({ askPricePolicy: FLAT })
+			// The halt the clamp counter sets, without driving the clamped fills that set it.
+			;(filler as unknown as { halted: boolean }).halted = true
+			expect(await filler.quotePhantomFill(makePhantomOrder("ph-k", STABLE, EXOTIC))).toBeNull()
+		})
 	})
 
 	// Regression: the gate must run even when another strategy already cached the


### PR DESCRIPTION
fetchPhantomOrder sat outside handlePhantomOrder's try/catch, and the promise queued onto globalQueue had no catch attached — so a throw from the offchain-storage read escaped as an unhandled rejection, which this process has no handler for and Node turns into an exit. Both are now contained

Also pins phantom-probe behaviour in the one-sided LP tests. A probe's direction is fixed by the pallet (token_a in, token_b out), so a one-sided LP sees only some probes facing its enabled side: assert it quotes those — exact amounts, not just non-null — and declines the ones facing its disabled side rather than pricing a quote it would not honour.