### PR TITLE
[simplex]: Allow editing market order caps and the chain set from the operator UI

### DIFF
--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/simplex",
-	"version": "0.8.4",
+	"version": "0.8.5",
 	"license": "Apache-2.0",
 	"description": "IntentGateway simplex package for hyperbridge",
 	"main": "dist/index.js",

--- a/sdk/packages/simplex/src/core/boot.ts
+++ b/sdk/packages/simplex/src/core/boot.ts
@@ -97,10 +97,11 @@ export function tradingPairFrom(pair: PairConfig): TradingPair {
 }
 
 /**
- * Editable-curve view of one trading pair for the UI server, or null for
+ * Editable view of one trading pair for the UI server, or null for
  * venue-priced (curve-less) pairs — they have nothing to edit. The
- * enableSide/disableSide closures mutate the live TradingPair: the engine
- * reads curve presence per order, so assignment opens or closes the direction.
+ * enableSide/disableSide/setMaxOrderSize closures mutate the live TradingPair:
+ * the engine reads curve presence and the cap per order, so assignment opens or
+ * closes a direction and resizes the market from the next evaluation.
  */
 export function adminStrategyFor(pair: TradingPair, pairIndex: number, index: number): AdminStrategy | null {
 	if (!pair.bidPricePolicy && !pair.askPricePolicy) return null
@@ -116,6 +117,20 @@ export function adminStrategyFor(pair: TradingPair, pairIndex: number, index: nu
 		ask: pair.askPricePolicy,
 		sameToken,
 		referenceOnly: pair.referenceOnly === true,
+	}
+	// A reference pair's cap is never consulted (it never fills), so leave it
+	// absent rather than surfacing the placeholder "0" as editable.
+	if (pair.referenceOnly !== true) {
+		adminStrategy.maxOrderSize = pair.maxOrderSize.toString()
+		adminStrategy.setMaxOrderSize = (value) => {
+			const previous = pair.maxOrderSize.toString()
+			pair.maxOrderSize = new Decimal(value)
+			adminStrategy.maxOrderSize = value
+			logger.warn(
+				{ pair: `${pair.token0}/${pair.token1}`, previous, next: value },
+				"Per-order cap resized by operator",
+			)
+		}
 	}
 	// Reference pairs never fill, so opening a side is a no-op; same-token
 	// markets are ask-only by engine rule.

--- a/sdk/packages/simplex/src/services/server/UiServer.ts
+++ b/sdk/packages/simplex/src/services/server/UiServer.ts
@@ -4,23 +4,36 @@ import { FillerPricePolicy, formatChainKey, parseChainKey, type PriceCurvePoint 
 import { AssetRegistry, registrySymbols, validateAssetDefinitions, type AssetDefinition } from "@/config/asset-registry"
 import { assertPairSymbolsResolve, validatePairConfigs, type PairConfig } from "@/config/pairs"
 import { VaultFundingPlanner } from "@/funding/vault/VaultFundingPlanner"
-import { INIT_CHAINS } from "@/cli/init/chains"
+import { chainsForNetwork, INIT_CHAINS, type InitNetwork } from "@/cli/init/chains"
+import { TESTNET_CONFIRMATION_POINTS } from "@/cli/init/state"
 import { ChainConfigService } from "@hyperbridge/sdk"
-import type { FillerTomlConfig, VaultToml } from "@/config/filler-toml"
+import { assertConfirmationCoverage, type FillerTomlConfig, type VaultToml } from "@/config/filler-toml"
 import { emitFillerToml, writeConfigFileAtomic } from "@/cli/init/emit-toml"
 import { saveRuntimeState } from "@/core/runtime-state"
 import { isAddress } from "viem"
-import type { AllowlistConfig } from "@/services/FillerConfigService"
+import { validateRpcUrls, type AllowlistConfig } from "@/services/FillerConfigService"
+import { withTimeout, PROBE_TIMEOUT_MS } from "@/cli/init/prompt-utils"
 import type { ActivityLogService, ActivityEvent } from "../ActivityLogService"
 import type { BalanceProvider } from "../BalanceProvider"
 import type { BidStorageService } from "../BidStorageService"
 import { configureLogger, getLogger, type LogLevel } from "../Logger"
 import { readBody, sendJson, isLoopbackHost, isContainerized, hostHeaderAllowed } from "./http-util"
 import { serveStatic } from "./static"
-import { handleSetupRequest, maskToml, validateToken, type SetupDeps } from "./setup-api"
+import {
+	handleSetupRequest,
+	maskToml,
+	resolveSetupDeps,
+	validateAlchemyKey,
+	validateBundler,
+	validateRpc,
+	validateToken,
+	type SetupDeps,
+} from "./setup-api"
 import {
 	LOG_LEVELS,
 	type AdminStrategyDto,
+	type ChainRowDto,
+	type ChainsDto,
 	type ConfigDto,
 	type SendTokenOption,
 	type StatusInit,
@@ -45,6 +58,14 @@ export interface AdminStrategy {
 	token1: string
 	bid?: FillerPricePolicy
 	ask?: FillerPricePolicy
+	/** Per-order cap in token0 units, as configured. Kept in step with `setMaxOrderSize`. */
+	maxOrderSize?: string
+	/**
+	 * Applies a new per-order cap to the live TradingPair — the engine reads it
+	 * per order, so the cap binds on the next evaluation. Absent when no engine
+	 * ran at boot (the edit is then persisted for the next start).
+	 */
+	setMaxOrderSize?: (value: string) => void
 	/** Same-asset cross-chain market: ask-only, prices strictly below par. */
 	sameToken?: boolean
 	/** Price feed only — the pair never fills; curves stay editable, sides are never opened. */
@@ -144,6 +165,14 @@ export interface SetupContext {
 
 export type StartState = "idle" | "starting" | "running" | "failed"
 
+/** Setup routes that stay open in operator mode: stateless probes with no wizard state. */
+const OPERATOR_PROBES = [
+	"/api/setup/validate-token",
+	"/api/setup/validate-rpc",
+	"/api/setup/validate-bundler",
+	"/api/setup/validate-alchemy-key",
+]
+
 const UI_NOT_BUILT_HTML = `<!doctype html><meta charset="utf-8"><title>simplex</title>
 <body style="font-family:system-ui;margin:4rem auto;max-width:32rem">
 <h1>UI not built</h1><p>The simplex web UI is missing from this build.
@@ -169,12 +198,28 @@ export class UiServer {
 	private sseClients = new Set<ServerResponse>()
 	private activityListener?: (event: ActivityEvent) => void
 	private boundLoopback = true
+	private deps: Required<SetupDeps>
+	/**
+	 * Chain ids aligned with `config.chains` rows. The TOML records no chain id
+	 * — boot derives it from each row's RPC — so the running set supplies the
+	 * mapping until the operator edits the chain list, after which the edited
+	 * ids stand in (the file is authoritative again on the next boot).
+	 */
+	private configuredChainIds?: number[]
 
-	constructor(opts: { mode: UiMode; uiDistDir?: string; setup?: SetupContext; operator?: OperatorContext }) {
+	constructor(opts: {
+		mode: UiMode
+		uiDistDir?: string
+		setup?: SetupContext
+		operator?: OperatorContext
+		/** Test injection for the operator-mode network probes (chain editor, token verify). */
+		deps?: SetupDeps
+	}) {
 		this.mode = opts.mode
 		this.operator = opts.operator
 		this.setup = opts.setup
 		this.uiDistDir = opts.uiDistDir
+		this.deps = resolveSetupDeps(opts.deps)
 		if (this.mode === "operator") this.startState = "running"
 		if (this.operator) this.subscribeActivity()
 		this.server = createServer((req, res) => {
@@ -297,12 +342,19 @@ export class UiServer {
 		}
 
 		if (path.startsWith("/api/setup/")) {
-			// Stateless RPC probe, also needed by the operator add-market form
-			// to verify custom tokens — the only setup route usable after boot.
-			if (path === "/api/setup/validate-token" && this.mode === "operator") {
+			// Stateless probes, also needed by the operator forms (custom-token
+			// verify, chain editor) — the only setup routes usable after boot.
+			if (OPERATOR_PROBES.includes(path) && this.mode === "operator") {
 				if (method !== "POST") return sendJson(res, 405, { error: "Method not allowed" })
 				try {
 					const body = JSON.parse(await readBody(req)) as Record<string, unknown>
+					if (path === "/api/setup/validate-rpc") return sendJson(res, 200, await validateRpc(body, this.deps))
+					if (path === "/api/setup/validate-bundler") {
+						return sendJson(res, 200, await validateBundler(body, this.deps))
+					}
+					if (path === "/api/setup/validate-alchemy-key") {
+						return sendJson(res, 200, await validateAlchemyKey(body, this.deps))
+					}
 					// The operator form sends a chain key, not an RPC URL — the
 					// running config's endpoint for that chain backs the probe.
 					if (!body.rpcUrl && typeof body.chain === "string") {
@@ -331,8 +383,9 @@ export class UiServer {
 		const strategyMatch = path.match(/^\/api\/strategies\/(\d+)$/)
 		if (strategyMatch) {
 			if (this.mode !== "operator") return sendJson(res, 409, { error: "Filler is not running" })
-			if (method !== "DELETE") return sendJson(res, 405, { error: "Method not allowed" })
-			return this.handleMarketRemove(res, Number(strategyMatch[1]))
+			if (method === "DELETE") return this.handleMarketRemove(res, Number(strategyMatch[1]))
+			if (method === "PUT") return this.handleMarketUpdate(req, res, Number(strategyMatch[1]))
+			return sendJson(res, 405, { error: "Method not allowed" })
 		}
 
 		const curvesMatch = path.match(/^\/api\/strategies\/(\d+)\/curves$/)
@@ -433,6 +486,13 @@ export class UiServer {
 				knownVaults: this.knownVaultCatalog(op),
 			}
 			return sendJson(res, 200, configDto)
+		}
+
+		if (path === "/api/chains") {
+			if (this.mode !== "operator") return sendJson(res, 409, { error: "Filler is not running" })
+			if (method === "GET") return this.handleChainsGet(res)
+			if (method === "PUT") return this.handleChainsUpdate(req, res)
+			return sendJson(res, 405, { error: "Method not allowed" })
 		}
 
 		if (path === "/api/log-level") {
@@ -551,9 +611,7 @@ export class UiServer {
 			strategyTypes: op.strategyTypes,
 			configPath: op.configPath,
 			addresses: op.addresses,
-			chainLabels: Object.fromEntries(
-				op.chains.map((id) => [id, INIT_CHAINS.find((c) => c.chainId === id)?.label ?? `chain ${id}`]),
-			),
+			chainLabels: Object.fromEntries(op.chains.map((id) => [id, chainLabel(id)])),
 		}
 		return sendJson(res, 200, status)
 	}
@@ -786,6 +844,63 @@ export class UiServer {
 	}
 
 	/**
+	 * PUT /api/strategies/:index — edits a live market's per-order cap. The
+	 * engine reads `maxOrderSize` while sizing each order, so a new cap binds on
+	 * the next evaluation; it is persisted to the pair's config entry either way.
+	 */
+	private async handleMarketUpdate(req: IncomingMessage, res: ServerResponse, index: number): Promise<void> {
+		const op = this.operator!
+		const strategy = op.strategies.find((s) => s.index === index)
+		if (!strategy) return sendJson(res, 404, { error: `No strategy with index ${index}` })
+
+		let body: Record<string, unknown>
+		try {
+			body = JSON.parse(await readBody(req))
+		} catch {
+			return sendJson(res, 400, { error: "Invalid JSON body" })
+		}
+		const { maxOrderSize, ...rest } = body
+		if (Object.keys(rest).length > 0) {
+			return sendJson(res, 400, { error: `Unknown fields: ${Object.keys(rest).join(", ")}` })
+		}
+		if (maxOrderSize === undefined) {
+			return sendJson(res, 400, { error: "Provide maxOrderSize" })
+		}
+		if (strategy.referenceOnly) {
+			return sendJson(res, 409, {
+				error: "Reference-only markets never fill orders — their order cap is never consulted",
+			})
+		}
+		const value = String(maxOrderSize).trim()
+		let parsed: Decimal
+		try {
+			parsed = new Decimal(value)
+		} catch {
+			return sendJson(res, 400, { error: `maxOrderSize must be a decimal string, got '${value}'` })
+		}
+		if (!parsed.isFinite() || parsed.lte(0)) {
+			return sendJson(res, 400, { error: `maxOrderSize must be a positive number, got '${value}'` })
+		}
+
+		strategy.setMaxOrderSize?.(value)
+		strategy.maxOrderSize = value
+		const pair = op.config.pairs?.[strategy.pairIndex]
+		if (pair) pair.maxOrderSize = value
+		const persisted = this.persistConfig()
+		const applied = Boolean(strategy.setMaxOrderSize)
+		this.logger.warn(
+			{ strategy: index, pair: `${strategy.token0}/${strategy.token1}`, maxOrderSize: value, applied },
+			"Max order size updated by operator",
+		)
+		return sendJson(res, 200, {
+			...serializeStrategy(strategy),
+			applied,
+			restartNeeded: !applied,
+			persisted,
+		})
+	}
+
+	/**
 	 * DELETE /api/strategies/:index — removes a market. The remaining config
 	 * must still validate (at least one market, no orphaned USD anchor) before
 	 * anything mutates. Funds are never touched: vault treasury is per-asset
@@ -818,16 +933,195 @@ export class UiServer {
 		return sendJson(res, 200, { applied, restartNeeded: !applied, persisted })
 	}
 
-	/** Regenerates the config file from the (mutated) running config. */
+	/**
+	 * Regenerates the config file from the (mutated) running config. Chain rows
+	 * carry no chain id, so each is re-labelled from the known mapping — without
+	 * it a rewritten file loses track of which `[[chains]]` entry is which.
+	 */
 	private persistConfig(): boolean {
 		const op = this.operator!
 		try {
-			writeConfigFileAtomic(op.configPath, emitFillerToml(op.config))
+			const chainComments = this.configChainIds().map((id) => chainLabel(id))
+			writeConfigFileAtomic(op.configPath, emitFillerToml(op.config, { chainComments }))
 			return true
 		} catch (err) {
 			this.logger.warn({ err, configPath: op.configPath }, "Change applied in memory but could not be persisted")
 			return false
 		}
+	}
+
+	/** Chain ids positionally aligned with `config.chains`; see `configuredChainIds`. */
+	private configChainIds(): number[] {
+		const op = this.operator!
+		const ids = this.configuredChainIds ?? op.chains
+		// Positional: a shorter mapping (config edited outside the UI) leaves the
+		// trailing rows unidentified rather than mislabelling every row.
+		return op.config.chains.map((_, index) => ids[index] ?? 0)
+	}
+
+	/** GET /api/chains — the editable chain set plus the catalog of chains that can be added. */
+	private handleChainsGet(res: ServerResponse): void {
+		const op = this.operator!
+		const ids = this.configChainIds()
+		const running = new Set(op.chains)
+		const watchOnly = op.config.simplex.watchOnly
+		const globalWatchOnly = typeof watchOnly === "boolean"
+		// RPC URLs are returned unmasked: the editor round-trips them, and masked
+		// values would be written straight back into the config. Same trust
+		// boundary as the wizard, which collects private keys over this listener.
+		const chains: ChainRowDto[] = op.config.chains.map((chain, index) => {
+			const chainId = ids[index]
+			return {
+				chainId,
+				stateMachineId: formatChainKey(chainId),
+				label: chainLabel(chainId),
+				rpcUrls: chain.rpcUrls,
+				bundlerUrl: chain.bundlerUrl,
+				watchOnly: globalWatchOnly
+					? (watchOnly as boolean)
+					: Boolean((watchOnly as Record<string, boolean> | undefined)?.[String(chainId)]),
+				running: running.has(chainId),
+			}
+		})
+		// One network per filler (the Hyperbridge endpoint and the deployments
+		// differ), so the catalog is scoped the way the wizard scopes it.
+		const network: InitNetwork = chains.some(
+			(row) => INIT_CHAINS.find((meta) => meta.chainId === row.chainId)?.network === "testnet",
+		)
+			? "testnet"
+			: "mainnet"
+		const dto: ChainsDto = { chains, catalog: chainsForNetwork(network), network, globalWatchOnly }
+		return sendJson(res, 200, dto)
+	}
+
+	/**
+	 * PUT /api/chains — replaces the chain set (selection, quorum RPC endpoints,
+	 * bundler, watch-only). Chain topology is wired at boot — clients, event
+	 * monitors, delegation and balance tracking all key off it — so the new set
+	 * is validated and persisted, then takes effect on the next start.
+	 *
+	 * Every candidate is checked the way boot would check it: reachable RPCs
+	 * reporting the claimed chain, confirmation coverage, pair symbols still
+	 * resolving somewhere, and no funding venue left stranded on a dropped chain.
+	 */
+	private async handleChainsUpdate(req: IncomingMessage, res: ServerResponse): Promise<void> {
+		const op = this.operator!
+		let body: { chains?: Array<Record<string, unknown>> }
+		try {
+			body = JSON.parse(await readBody(req))
+		} catch {
+			return sendJson(res, 400, { error: "Invalid JSON body" })
+		}
+		if (!Array.isArray(body.chains) || body.chains.length === 0) {
+			return sendJson(res, 400, { error: "Provide chains as a non-empty array — the filler needs at least one chain" })
+		}
+
+		const rows: Array<{ chainId: number; rpcUrls: string[]; bundlerUrl: string; watchOnly: boolean }> = []
+		try {
+			for (const row of body.chains) {
+				const chainId = Number(row.chainId)
+				if (!Number.isInteger(chainId) || chainId <= 0) {
+					throw new Error(`Invalid chainId: ${String(row.chainId)}`)
+				}
+				if (rows.some((r) => r.chainId === chainId)) {
+					throw new Error(`Chain ${chainId} is listed twice`)
+				}
+				const rpcUrls = (Array.isArray(row.rpcUrls) ? row.rpcUrls : [])
+					.map((url) => String(url).trim())
+					.filter(Boolean)
+				// Same non-empty/distinct-host rule boot applies to every chain.
+				validateRpcUrls(rpcUrls)
+				const bundlerUrl = String(row.bundlerUrl ?? "").trim()
+				if (!bundlerUrl) {
+					throw new Error(`${chainLabel(chainId)} needs a bundler URL to submit fill UserOperations`)
+				}
+				rows.push({ chainId, rpcUrls, bundlerUrl, watchOnly: row.watchOnly === true })
+			}
+		} catch (err) {
+			return sendJson(res, 400, { error: err instanceof Error ? err.message : String(err) })
+		}
+
+		const chainIds = rows.map((r) => r.chainId)
+		const previous = new Map(this.configChainIds().map((id, index) => [id, op.config.chains[index]]))
+		const removed = [...previous.keys()].filter((id) => id > 0 && !chainIds.includes(id))
+
+		// Testnet chain ids have no built-in confirmation curve; write the same
+		// low-value default the wizard does rather than rejecting the addition.
+		const confirmationPolicies = { ...(op.config.confirmationPolicies ?? {}) }
+		for (const row of rows) {
+			if (INIT_CHAINS.find((meta) => meta.chainId === row.chainId)?.network === "testnet") {
+				confirmationPolicies[String(row.chainId)] ??= { points: TESTNET_CONFIRMATION_POINTS }
+			}
+		}
+
+		try {
+			assertConfirmationCoverage(confirmationPolicies, chainIds)
+			if (op.config.pairs?.length) {
+				const registry = new AssetRegistry(new ChainConfigService({}), op.config.assets)
+				assertPairSymbolsResolve(op.config.pairs, registry, chainIds.map(formatChainKey))
+			}
+			// Funding venues hydrate per chain at boot: one left on a dropped
+			// chain would fall back to a default RPC or fail the next start.
+			for (const chainId of removed) {
+				const chainKey = formatChainKey(chainId)
+				if (op.config.vault?.vaults?.some((vault) => vault.chain === chainKey)) {
+					throw new Error(
+						`${chainLabel(chainId)} still holds a vault entry — remove it from the vault treasury before dropping the chain`,
+					)
+				}
+				if (op.config.vault?.uniswapV4?.positions?.some((position) => position.chain === chainKey)) {
+					throw new Error(
+						`${chainLabel(chainId)} still holds a Uniswap V4 position — remove it from the config before dropping the chain`,
+					)
+				}
+			}
+			// Probe only what the operator newly asserts: an unreachable endpoint
+			// or one answering for another chain would brick the next boot.
+			await this.probeChainRows(rows, previous)
+		} catch (err) {
+			return sendJson(res, 400, { error: err instanceof Error ? err.message : String(err) })
+		}
+
+		op.config.chains = rows.map(({ rpcUrls, bundlerUrl }) => ({ rpcUrls, bundlerUrl }))
+		if (Object.keys(confirmationPolicies).length > 0) op.config.confirmationPolicies = confirmationPolicies
+		// A global boolean watchOnly is left as-is: expanding it per chain would
+		// stop validateConfig treating the config as all-watch-only, which is
+		// what lets a signer-less observer boot at all.
+		if (typeof op.config.simplex.watchOnly !== "boolean") {
+			const perChain = Object.fromEntries(rows.filter((r) => r.watchOnly).map((r) => [String(r.chainId), true]))
+			op.config.simplex.watchOnly = Object.keys(perChain).length > 0 ? perChain : undefined
+		}
+		this.configuredChainIds = chainIds
+		const persisted = this.persistConfig()
+		this.logger.warn({ chains: chainIds, removed }, "Chain set updated by operator")
+		return sendJson(res, 200, { applied: false, restartNeeded: true, persisted, chains: chainIds, removed })
+	}
+
+	/** Verifies every RPC URL that is new to its chain actually answers for that chain. */
+	private async probeChainRows(
+		rows: Array<{ chainId: number; rpcUrls: string[] }>,
+		previous: Map<number, { rpcUrls: string[] } | undefined>,
+	): Promise<void> {
+		const probes: Array<{ chainId: number; url: string }> = []
+		for (const row of rows) {
+			const known = new Set(previous.get(row.chainId)?.rpcUrls ?? [])
+			for (const url of row.rpcUrls) {
+				if (!known.has(url)) probes.push({ chainId: row.chainId, url })
+			}
+		}
+		await Promise.all(
+			probes.map(async ({ chainId, url }) => {
+				let reported: number
+				try {
+					reported = await withTimeout(this.deps.fetchChainId(url), PROBE_TIMEOUT_MS, "RPC check")
+				} catch (err) {
+					throw new Error(`RPC ${url} is unreachable: ${err instanceof Error ? err.message : err}`)
+				}
+				if (reported !== chainId) {
+					throw new Error(`RPC ${url} reports chain ${reported}, expected ${chainId} (${chainLabel(chainId)})`)
+				}
+			}),
+		)
 	}
 
 	private async handleLogLevel(req: IncomingMessage, res: ServerResponse): Promise<void> {
@@ -1060,9 +1354,15 @@ function serializeStrategy(strategy: AdminStrategy): AdminStrategyDto {
 		pricingMode: strategy.bid || strategy.ask ? ("static" as const) : ("venue" as const),
 		sameToken: strategy.sameToken ?? false,
 		referenceOnly: strategy.referenceOnly ?? false,
+		maxOrderSize: strategy.maxOrderSize,
 		bid: strategy.bid?.getPoints(),
 		ask: strategy.ask?.getPoints(),
 	}
+}
+
+/** Catalog label for a chain id, falling back to the bare id for unlisted chains. */
+function chainLabel(chainId: number): string {
+	return INIT_CHAINS.find((meta) => meta.chainId === chainId)?.label ?? `chain ${chainId}`
 }
 
 /** Returns an error message when the body is not a well-formed curve update, else null. */

--- a/sdk/packages/simplex/src/services/server/dto.ts
+++ b/sdk/packages/simplex/src/services/server/dto.ts
@@ -74,7 +74,7 @@ export interface BalanceSnapshot {
 	hyperbridge?: { address: string; free: number; reserved: number }
 }
 
-/** GET /api/strategies rows; PUT /api/strategies/:index/curves response */
+/** GET /api/strategies rows; PUT /api/strategies/:index(/curves) response */
 export interface AdminStrategyDto {
 	index: number
 	/** Display label, e.g. "USDC/CNGN" (reference pairs carry a " (reference)" suffix). */
@@ -84,8 +84,34 @@ export interface AdminStrategyDto {
 	pricingMode: "static" | "venue"
 	sameToken: boolean
 	referenceOnly: boolean
+	/** Per-order cap in token0 units; absent for reference-only pairs (never consulted). */
+	maxOrderSize?: string
 	bid?: PriceCurvePoint[]
 	ask?: PriceCurvePoint[]
+}
+
+/** GET /api/chains rows; one per `[[chains]]` entry in the running config. */
+export interface ChainRowDto {
+	chainId: number
+	/** State machine id, e.g. "EVM-8453". */
+	stateMachineId: string
+	label: string
+	rpcUrls: string[]
+	bundlerUrl: string
+	watchOnly: boolean
+	/** False for rows added since boot — they only start filling after a restart. */
+	running: boolean
+}
+
+/** GET /api/chains */
+export interface ChainsDto {
+	chains: ChainRowDto[]
+	/** Every chain selectable on this network — the same catalog the setup wizard offers. */
+	catalog: InitChainMeta[]
+	/** Network the configured chains belong to; scopes the catalog and the Alchemy prefill. */
+	network: InitNetwork
+	/** True when `[simplex].watchOnly` is the global boolean — per-chain toggles are then frozen. */
+	globalWatchOnly: boolean
 }
 
 /** GET /api/activity/orders rows; SSE /api/events frames */

--- a/sdk/packages/simplex/src/services/server/setup-api.ts
+++ b/sdk/packages/simplex/src/services/server/setup-api.ts
@@ -46,6 +46,14 @@ async function defaultRpcRequest(url: string, method: string, params: unknown[])
 	return json.result
 }
 
+/** Fills in the real network-facing validators for anything a caller did not stub. */
+export function resolveSetupDeps(deps?: SetupDeps): Required<SetupDeps> {
+	return {
+		fetchChainId: deps?.fetchChainId ?? fetchChainId,
+		rpcRequest: deps?.rpcRequest ?? defaultRpcRequest,
+	}
+}
+
 /**
  * Routes /api/setup/* requests in init mode. Request bodies carry private keys
  * and API tokens — they are never logged and never echoed back unmasked.
@@ -100,10 +108,7 @@ export async function handleSetupRequest(
 		return sendJson(res, 400, { error: err instanceof Error ? err.message : "Invalid JSON body" })
 	}
 
-	const deps: Required<SetupDeps> = {
-		fetchChainId: setup.deps?.fetchChainId ?? fetchChainId,
-		rpcRequest: setup.deps?.rpcRequest ?? defaultRpcRequest,
-	}
+	const deps = resolveSetupDeps(setup.deps)
 
 	try {
 		switch (endpoint) {
@@ -136,7 +141,7 @@ export async function handleSetupRequest(
 	}
 }
 
-async function validateAlchemyKey(body: Record<string, unknown>, deps: Required<SetupDeps>) {
+export async function validateAlchemyKey(body: Record<string, unknown>, deps: Required<SetupDeps>) {
 	const apiKey = String(body.apiKey ?? "").trim()
 	const network = (body.network === "testnet" ? "testnet" : "mainnet") as InitNetwork
 	if (!apiKey) return { valid: false, error: "apiKey is required", chains: [] }
@@ -167,7 +172,7 @@ async function validateAlchemyKey(body: Record<string, unknown>, deps: Required<
 	return { valid: true, chains }
 }
 
-async function validateRpc(body: Record<string, unknown>, deps: Required<SetupDeps>) {
+export async function validateRpc(body: Record<string, unknown>, deps: Required<SetupDeps>) {
 	const urls = Array.isArray(body.urls) ? body.urls.map(String) : [String(body.url ?? "")]
 	const expectedChainId = body.expectedChainId === undefined ? undefined : Number(body.expectedChainId)
 	try {
@@ -193,7 +198,7 @@ async function validateRpc(body: Record<string, unknown>, deps: Required<SetupDe
 }
 
 /** Warning-only: bundler probes never block the wizard. */
-async function validateBundler(body: Record<string, unknown>, deps: Required<SetupDeps>) {
+export async function validateBundler(body: Record<string, unknown>, deps: Required<SetupDeps>) {
 	const url = String(body.url ?? "").trim()
 	if (!url) return { ok: false, warning: "Bundler URL is empty" }
 	try {

--- a/sdk/packages/simplex/src/tests/ui-server.test.ts
+++ b/sdk/packages/simplex/src/tests/ui-server.test.ts
@@ -5,6 +5,7 @@ import {
 	type OperatorContext,
 	type PauseControl,
 } from "@/services/server/UiServer"
+import type { SetupDeps } from "@/services/server/setup-api"
 import { ActivityLogService } from "@/services/ActivityLogService"
 import { FillerPricePolicy } from "@/config/interpolated-curve"
 import type { FillerTomlConfig } from "@/config/filler-toml"
@@ -177,7 +178,7 @@ describe("UiServer (operator mode)", () => {
 		server = undefined
 	})
 
-	async function startServer(overrides: Partial<OperatorContext> = {}) {
+	async function startServer(overrides: Partial<OperatorContext> = {}, deps?: SetupDeps) {
 		const sameAsset = new FillerPricePolicy({ points: SAME_ASSET_POINTS })
 		const bid = new FillerPricePolicy({ points: BID_POINTS })
 		const ask = new FillerPricePolicy({ points: ASK_POINTS })
@@ -185,16 +186,16 @@ describe("UiServer (operator mode)", () => {
 		const filler = fakePauseControl()
 		const operator = baseOperator({
 			strategies: [
-				{ index: 0, pairIndex: 0, exotic: "USDC/USDC", token0: "USDC", token1: "USDC", ask: sameAsset, sameToken: true },
-				{ index: 1, pairIndex: 1, exotic: "USDC/CNGN", token0: "USDC", token1: "CNGN", bid, ask, sameToken: false },
+				{ index: 0, pairIndex: 0, exotic: "USDC/USDC", token0: "USDC", token1: "USDC", ask: sameAsset, sameToken: true, maxOrderSize: "100000" },
+				{ index: 1, pairIndex: 1, exotic: "USDC/CNGN", token0: "USDC", token1: "CNGN", bid, ask, sameToken: false, maxOrderSize: "5000" },
 				{ index: 2, pairIndex: 2, token0: "USDC", token1: "CNGN", sameToken: false }, // venue-priced: no editable curves
-				{ index: 3, pairIndex: 3, exotic: "USDC/ZARP", token0: "USDC", token1: "ZARP", ask: askOnly, sameToken: false }, // one-sided LP
+				{ index: 3, pairIndex: 3, exotic: "USDC/ZARP", token0: "USDC", token1: "ZARP", ask: askOnly, sameToken: false, maxOrderSize: "5000" }, // one-sided LP
 			],
 			filler,
 			balances: { getSnapshot: () => ({ updatedAt: 123, chains: [{ chainId: 8453, usdc: 1500 }] }) },
 			...overrides,
 		})
-		server = new UiServer({ mode: "operator", operator })
+		server = new UiServer({ mode: "operator", operator, deps })
 		const port = await server.start(0)
 		return {
 			base: `http://127.0.0.1:${port}`,
@@ -270,6 +271,7 @@ describe("UiServer (operator mode)", () => {
 					pricingMode: "static",
 					sameToken: true,
 					referenceOnly: false,
+					maxOrderSize: "100000",
 					ask: SAME_ASSET_POINTS,
 				},
 				{
@@ -280,6 +282,7 @@ describe("UiServer (operator mode)", () => {
 					pricingMode: "static",
 					sameToken: false,
 					referenceOnly: false,
+					maxOrderSize: "5000",
 					bid: BID_POINTS,
 					ask: ASK_POINTS,
 				},
@@ -292,6 +295,7 @@ describe("UiServer (operator mode)", () => {
 					pricingMode: "static",
 					sameToken: false,
 					referenceOnly: false,
+					maxOrderSize: "5000",
 					ask: ASK_POINTS,
 				},
 			],
@@ -314,6 +318,7 @@ describe("UiServer (operator mode)", () => {
 			pricingMode: "static",
 			sameToken: false,
 			referenceOnly: false,
+			maxOrderSize: "5000",
 			bid: BID_POINTS,
 			ask: newAsk,
 			persisted: true,
@@ -1042,6 +1047,243 @@ describe("UiServer (operator mode)", () => {
 		// traversal is blocked (fetch normalizes ../, so send the raw path over a socket)
 		const traversal = await rawRequest(port, "/../secret.txt")
 		expect(traversal).toContain("403")
+	})
+
+	it("resizes a market's per-order cap on the live pair and persists it", async () => {
+		const { base, operator } = await startServer({ config: marketConfig() })
+		const setMaxOrderSize = vi.fn()
+		operator.strategies.find((s) => s.index === 1)!.setMaxOrderSize = setMaxOrderSize
+
+		const res = await put(base, "/api/strategies/1", { maxOrderSize: "12500" })
+		expect(res.status).toBe(200)
+		const payload = await res.json()
+		expect(payload.applied).toBe(true)
+		expect(payload.restartNeeded).toBe(false)
+		expect(payload.maxOrderSize).toBe("12500")
+		expect(setMaxOrderSize).toHaveBeenCalledWith("12500")
+		expect(operator.config.pairs?.[1]?.maxOrderSize).toBe("12500")
+		const written = parse(readFileSync(operator.configPath, "utf-8")) as FillerTomlConfig
+		expect(written.pairs?.[1]?.maxOrderSize).toBe("12500")
+	})
+
+	it("persists a cap for restart when the pair cannot be resized live", async () => {
+		const { base, operator } = await startServer({ config: marketConfig() })
+		// No setMaxOrderSize hook: no engine ran at boot.
+		const res = await put(base, "/api/strategies/1", { maxOrderSize: "7500" })
+		expect(await res.json()).toMatchObject({ applied: false, restartNeeded: true, persisted: true })
+		expect(operator.config.pairs?.[1]?.maxOrderSize).toBe("7500")
+	})
+
+	it("rejects non-positive caps and reference-only markets, leaving the pair untouched", async () => {
+		const { base, operator } = await startServer({ config: marketConfig() })
+		const strategy = operator.strategies.find((s) => s.index === 1)!
+		strategy.setMaxOrderSize = vi.fn()
+
+		for (const value of ["0", "-5", "abc", ""]) {
+			const res = await put(base, "/api/strategies/1", { maxOrderSize: value })
+			expect(res.status).toBe(400)
+			expect((await res.json()).error).toMatch(/maxOrderSize must be a (positive number|decimal string)/)
+		}
+		const unknown = await put(base, "/api/strategies/1", { maxOrderSize: "1", token0: "USDC" })
+		expect(unknown.status).toBe(400)
+		expect((await unknown.json()).error).toContain("Unknown fields")
+
+		strategy.referenceOnly = true
+		const reference = await put(base, "/api/strategies/1", { maxOrderSize: "1000" })
+		expect(reference.status).toBe(409)
+		expect((await reference.json()).error).toContain("never fill")
+
+		expect(strategy.setMaxOrderSize).not.toHaveBeenCalled()
+		expect(operator.config.pairs?.[1]?.maxOrderSize).toBe("5000")
+		expect(existsSync(operator.configPath)).toBe(false)
+	})
+
+	/** Two chain rows aligned with the operator's running chain ids. */
+	function chainsConfig(): FillerTomlConfig {
+		const config = marketConfig()
+		config.chains = [
+			{ rpcUrls: ["https://base.example"], bundlerUrl: "https://base-bundler.example" },
+			{ rpcUrls: ["https://bsc.example"], bundlerUrl: "https://bsc-bundler.example" },
+		]
+		return config
+	}
+
+	it("lists the configured chains alongside the wizard's catalog for their network", async () => {
+		const { base } = await startServer({ config: chainsConfig() })
+		const dto = await (await fetch(`${base}/api/chains`)).json()
+		expect(dto.chains).toEqual([
+			{
+				chainId: 8453,
+				stateMachineId: "EVM-8453",
+				label: "Base",
+				rpcUrls: ["https://base.example"],
+				bundlerUrl: "https://base-bundler.example",
+				watchOnly: false,
+				running: true,
+			},
+			{
+				chainId: 56,
+				stateMachineId: "EVM-56",
+				label: "BNB Chain",
+				rpcUrls: ["https://bsc.example"],
+				bundlerUrl: "https://bsc-bundler.example",
+				watchOnly: false,
+				running: true,
+			},
+		])
+		expect(dto.globalWatchOnly).toBe(false)
+		// The catalog is every selectable chain on the network — configured ones
+		// included, since the editor toggles them in place like the wizard does.
+		expect(dto.network).toBe("mainnet")
+		const catalogIds = dto.catalog.map((c: { chainId: number }) => c.chainId)
+		expect(catalogIds).toEqual(expect.arrayContaining([1, 8453, 56, 42161, 137]))
+		expect(catalogIds).not.toContain(84532)
+	})
+
+	it("scopes the catalog to testnet when the configured chains are testnets", async () => {
+		const config = chainsConfig()
+		const { base } = await startServer({ config, chains: [84532, 11155111] })
+		const dto = await (await fetch(`${base}/api/chains`)).json()
+		expect(dto.network).toBe("testnet")
+		expect(dto.catalog.map((c: { chainId: number }) => c.chainId)).toEqual(
+			expect.arrayContaining([84532, 11155111]),
+		)
+		expect(dto.catalog.map((c: { chainId: number }) => c.chainId)).not.toContain(1)
+	})
+
+	it("replaces the chain set: probes only new endpoints, persists, and asks for a restart", async () => {
+		const fetchChainId = vi.fn(async (url: string) => (url.includes("arb") ? 42161 : 8453))
+		const { base, operator } = await startServer({ config: chainsConfig() }, { fetchChainId })
+		// Drop BNB Chain, add Arbitrum, and give Base a second quorum provider.
+		const res = await put(base, "/api/chains", {
+			chains: [
+				{
+					chainId: 8453,
+					rpcUrls: ["https://base.example", "https://base-two.example"],
+					bundlerUrl: "https://base-bundler.example",
+				},
+				{ chainId: 42161, rpcUrls: ["https://arb.example"], bundlerUrl: "https://arb-bundler.example", watchOnly: true },
+			],
+		})
+		expect(res.status).toBe(200)
+		expect(await res.json()).toMatchObject({ applied: false, restartNeeded: true, persisted: true, removed: [56] })
+		// The pre-existing Base endpoint is not re-probed; the two new ones are.
+		expect(fetchChainId.mock.calls.map((c) => c[0]).sort()).toEqual([
+			"https://arb.example",
+			"https://base-two.example",
+		])
+		expect(operator.config.chains).toHaveLength(2)
+		expect(operator.config.simplex.watchOnly).toEqual({ "42161": true })
+
+		const written = parse(readFileSync(operator.configPath, "utf-8")) as FillerTomlConfig
+		expect(written.chains[1].bundlerUrl).toBe("https://arb-bundler.example")
+		// The rewritten file keeps the chain rows identifiable — the TOML has no chain id.
+		expect(readFileSync(operator.configPath, "utf-8")).toContain("# Arbitrum")
+
+		// The new row is reported as configured but not yet live.
+		const dto = await (await fetch(`${base}/api/chains`)).json()
+		expect(dto.chains.map((c: { chainId: number; running: boolean }) => [c.chainId, c.running])).toEqual([
+			[8453, true],
+			[42161, false],
+		])
+	})
+
+	it("rejects chain edits that boot would reject, with nothing persisted", async () => {
+		const fetchChainId = vi.fn(async () => 999)
+		const { base, operator } = await startServer({ config: chainsConfig() }, { fetchChainId })
+		const base8453 = { chainId: 8453, rpcUrls: ["https://base.example"], bundlerUrl: "https://base-bundler.example" }
+
+		const empty = await put(base, "/api/chains", { chains: [] })
+		expect((await empty.json()).error).toContain("at least one chain")
+
+		const sameHost = await put(base, "/api/chains", {
+			chains: [{ ...base8453, rpcUrls: ["https://base.example", "https://base.example/two"] }],
+		})
+		expect((await sameHost.json()).error).toContain("different domains")
+
+		const noBundler = await put(base, "/api/chains", { chains: [{ ...base8453, bundlerUrl: "  " }] })
+		expect((await noBundler.json()).error).toContain("bundler URL")
+
+		const uncovered = await put(base, "/api/chains", {
+			chains: [base8453, { chainId: 999, rpcUrls: ["https://odd.example"], bundlerUrl: "https://odd.example" }],
+		})
+		expect((await uncovered.json()).error).toContain("No confirmation policy")
+
+		const wrongChain = await put(base, "/api/chains", {
+			chains: [{ ...base8453, rpcUrls: ["https://impostor.example"] }],
+		})
+		expect((await wrongChain.json()).error).toContain("reports chain 999, expected 8453")
+
+		expect(operator.config.chains).toHaveLength(2)
+		expect(existsSync(operator.configPath)).toBe(false)
+	})
+
+	it("refuses to drop a chain that still holds a funding venue", async () => {
+		const config = chainsConfig()
+		config.vault = { vaults: [{ chain: "EVM-56", vault: "0x1111111111111111111111111111111111111111" }] }
+		const { base, operator } = await startServer({ config }, { fetchChainId: vi.fn(async () => 8453) })
+		const res = await put(base, "/api/chains", {
+			chains: [{ chainId: 8453, rpcUrls: ["https://base.example"], bundlerUrl: "https://base-bundler.example" }],
+		})
+		expect(res.status).toBe(400)
+		expect((await res.json()).error).toContain("vault treasury")
+		expect(operator.config.chains).toHaveLength(2)
+	})
+
+	it("writes a testnet confirmation policy for an added testnet chain", async () => {
+		const { base, operator } = await startServer({ config: chainsConfig() }, { fetchChainId: vi.fn(async () => 84532) })
+		const res = await put(base, "/api/chains", {
+			chains: [
+				{ chainId: 8453, rpcUrls: ["https://base.example"], bundlerUrl: "https://base-bundler.example" },
+				{ chainId: 84532, rpcUrls: ["https://base-sepolia.example"], bundlerUrl: "https://bundler.example" },
+			],
+		})
+		expect(res.status).toBe(200)
+		expect(operator.config.confirmationPolicies?.["84532"]?.points.length).toBeGreaterThan(0)
+	})
+
+	it("keeps a global watch-only switch intact when the chain set changes", async () => {
+		const config = chainsConfig()
+		config.simplex.watchOnly = true
+		const { base, operator } = await startServer({ config }, { fetchChainId: vi.fn(async () => 8453) })
+		const dto = await (await fetch(`${base}/api/chains`)).json()
+		expect(dto.globalWatchOnly).toBe(true)
+		expect(dto.chains.every((c: { watchOnly: boolean }) => c.watchOnly)).toBe(true)
+
+		await put(base, "/api/chains", {
+			chains: [{ chainId: 8453, rpcUrls: ["https://base.example"], bundlerUrl: "https://base-bundler.example" }],
+		})
+		// Expanding it per chain would stop validateConfig treating this as an
+		// all-watch-only (signer-less) config.
+		expect(operator.config.simplex.watchOnly).toBe(true)
+	})
+
+	it("serves the wizard's stateless probes in operator mode but not its stateful routes", async () => {
+		// The Alchemy check probes the first derived URL, which is Ethereum's.
+		const fetchChainId = vi.fn(async (url: string) => (url.includes("eth-mainnet") ? 1 : 8453))
+		const { base } = await startServer({ config: chainsConfig() }, { fetchChainId })
+		const rpc = await fetch(`${base}/api/setup/validate-rpc`, {
+			method: "POST",
+			headers: CSRF,
+			body: JSON.stringify({ urls: ["https://base.example"], expectedChainId: 8453 }),
+		})
+		expect(await rpc.json()).toMatchObject({ ok: true })
+
+		// The chain editor prefills endpoints from one Alchemy key, like the wizard.
+		const alchemy = await fetch(`${base}/api/setup/validate-alchemy-key`, {
+			method: "POST",
+			headers: CSRF,
+			body: JSON.stringify({ apiKey: "test-key", network: "mainnet" }),
+		})
+		const prefill = await alchemy.json()
+		expect(prefill.valid).toBe(true)
+		const base8453 = prefill.chains.find((c: { chainId: number }) => c.chainId === 8453)
+		expect(base8453.rpcUrl).toContain("test-key")
+		// Alchemy serves ERC-4337 bundler methods on the same endpoint.
+		expect(base8453.bundlerUrl).toBe(base8453.rpcUrl)
+
+		expect((await fetch(`${base}/api/setup/defaults`)).status).toBe(410)
+		expect((await fetch(`${base}/api/setup/save-and-start`, { method: "POST", headers: CSRF, body: "{}" })).status).toBe(410)
 	})
 
 })

--- a/sdk/packages/simplex/ui/src/operator/Chains.tsx
+++ b/sdk/packages/simplex/ui/src/operator/Chains.tsx
@@ -1,0 +1,346 @@
+import { useCallback, useState } from "react"
+import { api } from "../api"
+import { useAction, usePolling } from "../lib/hooks"
+import type { ChainDefault, ChainsDto } from "../types"
+
+interface AlchemyChainRow {
+	chainId: number
+	rpcUrl: string | null
+	bundlerUrl: string | null
+}
+
+/**
+ * Same draft shape the setup wizard edits chains with, plus `running` — false
+ * for a chain the operator selected since boot, which the filler only picks up
+ * on the next start.
+ */
+interface ChainDraft {
+	meta: ChainDefault
+	enabled: boolean
+	rpcUrls: string[]
+	bundlerUrl: string
+	viaAlchemy: boolean
+	watchOnly: boolean
+	running: boolean
+	rpcStatus?: "ok" | "err" | "checking"
+	rpcError?: string
+	bundlerWarning?: string
+	bundlerOk?: boolean
+}
+
+/**
+ * Seeds one draft per catalog chain, enabled where the running config already
+ * has it. A configured chain outside the catalog (hand-written chain id) keeps
+ * its own card so an edit here can never silently drop it.
+ */
+function seedDrafts(dto: ChainsDto): ChainDraft[] {
+	const configured = new Map(dto.chains.map((row) => [row.chainId, row]))
+	const drafts = dto.catalog.map((meta) => {
+		const row = configured.get(meta.chainId)
+		return {
+			meta,
+			enabled: Boolean(row),
+			rpcUrls: row ? [...row.rpcUrls] : [""],
+			bundlerUrl: row?.bundlerUrl ?? "",
+			viaAlchemy: false,
+			watchOnly: row?.watchOnly ?? false,
+			running: row?.running ?? false,
+		}
+	})
+	for (const row of dto.chains) {
+		if (dto.catalog.some((meta) => meta.chainId === row.chainId)) continue
+		drafts.push({
+			meta: { chainId: row.chainId, stateMachineId: row.stateMachineId, label: row.label, network: dto.network },
+			enabled: true,
+			rpcUrls: [...row.rpcUrls],
+			bundlerUrl: row.bundlerUrl,
+			viaAlchemy: false,
+			watchOnly: row.watchOnly,
+			running: row.running,
+		})
+	}
+	return drafts
+}
+
+/**
+ * Chain selection and endpoints for a running filler — the setup wizard's chain
+ * step, against the live config. Chain topology is wired at boot (clients, event
+ * monitors, balance tracking), so saves are validated and persisted here and
+ * take effect on the next start.
+ */
+export function Chains() {
+	const [dto, setDto] = useState<ChainsDto>()
+	const [drafts, setDrafts] = useState<ChainDraft[]>()
+	const [alchemyKey, setAlchemyKey] = useState("")
+	const [alchemy, setAlchemy] = useState<{ status?: "ok" | "err"; error?: string; busy?: boolean }>({})
+	const [saved, setSaved] = useState(false)
+	const { run, message, error } = useAction()
+
+	const load = useCallback(async () => {
+		const next = await api.get<ChainsDto>("/api/chains")
+		setDto(next)
+		// Seed the editor once; later edits stay local until saved.
+		setDrafts((current) => current ?? seedDrafts(next))
+	}, [])
+	usePolling(useCallback(() => run(load), [run, load]))
+
+	const patch = (chainId: number, changes: Partial<ChainDraft>) =>
+		setDrafts((rows) => rows?.map((row) => (row.meta.chainId === chainId ? { ...row, ...changes } : row)))
+
+	const chains = drafts ?? []
+
+	const applyAlchemyKey = async () => {
+		if (!alchemyKey.trim() || !dto) return
+		setAlchemy({ busy: true })
+		try {
+			const res = await api.post<{ valid: boolean; error?: string; chains: AlchemyChainRow[] }>(
+				"/api/setup/validate-alchemy-key",
+				{ apiKey: alchemyKey.trim(), network: dto.network },
+			)
+			setAlchemy({ status: res.valid ? "ok" : "err", error: res.error })
+			if (!res.valid) return
+			setDrafts((rows) =>
+				rows?.map((row) => {
+					const filled = res.chains.find((r) => r.chainId === row.meta.chainId)
+					if (!filled?.rpcUrl) return row
+					return {
+						...row,
+						rpcUrls: [filled.rpcUrl, ...row.rpcUrls.slice(1)],
+						bundlerUrl: filled.bundlerUrl ?? row.bundlerUrl,
+						viaAlchemy: true,
+						rpcStatus: undefined,
+					}
+				}),
+			)
+		} catch (err) {
+			setAlchemy({ status: "err", error: err instanceof Error ? err.message : String(err) })
+		}
+	}
+
+	const verifyChain = async (chain: ChainDraft) => {
+		patch(chain.meta.chainId, { rpcStatus: "checking", rpcError: undefined, bundlerWarning: undefined })
+		const urls = chain.rpcUrls.map((u) => u.trim()).filter(Boolean)
+		try {
+			const rpc = await api.post<{ ok: boolean; results: Array<{ error?: string }>; error?: string }>(
+				"/api/setup/validate-rpc",
+				{ urls, expectedChainId: chain.meta.chainId },
+			)
+			if (!rpc.ok) {
+				const firstError = rpc.error ?? rpc.results.find((r) => r.error)?.error ?? "RPC check failed"
+				patch(chain.meta.chainId, { rpcStatus: "err", rpcError: firstError })
+				return
+			}
+			patch(chain.meta.chainId, { rpcStatus: "ok" })
+		} catch (err) {
+			patch(chain.meta.chainId, { rpcStatus: "err", rpcError: err instanceof Error ? err.message : String(err) })
+			return
+		}
+
+		if (chain.bundlerUrl.trim()) {
+			try {
+				const bundler = await api.post<{ ok: boolean; warning?: string }>("/api/setup/validate-bundler", {
+					url: chain.bundlerUrl.trim(),
+					chainId: chain.meta.chainId,
+				})
+				patch(chain.meta.chainId, { bundlerWarning: bundler.warning, bundlerOk: !bundler.warning })
+			} catch (err) {
+				patch(chain.meta.chainId, {
+					bundlerWarning: `Bundler check failed: ${err instanceof Error ? err.message : err}`,
+					bundlerOk: false,
+				})
+			}
+		}
+	}
+
+	/** Dropping a chain the filler is trading is worth a beat the wizard doesn't need. */
+	const toggleChain = (chain: ChainDraft, enabled: boolean) => {
+		if (
+			!enabled &&
+			chain.running &&
+			!window.confirm(`Stop filling on ${chain.meta.label}? It keeps trading until you restart the filler.`)
+		) {
+			return
+		}
+		patch(chain.meta.chainId, { enabled })
+	}
+
+	const save = () => {
+		setSaved(false)
+		return run(async () => {
+			await api.put("/api/chains", {
+				chains: chains
+					.filter((chain) => chain.enabled)
+					.map((chain) => ({
+						chainId: chain.meta.chainId,
+						rpcUrls: chain.rpcUrls.map((url) => url.trim()).filter(Boolean),
+						bundlerUrl: chain.bundlerUrl.trim(),
+						watchOnly: chain.watchOnly,
+					})),
+			})
+			setSaved(true)
+			const next = await api.get<ChainsDto>("/api/chains")
+			setDto(next)
+			setDrafts(seedDrafts(next))
+		}, "Chains saved")
+	}
+
+	return (
+		<div>
+			<h2 style={{ marginTop: "1.5rem" }}>Chains & endpoints</h2>
+			<p className="hint">
+				The chains this filler watches and fills on, and the endpoints it reaches them through — the setup
+				wizard's chain step against the running config.
+			</p>
+
+			<div className="card">
+				<h2>Provider key</h2>
+				<p className="hint">
+					One Alchemy API key can fill in the RPC and bundler URL for every supported chain — Alchemy serves
+					ERC-4337 bundler methods on the same endpoint. Use premium endpoints with archive access; free tiers
+					rate-limit and break event scanning. Every field stays editable if you prefer other providers (e.g. a
+					Pimlico bundler).
+				</p>
+				<div className="row">
+					<input
+						type="password"
+						style={{ maxWidth: "24rem" }}
+						placeholder="Alchemy API key (optional)"
+						value={alchemyKey}
+						onChange={(e) => {
+							setAlchemyKey(e.target.value)
+							setAlchemy({})
+						}}
+					/>
+					<button type="button" onClick={applyAlchemyKey} disabled={alchemy.busy || !alchemyKey.trim()}>
+						Validate & prefill
+					</button>
+					{alchemy.status === "ok" && <span className="badge ok">key valid — URLs prefilled</span>}
+					{alchemy.status === "err" && <span className="badge err">{alchemy.error}</span>}
+				</div>
+			</div>
+
+			{chains.map((chain) => (
+				<div className="card" key={chain.meta.chainId}>
+					<div className="spread">
+						<h2>
+							{chain.meta.label} <span className="badge">chainId {chain.meta.chainId}</span>{" "}
+							{chain.viaAlchemy && <span className="badge ok">via Alchemy</span>}{" "}
+							{chain.enabled && !chain.running && <span className="badge warn">pending restart</span>}
+						</h2>
+						<label className="row">
+							<input
+								type="checkbox"
+								checked={chain.enabled}
+								onChange={(e) => toggleChain(chain, e.target.checked)}
+							/>
+							fill on this chain
+						</label>
+					</div>
+					{chain.meta.note && <p className="hint">Note: {chain.meta.note}</p>}
+					{chain.enabled && (
+						<div>
+							{chain.rpcUrls.map((url, index) => (
+								// biome-ignore lint/suspicious/noArrayIndexKey: positional quorum rows
+								<label className="field" key={index}>
+									<span>{index === 0 ? "RPC URL" : "Additional RPC (different provider)"}</span>
+									<div className="row">
+										<input
+											type="text"
+											style={{ flex: 1 }}
+											value={url}
+											onChange={(e) =>
+												patch(chain.meta.chainId, {
+													rpcUrls: chain.rpcUrls.map((u, i) => (i === index ? e.target.value : u)),
+													rpcStatus: undefined,
+													viaAlchemy: index === 0 ? false : chain.viaAlchemy,
+												})
+											}
+										/>
+										{index > 0 && (
+											<button
+												type="button"
+												onClick={() =>
+													patch(chain.meta.chainId, {
+														rpcUrls: chain.rpcUrls.filter((_, i) => i !== index),
+													})
+												}
+											>
+												✕
+											</button>
+										)}
+									</div>
+								</label>
+							))}
+							<div className="row">
+								<button
+									type="button"
+									title="Order scans require a quorum of providers to agree, so one lying RPC can't feed you fake orders. The quorum is exactly the URLs you list here — add at least two organisationally independent providers; four or more to tolerate a faulty one."
+									onClick={() => patch(chain.meta.chainId, { rpcUrls: [...chain.rpcUrls, ""] })}
+								>
+									+ quorum RPC
+								</button>
+							</div>
+
+							<label className="field">
+								<span>Bundler URL</span>
+								<input
+									type="text"
+									value={chain.bundlerUrl}
+									onChange={(e) => patch(chain.meta.chainId, { bundlerUrl: e.target.value, bundlerOk: false })}
+									placeholder="https://api.pimlico.io/v2/<chainId>/rpc?apikey=…"
+								/>
+							</label>
+
+							<div className="row">
+								<button
+									type="button"
+									disabled={!chain.rpcUrls[0]?.trim() || chain.rpcStatus === "checking"}
+									onClick={() => verifyChain(chain)}
+								>
+									{chain.rpcStatus === "checking" ? "Verifying…" : "Verify"}
+								</button>
+								{chain.rpcStatus === "ok" && <span className="badge ok">RPC verified</span>}
+								{chain.rpcStatus === "err" && <span className="badge err">{chain.rpcError}</span>}
+								{chain.bundlerOk && <span className="badge ok">bundler ok</span>}
+								{chain.bundlerWarning && <span className="badge warn">{chain.bundlerWarning}</span>}
+								<label
+									className="row"
+									title={
+										dto?.globalWatchOnly
+											? "[simplex].watchOnly is set globally — edit the config to change it"
+											: undefined
+									}
+								>
+									<input
+										type="checkbox"
+										checked={chain.watchOnly}
+										disabled={dto?.globalWatchOnly}
+										onChange={(e) => patch(chain.meta.chainId, { watchOnly: e.target.checked })}
+									/>
+									watch-only (observe orders, never fill)
+								</label>
+							</div>
+						</div>
+					)}
+				</div>
+			))}
+
+			<div className="card">
+				<div className="row">
+					<button type="button" className="primary" disabled={drafts === undefined} onClick={save}>
+						Save chains
+					</button>
+					{saved && <span className="badge warn">restart the filler to apply</span>}
+					{message && <span className="badge ok">{message}</span>}
+					{error && <span className="badge err">{error}</span>}
+				</div>
+				<p className="hint">
+					Saving validates every new endpoint against the chain it claims to serve and writes the config; the
+					filler picks the changes up on the next start. Dropping a chain is refused while a market symbol or a
+					funding venue still depends on it. A newly selected chain needs funding — the filler wallet must hold
+					the assets it quotes there before it can fill.
+				</p>
+			</div>
+		</div>
+	)
+}

--- a/sdk/packages/simplex/ui/src/operator/Operations.tsx
+++ b/sdk/packages/simplex/ui/src/operator/Operations.tsx
@@ -4,6 +4,7 @@ import { api } from "../api"
 import { AddressListEditor } from "../components/AddressListEditor"
 import { CopyHash } from "../components/CopyHash"
 import { VaultRowsEditor } from "../components/VaultRowsEditor"
+import { Chains } from "./Chains"
 import { useAction, usePolling } from "../lib/hooks"
 import { vaultRowsToToml, type VaultRowDraft } from "../lib/vault-rows"
 import type { ConfigDto, SendTokenOption } from "../types"
@@ -95,10 +96,11 @@ export function Operations(props: { chains: number[]; chainLabels?: Record<strin
 				/>
 			</div>
 
+			<Chains />
+
 			{config && (
 				<p className="hint">
-					Config: <span className="mono">{config.configPath}</span> — chains, endpoints and signer changes require
-					an edit + restart.
+					Config: <span className="mono">{config.configPath}</span> — signer changes require an edit + restart.
 				</p>
 			)}
 

--- a/sdk/packages/simplex/ui/src/operator/Operator.tsx
+++ b/sdk/packages/simplex/ui/src/operator/Operator.tsx
@@ -271,6 +271,7 @@ function StrategyCurves(props: {
 	const { strategy, onApplied, removable, hasVaults } = props
 	const [bid, setBid] = useState<EditorPoint[]>(() => fromPricePoints(strategy.bid))
 	const [ask, setAsk] = useState<EditorPoint[]>(() => fromPricePoints(strategy.ask))
+	const [maxOrderSize, setMaxOrderSize] = useState(strategy.maxOrderSize ?? "")
 	// One-sided LP: an absent side of a curve-priced cross-asset market can be
 	// opened by submitting a curve for it. Same-token markets stay ask-only.
 	const [enableBid, setEnableBid] = useState(false)
@@ -310,6 +311,26 @@ function StrategyCurves(props: {
 			setMessage(res.persisted ? "Applied & saved to config" : "Applied in memory — config file could not be written")
 			setEnableBid(false)
 			setEnableAsk(false)
+			onApplied()
+		} catch (err) {
+			setError(err instanceof Error ? err.message : String(err))
+		}
+	}
+
+	const applyMaxOrderSize = async () => {
+		setMessage(undefined)
+		setError(undefined)
+		try {
+			const res = await api.put<{ persisted: boolean; restartNeeded: boolean }>(`/api/strategies/${strategy.index}`, {
+				maxOrderSize: maxOrderSize.trim(),
+			})
+			setMessage(
+				res.restartNeeded
+					? "Saved to config — restart the filler to apply the new cap"
+					: res.persisted
+						? "Cap applied & saved to config"
+						: "Cap applied in memory — config file could not be written",
+			)
 			onApplied()
 		} catch (err) {
 			setError(err instanceof Error ? err.message : String(err))
@@ -365,6 +386,25 @@ function StrategyCurves(props: {
 					⚠ The book is crossed at order size {crossedAt} (bid at or below ask) — both sides still fill at
 					their own curve, but a full round trip at these prices loses money. Leave it only if deliberate.
 				</p>
+			)}
+			{!strategy.referenceOnly && (
+				<div className="row" style={{ alignItems: "flex-end" }}>
+					<label className="field" style={{ maxWidth: "11rem", margin: 0 }}>
+						<span>Max order size ({token0})</span>
+						<input type="text" value={maxOrderSize} onChange={(e) => setMaxOrderSize(e.target.value)} />
+					</label>
+					<button
+						type="button"
+						disabled={!maxOrderSize.trim() || maxOrderSize.trim() === strategy.maxOrderSize}
+						onClick={applyMaxOrderSize}
+					>
+						Save cap
+					</button>
+					<span className="hint">
+						Per-order cap on the {token0} notional — orders needing more than the cap allows are skipped. A
+						new cap binds from the next order.
+					</span>
+				</div>
 			)}
 			<div className="row" style={{ alignItems: "flex-start", gap: "2rem" }}>
 				{(strategy.bid || enableBid) && (

--- a/sdk/packages/simplex/ui/src/types.ts
+++ b/sdk/packages/simplex/ui/src/types.ts
@@ -11,6 +11,8 @@ export type {
 	BalanceSnapshot,
 	BidDto,
 	BidStatsDto,
+	ChainRowDto,
+	ChainsDto,
 	ConfigDto,
 	KnownToken,
 	KnownVault,


### PR DESCRIPTION
Markets gain an editable per-order cap: PUT /api/strategies/:index applies it to the live TradingPair — the engine reads maxOrderSize while sizing each order, so the new cap binds from the next one — and persists it to the pair's config entry.

Chains and endpoints become editable too, as the setup wizard's chain step against the running config: Alchemy prefill, per-chain enable, quorum RPC rows, bundler URL and watch-only. Every candidate is checked the way boot checks it (distinct-host RPCs reporting the chain they claim, confirmation coverage, pair symbols still resolving, no funding venue stranded on a dropped chain) before anything is written. Chain topology is wired at boot, so the new set is persisted and takes effect on the next start.

validate-rpc, validate-bundler and validate-alchemy-key are now served in operator mode alongside validate-token; the stateful wizard routes stay closed. Operator-side config writes also keep the chain label comments, which were previously dropped on every rewrite.