### PR TITLE
[sdk, simplex]: stop bid retraction racing its own resubmission, treat BidNotFound as terminal

### DIFF
--- a/sdk/packages/sdk/src/chains/intentsCoprocessor.ts
+++ b/sdk/packages/sdk/src/chains/intentsCoprocessor.ts
@@ -226,20 +226,30 @@ export class IntentsCoprocessor {
 	/**
 	 * Signs and sends an extrinsic. Submissions are serialised through {@link submissionQueue} so
 	 * concurrent calls never collide on the substrate account nonce — each extrinsic reaches a block
-	 * before the next is signed.
+	 * (or is confirmed still pooled and returned as `pending`) before the next is signed; auto-nonce
+	 * via `system.accountNextIndex` counts pooled extrinsics, so a pending one is never re-used.
 	 */
 	private async signAndSendExtrinsic(
 		extrinsic: SubmittableExtrinsic<"promise">,
 		maxRetries: number = 3,
 		timeoutMs: number = 30_000,
 	): Promise<BidSubmissionResult> {
-		const result = await this.submissionQueue.add(() => this.sendExtrinsicWithRetries(extrinsic, maxRetries, timeoutMs))
+		const result = await this.submissionQueue.add(() =>
+			this.sendExtrinsicWithRetries(extrinsic, maxRetries, timeoutMs),
+		)
 		return result ?? { success: false, error: "Submission queue returned no result" }
 	}
 
 	/**
 	 * Signs and sends an extrinsic, handling status updates and errors.
 	 * Implements retry logic with progressive tip increases for stuck transactions.
+	 *
+	 * A retry only happens when the previous attempt verifiably went nowhere. Once an attempt's
+	 * extrinsic is known to be pooled (`pending`), re-signing the same call would race our own
+	 * submission: the copy either bounces off the pool (1014, same nonce below the replacement
+	 * priority bump) or — if the original lands first, freeing the nonce — executes as a duplicate
+	 * and fails on-chain (e.g. `BidNotFound` for a retraction). Neither can succeed, so the pending
+	 * result is returned for the caller to confirm later.
 	 */
 	private async sendExtrinsicWithRetries(
 		extrinsic: SubmittableExtrinsic<"promise">,
@@ -256,8 +266,9 @@ export class IntentsCoprocessor {
 
 			try {
 				const result = await this.sendWithTimeout(extrinsic, keyPair, currentTip, timeoutMs)
-				if (result.success || result.error?.includes("Dispatch error")) {
-					// Return immediately on success or dispatch errors (non-recoverable)
+				if (result.success || result.pending || result.error?.includes("Dispatch error")) {
+					// Return immediately on success, an in-flight extrinsic, or dispatch errors
+					// (non-recoverable)
 					return result
 				}
 			} catch (err) {
@@ -276,7 +287,28 @@ export class IntentsCoprocessor {
 	}
 
 	/**
-	 * Sends an extrinsic with a timeout
+	 * Classifies a submission rejection. Codes 1013 ("already imported") and 1014 ("priority is
+	 * too low") both mean a copy of this account+nonce is already in the pool — almost always our
+	 * own earlier attempt whose watch handle didn't confirm cleanly. That extrinsic is in flight;
+	 * resubmitting can only bounce again or land a duplicate, so these are surfaced as `pending`
+	 * rather than failure.
+	 */
+	private classifySubmissionError(err: Error): BidSubmissionResult {
+		const code = (err as { code?: number }).code
+		const inFlight =
+			code === 1013 ||
+			code === 1014 ||
+			/already imported|already in the pool|priority is too low/i.test(err.message)
+		return { success: false, pending: inFlight || undefined, error: err.message }
+	}
+
+	/**
+	 * Sends an extrinsic with a timeout.
+	 *
+	 * A timeout is only a failure when the extrinsic never made it into the transaction pool.
+	 * Once a pool-entry status (Future/Ready/Broadcast/Retracted) has been seen, the extrinsic is
+	 * in flight and may well execute after the watch is abandoned — the result is then `pending`,
+	 * telling the caller to confirm the outcome later instead of re-signing the same call.
 	 */
 	private async sendWithTimeout(
 		extrinsic: SubmittableExtrinsic<"promise">,
@@ -287,6 +319,7 @@ export class IntentsCoprocessor {
 		return new Promise<BidSubmissionResult>((resolve) => {
 			let resolved = false
 			let unsubscribe: (() => void) | null = null
+			let enteredPool = false
 
 			// Set timeout to detect stuck transactions
 			const timeoutId = setTimeout(() => {
@@ -297,7 +330,9 @@ export class IntentsCoprocessor {
 					}
 					resolve({
 						success: false,
-						error: `Transaction timed out after ${timeoutMs}ms`,
+						pending: enteredPool || undefined,
+						extrinsicHash: enteredPool ? (extrinsic.hash.toHex() as HexString) : undefined,
+						error: `Transaction timed out after ${timeoutMs}ms${enteredPool ? " while in the transaction pool" : ""}`,
 					})
 				}
 			}, timeoutMs)
@@ -305,6 +340,15 @@ export class IntentsCoprocessor {
 			extrinsic
 				.signAndSend(keyPair, { tip }, (result) => {
 					if (resolved) return
+
+					if (
+						result.status.isFuture ||
+						result.status.isReady ||
+						result.status.isBroadcast ||
+						result.status.isRetracted
+					) {
+						enteredPool = true
+					}
 
 					if (result.dispatchError && (result.status.isInBlock || result.status.isFinalized)) {
 						resolved = true
@@ -384,7 +428,7 @@ export class IntentsCoprocessor {
 					if (!resolved) {
 						resolved = true
 						clearTimeout(timeoutId)
-						resolve({ success: false, error: err.message })
+						resolve(this.classifySubmissionError(err))
 					}
 				})
 		})
@@ -590,9 +634,9 @@ export class IntentsCoprocessor {
 		const rawHex = result.unwrap().toHex() as HexString
 		if (rawHex === "0x" || rawHex === "0x00") return null
 
-		const placeOrderAbi = (IntentGatewayV2.ABI as readonly { type: string; name?: string; inputs?: unknown[] }[]).find(
-			(item) => item.type === "function" && item.name === "placeOrder",
-		)
+		const placeOrderAbi = (
+			IntentGatewayV2.ABI as readonly { type: string; name?: string; inputs?: unknown[] }[]
+		).find((item) => item.type === "function" && item.name === "placeOrder")
 		const orderType = placeOrderAbi?.inputs?.[0]
 		if (!orderType) return null
 
@@ -677,7 +721,10 @@ export class IntentsCoprocessor {
 	 *
 	 * Returns a function that stops polling.
 	 */
-	pollPhantomOrders(callback: (event: PhantomOrderEvent) => void, options: PollPhantomOrdersOptions = {}): () => void {
+	pollPhantomOrders(
+		callback: (event: PhantomOrderEvent) => void,
+		options: PollPhantomOrdersOptions = {},
+	): () => void {
 		const { intervalMs = 6_000, maxBlocksPerPoll = 500, lookbackBlocks = 0, onError } = options
 
 		// Last block whose events have been delivered. Null until the first successful head read.

--- a/sdk/packages/sdk/src/tests/intentsCoprocessorPending.test.ts
+++ b/sdk/packages/sdk/src/tests/intentsCoprocessorPending.test.ts
@@ -1,0 +1,176 @@
+import { beforeAll, describe, expect, it } from "vitest"
+import { cryptoWaitReady } from "@polkadot/util-crypto"
+import { IntentsCoprocessor } from "@/chains/intentsCoprocessor"
+import type { BidSubmissionResult, HexString } from "@/types"
+
+/**
+ * Regression tests for the "retraction races its own resubmission" incident (#1074).
+ *
+ * A retraction entered the Hyperbridge tx pool but its submitAndWatch handle never confirmed.
+ * The retry loop then re-signed the same call: the copies bounced off the pooled original with
+ * RPC 1014 ("priority is too low"), and once the original executed — retracting the bid — a late
+ * duplicate landed on-chain only to fail with `BidNotFound`. On-chain cleanup had succeeded;
+ * locally it was recorded as a failure.
+ *
+ * The fix: an extrinsic known to be in the pool is in flight, not failed. Submission bounces
+ * 1013/1014 and watch timeouts after a pool-entry status now return `pending` immediately instead
+ * of re-signing, and callers confirm the outcome later.
+ *
+ * These tests drive the real code paths through a mock ApiPromise (via the public `fromApi`
+ * factory) so no node is required.
+ */
+
+const COMMITMENT = "0x4380111111111111111111111111111111111111111111111111111111114818" as HexString
+
+const readyStatus = {
+	isFuture: false,
+	isReady: true,
+	isBroadcast: false,
+	isRetracted: false,
+	isInBlock: false,
+	isFinalized: false,
+	isDropped: false,
+	isInvalid: false,
+	isUsurped: false,
+	isFinalityTimeout: false,
+	type: "Ready",
+}
+
+/** The exact shape of a pool rejection as polkadot-js surfaces it: an RpcError with a code. */
+function rpcError(code: number, message: string): Error {
+	const err = new Error(message) as Error & { code: number }
+	err.code = code
+	return err
+}
+
+/**
+ * Builds a mock ApiPromise whose retractBid extrinsic behaves per `behaviour` on each
+ * successive signAndSend attempt. `calls` counts signAndSend invocations.
+ */
+function mockApi(behaviour: (attempt: number, cb: (result: unknown) => void) => Promise<() => void>) {
+	const calls = { count: 0 }
+	const sendable = {
+		hash: { toHex: () => "0xextrinsichash" },
+		signAndSend: (_keyPair: unknown, _opts: unknown, cb: (result: unknown) => void) => {
+			calls.count++
+			return behaviour(calls.count, cb)
+		},
+	}
+	const api = {
+		tx: {
+			intentsCoprocessor: {
+				retractBid: () => sendable,
+			},
+		},
+		registry: {
+			findMetaError: () => ({ section: "intentsCoprocessor", name: "BidNotFound" }),
+		},
+	} as any
+	return { api, calls }
+}
+
+/** Runs retractBid with a short watch timeout so timeout paths don't take 30s. */
+async function retractWithShortTimeout(coproc: IntentsCoprocessor, timeoutMs: number): Promise<BidSubmissionResult> {
+	const extrinsic = (coproc as any).api.tx.intentsCoprocessor.retractBid(COMMITMENT)
+	return await (coproc as any).signAndSendExtrinsic(extrinsic, 3, timeoutMs)
+}
+
+describe("in-flight extrinsic handling", () => {
+	beforeAll(async () => {
+		await cryptoWaitReady()
+	})
+
+	it("returns pending on a 1014 pool bounce without re-signing — the pooled original is in flight", async () => {
+		const { api, calls } = mockApi(() =>
+			Promise.reject(
+				rpcError(
+					1014,
+					"1014: Priority is too low: (733000000733 vs 726000000726): The transaction has too low priority to replace another transaction already in the pool.",
+				),
+			),
+		)
+		const coproc = IntentsCoprocessor.fromApi(api, "//Alice")
+
+		const result = await coproc.retractBid(COMMITMENT)
+
+		expect(result.success).toBe(false)
+		expect(result.pending).toBe(true)
+		expect(calls.count).toBe(1)
+	})
+
+	it("returns pending on a 1013 already-imported bounce, matching by message when no code is set", async () => {
+		const { api, calls } = mockApi(() => Promise.reject(new Error("Transaction is already in the pool")))
+		const coproc = IntentsCoprocessor.fromApi(api, "//Alice")
+
+		const result = await coproc.retractBid(COMMITMENT)
+
+		expect(result.pending).toBe(true)
+		expect(calls.count).toBe(1)
+	})
+
+	it("returns pending when the watch times out after the extrinsic entered the pool", async () => {
+		const { api, calls } = mockApi((_attempt, cb) => {
+			// Ready arrives, then the watch goes silent — the production failure mode.
+			queueMicrotask(() => cb({ dispatchError: undefined, status: readyStatus, events: [] }))
+			return Promise.resolve(() => {})
+		})
+		const coproc = IntentsCoprocessor.fromApi(api, "//Alice")
+
+		const result = await retractWithShortTimeout(coproc, 100)
+
+		expect(result.success).toBe(false)
+		expect(result.pending).toBe(true)
+		expect(result.extrinsicHash).toBe("0xextrinsichash")
+		expect(result.error).toContain("in the transaction pool")
+		expect(calls.count).toBe(1)
+	})
+
+	it("still retries when the watch times out with no pool status at all", async () => {
+		const { api, calls } = mockApi(() => Promise.resolve(() => {}))
+		const coproc = IntentsCoprocessor.fromApi(api, "//Alice")
+
+		const result = await retractWithShortTimeout(coproc, 50)
+
+		expect(result.success).toBe(false)
+		expect(result.pending).toBeUndefined()
+		expect(result.error).toBe("Transaction failed after 3 attempts")
+		expect(calls.count).toBe(3)
+	})
+
+	it("still retries on submission errors that do not indicate a pooled copy", async () => {
+		const { api, calls } = mockApi(() =>
+			Promise.reject(rpcError(1010, "1010: Invalid Transaction: Inability to pay some fees")),
+		)
+		const coproc = IntentsCoprocessor.fromApi(api, "//Alice")
+
+		const result = await coproc.retractBid(COMMITMENT)
+
+		expect(result.success).toBe(false)
+		expect(result.pending).toBeUndefined()
+		expect(calls.count).toBe(3)
+	})
+
+	it("reports a dispatch error as terminal failure, not pending", async () => {
+		const inBlockWithError = {
+			...readyStatus,
+			isReady: false,
+			isInBlock: true,
+			asInBlock: { toHex: () => "0xblockhash" },
+			type: "InBlock",
+		}
+		const { api, calls } = mockApi((_attempt, cb) => {
+			queueMicrotask(() =>
+				cb({ dispatchError: { isModule: true, asModule: {} }, status: inBlockWithError, events: [] }),
+			)
+			return Promise.resolve(() => {})
+		})
+		const coproc = IntentsCoprocessor.fromApi(api, "//Alice")
+
+		const result = await coproc.retractBid(COMMITMENT)
+
+		expect(result.success).toBe(false)
+		expect(result.pending).toBeUndefined()
+		expect(result.error).toContain("BidNotFound")
+		expect(calls.count).toBe(1)
+	})
+})

--- a/sdk/packages/sdk/src/types/index.ts
+++ b/sdk/packages/sdk/src/types/index.ts
@@ -1404,6 +1404,16 @@ export interface BidSubmissionResult {
 	 * Error message if submission failed
 	 */
 	error?: string
+
+	/**
+	 * The extrinsic is (or may still be) in the transaction pool: it was accepted but its
+	 * inclusion was not observed before the watch timed out, or a resubmission bounced off an
+	 * earlier copy already pooled (RPC 1013/1014). Only meaningful when `success` is false —
+	 * the operation is in flight, not failed, and must not be re-signed with the same nonce.
+	 * Callers should confirm the outcome later (e.g. re-check on-chain state) instead of
+	 * treating this as a terminal failure.
+	 */
+	pending?: boolean
 }
 
 /**

--- a/sdk/packages/simplex/src/core/filler.ts
+++ b/sdk/packages/simplex/src/core/filler.ts
@@ -185,7 +185,8 @@ export class IntentFiller {
 	}
 
 	/**
-	 * Immediately enqueues retraction for all stale bids (older than maxAgeMs).
+	 * Immediately enqueues retraction for all bids due for it: stale bids (older than maxAgeMs)
+	 * and dead bids (order already filled) of any age.
 	 * Returns the number of bids queued for retraction.
 	 */
 	public async retractStaleBids(maxAgeMs = 60 * 60 * 1000): Promise<number> {
@@ -317,7 +318,7 @@ export class IntentFiller {
 			})
 		}, SWEEP_INTERVAL_MS)
 
-		this.logger.info("Periodic retraction sweep started (every 5 minutes, 1h TTL)")
+		this.logger.info("Periodic retraction sweep started (every 5 minutes; 1h TTL, dead bids swept next cycle)")
 	}
 
 	private async sweepExpiredBids(maxAgeMs: number): Promise<void> {
@@ -762,6 +763,7 @@ export class IntentFiller {
 
 					if (this.pendingRetractions.delete(commitment)) {
 						this.logger.info({ commitment }, "OrderFilled arrived before bid was stored, retracting now")
+						this.bidStorage?.markBidAsDead(commitment)
 						this.enqueueRetraction(commitment)
 					}
 				}
@@ -806,20 +808,45 @@ export class IntentFiller {
 			return
 		}
 
+		// The order is filled, so the bid is dead weight from here on. Should the immediate
+		// retraction below not confirm, the sweep re-attempts dead bids on its next cycle
+		// instead of waiting out the stale-bid TTL.
+		this.bidStorage.markBidAsDead(commitment)
 		this.enqueueRetraction(commitment)
 	}
 
 	private enqueueRetraction(commitment: HexString): void {
 		this.retractionQueue.add(async () => {
 			try {
-				this.logger.info({ commitment }, "Retracting bid after on-chain OrderFilled")
+				// Both OrderFilled and the periodic sweep can enqueue the same commitment; a fresh
+				// read at dequeue time skips the duplicate instead of paying for a BidNotFound.
+				if (this.bidStorage!.getBidByCommitment(commitment)?.retracted) {
+					return
+				}
+
+				this.logger.info({ commitment }, "Retracting bid")
 
 				const coprocessor = await this.hyperbridge!
 				const result = await coprocessor.retractBid(commitment)
 
 				if (result.success) {
-					this.bidStorage!.markBidAsRetracted(commitment, result.extrinsicHash as HexString)
+					this.bidStorage!.markBidAsRetracted(commitment, (result.extrinsicHash as HexString) ?? null)
 					this.logger.info({ commitment, retractHash: result.extrinsicHash }, "Bid retracted successfully")
+				} else if (result.error?.includes("BidNotFound")) {
+					// Terminal, not retryable: bids only leave the pallet by retraction, so "no bid"
+					// means there is nothing left to reclaim — an earlier submission of ours landed,
+					// someone retracted manually, or the placement never landed. Anything else seeds
+					// a zombie the sweep re-retracts forever.
+					this.bidStorage!.markBidAsRetracted(commitment, null)
+					this.logger.debug({ commitment }, "No bid on chain, marked as retracted")
+				} else if (result.pending) {
+					// Our extrinsic is still in the Hyperbridge tx pool. Resubmitting can only bounce
+					// off it (1014) or land a duplicate; leave the bid as-is and let the sweep confirm
+					// — if the pooled retraction lands, the next attempt's BidNotFound closes it out.
+					this.logger.debug(
+						{ commitment, error: result.error },
+						"Retraction already in flight, deferring to sweep",
+					)
 				} else {
 					this.logger.error({ commitment, error: result.error }, "Failed to retract bid")
 				}
@@ -889,7 +916,9 @@ export class IntentFiller {
 	}
 
 	private async handlePhantomOrder(event: PhantomOrderEvent, coprocessor: IntentsCoprocessor): Promise<void> {
-		const entryPointAddress = this.configService.getEntryPointAddress(`EVM-${getChainId(event.chain) ?? event.chain}`)
+		const entryPointAddress = this.configService.getEntryPointAddress(
+			`EVM-${getChainId(event.chain) ?? event.chain}`,
+		)
 		if (!entryPointAddress) {
 			this.logger.debug({ chain: event.chain }, "No entry point configured for phantom order chain, skipping")
 			return
@@ -966,6 +995,15 @@ export class IntentFiller {
 						blockHash: result.blockHash,
 					},
 					"Phantom bid submitted",
+				)
+			} else if (result.pending) {
+				// The extrinsic reached the tx pool but inclusion wasn't observed — it will almost
+				// certainly land. Record the commitment so the next interval's batch retracts it;
+				// if it never lands, that retraction degrades to a harmless trailing BidNotFound.
+				this.lastPhantomCommitmentByChain.set(event.chain, event.commitment)
+				this.logger.info(
+					{ commitment: event.commitment, chain: event.chain, error: result.error },
+					"Phantom bid in flight, inclusion not yet observed",
 				)
 			} else {
 				this.logger.warn(

--- a/sdk/packages/simplex/src/services/BidStorageService.ts
+++ b/sdk/packages/simplex/src/services/BidStorageService.ts
@@ -15,6 +15,8 @@ export interface StoredBid {
 	retracted: boolean
 	retractedAt: string | null
 	retractExtrinsicHash: HexString | null
+	/** The order was observed filled on-chain, so this bid can never win and should be retracted ASAP. */
+	dead: boolean
 }
 
 export interface BidInsertData {
@@ -24,6 +26,21 @@ export interface BidInsertData {
 	success: boolean
 	error?: string
 }
+
+/** Column list shared by every SELECT that returns a StoredBid. */
+const BID_COLUMNS = `
+	id,
+	commitment,
+	extrinsic_hash as extrinsicHash,
+	block_hash as blockHash,
+	success,
+	error,
+	created_at as createdAt,
+	retracted,
+	retracted_at as retractedAt,
+	retract_extrinsic_hash as retractExtrinsicHash,
+	dead
+`
 
 /**
  * Service for persistent storage of Hyperbridge bid submissions.
@@ -69,7 +86,8 @@ export class BidStorageService {
 				created_at TEXT NOT NULL DEFAULT (datetime('now')),
 				retracted INTEGER NOT NULL DEFAULT 0,
 				retracted_at TEXT,
-				retract_extrinsic_hash TEXT
+				retract_extrinsic_hash TEXT,
+				dead INTEGER NOT NULL DEFAULT 0
 			);
 
 			CREATE INDEX IF NOT EXISTS idx_bids_commitment ON bids(commitment);
@@ -79,7 +97,23 @@ export class BidStorageService {
 
 		`)
 
+		// Databases created before the column existed need it added in place.
+		const columns = this.db.pragma("table_info(bids)") as { name: string }[]
+		if (!columns.some((column) => column.name === "dead")) {
+			this.db.exec("ALTER TABLE bids ADD COLUMN dead INTEGER NOT NULL DEFAULT 0")
+			this.logger.info("Migrated bid storage schema: added 'dead' column")
+		}
+
 		this.logger.debug("Bid storage schema initialized")
+	}
+
+	private toStoredBid(row: any): StoredBid {
+		return {
+			...row,
+			success: Boolean(row.success),
+			retracted: Boolean(row.retracted),
+			dead: Boolean(row.dead),
+		}
 	}
 
 	/**
@@ -116,18 +150,8 @@ export class BidStorageService {
 	 */
 	getBidByCommitment(commitment: HexString): StoredBid | null {
 		const stmt = this.db.prepare(`
-			SELECT 
-				id,
-				commitment,
-				extrinsic_hash as extrinsicHash,
-				block_hash as blockHash,
-				success,
-				error,
-				created_at as createdAt,
-				retracted,
-				retracted_at as retractedAt,
-				retract_extrinsic_hash as retractExtrinsicHash
-			FROM bids 
+			SELECT ${BID_COLUMNS}
+			FROM bids
 			WHERE commitment = ?
 			ORDER BY created_at DESC
 			LIMIT 1
@@ -137,11 +161,7 @@ export class BidStorageService {
 
 		if (!row) return null
 
-		return {
-			...row,
-			success: Boolean(row.success),
-			retracted: Boolean(row.retracted),
-		}
+		return this.toStoredBid(row)
 	}
 
 	/**
@@ -150,65 +170,42 @@ export class BidStorageService {
 	 */
 	getUnretractedSuccessfulBids(): StoredBid[] {
 		const stmt = this.db.prepare(`
-			SELECT 
-				id,
-				commitment,
-				extrinsic_hash as extrinsicHash,
-				block_hash as blockHash,
-				success,
-				error,
-				created_at as createdAt,
-				retracted,
-				retracted_at as retractedAt,
-				retract_extrinsic_hash as retractExtrinsicHash
-			FROM bids 
+			SELECT ${BID_COLUMNS}
+			FROM bids
 			WHERE success = 1 AND retracted = 0
 			ORDER BY created_at ASC
 		`)
 
 		const rows = stmt.all() as any[]
 
-		return rows.map((row) => ({
-			...row,
-			success: Boolean(row.success),
-			retracted: Boolean(row.retracted),
-		}))
+		return rows.map((row) => this.toStoredBid(row))
 	}
 
 	/**
-	 * Retrieves successful, unretracted bids older than the given age.
-	 * Used by the periodic sweep to retract stale bids after a TTL.
+	 * Retrieves successful, unretracted bids that are due for retraction: bids older than the
+	 * given age, plus dead bids (order already filled on-chain) regardless of age — a dead bid's
+	 * deposit is reclaimable now, so a failed retraction attempt is retried on the next sweep
+	 * cycle instead of waiting out the TTL.
 	 */
 	getExpiredUnretractedBids(maxAgeMs: number): StoredBid[] {
 		// Format must match SQLite's datetime('now'): "YYYY-MM-DD HH:MM:SS"
 		// Using .toISOString() produces "YYYY-MM-DDTHH:MM:SS.sssZ" which breaks
 		// lexicographic comparison because space (ASCII 32) < 'T' (ASCII 84),
 		// causing ALL bids to appear expired.
-		const cutoff = new Date(Date.now() - maxAgeMs).toISOString().replace("T", " ").replace(/\.\d{3}Z$/, "")
+		const cutoff = new Date(Date.now() - maxAgeMs)
+			.toISOString()
+			.replace("T", " ")
+			.replace(/\.\d{3}Z$/, "")
 		const stmt = this.db.prepare(`
-			SELECT 
-				id,
-				commitment,
-				extrinsic_hash as extrinsicHash,
-				block_hash as blockHash,
-				success,
-				error,
-				created_at as createdAt,
-				retracted,
-				retracted_at as retractedAt,
-				retract_extrinsic_hash as retractExtrinsicHash
-			FROM bids 
-			WHERE success = 1 AND retracted = 0 AND created_at < ?
+			SELECT ${BID_COLUMNS}
+			FROM bids
+			WHERE success = 1 AND retracted = 0 AND (dead = 1 OR created_at < ?)
 			ORDER BY created_at ASC
 		`)
 
 		const rows = stmt.all(cutoff) as any[]
 
-		return rows.map((row) => ({
-			...row,
-			success: Boolean(row.success),
-			retracted: Boolean(row.retracted),
-		}))
+		return rows.map((row) => this.toStoredBid(row))
 	}
 
 	/**
@@ -216,39 +213,32 @@ export class BidStorageService {
 	 */
 	getBidsByDateRange(startDate: Date, endDate: Date): StoredBid[] {
 		const stmt = this.db.prepare(`
-			SELECT 
-				id,
-				commitment,
-				extrinsic_hash as extrinsicHash,
-				block_hash as blockHash,
-				success,
-				error,
-				created_at as createdAt,
-				retracted,
-				retracted_at as retractedAt,
-				retract_extrinsic_hash as retractExtrinsicHash
-			FROM bids 
+			SELECT ${BID_COLUMNS}
+			FROM bids
 			WHERE created_at BETWEEN ? AND ?
 			ORDER BY created_at DESC
 		`)
 
-		const toSqliteDatetime = (d: Date) => d.toISOString().replace("T", " ").replace(/\.\d{3}Z$/, "")
+		const toSqliteDatetime = (d: Date) =>
+			d
+				.toISOString()
+				.replace("T", " ")
+				.replace(/\.\d{3}Z$/, "")
 		const rows = stmt.all(toSqliteDatetime(startDate), toSqliteDatetime(endDate)) as any[]
 
-		return rows.map((row) => ({
-			...row,
-			success: Boolean(row.success),
-			retracted: Boolean(row.retracted),
-		}))
+		return rows.map((row) => this.toStoredBid(row))
 	}
 
 	/**
-	 * Marks a bid as retracted after successful fund recovery
+	 * Marks a bid as retracted. Called after successful fund recovery, and also when the chain
+	 * reports `BidNotFound` — bids only leave the pallet by retraction, so "no bid" means there
+	 * is nothing left to reclaim (an earlier duplicate landed, or the bid never did) and no hash
+	 * is available.
 	 */
-	markBidAsRetracted(commitment: HexString, retractExtrinsicHash: HexString): boolean {
+	markBidAsRetracted(commitment: HexString, retractExtrinsicHash: HexString | null): boolean {
 		const stmt = this.db.prepare(`
-			UPDATE bids 
-			SET retracted = 1, 
+			UPDATE bids
+			SET retracted = 1,
 				retracted_at = datetime('now'),
 				retract_extrinsic_hash = ?
 			WHERE commitment = ? AND retracted = 0
@@ -258,6 +248,27 @@ export class BidStorageService {
 
 		if (result.changes > 0) {
 			this.logger.info({ commitment, retractExtrinsicHash }, "Bid marked as retracted")
+			return true
+		}
+
+		return false
+	}
+
+	/**
+	 * Marks a bid as dead: its order was observed filled on-chain, so the bid can never win and
+	 * its deposit should be reclaimed on the next retraction sweep regardless of the bid's age.
+	 */
+	markBidAsDead(commitment: HexString): boolean {
+		const stmt = this.db.prepare(`
+			UPDATE bids
+			SET dead = 1
+			WHERE commitment = ? AND retracted = 0 AND dead = 0
+		`)
+
+		const result = stmt.run(commitment)
+
+		if (result.changes > 0) {
+			this.logger.debug({ commitment }, "Bid marked as dead (order filled on-chain)")
 			return true
 		}
 
@@ -277,7 +288,7 @@ export class BidStorageService {
 		const stats = this.db
 			.prepare(
 				`
-			SELECT 
+			SELECT
 				COUNT(*) as total,
 				SUM(CASE WHEN success = 1 THEN 1 ELSE 0 END) as successful,
 				SUM(CASE WHEN success = 0 THEN 1 ELSE 0 END) as failed,
@@ -302,18 +313,8 @@ export class BidStorageService {
 	 */
 	getFailedBids(limit = 100): StoredBid[] {
 		const stmt = this.db.prepare(`
-			SELECT 
-				id,
-				commitment,
-				extrinsic_hash as extrinsicHash,
-				block_hash as blockHash,
-				success,
-				error,
-				created_at as createdAt,
-				retracted,
-				retracted_at as retractedAt,
-				retract_extrinsic_hash as retractExtrinsicHash
-			FROM bids 
+			SELECT ${BID_COLUMNS}
+			FROM bids
 			WHERE success = 0
 			ORDER BY created_at DESC
 			LIMIT ?
@@ -321,11 +322,7 @@ export class BidStorageService {
 
 		const rows = stmt.all(limit) as any[]
 
-		return rows.map((row) => ({
-			...row,
-			success: Boolean(row.success),
-			retracted: Boolean(row.retracted),
-		}))
+		return rows.map((row) => this.toStoredBid(row))
 	}
 
 	/**
@@ -333,17 +330,7 @@ export class BidStorageService {
 	 */
 	getRecentBids(limit = 100): StoredBid[] {
 		const stmt = this.db.prepare(`
-			SELECT
-				id,
-				commitment,
-				extrinsic_hash as extrinsicHash,
-				block_hash as blockHash,
-				success,
-				error,
-				created_at as createdAt,
-				retracted,
-				retracted_at as retractedAt,
-				retract_extrinsic_hash as retractExtrinsicHash
+			SELECT ${BID_COLUMNS}
 			FROM bids
 			ORDER BY id DESC
 			LIMIT ?
@@ -351,11 +338,7 @@ export class BidStorageService {
 
 		const rows = stmt.all(Math.min(Math.max(limit, 1), 500)) as any[]
 
-		return rows.map((row) => ({
-			...row,
-			success: Boolean(row.success),
-			retracted: Boolean(row.retracted),
-		}))
+		return rows.map((row) => this.toStoredBid(row))
 	}
 
 	/**

--- a/sdk/packages/simplex/src/tests/core/filler-retraction.test.ts
+++ b/sdk/packages/simplex/src/tests/core/filler-retraction.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { mkdtempSync, rmSync } from "fs"
+import { tmpdir } from "os"
+import { join } from "path"
+import type { BidSubmissionResult, HexString } from "@hyperbridge/sdk"
+import { IntentFiller } from "@/core/filler"
+import { BidStorageService } from "@/services/BidStorageService"
+
+/**
+ * Regression tests for #1074: the filler's handling of retraction outcomes.
+ *
+ * The incident: a retraction's watch handle didn't confirm, the SDK's retry bounced off its own
+ * pooled copy (1014), the pooled original then executed, and the late duplicate's `BidNotFound`
+ * was recorded as an ERROR. Because only observed successes ran `markBidAsRetracted`, the bid
+ * stayed "unretracted" in SQLite and the sweep re-retracted it every cycle after the TTL —
+ * `BidNotFound` every 5 minutes, forever.
+ *
+ * The rules under test, driven through handleOrderFilledOnChain with a stubbed coprocessor:
+ *   - `BidNotFound` is terminal: nothing is left to reclaim, mark retracted (no zombie sweeps).
+ *   - `pending` (in-flight) is not failure: leave unretracted; the bid is dead, so the sweep
+ *     re-checks next cycle and the follow-up's BidNotFound closes it out.
+ *   - OrderFilled marks the bid dead, so failed retractions retry on the next sweep cycle
+ *     regardless of the bid's age.
+ *   - A commitment already retracted at dequeue time is skipped, not re-submitted.
+ */
+
+const COMMITMENT = "0x4380111111111111111111111111111111111111111111111111111111114818" as HexString
+const OUR_ADDRESS = "0xAAAA00000000000000000000000000000000AAAA" as HexString
+const OTHER_FILLER = "0xBBBB00000000000000000000000000000000BBBB"
+const HOUR_MS = 60 * 60 * 1000
+
+describe("IntentFiller bid retraction", () => {
+	const dirs: string[] = []
+
+	afterEach(() => {
+		for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+	})
+
+	function build(results: BidSubmissionResult[]) {
+		const dir = mkdtempSync(join(tmpdir(), "simplex-retraction-"))
+		dirs.push(dir)
+		const bidStorage = new BidStorageService(dir)
+
+		const retractBid = vi.fn(async (): Promise<BidSubmissionResult> => {
+			const next = results.shift()
+			if (!next) throw new Error("unexpected retractBid call")
+			return next
+		})
+
+		const configService = {
+			getHyperbridgeWsUrl: () => undefined,
+			getSubstratePrivateKey: () => undefined,
+		} as any
+
+		const filler = new IntentFiller(
+			[],
+			[],
+			{},
+			configService,
+			{} as any, // ChainClientManager — unused with no chains configured
+			{} as any, // ContractInteractionService — unused on the retraction path
+			{ account: { address: OUR_ADDRESS } } as any,
+			undefined,
+			bidStorage,
+		)
+		;(filler as any).hyperbridge = Promise.resolve({ retractBid })
+
+		return { filler, bidStorage, retractBid }
+	}
+
+	async function orderFilled(filler: IntentFiller, commitment: HexString): Promise<void> {
+		;(filler as any).handleOrderFilledOnChain(commitment, OTHER_FILLER, 8453)
+		await (filler as any).retractionQueue.onIdle()
+	}
+
+	it("marks the bid retracted on a successful retraction", async () => {
+		const { filler, bidStorage, retractBid } = build([
+			{ success: true, extrinsicHash: "0xretract" as HexString, blockHash: "0xblock" as HexString },
+		])
+		bidStorage.storeBid({ commitment: COMMITMENT, success: true })
+
+		await orderFilled(filler, COMMITMENT)
+
+		const bid = bidStorage.getBidByCommitment(COMMITMENT)
+		expect(bid!.retracted).toBe(true)
+		expect(bid!.retractExtrinsicHash).toBe("0xretract")
+		expect(retractBid).toHaveBeenCalledTimes(1)
+	})
+
+	it("treats BidNotFound as terminal: marks retracted so the sweep never re-attempts", async () => {
+		const { filler, bidStorage, retractBid } = build([
+			{ success: false, error: "Dispatch error: intentsCoprocessor::BidNotFound" },
+		])
+		bidStorage.storeBid({ commitment: COMMITMENT, success: true })
+
+		await orderFilled(filler, COMMITMENT)
+
+		const bid = bidStorage.getBidByCommitment(COMMITMENT)
+		expect(bid!.retracted).toBe(true)
+		expect(bid!.retractExtrinsicHash).toBeNull()
+		expect(bidStorage.getExpiredUnretractedBids(0)).toHaveLength(0)
+		expect(retractBid).toHaveBeenCalledTimes(1)
+	})
+
+	it("leaves an in-flight retraction unretracted, then closes it out via the sweep's BidNotFound", async () => {
+		const { filler, bidStorage, retractBid } = build([
+			{
+				success: false,
+				pending: true,
+				error: "Transaction timed out after 30000ms while in the transaction pool",
+			},
+			{ success: false, error: "Dispatch error: intentsCoprocessor::BidNotFound" },
+		])
+		bidStorage.storeBid({ commitment: COMMITMENT, success: true })
+
+		await orderFilled(filler, COMMITMENT)
+
+		// In flight: not retracted yet, but dead — due on the next sweep cycle despite its age.
+		let bid = bidStorage.getBidByCommitment(COMMITMENT)
+		expect(bid!.retracted).toBe(false)
+		expect(bid!.dead).toBe(true)
+		expect(bidStorage.getExpiredUnretractedBids(HOUR_MS).map((b) => b.commitment)).toEqual([COMMITMENT])
+
+		// Next cycle: the pooled original landed meanwhile, so the sweep's attempt sees
+		// BidNotFound and marks the bid retracted. The zombie loop from #1074 ends here.
+		await (filler as any).sweepExpiredBids(HOUR_MS)
+		await (filler as any).retractionQueue.onIdle()
+
+		bid = bidStorage.getBidByCommitment(COMMITMENT)
+		expect(bid!.retracted).toBe(true)
+		expect(retractBid).toHaveBeenCalledTimes(2)
+	})
+
+	it("marks the bid dead on OrderFilled so a failed retraction retries next sweep, not after the TTL", async () => {
+		const { filler, bidStorage } = build([{ success: false, error: "Transaction failed after 3 attempts" }])
+		bidStorage.storeBid({ commitment: COMMITMENT, success: true })
+
+		await orderFilled(filler, COMMITMENT)
+
+		const bid = bidStorage.getBidByCommitment(COMMITMENT)
+		expect(bid!.retracted).toBe(false)
+		expect(bid!.dead).toBe(true)
+		// Minutes old at most, yet already due for the next sweep.
+		expect(bidStorage.getExpiredUnretractedBids(HOUR_MS).map((b) => b.commitment)).toEqual([COMMITMENT])
+	})
+
+	it("skips a queued duplicate whose bid was retracted by the time it dequeues", async () => {
+		const { filler, bidStorage, retractBid } = build([
+			{ success: true, extrinsicHash: "0xretract" as HexString, blockHash: "0xblock" as HexString },
+		])
+		bidStorage.storeBid({ commitment: COMMITMENT, success: true })
+
+		// OrderFilled and a sweep race to enqueue the same commitment.
+		;(filler as any).handleOrderFilledOnChain(COMMITMENT, OTHER_FILLER, 8453)
+		;(filler as any).enqueueRetraction(COMMITMENT)
+		await (filler as any).retractionQueue.onIdle()
+
+		expect(bidStorage.getBidByCommitment(COMMITMENT)!.retracted).toBe(true)
+		expect(retractBid).toHaveBeenCalledTimes(1)
+	})
+})

--- a/sdk/packages/simplex/src/tests/services/BidStorageService.test.ts
+++ b/sdk/packages/simplex/src/tests/services/BidStorageService.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it } from "vitest"
+import Database from "better-sqlite3"
+import { mkdtempSync, rmSync } from "fs"
+import { tmpdir } from "os"
+import { join } from "path"
+import type { HexString } from "@hyperbridge/sdk"
+import { BidStorageService } from "@/services/BidStorageService"
+
+/**
+ * Tests for the dead-bid bookkeeping introduced for #1074: a bid whose order was observed
+ * filled on-chain is "dead" — it can never win, so the retraction sweep must pick it up on
+ * its next cycle instead of waiting out the 1h stale-bid TTL. Also covers marking a bid
+ * retracted without a retraction extrinsic hash (the BidNotFound-is-terminal path) and the
+ * in-place schema migration for databases created before the `dead` column existed.
+ */
+
+const COMMITMENT = "0x1111111111111111111111111111111111111111111111111111111111111111" as HexString
+const OTHER = "0x2222222222222222222222222222222222222222222222222222222222222222" as HexString
+const HOUR_MS = 60 * 60 * 1000
+
+describe("BidStorageService", () => {
+	const dirs: string[] = []
+	const services: BidStorageService[] = []
+
+	function freshService(): { service: BidStorageService; dir: string } {
+		const dir = mkdtempSync(join(tmpdir(), "simplex-bids-"))
+		dirs.push(dir)
+		const service = new BidStorageService(dir)
+		services.push(service)
+		return { service, dir }
+	}
+
+	/** Backdates a bid so it falls outside the given age, via a second connection to the same file. */
+	function backdate(dir: string, commitment: HexString, ageMs: number): void {
+		const db = new Database(join(dir, "bids.db"))
+		const past = new Date(Date.now() - ageMs)
+			.toISOString()
+			.replace("T", " ")
+			.replace(/\.\d{3}Z$/, "")
+		db.prepare("UPDATE bids SET created_at = ? WHERE commitment = ?").run(past, commitment)
+		db.close()
+	}
+
+	afterEach(() => {
+		for (const service of services.splice(0)) {
+			try {
+				service.close()
+			} catch {
+				// already closed
+			}
+		}
+		for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+	})
+
+	it("stores bids with dead=false and exposes the flag on reads", () => {
+		const { service } = freshService()
+		service.storeBid({ commitment: COMMITMENT, success: true })
+
+		const bid = service.getBidByCommitment(COMMITMENT)
+		expect(bid).not.toBeNull()
+		expect(bid!.dead).toBe(false)
+		expect(bid!.retracted).toBe(false)
+	})
+
+	it("returns dead bids from getExpiredUnretractedBids regardless of age", () => {
+		const { service } = freshService()
+		service.storeBid({ commitment: COMMITMENT, success: true })
+		service.storeBid({ commitment: OTHER, success: true })
+
+		// Neither bid is older than the TTL, so only the dead one is due.
+		expect(service.getExpiredUnretractedBids(HOUR_MS)).toHaveLength(0)
+
+		expect(service.markBidAsDead(COMMITMENT)).toBe(true)
+
+		const due = service.getExpiredUnretractedBids(HOUR_MS)
+		expect(due.map((bid) => bid.commitment)).toEqual([COMMITMENT])
+		expect(due[0].dead).toBe(true)
+	})
+
+	it("still returns stale bids past the TTL even when not dead", () => {
+		const { service, dir } = freshService()
+		service.storeBid({ commitment: COMMITMENT, success: true })
+		backdate(dir, COMMITMENT, 2 * HOUR_MS)
+
+		const due = service.getExpiredUnretractedBids(HOUR_MS)
+		expect(due.map((bid) => bid.commitment)).toEqual([COMMITMENT])
+		expect(due[0].dead).toBe(false)
+	})
+
+	it("never returns failed or retracted bids, dead or not", () => {
+		const { service } = freshService()
+		service.storeBid({ commitment: COMMITMENT, success: false, error: "bid submission failed" })
+		service.markBidAsDead(COMMITMENT)
+		service.storeBid({ commitment: OTHER, success: true })
+		service.markBidAsDead(OTHER)
+		service.markBidAsRetracted(OTHER, "0xretract" as HexString)
+
+		expect(service.getExpiredUnretractedBids(HOUR_MS)).toHaveLength(0)
+	})
+
+	it("marks a bid retracted with a null extrinsic hash (BidNotFound: nothing left to reclaim)", () => {
+		const { service } = freshService()
+		service.storeBid({ commitment: COMMITMENT, success: true })
+
+		expect(service.markBidAsRetracted(COMMITMENT, null)).toBe(true)
+
+		const bid = service.getBidByCommitment(COMMITMENT)
+		expect(bid!.retracted).toBe(true)
+		expect(bid!.retractExtrinsicHash).toBeNull()
+
+		// Terminal: neither re-retraction nor death apply afterwards.
+		expect(service.markBidAsRetracted(COMMITMENT, null)).toBe(false)
+		expect(service.markBidAsDead(COMMITMENT)).toBe(false)
+	})
+
+	it("adds the dead column in place to databases created before it existed", () => {
+		const dir = mkdtempSync(join(tmpdir(), "simplex-bids-legacy-"))
+		dirs.push(dir)
+
+		// The exact pre-#1074 schema, with a row already in it.
+		const legacy = new Database(join(dir, "bids.db"))
+		legacy.exec(`
+			CREATE TABLE bids (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				commitment TEXT NOT NULL,
+				extrinsic_hash TEXT,
+				block_hash TEXT,
+				success INTEGER NOT NULL,
+				error TEXT,
+				created_at TEXT NOT NULL DEFAULT (datetime('now')),
+				retracted INTEGER NOT NULL DEFAULT 0,
+				retracted_at TEXT,
+				retract_extrinsic_hash TEXT
+			);
+		`)
+		legacy.prepare("INSERT INTO bids (commitment, success) VALUES (?, 1)").run(COMMITMENT)
+		legacy.close()
+
+		const service = new BidStorageService(dir)
+		services.push(service)
+
+		const bid = service.getBidByCommitment(COMMITMENT)
+		expect(bid).not.toBeNull()
+		expect(bid!.dead).toBe(false)
+
+		expect(service.markBidAsDead(COMMITMENT)).toBe(true)
+		expect(service.getExpiredUnretractedBids(HOUR_MS).map((b) => b.commitment)).toEqual([COMMITMENT])
+	})
+})


### PR DESCRIPTION
Closes #1074.

A won fill's retraction entered the Hyperbridge tx pool, but its `submitAndWatch` handle didn't confirm. The retry re-signed the same call and bounced off **its own pooled copy** (`1014: Priority is too low`); the pooled original then executed and retracted the bid, and the late duplicate found nothing and logged `BidNotFound` as an ERROR. On-chain the cleanup succeeded; locally it was a failure — and since `markBidAsRetracted` only ran on an observed success, the bid stayed "unretracted" in SQLite and the 5-minute sweep re-retracted it forever after the 1h TTL, paying an extrinsic fee each time.

## Changes

**`signAndSendExtrinsic` — in-flight is not failure** (`BidSubmissionResult.pending`)

An extrinsic known to be in the pool must not be re-signed: the copy either bounces (same nonce, below the replacement priority bump) or, if the original lands first, executes as a duplicate and fails on-chain. Two paths now return `pending` and stop retrying:

- Watch timeout *after* a pool-entry status (`Future`/`Ready`/`Broadcast`/`Retracted`). A timeout with no pool status at all still retries as before.
- Submission rejection with RPC code 1013 ("already imported") / 1014 ("priority is too low"), or a message matching those.

**`enqueueRetraction` — `BidNotFound` is terminal**

Bids only leave the pallet by explicit retraction, so "no bid exists" means there is nothing left to reclaim, however it came to be. It now marks the bid retracted (with a null retraction hash) and logs at debug rather than error — this is what ends the zombie sweep loop. A `pending` result leaves the bid alone and defers to the sweep, whose follow-up attempt sees `BidNotFound` once the pooled original lands and closes the bid out. A commitment already retracted at dequeue time is skipped, so an `OrderFilled`/sweep race costs nothing.

**Dead bids swept on the next cycle, not after the TTL**

`OrderFilled` marks the stored bid `dead` (new column, migrated in place for existing databases). `getExpiredUnretractedBids` returns dead bids regardless of age, so a retraction that failed or is still in flight is retried within 5 minutes instead of waiting out the 1h stale-bid TTL.

**Phantom bids**

A `pending` phantom submission now records its commitment in `lastPhantomCommitmentByChain`, so the next interval's batch retracts it. If it never landed, that retraction degrades to a harmless trailing `BidNotFound` — the batch places the new bid first, so nothing is lost.

## On nonce contention

The issue's third point (route retractions and phantom batches through one nonce-aware submitter) is already the case: every submit/retract path funnels through `IntentsCoprocessor.signAndSendExtrinsic`, which serialises on a `concurrency: 1` PQueue against the shared substrate account. The gap wasn't the queue — it was that a submission the queue considered finished could still be pooled, so the *next* thing signed collided with it. Returning `pending` instead of retrying closes that.

## Tests

- `intentsCoprocessorPending.test.ts` — 1014 and 1013 bounces return pending without re-signing; timeout-in-pool returns pending; timeout with no pool status still retries 3×; a non-pool submission error (1010) still retries; dispatch errors stay terminal.
- `BidStorageService.test.ts` — dead bids are due regardless of age, stale bids still are, failed/retracted bids never are; retraction with a null hash; the in-place migration of a pre-existing database.
- `filler-retraction.test.ts` — the retraction decision matrix end to end, including the full incident: pending on the first attempt, `BidNotFound` on the sweep's follow-up, bid closed out.

Both packages build (DTS included). Offline simplex sweep passes; the 3 failures in `rebalancers/{cctp,usdt0}` are pre-existing and env-gated (`Invalid RPC URL: undefined`).
