### PR TITLE
[evm]: read the call dispatcher address from config when deploying the bridge token

### DIFF
--- a/evm/script/DeployBridgeToken.s.sol
+++ b/evm/script/DeployBridgeToken.s.sol
@@ -4,20 +4,19 @@ pragma solidity ^0.8.17;
 import "forge-std/Script.sol";
 import {HyperFungibleToken} from "@hyperbridge/core/apps/HyperFungibleToken.sol";
 import {BridgeToken} from "../src/apps/BridgeToken.sol";
-import {CallDispatcher} from "../src/utils/CallDispatcher.sol";
 import {BaseScript} from "./BaseScript.sol";
 
 contract DeployBridgeToken is BaseScript {
     function deploy() internal override {
-        CallDispatcher dispatcher = new CallDispatcher{salt: salt}();
+        address dispatcher = config.get("CALL_DISPATCHER").toAddress();
         BridgeToken bridge = new BridgeToken{salt: salt}(admin);
 
-        bridge.configure(HyperFungibleToken.ConfigOptions({host: HOST_ADDRESS, dispatcher: address(dispatcher)}));
+        bridge.configure(HyperFungibleToken.ConfigOptions({host: HOST_ADDRESS, dispatcher: dispatcher}));
 
         vm.stopBroadcast();
         console.log("=== BridgeToken Deployment ===");
         console.log("BridgeToken:", address(bridge));
-        console.log("CallDispatcher:", address(dispatcher));
+        console.log("CallDispatcher:", dispatcher);
         console.log("Nexus peer:", string(bridge.nexus()));
     }
 }


### PR DESCRIPTION
 `DeployBridgeToken.s.sol` was deploying a fresh `CallDispatcher`, but one is already deployed on every chain by `DeployIsmp.s.sol` and recorded in the config, which is how `DeployIntentGateway.s.sol` picks it up. This reads it from `CALL_DISPATCHER` instead. 