### PR TITLE
[simplex]: Stop phantom bids advertising chains the operator never configured

### DIFF
--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/simplex",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"license": "Apache-2.0",
 	"description": "IntentGateway simplex package for hyperbridge",
 	"main": "dist/index.js",

--- a/sdk/packages/simplex/src/core/filler.ts
+++ b/sdk/packages/simplex/src/core/filler.ts
@@ -916,9 +916,24 @@ export class IntentFiller {
 	}
 
 	private async handlePhantomOrder(event: PhantomOrderEvent, coprocessor: IntentsCoprocessor): Promise<void> {
-		const entryPointAddress = this.configService.getEntryPointAddress(
-			`EVM-${getChainId(event.chain) ?? event.chain}`,
-		)
+		// A phantom bid is a public quote — it advertises that this filler stands ready to fill that
+		// chain's pairs at the quoted rate. The pallet registers one order per chain *it* knows about,
+		// which is a superset of what any single operator runs, and the strategies price legs off the
+		// shared asset registry rather than the operator's config, so an unconfigured chain quotes
+		// happily. Bidding there advertises liquidity no real order could ever draw on: without RPCs
+		// or a bundler for the chain, the fill path cannot even see the order, let alone fill it.
+		// Watch-only chains are the same story — `evaluateOrder` refuses to fill them by design.
+		const chainId = getChainId(event.chain)
+		if (chainId === undefined || !this.configService.getConfiguredChainIds().includes(chainId)) {
+			this.logger.debug({ chain: event.chain }, "Phantom order chain is not configured, skipping")
+			return
+		}
+		if (this.isChainWatchOnly(chainId)) {
+			this.logger.debug({ chain: event.chain }, "Phantom order chain is watch-only, skipping")
+			return
+		}
+
+		const entryPointAddress = this.configService.getEntryPointAddress(`EVM-${chainId}`)
 		if (!entryPointAddress) {
 			this.logger.debug({ chain: event.chain }, "No entry point configured for phantom order chain, skipping")
 			return

--- a/sdk/packages/simplex/src/tests/core/phantom-bid-chain-gating.test.ts
+++ b/sdk/packages/simplex/src/tests/core/phantom-bid-chain-gating.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest"
+import type { HexString, PhantomOrderEvent } from "@hyperbridge/sdk"
+import { IntentFiller } from "@/core/filler"
+
+/**
+ * The pallet registers one phantom order per chain it knows about — a superset of what any single
+ * operator runs. Nothing downstream narrows that set on its own: the strategies price legs off the
+ * shared asset registry, not the operator's config, so an unconfigured chain quotes happily and the
+ * filler publishes a bid it could never honour (it has no RPC or bundler for that chain, so the
+ * fill path never even sees the real order). Watch-only chains are the same story by config.
+ */
+
+const COMMITMENT = "0x1111111111111111111111111111111111111111111111111111111111111111" as HexString
+const ENTRY_POINT = "0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108" as HexString
+const CONFIGURED_CHAIN_ID = 8453 // Base — the only chain in the operator's config below
+
+function event(chain: string): PhantomOrderEvent {
+	return { commitment: COMMITMENT, chain, createdAt: 1, legs: [] }
+}
+
+function build(watchOnly: Record<number, boolean> = {}) {
+	const configService = {
+		getConfiguredChainIds: () => [CONFIGURED_CHAIN_ID],
+		getEntryPointAddress: () => ENTRY_POINT,
+		getHyperbridgeWsUrl: () => undefined,
+		getSubstratePrivateKey: () => undefined,
+	} as any
+
+	const filler = new IntentFiller(
+		[],
+		[],
+		{ maxConcurrentOrders: 1, watchOnly } as any,
+		configService,
+		{} as any, // ChainClientManager — the gate returns before any client is touched
+		{} as any, // ContractInteractionService — likewise
+		{ account: { address: "0xAAAA00000000000000000000000000000000AAAA" as HexString } } as any,
+	)
+
+	// Returning null stops the handler right after the fetch, so the call itself is the signal
+	// that the chain gate let the order through.
+	const fetchPhantomOrder = vi.fn(async () => null)
+	const coprocessor = { fetchPhantomOrder } as any
+
+	const handle = (chain: string) => (filler as any).handlePhantomOrder(event(chain), coprocessor)
+
+	return { handle, fetchPhantomOrder }
+}
+
+describe("phantom bidding chain gating", () => {
+	it("skips a chain absent from the config", async () => {
+		const { handle, fetchPhantomOrder } = build()
+
+		await handle("EVM-56") // BSC: a real chain in the registry, just not one this operator runs
+
+		expect(fetchPhantomOrder).not.toHaveBeenCalled()
+	})
+
+	it("skips a chain the registry does not know", async () => {
+		const { handle, fetchPhantomOrder } = build()
+
+		await handle("EVM-999999")
+
+		expect(fetchPhantomOrder).not.toHaveBeenCalled()
+	})
+
+	it("skips a configured chain that is watch-only", async () => {
+		const { handle, fetchPhantomOrder } = build({ [CONFIGURED_CHAIN_ID]: true })
+
+		await handle("EVM-8453")
+
+		expect(fetchPhantomOrder).not.toHaveBeenCalled()
+	})
+
+	it("quotes a configured chain", async () => {
+		const { handle, fetchPhantomOrder } = build()
+
+		await handle("EVM-8453")
+
+		expect(fetchPhantomOrder).toHaveBeenCalledWith(COMMITMENT)
+	})
+})


### PR DESCRIPTION
The pallet registers one phantom order per chain it knows about, a superset of what any single operator runs. handlePhantomOrder only checked for an EntryPoint address, which resolves from the SDK's static chain registry rather than the operator's config, and the strategies price legs off the shared asset registry, so an unconfigured chain quoted happily. The filler then published a bid it could never honour: with no RPC or bundler for that chain the fill path never sees the real order.

Gate on getConfiguredChainIds() before any work, and skip watch-only chains too — evaluateOrder refuses to fill those by design, so a quote there is equally unbacked. The EntryPoint lookup now reuses the resolved chain id instead of re-deriving it, dropping a fallback that could only produce a nonsense key.