### PR TITLE
feat(sdk): public-RPC gas estimation — token storage slots + fixed no-bundler budgets

### DIFF
--- a/sdk/packages/sdk/CHANGELOG.md
+++ b/sdk/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @hyperbridge/sdk
 
+## 2.8.1
+
+### Patch Changes
+
+- Recorded balance/allowance storage slots and decimals for cNGN, ZARP, EURC, XSGD, TRYB and USDR on Ethereum, Base and Polygon, so `GasEstimator` state overrides for these tokens resolve from config instead of requiring an RPC with `debug_traceCall`.
+
 ## 2.8.0
 
 ### Minor Changes

--- a/sdk/packages/sdk/package.json
+++ b/sdk/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/sdk",
-	"version": "2.8.0",
+	"version": "2.8.1",
 	"description": "The hyperclient SDK provides utilities for querying proofs and statuses for cross-chain requests from HyperBridge.",
 	"type": "module",
 	"types": "./dist/node/index.d.ts",

--- a/sdk/packages/sdk/src/configs/chain.ts
+++ b/sdk/packages/sdk/src/configs/chain.ts
@@ -158,12 +158,23 @@ export interface ChainConfigData {
 		USDT: number
 		cNGN?: number
 		EXT?: number
+		ZARP?: number
+		EURC?: number
+		XSGD?: number
+		TRYB?: number
+		USDR?: number
 	}
 	tokenStorageSlots?: {
 		USDT?: { balanceSlot: number; allowanceSlot: number }
 		USDC?: { balanceSlot: number; allowanceSlot: number }
 		WETH?: { balanceSlot: number; allowanceSlot: number }
 		DAI?: { balanceSlot: number; allowanceSlot: number }
+		cNGN?: { balanceSlot: number; allowanceSlot: number }
+		ZARP?: { balanceSlot: number; allowanceSlot: number }
+		EURC?: { balanceSlot: number; allowanceSlot: number }
+		XSGD?: { balanceSlot: number; allowanceSlot: number }
+		TRYB?: { balanceSlot: number; allowanceSlot: number }
+		USDR?: { balanceSlot: number; allowanceSlot: number }
 	}
 	addresses: {
 		IntentGateway?: `0x${string}`
@@ -344,12 +355,23 @@ export const chainConfigs: Record<number, ChainConfigData> = {
 			USDC: 6,
 			USDT: 6,
 			cNGN: 6,
+			ZARP: 18,
+			EURC: 6,
+			XSGD: 6,
+			TRYB: 6,
+			USDR: 6,
 		},
 		tokenStorageSlots: {
 			USDT: { balanceSlot: 2, allowanceSlot: 5 },
 			USDC: { balanceSlot: 9, allowanceSlot: 10 },
 			WETH: { balanceSlot: 3, allowanceSlot: 4 },
 			DAI: { balanceSlot: 0, allowanceSlot: 0 },
+			cNGN: { balanceSlot: 201, allowanceSlot: 202 }, // custom upgradeable layout
+			ZARP: { balanceSlot: 51, allowanceSlot: 52 },
+			EURC: { balanceSlot: 9, allowanceSlot: 10 }, // Circle FiatToken layout
+			XSGD: { balanceSlot: 7, allowanceSlot: 8 },
+			TRYB: { balanceSlot: 9, allowanceSlot: 10 },
+			USDR: { balanceSlot: 51, allowanceSlot: 52 },
 		},
 		addresses: {
 			IntentGateway: "0xAe041F7B0CB581876832830baeB6a2Aa2a3C9716",
@@ -530,12 +552,19 @@ export const chainConfigs: Record<number, ChainConfigData> = {
 			USDT: 6,
 			cNGN: 6,
 			EXT: 18,
+			ZARP: 18,
+			EURC: 6,
+			USDR: 6,
 		},
 		tokenStorageSlots: {
 			USDT: { balanceSlot: 0, allowanceSlot: 1 },
 			USDC: { balanceSlot: 9, allowanceSlot: 10 },
 			WETH: { balanceSlot: 3, allowanceSlot: 4 },
 			DAI: { balanceSlot: 0, allowanceSlot: 0 },
+			cNGN: { balanceSlot: 201, allowanceSlot: 202 }, // custom upgradeable layout
+			ZARP: { balanceSlot: 51, allowanceSlot: 52 },
+			EURC: { balanceSlot: 9, allowanceSlot: 10 }, // Circle FiatToken layout
+			USDR: { balanceSlot: 51, allowanceSlot: 52 },
 		},
 		addresses: {
 			IntentGateway: "0xAe041F7B0CB581876832830baeB6a2Aa2a3C9716",
@@ -597,12 +626,19 @@ export const chainConfigs: Record<number, ChainConfigData> = {
 			USDT: 6,
 			EXT: 18,
 			cNGN: 6,
+			ZARP: 18,
+			XSGD: 6,
+			USDR: 6,
 		},
 		tokenStorageSlots: {
 			USDT: { balanceSlot: 0, allowanceSlot: 1 },
 			USDC: { balanceSlot: 9, allowanceSlot: 10 },
 			WETH: { balanceSlot: 3, allowanceSlot: 4 },
 			DAI: { balanceSlot: 0, allowanceSlot: 0 },
+			cNGN: { balanceSlot: 201, allowanceSlot: 202 }, // custom upgradeable layout
+			ZARP: { balanceSlot: 51, allowanceSlot: 52 },
+			XSGD: { balanceSlot: 7, allowanceSlot: 8 },
+			USDR: { balanceSlot: 51, allowanceSlot: 52 },
 		},
 		addresses: {
 			IntentGateway: "0xAe041F7B0CB581876832830baeB6a2Aa2a3C9716",

--- a/sdk/packages/sdk/src/protocols/intents/GasEstimator.ts
+++ b/sdk/packages/sdk/src/protocols/intents/GasEstimator.ts
@@ -28,7 +28,9 @@ import { CryptoUtils } from "./CryptoUtils"
  * When a bundler URL is configured, estimation uses
  * `eth_estimateUserOperationGas` with realistic state overrides (token
  * balances, allowances, EntryPoint deposits, and optional solver account
- * bytecode). Without a bundler, it falls back to `estimateContractGas`.
+ * bytecode). Without a bundler, a fixed gas budget
+ * ({@link NO_BUNDLER_FILL_GAS_BASE} plus a per-output increment) is used
+ * instead of a live estimate.
  * Bundler-specific gas-price refinement is applied automatically:
  * Pimlico (`pimlico_getUserOperationGasPrice`) when the URL contains
  * `pimlico.io`, and Alchemy (`rundler_maxPriorityFeePerGas`) when the
@@ -51,6 +53,27 @@ import { CryptoUtils } from "./CryptoUtils"
  * track per-chain differences like L1 data costs.
  */
 export const RELAYER_MESSAGE_GAS = 1_000_000n
+
+/**
+ * Gas budget for `fillOrder` when no bundler is configured. Live estimation
+ * would need `eth_estimateGas` with state overrides, which public RPCs don't
+ * reliably support, so the budget is fixed: a base sized for a fill that
+ * unlocks and redeems a vault position plus the cross-chain dispatch, and a
+ * per-output-leg increment for each token approval + transfer. Out-of-gas is
+ * the expensive failure (a reverted op still bills the paymaster), so both
+ * numbers err high; the EntryPoint refunds unused limit less its 10% penalty.
+ */
+export const NO_BUNDLER_FILL_GAS_BASE = 700_000n
+export const NO_BUNDLER_FILL_GAS_PER_OUTPUT = 150_000n
+
+/**
+ * Paymaster gas assumed on the no-bundler path. The executing UserOp carries
+ * its real limits inside `paymasterAndData`; these mirror them (up to ~250k
+ * verification for a permit executed during validation, 100k postOp) so the
+ * cost quote covers what a paymaster-sponsored fill is actually charged.
+ */
+export const NO_BUNDLER_PAYMASTER_VERIFICATION_GAS = 250_000n
+export const NO_BUNDLER_PAYMASTER_POST_OP_GAS = 100_000n
 
 /** Internal pricing policy used by SDK order-fee quotes. */
 interface GasEstimationPricingOptions {
@@ -90,8 +113,10 @@ export class GasEstimator {
 	 * headroom. If the bundler is Pimlico, gas prices are refined with
 	 * `pimlico_getUserOperationGasPrice`.
 	 *
-	 * **Fallback path (no bundler):** calls `estimateContractGas` directly on
-	 * `fillOrder` with state overrides.
+	 * **Fallback path (no bundler):** uses a fixed budget
+	 * ({@link NO_BUNDLER_FILL_GAS_BASE} plus {@link NO_BUNDLER_FILL_GAS_PER_OUTPUT}
+	 * per output leg) — public RPCs don't reliably support estimation with
+	 * state overrides.
 	 *
 	 * @param params - Parameters including the order to estimate and optional
 	 *   percentage bumps for `maxPriorityFeePerGas` and `maxFeePerGas`.
@@ -135,15 +160,19 @@ export class GasEstimator {
 
 		const isSameChain = souceStateMachineId === destStateMachineId
 
+		// State overrides only feed the bundler estimate; without a bundler the
+		// gas budget is flat, so skip the storage-slot resolution entirely.
 		const [stateOverridesResult, crossChainFees] = await Promise.all([
-			this.buildStateOverride({
-				accountAddress: solverAccountAddress,
-				chain: destStateMachineId,
-				outputAssets: assetsForOverrides,
-				spenderAddress: intentGatewayV2Address,
-				intentGatewayV2Address,
-				entryPointAddress,
-			}),
+			this.ctx.bundlerUrl
+				? this.buildStateOverride({
+						accountAddress: solverAccountAddress,
+						chain: destStateMachineId,
+						outputAssets: assetsForOverrides,
+						spenderAddress: intentGatewayV2Address,
+						intentGatewayV2Address,
+						entryPointAddress,
+					})
+				: Promise.resolve({ viem: [], bundler: {} }),
 			isSameChain
 				? Promise.resolve({ postRequestFee: 0n, relayerFeeInSourceFeeToken: 0n })
 				: this.estimateCrossChainFees(
@@ -154,7 +183,7 @@ export class GasEstimator {
 					),
 		])
 
-		const { viem: stateOverrides, bundler: bundlerStateOverrides } = stateOverridesResult
+		const { bundler: bundlerStateOverrides } = stateOverridesResult
 
 		const fillOptions: FillOptions = {
 			relayerFee: crossChainFees.postRequestFee,
@@ -322,20 +351,10 @@ export class GasEstimator {
 				console.warn("Bundler gas estimation failed, using fallback values:", e)
 			}
 		} else {
-			try {
-				const estimatedGas = await this.ctx.dest.client.estimateContractGas({
-					abi: IntentGatewayV2ABI,
-					address: intentGatewayV2Address,
-					functionName: "fillOrder",
-					args: [transformOrderForContract(order), fillOptions],
-					account: solverAccountAddress,
-					value: totalNativeValue,
-					stateOverride: stateOverrides as any,
-				})
-				callGasLimit = (estimatedGas * 105n) / 100n
-			} catch (e) {
-				console.warn("fillOrder gas estimation failed, using fallback:", e)
-			}
+			callGasLimit =
+				NO_BUNDLER_FILL_GAS_BASE + NO_BUNDLER_FILL_GAS_PER_OUTPUT * BigInt(order.output.assets.length)
+			paymasterVerificationGasLimit = NO_BUNDLER_PAYMASTER_VERIFICATION_GAS
+			paymasterPostOpGasLimit = NO_BUNDLER_PAYMASTER_POST_OP_GAS
 		}
 
 		const totalGas =


### PR DESCRIPTION
## Summary

Makes gas estimation work on RPCs without the debug API:

1. Adds ERC20 balance/allowance storage slots and decimals for the exotic stablecoins to the SDK chain config, so `GasEstimator` state overrides resolve from config instead of falling back to a live `debug_traceCall`.
2. Replaces the no-bundler `estimateContractGas` fallback (which needs `eth_estimateGas` with state overrides, also unsupported on public RPCs) with fixed gas budgets.

## Changes

### Token storage slots (`sdk/packages/sdk/src/configs/chain.ts`)

- Extended the `tokenStorageSlots` type with `cNGN`, `ZARP`, `EURC`, `XSGD`, `TRYB`, `USDR` keys (previously only `USDT | USDC | WETH | DAI` were expressible)
- Extended the `tokenDecimals` type likewise and added on-chain-verified decimals
- Added slot entries for Ethereum (1), Base (8453) and Polygon (137):

| Token | balanceSlot / allowanceSlot | Decimals | Chains |
|---|---|---|---|
| cNGN | 201 / 202 (custom upgradeable layout) | 6 | ETH, Base, Polygon |
| ZARP | 51 / 52 | 18 | ETH, Base, Polygon |
| EURC | 9 / 10 (Circle FiatToken) | 6 | ETH, Base |
| XSGD | 7 / 8 | 6 | ETH, Polygon |
| TRYB | 9 / 10 | 6 | ETH |
| USDR | 51 / 52 | 6 | ETH, Base, Polygon |

### No-bundler gas estimation (`sdk/packages/sdk/src/protocols/intents/GasEstimator.ts`)

- Removed the `estimateContractGas` + `stateOverride` fallback in `estimateFillOrder`. Without a bundler, `callGasLimit` is now `NO_BUNDLER_FILL_GAS_BASE` (700k, sized for a vault unlock and redeem plus cross-chain dispatch) plus `NO_BUNDLER_FILL_GAS_PER_OUTPUT` (150k) per output leg.
- The no-bundler quote now also carries paymaster gas (250k verification, 100k postOp) instead of zero, mirroring the limits the paymaster packs into `paymasterAndData`, so paymaster-sponsored fills are no longer under-quoted.
- State override building is skipped entirely when no bundler is configured, so the no-bundler path never touches storage-slot resolution.

## Verification

- Slots discovered via `debug_traceCall` (prestateTracer) and reverse-engineered by matching keccak mapping locations across candidate base slots; every slot confirmed with a second independent address. All tokens use the Solidity mapping layout.
- Base cNGN (201/202) matches the values already recorded in the indexer's `config-mainnet.json`, and the yield-vault holder's balance matched `eth_getStorageAt` exactly.
- End-to-end through `getRecordedStorageSlot()`: computed locations matched live chain state (`eth_getStorageAt` vs `balanceOf`) for cNGN, XSGD and EURC with real holders.
- Gas budgets sanity-checked against a live Base fill (`0xb16fe2eabe02406d9cc41191b11a28b6328ca433d9d4342f37428f135c47e66c`): 432,375 gas used for the whole handleOps transaction against a 1,200,000 call limit, so a single-output budget of 850k leaves roughly 2.5x margin over actual call-phase usage.
- `tsc --noEmit` on the sdk package introduces no new errors.

Note: EURC/TRYB (FiatToken v2.2) pack a blacklist flag into the top bit of the balance slot; harmless here since the estimator's override value (`maxUint256/2`) keeps that bit clear, same as the existing USDC entries.
