### PR TITLE
[simplex]: use configured RPCs for SDK helpers, configurable scan interval, compact error logs

### DIFF
--- a/sdk/packages/sdk/src/tests/sequential/intentsCoprocessor.test.ts
+++ b/sdk/packages/sdk/src/tests/sequential/intentsCoprocessor.test.ts
@@ -27,7 +27,9 @@ describe.sequential("IntentsCoprocessor", () => {
 	const encodedUserOp = encodeUserOp(testUserOp)
 
 	// The default 10s hook timeout races websocket jitter on the public
-	// Hyperbridge endpoint; give the connection a real window.
+	// Hyperbridge endpoint; give the connection a real window. 60s still lost
+	// the race in CI — the hook timed out and took all five tests down as
+	// skipped — so this matches the per-test budget below.
 	beforeAll(async () => {
 		hyperbridge = await SubstrateChain.connect({
 			wsUrl: process.env.HYPERBRIDGE_GARGANTUA!,
@@ -42,7 +44,7 @@ describe.sequential("IntentsCoprocessor", () => {
 
 		console.log("Test commitment:", testCommitment)
 		console.log("Test userOp sender:", testUserOp.sender)
-	}, 60_000)
+	}, 300_000)
 
 	afterAll(async () => {
 		await hyperbridge?.disconnect()

--- a/sdk/packages/simplex/CHANGELOG.md
+++ b/sdk/packages/simplex/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @hyperbridge/filler
 
+## 0.9.2
+
+### Patch Changes
+
+- SDK helpers now take their endpoint from the operator's configured `rpcUrls` instead of `publicClient.transport.url`. A chain with more than one RPC is served by a viem `fallback` transport, whose `url` is `undefined`; passing that through left the SDK's `EvmChain` with no RPC, so viem silently substituted the chain's built-in public default (`polygon.drpc.org` on Polygon, `eth.merkle.io` on Ethereum) and every `IntentGateway` call — phantom bids included — bypassed the configured endpoints. Quorum configs were affected on every chain with two or more URLs. An unconfigured chain now throws instead of degrading to a public endpoint.
+- Block-scanner poll period is configurable via `simplex.blockScanIntervalSeconds`, and the default drops from the previously hardcoded 1 second to **3 seconds**. Each tick costs one `eth_blockNumber` plus one `eth_getLogs` per chain per endpoint, so this takes a chain from ~172k to ~58k requests per endpoint per day — the difference between exhausting a free RPC's quota and fitting inside it. The cost is seeing new orders up to 3 seconds later, which matters in a contested market: set `blockScanIntervalSeconds = 1` to restore the old cadence. Fractional values are allowed (0.5 polls twice a second) with a 0.1 minimum; zero, negative and non-numeric values are rejected at config-parse time rather than being coerced by `setInterval` into a spin loop.
+- Error logging no longer dumps the contract ABI. viem hangs the full ABI off its errors and repeats the message once per wrapper in the cause chain, so a single failed `readContract` printed roughly 1,800 lines; the log serialiser now keeps the type, short message, details, failing endpoint and root cause, and trims the stack to six frames — the same failure prints 10 lines. The endpoint and root cause are newly surfaced as their own fields.
+
 ## 0.9.0
 
 ### Minor Changes

--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/simplex",
-	"version": "0.9.1",
+	"version": "0.9.2",
 	"license": "Apache-2.0",
 	"description": "IntentGateway simplex package for hyperbridge",
 	"main": "dist/index.js",

--- a/sdk/packages/simplex/src/config/filler-toml.ts
+++ b/sdk/packages/simplex/src/config/filler-toml.ts
@@ -4,6 +4,7 @@ import { ConfirmationPolicy, DEFAULT_CONFIRMATION_POLICIES } from "@/config/inte
 import { USD_STABLE_SYMBOLS, validateAssetDefinitions, type AssetDefinition } from "@/config/asset-registry"
 import { validatePairConfigs, type PairConfig } from "@/config/pairs"
 import type { SignerConfig } from "@/services/wallet"
+import { MIN_BLOCK_SCAN_INTERVAL_SECONDS } from "@/services/FillerConfigService"
 import type { UserProvidedChainConfig, AllowlistConfig } from "@/services/FillerConfigService"
 import type { PaymasterKeeperConfig } from "@/services/PaymasterKeeperService"
 
@@ -129,6 +130,14 @@ export interface FillerTomlConfig {
 		solverAccountContractAddress?: string
 		/** Target gas units for EntryPoint deposits per chain. Defaults to 3,000,000. */
 		targetGasUnits?: number
+		/**
+		 * Block-scanner poll period per chain in seconds. Defaults to 3, and
+		 * fractional values are allowed (0.5 = twice a second). Each tick costs
+		 * one `eth_blockNumber` + one `eth_getLogs` per chain per endpoint, so
+		 * raising this is the lever for fitting inside a rate-limited RPC's
+		 * budget; the cost is seeing new orders that much later.
+		 */
+		blockScanIntervalSeconds?: number
 		/** Gas fee bump (percentages added to base gasPrice). Defaults: priority=8%, max=10%. */
 		gasFeeBump?: {
 			maxPriorityFeePerGasBumpPercent?: number
@@ -272,6 +281,18 @@ export function validateConfig(config: FillerTomlConfig, cliWatchOnly = false): 
 		}
 		if (!chain.bundlerUrl) {
 			throw new Error("Each chain configuration must have bundlerUrl")
+		}
+	}
+
+	// A zero/negative/NaN interval would spin the scanner as fast as the event
+	// loop allows and exhaust any RPC budget in minutes, so reject it at the gate
+	// rather than letting setInterval coerce it.
+	const scanInterval = config.simplex.blockScanIntervalSeconds
+	if (scanInterval !== undefined) {
+		if (!Number.isFinite(scanInterval) || scanInterval < MIN_BLOCK_SCAN_INTERVAL_SECONDS) {
+			throw new Error(
+				`simplex.blockScanIntervalSeconds must be a number >= ${MIN_BLOCK_SCAN_INTERVAL_SECONDS} (seconds); got ${scanInterval}`,
+			)
 		}
 	}
 

--- a/sdk/packages/simplex/src/core/boot.ts
+++ b/sdk/packages/simplex/src/core/boot.ts
@@ -199,6 +199,7 @@ export async function bootFiller(config: FillerTomlConfig, options: BootOptions)
 		dataDir: options.dataDir,
 		rebalancing: config.rebalancing,
 		targetGasUnits: config.simplex.targetGasUnits,
+		blockScanIntervalSeconds: config.simplex.blockScanIntervalSeconds,
 		gasFeeBump: config.simplex.gasFeeBump,
 		overfillProtection: config.simplex.overfillProtection,
 		allowlist: config.allowlist,

--- a/sdk/packages/simplex/src/core/event-monitor.ts
+++ b/sdk/packages/simplex/src/core/event-monitor.ts
@@ -126,6 +126,8 @@ export class EventMonitor extends EventEmitter {
 				(item.name === "OrderPlaced" || item.name === "OrderFilled" || item.name === "PartialFill"),
 		)
 
+		const scanIntervalMs = this.configService.getBlockScanIntervalMs()
+
 		for (const chainId of this.quorumClients.keys()) {
 			try {
 				const intentGatewayAddress = this.configService.getIntentGatewayAddress(`EVM-${chainId}`)
@@ -159,11 +161,11 @@ export class EventMonitor extends EventEmitter {
 							this.logger.error({ chainId, err: error }, "Error in block scanner")
 						}
 					})
-				}, 1000)
+				}, scanIntervalMs)
 
 				this.blockScanIntervals.set(chainId, scanInterval)
 
-				this.logger.info({ chainId }, "Started monitoring for new orders and fills")
+				this.logger.info({ chainId, scanIntervalMs }, "Started monitoring for new orders and fills")
 			} catch (error) {
 				this.logger.error({ chainId, err: error }, "Failed to start block scanner")
 			}

--- a/sdk/packages/simplex/src/services/ContractInteractionService.ts
+++ b/sdk/packages/simplex/src/services/ContractInteractionService.ts
@@ -58,6 +58,18 @@ export class ContractInteractionService {
 	}
 
 	/**
+	 * The endpoint SDK helpers should use for `chain`: the first configured RPC,
+	 * matching the one viem's `fallback` transport tries first.
+	 */
+	private primaryRpcUrl(chain: string): string {
+		const [rpcUrl] = this.configService.getRpcUrls(chain)
+		if (!rpcUrl) {
+			throw new Error(`No RPC URL configured for ${chain}`)
+		}
+		return rpcUrl
+	}
+
+	/**
 	 * Gets the SDK helper for a given source and destination chain.
 	 * Instances are cached and reused to avoid redundant RPC calls.
 	 */
@@ -69,18 +81,22 @@ export class ContractInteractionService {
 			return cached
 		}
 
-		const sourceClient = this.clientManager.getPublicClient(source)
-		const destinationClient = this.clientManager.getPublicClient(destination)
+		// Read the endpoint from the config, NOT from `publicClient.transport.url`:
+		// a multi-URL chain is built on a viem `fallback` transport, whose `url`
+		// is undefined. Passing that through leaves the SDK's EvmChain with no
+		// RPC, so viem silently substitutes the chain's built-in public default
+		// (e.g. polygon.drpc.org for Polygon) and the operator's endpoints are
+		// bypassed entirely on this path.
 		const sourceEvmChain = EvmChain.fromParams({
 			chainId: getChainId(source)!,
 			host: this.configService.getHostAddress(source),
-			rpcUrl: sourceClient.transport.url,
+			rpcUrl: this.primaryRpcUrl(source),
 		})
 		const bundlerUrl = this.configService.getBundlerUrl(destination)
 		const destinationEvmChain = EvmChain.fromParams({
 			chainId: getChainId(destination)!,
 			host: this.configService.getHostAddress(destination),
-			rpcUrl: destinationClient.transport.url,
+			rpcUrl: this.primaryRpcUrl(destination),
 			bundlerUrl,
 		})
 

--- a/sdk/packages/simplex/src/services/FillerConfigService.ts
+++ b/sdk/packages/simplex/src/services/FillerConfigService.ts
@@ -2,6 +2,12 @@ import type { ChainConfig, HexString } from "@hyperbridge/sdk"
 import { ChainConfigService, bytes32ToBytes20 } from "@hyperbridge/sdk"
 import { LogLevel } from "./Logger"
 
+/** Block-scanner poll period in seconds when `simplex.blockScanIntervalSeconds` is not set. */
+export const DEFAULT_BLOCK_SCAN_INTERVAL_SECONDS = 3
+
+/** Below this the scanner would hammer the RPC faster than any chain produces blocks. */
+export const MIN_BLOCK_SCAN_INTERVAL_SECONDS = 0.1
+
 export interface UserProvidedChainConfig {
 	/** One or more RPC URLs. When multiple are provided, event scans use quorum consensus. */
 	rpcUrls: string[]
@@ -144,6 +150,13 @@ export interface FillerConfig {
 	 * accepted; a chain whose merged set is empty rejects every order.
 	 */
 	allowlist?: AllowlistConfig
+	/**
+	 * How often the block scanner polls each chain, in seconds. Defaults to 3.
+	 * Each tick costs one `eth_blockNumber` plus one `eth_getLogs` per chain per
+	 * endpoint, so raising it is the main lever for staying inside a
+	 * rate-limited RPC's budget — at the cost of seeing orders that much later.
+	 */
+	blockScanIntervalSeconds?: number
 }
 
 /**
@@ -514,6 +527,15 @@ export class FillerConfigService {
 	 */
 	getTargetGasUnits(): bigint {
 		return BigInt(this.fillerConfig?.targetGasUnits ?? 3_000_000)
+	}
+
+	/**
+	 * Block-scanner poll period in milliseconds — configured in seconds, consumed
+	 * by `setInterval`. Defaults to 3 seconds.
+	 */
+	getBlockScanIntervalMs(): number {
+		const seconds = this.fillerConfig?.blockScanIntervalSeconds ?? DEFAULT_BLOCK_SCAN_INTERVAL_SECONDS
+		return Math.round(seconds * 1000)
 	}
 
 	/** Ceiling bps above user-requested output. Default 500 (5%). */

--- a/sdk/packages/simplex/src/services/Logger.ts
+++ b/sdk/packages/simplex/src/services/Logger.ts
@@ -5,6 +5,100 @@ type LoggerOptions = {
 	module?: string
 }
 
+/**
+ * viem hangs the whole contract ABI off its errors and repeats the same message
+ * once per wrapper in the cause chain. Serialised verbatim, one failed
+ * `readContract` prints several hundred lines of ABI JSON. None of it says
+ * anything the short message and the root cause don't.
+ */
+const NOISY_ERROR_FIELDS = [
+	"abi",
+	"args",
+	"formattedArgs",
+	"metaMessages",
+	"docsPath",
+	"version",
+	"contractAddress",
+	"functionName",
+	"sender",
+] as const
+
+/** Deep frames are bundler offsets into dist/bin/simplex.js — useless for diagnosis. */
+const MAX_STACK_FRAMES = 6
+
+/** `at fn (/very/long/.pnpm/viem@x/node_modules/viem/a/b.ts:1:2)` -> `at fn (b.ts:1:2)`. */
+function compactFrame(frame: string): string {
+	return frame.trim().replace(/\(?([^\s(]*[/\\])?([^/\\\s()]+:\d+:\d+)\)?$/, "($2)")
+}
+
+/** Innermost `cause` message: the line that actually says what went wrong. */
+function rootCause(error: unknown): string | undefined {
+	let current: unknown = error
+	let deepest: string | undefined
+	for (let depth = 0; depth < 8; depth++) {
+		const cause = (current as { cause?: unknown })?.cause
+		if (!cause) break
+		if (cause instanceof Error) {
+			deepest = `${cause.name}: ${cause.message}`.split("\n")[0]
+		} else if (typeof cause === "string") {
+			deepest = cause.split("\n")[0]
+		}
+		current = cause
+	}
+	return deepest
+}
+
+/** The endpoint viem was talking to, recovered before metaMessages is dropped. */
+function endpointOf(error: unknown): string | undefined {
+	const meta = (error as { metaMessages?: unknown })?.metaMessages
+	if (!Array.isArray(meta)) return undefined
+	const line = meta.find((m) => typeof m === "string" && m.startsWith("URL: "))
+	return typeof line === "string" ? line.slice(5) : undefined
+}
+
+/**
+ * Keeps what identifies the failure — type, short message, details, the failing
+ * endpoint and the root cause — and discards the ABI dump, the repeated message
+ * bodies and the deep bundler stack frames.
+ */
+function compactError(error: unknown): unknown {
+	if (!(error instanceof Error)) return stdSerializers.err(error as Error)
+
+	const serialized = stdSerializers.err(error) as Record<string, unknown>
+	const endpoint = endpointOf(error)
+	const cause = rootCause(error)
+
+	for (const field of NOISY_ERROR_FIELDS) delete serialized[field]
+
+	// `message` restates shortMessage plus every wrapper's context; the short
+	// form carries the same information in one line.
+	const shortMessage = serialized.shortMessage
+	if (typeof shortMessage === "string" && shortMessage.length > 0) {
+		serialized.message = shortMessage
+		delete serialized.shortMessage
+	} else if (typeof serialized.message === "string") {
+		serialized.message = serialized.message.split("\n")[0]
+	}
+
+	if (typeof serialized.stack === "string") {
+		const frames = serialized.stack
+			.split("\n")
+			.filter((line) => line.trim().startsWith("at "))
+			.slice(0, MAX_STACK_FRAMES)
+			.map(compactFrame)
+		if (frames.length > 0) serialized.stack = frames.join(" <- ")
+		else delete serialized.stack
+	}
+
+	// `name` is always the same string as `type`.
+	delete serialized.name
+
+	if (endpoint) serialized.endpoint = endpoint
+	if (cause && cause !== serialized.message) serialized.cause = cause
+
+	return serialized
+}
+
 let logLevel: LogLevel = "info"
 
 let baseLogger: pino.Logger
@@ -14,8 +108,8 @@ function initializeLogger() {
 	baseLogger = pino({
 		level: logLevel,
 		serializers: {
-			error: stdSerializers.err,
-			err: stdSerializers.err,
+			error: compactError,
+			err: compactError,
 		},
 		transport: {
 			target: "pino-pretty",

--- a/sdk/packages/simplex/src/tests/services/ContractInteractionService.rpc.test.ts
+++ b/sdk/packages/simplex/src/tests/services/ContractInteractionService.rpc.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { fallback, http } from "viem"
+import { ContractInteractionService } from "@/services/ContractInteractionService"
+import type { ChainClientManager } from "@/services/ChainClientManager"
+import type { FillerConfigService } from "@/services/FillerConfigService"
+import type { CacheService } from "@/services/CacheService"
+import type { SigningAccount } from "@/services/wallet"
+
+const HOST = "0x620128E2B19193d6Bd244a3AC8D3bBa0541B19c3"
+const PRIMARY = "https://polygon-bor-rpc.publicnode.com"
+const SECONDARY = "https://gateway.tenderly.co/public/polygon"
+
+const fromParams = vi.hoisted(() => vi.fn((params: unknown) => params))
+const create = vi.hoisted(() => vi.fn(async () => ({}) as never))
+
+vi.mock("@hyperbridge/sdk", async (importOriginal) => ({
+	...(await importOriginal<Record<string, unknown>>()),
+	EvmChain: { fromParams },
+	IntentGateway: { create },
+}))
+
+/**
+ * A multi-URL chain is served by a viem `fallback` transport, whose `url` is
+ * undefined — the shape that used to leak through to the SDK.
+ */
+function makeService(rpcUrls: string[]) {
+	const transport = rpcUrls.length === 1 ? http(rpcUrls[0]) : fallback(rpcUrls.map((u) => http(u)))
+	const publicClient = { transport: transport({ chain: undefined } as never) }
+
+	const clientManager = { getPublicClient: vi.fn().mockReturnValue(publicClient) } as unknown as ChainClientManager
+	const configService = {
+		getRpcUrls: vi.fn().mockReturnValue(rpcUrls),
+		getHostAddress: vi.fn().mockReturnValue(HOST),
+		getBundlerUrl: vi.fn().mockReturnValue(undefined),
+		getChainConfig: vi.fn().mockReturnValue({ chainId: 137 }),
+		// The constructor kicks off initCache() without awaiting it.
+		getConfiguredChainIds: vi.fn().mockReturnValue([]),
+	} as unknown as FillerConfigService
+	const cacheService = { getSolverSelection: () => null, setSolverSelection: () => {} } as unknown as CacheService
+	const signer = {
+		account: { address: "0x1111111111111111111111111111111111111111" },
+	} as unknown as SigningAccount
+
+	return new ContractInteractionService(clientManager, configService, signer, cacheService)
+}
+
+describe("ContractInteractionService RPC selection", () => {
+	beforeEach(() => {
+		fromParams.mockClear()
+		create.mockClear()
+	})
+
+	it("passes the operator's first endpoint when a chain has several RPCs", async () => {
+		const service = makeService([PRIMARY, SECONDARY])
+
+		await service.getIntentGateway("EVM-137", "EVM-137")
+
+		// Regression: reading publicClient.transport.url yields undefined for a
+		// fallback transport, and viem then silently substitutes its built-in
+		// default (polygon.drpc.org), bypassing the configured endpoints.
+		for (const call of fromParams.mock.calls) {
+			expect((call[0] as { rpcUrl?: string }).rpcUrl).toBe(PRIMARY)
+		}
+		expect(fromParams).toHaveBeenCalledTimes(2)
+	})
+
+	it("passes the sole endpoint when a chain has exactly one RPC", async () => {
+		const service = makeService([PRIMARY])
+
+		await service.getIntentGateway("EVM-137", "EVM-137")
+
+		for (const call of fromParams.mock.calls) {
+			expect((call[0] as { rpcUrl?: string }).rpcUrl).toBe(PRIMARY)
+		}
+	})
+
+	it("fails loudly rather than falling back to a public default when unconfigured", async () => {
+		const service = makeService([])
+
+		await expect(service.getIntentGateway("EVM-137", "EVM-137")).rejects.toThrow(/No RPC URL configured/)
+	})
+})

--- a/sdk/packages/simplex/src/tests/services/block-scan-interval.test.ts
+++ b/sdk/packages/simplex/src/tests/services/block-scan-interval.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest"
+import {
+	FillerConfigService,
+	DEFAULT_BLOCK_SCAN_INTERVAL_SECONDS,
+	MIN_BLOCK_SCAN_INTERVAL_SECONDS,
+	type ResolvedChainConfig,
+} from "@/services/FillerConfigService"
+import { validateConfig, type FillerTomlConfig } from "@/config/filler-toml"
+
+const CHAINS: ResolvedChainConfig[] = [{ chainId: 8453, rpcUrls: ["https://mainnet.base.org"], bundlerUrl: "https://b" }]
+
+function baseToml(blockScanIntervalSeconds?: number): FillerTomlConfig {
+	return {
+		pairs: [{ token0: "USDC", token1: "USDC", maxOrderSize: "100", askPriceCurve: [{ amount: "0", price: "0.99" }] }],
+		simplex: {
+			signer: { type: "privateKey", key: `0x${"11".repeat(32)}` },
+			maxConcurrentOrders: 1,
+			queue: { maxRechecks: 1, recheckDelayMs: 1000 },
+			substratePrivateKey: "0xabc",
+			hyperbridgeWsUrl: "wss://example",
+			blockScanIntervalSeconds,
+		},
+		chains: [{ rpcUrls: ["https://mainnet.base.org"], bundlerUrl: "https://b" }],
+	} as FillerTomlConfig
+}
+
+describe("block scan interval", () => {
+	it("defaults to 3 seconds when unset", () => {
+		const service = new FillerConfigService(CHAINS, { maxConcurrentOrders: 1 })
+		expect(DEFAULT_BLOCK_SCAN_INTERVAL_SECONDS).toBe(3)
+		expect(service.getBlockScanIntervalMs()).toBe(3000)
+	})
+
+	it("converts the configured seconds to the milliseconds setInterval wants", () => {
+		const service = new FillerConfigService(CHAINS, { maxConcurrentOrders: 1, blockScanIntervalSeconds: 5 })
+		expect(service.getBlockScanIntervalMs()).toBe(5000)
+	})
+
+	it("supports sub-second polling", () => {
+		const service = new FillerConfigService(CHAINS, { maxConcurrentOrders: 1, blockScanIntervalSeconds: 0.5 })
+		expect(service.getBlockScanIntervalMs()).toBe(500)
+	})
+
+	it("accepts valid intervals through validateConfig", () => {
+		expect(() => validateConfig(baseToml(5))).not.toThrow()
+		expect(() => validateConfig(baseToml(0.5))).not.toThrow()
+		expect(() => validateConfig(baseToml(MIN_BLOCK_SCAN_INTERVAL_SECONDS))).not.toThrow()
+		expect(() => validateConfig(baseToml(undefined))).not.toThrow()
+	})
+
+	it("rejects intervals that would spin the scanner", () => {
+		// 0 and negatives make setInterval fire every tick, draining an RPC budget
+		// in minutes.
+		for (const bad of [0, -1, 0.05]) {
+			expect(() => validateConfig(baseToml(bad))).toThrow(/blockScanIntervalSeconds/)
+		}
+	})
+
+	it("rejects a non-numeric interval", () => {
+		expect(() => validateConfig(baseToml(Number.NaN))).toThrow(/blockScanIntervalSeconds/)
+	})
+})


### PR DESCRIPTION
Three independent fixes surfaced while running the filler against free public RPCs. Patch bump to 0.9.2.

## SDK helpers ignored the configured RPCs

`getIntentGateway` read its endpoint from `publicClient.transport.url`. A chain with more than one `rpcUrl` is served by a viem `fallback` transport, whose `url` is `undefined` — so `EvmChain` was built with no RPC and viem silently substituted the chain's **built-in public default**:

| chain | what it actually used |
|---|---|
| Polygon | `polygon.drpc.org` |
| Ethereum | `eth.merkle.io` |

Every `IntentGateway` call on a quorum chain — phantom bids included — bypassed the operator's endpoints. This showed up as `getaddrinfo ENOTFOUND polygon.drpc.org` on a config that never mentioned drpc.

Now reads from `configService.getRpcUrls(chain)[0]`, the same endpoint `fallback` tries first, and throws when a chain has none instead of degrading to a public endpoint.

## Configurable block-scan interval

The 1s poll was hardcoded. Each tick is one `eth_blockNumber` + one `eth_getLogs` per chain per endpoint — ~172k requests/endpoint/day — which is what exhausts a free RPC's quota.

**The default drops from 1s to 3s**, taking a chain from ~172k to ~58k requests/endpoint/day. Existing operators see new orders up to 3s later; set `blockScanIntervalSeconds = 1` to restore the old cadence.

```toml
[simplex]
blockScanIntervalSeconds = 1    # default 3, fractional allowed, minimum 0.1
```

| interval | requests/day/endpoint | added order latency |
|---|---|---|
| 1s | ~172,800 | — |
| **3s (new default)** | **~57,600** | up to +3s |
| 15s | ~11,520 | up to +14s |

Zero, negative and non-numeric values are rejected at config-parse time rather than coerced by `setInterval` into a spin loop. The resolved value is now in the startup log line.

## Compact error logs

viem hangs the full contract ABI off its errors and repeats the message once per wrapper in the cause chain. One failed `readContract` printed **1,825 lines / 55,762 chars**. The same failure now prints **10 lines / 678 chars** — 82x smaller — and newly surfaces `endpoint` and `cause` as their own fields instead of burying them under the ABI dump.

```
err: {
  "type": "ContractFunctionExecutionError",
  "message": "HTTP request failed.",
  "stack": at getContractError (getContractError.ts:82:10) <- at readContract (readContract.ts:138:11) <- ...
  "details": "fetch failed",
  "endpoint": "https://polygon.drpc.org/",
  "cause": "Error: getaddrinfo ENOTFOUND polygon.drpc.org"
}
```

Applied at the pino serialiser, so it covers every viem error in simplex, not just one call site.

## Testing

- 8 new tests: RPC selection (multi-URL, single-URL, unconfigured) and scan interval (default, conversion, sub-second, validation). The RPC test was confirmed to fail against the old code with `expected undefined to be 'https://polygon-bor-rpc.publicnode.com'`.
- Offline suite: 331 passed. The 3 `rebalancers` failures are pre-existing and unrelated (they need RPC env vars) — verified identical with these changes stashed.
- `tsc --noEmit`: 0 errors in `src/`.
- Verified end-to-end against a built binary on mainnet: unset → `scanIntervalMs: 3000` on all five chains, `blockScanIntervalSeconds = 1` → `1000`, `5` → `5000`, `0.5` → `500`, `0` → refuses to boot.

## Note on scope

The root cause of the RPC bug is that `EvmChain.fromParams` accepts an `rpcUrl` of `undefined` and lets viem substitute a default downstream. This PR fixes the call site only; tightening `EvmChainParams` to reject an empty `rpcUrl` would close it for all consumers but is a breaking change in `@hyperbridge/sdk`.

