### PR TITLE
[indexer]: skip the pre-bundling phantom order event shape

### DIFF
--- a/sdk/packages/indexer/src/handlers/events/substrateChains/handlePhantomOrderRegistered.handler.ts
+++ b/sdk/packages/indexer/src/handlers/events/substrateChains/handlePhantomOrderRegistered.handler.ts
@@ -11,6 +11,14 @@ import { PhantomOrderLeg, PhantomOrderV2 } from "@/configs/src/types"
 // a registration carries a list of directed legs. Their position in the list is the leg's position
 // in the order's asset lists, which is what ties a leg back to the bid amounts quoted for it.
 export const handlePhantomOrderRegistered = wrap(async (event: SubstrateEvent): Promise<void> => {
+	// Before pairs were bundled, the pallet emitted one order per pair as a flat
+	// (commitment, chain, created_at, token_a, token_b, standard_amount). Nothing distinguishes the
+	// two shapes at the filter, so pre-upgrade blocks reach this handler too, and their fourth field
+	// is an H160 rather than a leg list — a Uint8Array, so reading it as legs iterates raw bytes
+	// instead of failing outright. Those orders belong to the retired PhantomOrder entity, so there
+	// is nothing to index for them.
+	if (event.event.data.length !== 4) return
+
 	const [commitmentData, chainData, createdAtData, legsData] = event.event.data
 
 	const commitment = commitmentData.toString()


### PR DESCRIPTION
The pallet used to emit one PhantomOrderRegistered per token pair, flat: (commitment, chain, created_at, token_a, token_b, standard_amount). The handler now reads the fourth field as the bundled leg list, but the manifest filter matches on module and method alone, so pre-upgrade blocks reach it too. Their fourth field is an H160, which polkadot-js models as a Uint8Array, so iterating it yields address bytes rather than legs and the first field access throws — killing the worker and stalling the sync at that block.

Skip those events: they belong to the retired PhantomOrder entity, so there is nothing left to index for them.