### PR TITLE
[simplex]: stop sponsored EIP-7702 delegation invalidating its own authorization on approve-mode chains

### DIFF
--- a/sdk/packages/simplex/src/services/DelegationService.ts
+++ b/sdk/packages/simplex/src/services/DelegationService.ts
@@ -166,10 +166,6 @@ export class DelegationService {
 		}
 
 		try {
-			// Build EIP-7702 authorization (bundler submits the tx, so use the current nonce)
-			// and carry it inside the UserOp so a not-yet-delegated EOA is delegated in the op.
-			const authorization = await this.buildAuthorization(chain, solverAccountContract, true)
-
 			this.logger.info(
 				{ chain, solverAccount: this.signer.account.address, solverAccountContract, mode: "bundler" },
 				"Setting up EIP-7702 delegation via bundler with paymaster",
@@ -196,10 +192,15 @@ export class DelegationService {
 			})
 			const isFreshEoa = !code || code === "0x"
 
+			// The EIP-7702 authorization rides inside the UserOp so a not-yet-delegated
+			// EOA is delegated in the op (bundler submits the tx, so it uses the current
+			// nonce). Passed as a factory: the sender signs it only after paymaster data
+			// is built, because approve-mode chains send an approve tx from this same EOA
+			// at that step, which would invalidate an authorization signed beforehand.
 			const result = await this.userOpSender.trySendSponsored({
 				chain,
 				callData: "0x" as HexString,
-				eip7702Auth: authorization,
+				eip7702Auth: () => this.buildAuthorization(chain, solverAccountContract, true),
 				gas: isFreshEoa
 					? { verificationGasLimit: 150_000n, callGasLimit: 50_000n, preVerificationGas: 100_000n }
 					: { verificationGasLimit: 80_000n, callGasLimit: 50_000n, preVerificationGas: 100_000n },

--- a/sdk/packages/simplex/src/services/UserOpSender.ts
+++ b/sdk/packages/simplex/src/services/UserOpSender.ts
@@ -6,6 +6,7 @@ import { FillerConfigService } from "./FillerConfigService"
 import { getLogger } from "./Logger"
 import type { SigningAccount } from "./wallet"
 import { buildPaymasterAndData, hasPaymaster } from "./paymaster"
+import type { PaymasterDataResult } from "./paymaster"
 
 /**
  * Raw EIP-7702 authorization, as produced by the delegation flow. Attached to the
@@ -30,8 +31,14 @@ export interface SponsoredUserOpRequest {
 	chain: string
 	/** ERC-7821 batch (or "0x" for a no-op, e.g. delegation). */
 	callData: HexString
-	/** Attach when the EOA still needs delegating in this op. */
-	eip7702Auth?: Eip7702Authorization
+	/**
+	 * Attach when the EOA still needs delegating in this op. Pass a factory rather
+	 * than a pre-signed tuple: building paymaster data can send an approve tx from
+	 * the authority EOA (Simplex approve mode), and an authorization signed before
+	 * that tx embeds a stale nonce the bundler will reject. The factory runs only
+	 * after paymaster data is built.
+	 */
+	eip7702Auth?: Eip7702Authorization | (() => Promise<Eip7702Authorization>)
 	/** EntryPoint nonce key. Defaults to 0. */
 	nonceKey?: bigint
 	/**
@@ -74,8 +81,9 @@ const FALLBACK_PRE_VERIFICATION_GAS = 150_000n
  * Submission contract (so callers can safely fall back to a native tx without
  * risking a double-execution):
  * - Returns `null` when the op was **never submitted** — paymaster/bundler not
- *   configured, insufficient USDC, or the bundler rejected `eth_sendUserOperation`
- *   outright (it never entered the mempool). The caller may fall back to native.
+ *   configured, insufficient USDC, preparation failed (approve tx or signing), or
+ *   the bundler rejected `eth_sendUserOperation` outright (it never entered the
+ *   mempool). The caller may fall back to native.
  * - Returns `{ txHash }` once a receipt is observed.
  * - **Throws** only when the op **was submitted** but no receipt arrived. The
  *   caller must NOT fall back (the op may still land) — retry on the next cycle.
@@ -120,21 +128,35 @@ export class UserOpSender {
 		const solverAccount = this.signer.account.address as HexString
 		const chainId = this.configService.getChainId(chain)
 
-		const pm = await buildPaymasterAndData({
-			chain,
-			solverAccount,
-			publicClient,
-			walletClient,
-			signer: this.signer,
-			configService: this.configService,
-			paymasterVerificationGasLimit,
-			forceApproveMode,
-		})
-		if (pm.type === "none") {
-			this.logger.warn(
-				{ chain, solverAccount, reason: pm.reason },
-				"No paymaster can sponsor this UserOp; caller should fall back to native",
-			)
+		let pm: PaymasterDataResult
+		let auth: Eip7702Authorization | undefined
+		try {
+			pm = await buildPaymasterAndData({
+				chain,
+				solverAccount,
+				publicClient,
+				walletClient,
+				signer: this.signer,
+				configService: this.configService,
+				paymasterVerificationGasLimit,
+				forceApproveMode,
+			})
+			if (pm.type === "none") {
+				this.logger.warn(
+					{ chain, solverAccount, reason: pm.reason },
+					"No paymaster can sponsor this UserOp; caller should fall back to native",
+				)
+				return null
+			}
+
+			// Sign the EIP-7702 authorization only after paymaster data is built —
+			// approve-mode building sends an approve tx from the authority EOA, and an
+			// authorization signed before that tx embeds a stale nonce (bundler reject).
+			auth = typeof eip7702Auth === "function" ? await eip7702Auth() : eip7702Auth
+		} catch (error) {
+			// Preparation failures (approve tx, permit/authorization signing) happen
+			// before anything reaches the bundler — never submitted, safe to fall back.
+			this.logger.warn({ chain, error }, "Failed to prepare sponsored UserOp; caller should fall back to native")
 			return null
 		}
 		this.logger.info({ chain, paymaster: pm.address, type: pm.type, token: pm.token }, "Paymaster selected")
@@ -149,14 +171,14 @@ export class UserOpSender {
 			args: [solverAccount, nonceKey],
 		})) as bigint
 
-		const formattedAuth = eip7702Auth
+		const formattedAuth = auth
 			? {
-					address: eip7702Auth.address,
-					chainId: toHex(eip7702Auth.chainId),
-					nonce: toHex(eip7702Auth.nonce),
-					r: eip7702Auth.r,
-					s: eip7702Auth.s,
-					yParity: toHex(eip7702Auth.yParity),
+					address: auth.address,
+					chainId: toHex(auth.chainId),
+					nonce: toHex(auth.nonce),
+					r: auth.r,
+					s: auth.s,
+					yParity: toHex(auth.yParity),
 				}
 			: undefined
 

--- a/sdk/packages/simplex/src/services/paymaster/provider/simplex.ts
+++ b/sdk/packages/simplex/src/services/paymaster/provider/simplex.ts
@@ -1,4 +1,4 @@
-import { encodePacked, maxUint256, erc20Abi, type PublicClient, type WalletClient } from "viem"
+import { encodePacked, formatEther, maxUint256, erc20Abi, type PublicClient, type WalletClient } from "viem"
 import type { HexString } from "@hyperbridge/sdk"
 import type { FillerConfigService } from "@/services/FillerConfigService"
 import {
@@ -15,6 +15,9 @@ interface TokenOption {
 	address: HexString
 	decimals: number
 }
+
+/** Gas ceiling for the one-time ERC-20 approve tx (typical approves need ~45-55k). */
+const APPROVE_TX_GAS = 60_000n
 
 /**
  * Builds the paymaster fields for a PackedUserOperation using the SimplexPaymaster.
@@ -192,6 +195,21 @@ async function ensureCappedApproval(
 
 	if (currentAllowance >= threshold) {
 		return
+	}
+
+	// The approve is a plain EOA tx paid in native — the very thing the paymaster
+	// exists to avoid needing. Pre-check the balance so an unfunded solver fails
+	// with one actionable line instead of viem's estimateGas error chain.
+	const [nativeBalance, gasPrice] = await Promise.all([
+		client.getBalance({ address: solverAccount }),
+		client.getGasPrice(),
+	])
+	const requiredNative = APPROVE_TX_GAS * gasPrice
+	if (nativeBalance < requiredNative) {
+		throw new Error(
+			`SimplexPaymaster needs a one-time funded approval on this chain — the fee token has no permit; ` +
+				`send native dust (>= ${formatEther(requiredNative)}) to ${solverAccount}`,
+		)
 	}
 
 	const approvalAmount = RECOMMENDED_AMOUNT_USD * 10n ** BigInt(tokenDecimals)

--- a/sdk/packages/simplex/src/tests/services/SimplexPaymaster.test.ts
+++ b/sdk/packages/simplex/src/tests/services/SimplexPaymaster.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from "vitest"
+import { encodePacked, type PublicClient, type WalletClient } from "viem"
+import type { HexString } from "@hyperbridge/sdk"
+
+import { buildSimplexPaymasterData } from "@/services/paymaster/provider/simplex"
+import { VERIFICATION_GAS_LIMIT_APPROVE, THRESHOLD_USD } from "@/services/paymaster/types"
+import type { FillerConfigService } from "@/services/FillerConfigService"
+
+/**
+ * Approve-mode bootstrap tests (#1070): on chains whose fee token has no
+ * EIP-2612 permit, the Simplex paymaster needs a one-time on-chain approve paid
+ * in native. An unfunded solver must fail fast with one actionable line —
+ * before any estimateGas round-trip — and a solver with an existing allowance
+ * must never need native at all.
+ */
+
+const USDC = "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d" as HexString // BSC pegged, 18 decimals
+const PAYMASTER = "0x0578cFB241215b77442a541325d6A4E6dFE700Ec" as HexString
+const SOLVER = "0x13E41CdE1D55880cbe031c69f206C2E9BC3c94C2" as HexString
+const CHAIN = "EVM-56"
+const DECIMALS = 18
+
+const configService = {
+	getChainId: () => 56,
+	getUsdcAsset: () => USDC,
+	getUsdcDecimals: () => DECIMALS,
+	getUsdtAsset: () => "0x" as HexString,
+	getUsdtDecimals: () => DECIMALS,
+} as unknown as FillerConfigService
+
+const signer = {
+	signTypedData: async () => ("0x" + "11".repeat(65)) as HexString,
+}
+
+function mockClient(opts: { allowance?: bigint; native?: bigint }): PublicClient {
+	return {
+		readContract: async ({ functionName }: { functionName: string }) => {
+			switch (functionName) {
+				case "balanceOf":
+					return 5n * 10n ** BigInt(DECIMALS)
+				case "allowance":
+					return opts.allowance ?? 0n
+				default:
+					throw new Error(`unexpected readContract: ${functionName}`)
+			}
+		},
+		getBalance: async () => opts.native ?? 0n,
+		getGasPrice: async () => 1_000_000_000n,
+		waitForTransactionReceipt: async () => ({ status: "success" }),
+	} as unknown as PublicClient
+}
+
+function mockWalletClient() {
+	const writeContract = vi.fn(async () => ("0x" + "ee".repeat(32)) as HexString)
+	const walletClient = {
+		chain: undefined,
+		account: { address: SOLVER },
+		writeContract,
+	} as unknown as WalletClient
+	return { walletClient, writeContract }
+}
+
+describe("buildSimplexPaymasterData approve-mode native pre-check", () => {
+	it("fails fast with an actionable message when the EOA cannot fund the approve", async () => {
+		const { walletClient, writeContract } = mockWalletClient()
+
+		await expect(
+			buildSimplexPaymasterData(
+				mockClient({ native: 0n }),
+				walletClient,
+				signer,
+				SOLVER,
+				PAYMASTER,
+				CHAIN,
+				configService,
+				true,
+			),
+		).rejects.toThrow(/one-time funded approval .* send native dust/)
+
+		// The pre-check must reject before any tx (and its estimateGas) is attempted.
+		expect(writeContract).not.toHaveBeenCalled()
+	})
+
+	it("sends the capped approve and returns approve-mode data when the EOA is funded", async () => {
+		const { walletClient, writeContract } = mockWalletClient()
+
+		const pm = await buildSimplexPaymasterData(
+			mockClient({ native: 10n ** 18n }),
+			walletClient,
+			signer,
+			SOLVER,
+			PAYMASTER,
+			CHAIN,
+			configService,
+			true,
+		)
+
+		expect(writeContract).toHaveBeenCalledOnce()
+		expect(pm?.paymasterData).toBe(encodePacked(["uint8", "address"], [1, USDC]))
+		expect(pm?.paymasterVerificationGasLimit).toBe(VERIFICATION_GAS_LIMIT_APPROVE)
+	})
+
+	it("needs no native once the allowance is in place (steady state)", async () => {
+		const { walletClient, writeContract } = mockWalletClient()
+
+		const pm = await buildSimplexPaymasterData(
+			mockClient({ allowance: THRESHOLD_USD * 10n ** BigInt(DECIMALS), native: 0n }),
+			walletClient,
+			signer,
+			SOLVER,
+			PAYMASTER,
+			CHAIN,
+			configService,
+			true,
+		)
+
+		expect(writeContract).not.toHaveBeenCalled()
+		expect(pm?.paymasterData).toBe(encodePacked(["uint8", "address"], [1, USDC]))
+	})
+})

--- a/sdk/packages/simplex/src/tests/services/UserOpSender.test.ts
+++ b/sdk/packages/simplex/src/tests/services/UserOpSender.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { toHex } from "viem"
+import type { HexString } from "@hyperbridge/sdk"
+
+import { UserOpSender, type Eip7702Authorization } from "@/services/UserOpSender"
+import { buildPaymasterAndData } from "@/services/paymaster"
+import { packPaymasterAndData, VERIFICATION_GAS_LIMIT_APPROVE, POST_OP_GAS_LIMIT } from "@/services/paymaster/types"
+import type { ChainClientManager } from "@/services/ChainClientManager"
+import type { FillerConfigService } from "@/services/FillerConfigService"
+import type { SigningAccount } from "@/services/wallet"
+
+/**
+ * Regression tests for the approve-mode nonce race (#1070): building Simplex
+ * paymaster data can send an on-chain `approve` from the authority EOA. An
+ * EIP-7702 authorization signed *before* that tx embeds the pre-approve nonce,
+ * so the bundler rejects the op ("EIP-7702 nonce mismatch"). The sender must
+ * therefore resolve the authorization factory only after paymaster data is
+ * built — and treat any preparation failure as "never submitted" (null).
+ */
+
+vi.mock("@/services/paymaster", () => ({
+	hasPaymaster: () => true,
+	buildPaymasterAndData: vi.fn(),
+}))
+
+const CHAIN = "EVM-56"
+const CHAIN_ID = 56
+const ENTRY_POINT = "0x4337843378433784337843378433784337843378" as HexString
+const PAYMASTER = "0x00000000000000000000000000000000000000aa" as HexString
+const TOKEN = "0x00000000000000000000000000000000000000bb" as HexString
+const DELEGATE = "0x00000000000000000000000000000000000000cc" as HexString
+const SOLVER = "0x13E41CdE1D55880cbe031c69f206C2E9BC3c94C2" as HexString
+
+// Fixed limits as passed by the delegation flow — skips bundler gas estimation.
+const GAS = { verificationGasLimit: 150_000n, callGasLimit: 50_000n, preVerificationGas: 100_000n }
+
+const configService = {
+	getEntryPointAddress: () => ENTRY_POINT,
+	getBundlerUrl: () => "http://127.0.0.1:1/bundler",
+	getChainId: () => CHAIN_ID,
+} as unknown as FillerConfigService
+
+const publicClient = {
+	getGasPrice: async () => 1_000_000_000n,
+	// Only EntryPoint.getNonce is read on this path (fixed gas limits skip estimation).
+	readContract: async () => 0n,
+}
+
+const clientManager = {
+	getPublicClient: () => publicClient,
+	getWalletClient: () => ({}),
+} as unknown as ChainClientManager
+
+const signer = {
+	account: { address: SOLVER },
+	signTypedData: async () => ("0x" + "11".repeat(65)) as HexString,
+} as unknown as SigningAccount
+
+const approveModePaymasterAndData = packPaymasterAndData({
+	paymaster: PAYMASTER,
+	paymasterData: "0x01" as HexString,
+	paymasterVerificationGasLimit: VERIFICATION_GAS_LIMIT_APPROVE,
+	paymasterPostOpGasLimit: POST_OP_GAS_LIMIT,
+})
+
+let bundlerCalls: Array<{ method: string; params: unknown[] }>
+
+beforeEach(() => {
+	bundlerCalls = []
+	vi.mocked(buildPaymasterAndData).mockReset()
+	vi.stubGlobal("fetch", async (_url: unknown, init?: { body?: string }) => {
+		const { method, params } = JSON.parse(init?.body ?? "{}") as { method: string; params: unknown[] }
+		bundlerCalls.push({ method, params })
+		let result: unknown
+		switch (method) {
+			case "eth_sendUserOperation":
+				result = ("0x" + "ab".repeat(32)) as HexString
+				break
+			case "eth_getUserOperationReceipt":
+				result = { success: true, receipt: { transactionHash: ("0x" + "cd".repeat(32)) as HexString } }
+				break
+			default:
+				return { json: async () => ({ jsonrpc: "2.0", id: 1, error: { message: `no ${method}` } }) }
+		}
+		return { json: async () => ({ jsonrpc: "2.0", id: 1, result }) }
+	})
+})
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+})
+
+describe("UserOpSender EIP-7702 authorization ordering", () => {
+	it("signs the authorization after paymaster data is built, so the approve tx nonce is reflected", async () => {
+		// Simulates the BSC incident: the EOA starts at nonce 0, and building
+		// approve-mode paymaster data mines an approve tx that bumps it to 1.
+		let eoaNonce = 0
+		vi.mocked(buildPaymasterAndData).mockImplementation(async () => {
+			eoaNonce += 1
+			return { paymasterAndData: approveModePaymasterAndData, type: "simplex", address: PAYMASTER, token: TOKEN }
+		})
+
+		// Mirrors DelegationService.buildAuthorization: reads the nonce at signing time.
+		const signAuthorization = vi.fn(
+			async (): Promise<Eip7702Authorization> => ({
+				chainId: CHAIN_ID,
+				address: DELEGATE,
+				nonce: eoaNonce,
+				r: ("0x" + "22".repeat(32)) as HexString,
+				s: ("0x" + "33".repeat(32)) as HexString,
+				yParity: 0,
+			}),
+		)
+
+		const sender = new UserOpSender(clientManager, configService, signer)
+		const result = await sender.trySendSponsored({
+			chain: CHAIN,
+			callData: "0x" as HexString,
+			eip7702Auth: signAuthorization,
+			gas: GAS,
+			forceApproveMode: true,
+		})
+
+		expect(result).toEqual({ txHash: "0x" + "cd".repeat(32) })
+		expect(signAuthorization).toHaveBeenCalledOnce()
+
+		// The authorization submitted to the bundler must carry the post-approve
+		// nonce (1) — a pre-signed tuple would carry the stale 0 and be rejected.
+		const send = bundlerCalls.find((c) => c.method === "eth_sendUserOperation")
+		expect(send).toBeDefined()
+		const [op] = send!.params as [{ eip7702Auth?: { nonce: string } }]
+		expect(op.eip7702Auth?.nonce).toBe(toHex(1))
+	})
+
+	it("returns null without signing an authorization when paymaster preparation fails", async () => {
+		vi.mocked(buildPaymasterAndData).mockRejectedValue(
+			new Error("SimplexPaymaster needs a one-time funded approval on this chain"),
+		)
+		const signAuthorization = vi.fn(async (): Promise<Eip7702Authorization> => {
+			throw new Error("should not be called")
+		})
+
+		const sender = new UserOpSender(clientManager, configService, signer)
+		await expect(
+			sender.trySendSponsored({
+				chain: CHAIN,
+				callData: "0x" as HexString,
+				eip7702Auth: signAuthorization,
+				gas: GAS,
+				forceApproveMode: true,
+			}),
+		).resolves.toBeNull()
+
+		expect(signAuthorization).not.toHaveBeenCalled()
+		expect(bundlerCalls.some((c) => c.method === "eth_sendUserOperation")).toBe(false)
+	})
+
+	it("returns null without signing an authorization when no paymaster is available", async () => {
+		vi.mocked(buildPaymasterAndData).mockResolvedValue({
+			paymasterAndData: "0x" as HexString,
+			type: "none",
+			reason: "insufficient stablecoin balance for all configured paymasters",
+		})
+		const signAuthorization = vi.fn(async (): Promise<Eip7702Authorization> => {
+			throw new Error("should not be called")
+		})
+
+		const sender = new UserOpSender(clientManager, configService, signer)
+		await expect(
+			sender.trySendSponsored({
+				chain: CHAIN,
+				callData: "0x" as HexString,
+				eip7702Auth: signAuthorization,
+				gas: GAS,
+			}),
+		).resolves.toBeNull()
+
+		expect(signAuthorization).not.toHaveBeenCalled()
+		expect(bundlerCalls.some((c) => c.method === "eth_sendUserOperation")).toBe(false)
+	})
+})


### PR DESCRIPTION
Closes #1070

## Problem

The sponsored delegation flow signed the EIP-7702 authorization **before** building paymaster data. On chains whose fee token has no EIP-2612 permit (BSC pegged USDC/USDT), `buildSimplexPaymasterData → ensureCappedApproval` sends an on-chain `approve` from the same EOA between those two steps. The approve consumes the nonce embedded in the pre-signed authorization, so the bundler rejects the op (`EIP-7702 nonce mismatch`) and the sponsored bootstrap always degrades to the native fallback — exactly the case the sponsored path exists for.

## Fix

- `SponsoredUserOpRequest.eip7702Auth` now also accepts a factory. `UserOpSender.trySendSponsored` resolves it only **after** `buildPaymasterAndData` completes, so any approve tx is already reflected in the authority's nonce. `DelegationService` passes `() => this.buildAuthorization(...)` instead of a pre-signed tuple.
- Preparation failures (approve tx, permit/authorization signing) now return `null` instead of throwing, matching the documented "never submitted — safe to fall back" contract. Previously a throw from `ensureCappedApproval` would have told the vault sweep/redeem callers *not* to fall back even though nothing was submitted.
- `ensureCappedApproval` pre-checks native balance before attempting the approve and fails fast with one actionable line — `SimplexPaymaster needs a one-time funded approval on this chain — the fee token has no permit; send native dust (>= X) to <account>` — instead of surfacing viem's `estimateGas` error chain, avoiding the estimate/retry round-trips.

## Tests

- `UserOpSender.test.ts` replays the BSC incident: EOA at nonce 0, the approve during paymaster building bumps it to 1, and the authorization submitted to the bundler must carry the post-approve nonce. Mutation-verified — restoring the old ordering fails all three tests. Also covers returning `null` without signing when preparation fails or no paymaster is available.
- `SimplexPaymaster.test.ts` covers the unfunded fail-fast (no tx attempted), the funded bootstrap approve, and steady state (allowance in place) needing zero native.