### PR TITLE
[sdk]: Pad the cancel order native quote to absorb pool reserve drift

### DIFF
--- a/sdk/packages/sdk/package.json
+++ b/sdk/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/sdk",
-	"version": "2.7.0",
+	"version": "2.7.1",
 	"description": "The hyperclient SDK provides utilities for querying proofs and statuses for cross-chain requests from HyperBridge.",
 	"type": "module",
 	"types": "./dist/node/index.d.ts",

--- a/sdk/packages/sdk/src/protocols/intents/OrderCanceller.ts
+++ b/sdk/packages/sdk/src/protocols/intents/OrderCanceller.ts
@@ -135,7 +135,9 @@ export class OrderCanceller {
 		)
 		const relayerFee = (feeInSourceFeeToken * 1005n) / 1000n
 
-		const nativeValue = await this.ctx.source.quoteNative(getRequest, relayerFee)
+		// getAmountsIn quotes are exact; pool reserves drift between quote and
+		// execution, so pad the swap input or the host's swapETHForExactTokens reverts.
+		const nativeValue = ((await this.ctx.source.quoteNative(getRequest, relayerFee)) * 101n) / 100n
 		return { nativeValue, relayerFee }
 	}
 
@@ -442,7 +444,7 @@ export class OrderCanceller {
 			timeoutTimestamp: 0n,
 		}
 
-		const nativeValue = await this.ctx.dest.quoteNative(postRequest, relayerFee)
+		const nativeValue = ((await this.ctx.dest.quoteNative(postRequest, relayerFee)) * 101n) / 100n
 		return { nativeValue, relayerFee }
 	}
 

--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/simplex",
-	"version": "0.8.6",
+	"version": "0.8.7",
 	"license": "Apache-2.0",
 	"description": "IntentGateway simplex package for hyperbridge",
 	"main": "dist/index.js",


### PR DESCRIPTION
`quoteCancelOrder` sent the exact `getAmountsIn` result as the transaction value, so any pool reserve drift between quote and execution made the host's `swapETHForExactTokens` revert with `EXCESSIVE_INPUT_AMOUNT`. Pads the native value by 1% on both the source and destination cancel paths, matching the buffer already applied in the token gateway and fill flows.