### PR TITLE
[indexer]: Drop phantom legs no bidder can back instead of pricing them

### DIFF
--- a/sdk/packages/indexer/src/configs/schema.graphql
+++ b/sdk/packages/indexer/src/configs/schema.graphql
@@ -2326,6 +2326,12 @@ over this order's userOpHash that recovers to the sender, and that sender is EIP
 the chain's SolverAccount. It then records the output amount distribution across the surviving bids,
 weighting each by the solver's liquidity. A snapshot is only written when at least one bid passes
 verification and an EVM RPC endpoint is configured for the phantom order's destination chain.
+
+A leg is also skipped when every bid quoting it holds none of that leg's output token on the
+destination chain. The weight IS that inventory, so an all-zero leg has nothing to weight the
+median by and no bidder able to deliver it at any price — reporting one would let a solver with no
+capital set the published rate by quoting an extreme. Such legs get no snapshot, exactly as if
+nobody had quoted them.
 """
 type PhantomOrderPriceSnapshotV2 @entity {
 	"""
@@ -2586,8 +2592,10 @@ type LiquidityPool @entity {
 The latest phantom sample for one (pool, destination chain, direction) — the chain-distribution
 view of a pool. Overwritten in place each snapshot (price history lives in
 PhantomOrderPriceSnapshotV2), so the pool-level merge is recomputable from these rows alone.
-A depth of 0 with a fresh lastUpdatedBlock means the latest bid window had no valid quotes for
-this direction on this chain; rate then still carries the last known price.
+A depth of 0 with a fresh lastUpdatedBlock means the latest bid window produced no backed quotes
+for this direction on this chain — either nobody quoted it, or every bidder that did holds none of
+the output token here and so could not deliver at any price. Either way no new rate is published;
+rate still carries the last known price, which lastUpdatedBlock will show as stale.
 
 Solver inventories behind depth are read at the chain head when the snapshot is taken, not at a
 historical block, so a reindex reproduces prices but not necessarily depths.
@@ -2694,8 +2702,10 @@ type PoolBidder @entity @compositeIndexes(fields: [["pool", "chain"]]) {
 
 	"""
 	The bidder's output-token inventory on `chain` (raw ERC-20 plus redeemable ERC-4626 vault
-	positions), 18-decimal normalized. May be 0: the bid still counts towards bidCount but
-	contributes no depth, and route consumers should treat it as no capacity.
+	positions), 18-decimal normalized. May be 0 when another bidder on the same leg does hold
+	inventory: the bid still counts towards bidCount but contributes no depth, and route consumers
+	should treat it as no capacity. A leg where EVERY bidder is at 0 is dropped entirely, so it
+	produces no rows here at all.
 	"""
 	liquidity: BigInt! @index
 

--- a/sdk/packages/indexer/src/configs/schema.graphql
+++ b/sdk/packages/indexer/src/configs/schema.graphql
@@ -2411,7 +2411,8 @@ type PhantomOrderPriceSnapshotV2 @entity {
 	highestPrice: BigInt @index
 
 	"""
-	Number of verified bids that contributed to this snapshot.
+	Number of verified, inventory-backed bids that contributed to this snapshot. A solver quoting a
+	leg it holds none of the output token for is not counted — it could not deliver at any price.
 	"""
 	bidCount: Int!
 
@@ -2548,12 +2549,12 @@ type LiquidityPool @entity {
 	buyDepth: BigInt!
 
 	"""
-	Verified bidders currently backing the SELL side, summed across chains.
+	Verified, inventory-backed bidders currently backing the SELL side, summed across chains.
 	"""
 	sellBidCount: Int!
 
 	"""
-	Verified bidders currently backing the BUY side, summed across chains.
+	Verified, inventory-backed bidders currently backing the BUY side, summed across chains.
 	"""
 	buyBidCount: Int!
 
@@ -2632,7 +2633,8 @@ type PoolChainLiquidity @entity @compositeIndexes(fields: [["pool", "direction"]
 	depth: BigInt!
 
 	"""
-	Verified bidders behind the latest sample, including ones with zero inventory.
+	Verified bidders behind the latest sample. Inventory-backed only: a solver holding none of the
+	output token on this chain is excluded, so this never overstates the depth behind `rate`.
 	"""
 	bidCount: Int!
 
@@ -2645,7 +2647,7 @@ type PoolChainLiquidity @entity @compositeIndexes(fields: [["pool", "direction"]
 	unrestrictedDepth: BigInt!
 
 	"""
-	Bidders in the latest window with no accepted-source declaration.
+	Inventory-backed bidders in the latest window with no accepted-source declaration.
 	"""
 	unrestrictedBidCount: Int!
 
@@ -2702,10 +2704,9 @@ type PoolBidder @entity @compositeIndexes(fields: [["pool", "chain"]]) {
 
 	"""
 	The bidder's output-token inventory on `chain` (raw ERC-20 plus redeemable ERC-4626 vault
-	positions), 18-decimal normalized. May be 0 when another bidder on the same leg does hold
-	inventory: the bid still counts towards bidCount but contributes no depth, and route consumers
-	should treat it as no capacity. A leg where EVERY bidder is at 0 is dropped entirely, so it
-	produces no rows here at all.
+	positions), 18-decimal normalized. Always greater than zero: a solver quoting a leg it holds
+	none of is dropped from the aggregation rather than recorded here at zero, so every row is a
+	bidder with capacity and the row set can be counted as well as summed.
 	"""
 	liquidity: BigInt! @index
 
@@ -2731,8 +2732,9 @@ type PoolBidder @entity @compositeIndexes(fields: [["pool", "chain"]]) {
 A currently-live cross-chain route into a pool, materialized from the bidders' explicit
 accepted-source declarations so routes are searchable in one query: filter on sourceChain for
 everything fillable from an origin, or on (sourceChain, chain) for one corridor. Rows reflect the
-latest bid window only and are removed when the last declaring bidder stops bidding, mirroring
-PoolBidder.
+latest bid window only and are removed when the last declaring bidder stops bidding — or runs its
+output-token inventory down to nothing, since a bidder that can deliver none of the token is
+dropped from the aggregation entirely. Mirrors PoolBidder.
 
 Only explicit declarations appear here. Bidders with no declaration (the legacy default: all
 CCTP/USDT0-covered chains) are not expanded into rows — which chains that default covers is a
@@ -2767,7 +2769,8 @@ type PoolRoute @entity @compositeIndexes(fields: [["sourceChain", "chain"], ["po
 
 	"""
 	Sum of the accepting bidders' output-token inventory on `chain`, 18-decimal normalized.
-	May be 0 when every accepting bidder currently holds nothing.
+	Always greater than zero — bidders holding nothing are excluded from the aggregation, so a
+	route row existing means real capacity, and the row set can be treated as the live routes.
 
 	An upper bound on fillable size, not a promise: the inventory is the solvers' global balance,
 	not earmarked for this route (the same tokens back every pool and route sharing them), solvers
@@ -2779,7 +2782,7 @@ type PoolRoute @entity @compositeIndexes(fields: [["sourceChain", "chain"], ["po
 	depth: BigInt!
 
 	"""
-	Bidders in the latest window that explicitly accept this source chain.
+	Inventory-backed bidders in the latest window that explicitly accept this source chain.
 	"""
 	bidCount: Int!
 

--- a/sdk/packages/indexer/src/handlers/events/substrateChains/__tests__/phantomOrder.handlers.test.ts
+++ b/sdk/packages/indexer/src/handlers/events/substrateChains/__tests__/phantomOrder.handlers.test.ts
@@ -113,13 +113,14 @@ function windowClosedEvent(block: bigint = 11n, commitment: string = COMMITMENT)
 }
 
 // A priced leg as aggregatePhantomBids reports it. Solvers default to one anonymous bidder so the
-// pool pipeline always has someone behind a quote.
+// pool pipeline always has someone behind a quote. Weights are positive because the aggregation
+// drops zero-inventory bidders before reporting a leg — a zero here would be an impossible input.
 function leg(
 	legIndex: number,
 	outputToken: string,
 	medianPrice: bigint,
 	bidders: { solver: string; weight: bigint; acceptedSources: string[] | null }[] = [
-		{ solver: "0xsolver", weight: 0n, acceptedSources: null },
+		{ solver: "0xsolver", weight: 1n, acceptedSources: null },
 	],
 ) {
 	return {
@@ -175,13 +176,13 @@ describe("handlePhantomOrderPrices", () => {
 		aggregatePhantomBids.mockResolvedValue({
 			legs: [
 				leg(0, CNGN, 1_500n, [
-					{ solver: "0xs1", weight: 0n, acceptedSources: null },
-					{ solver: "0xs2", weight: 0n, acceptedSources: null },
-					{ solver: "0xs3", weight: 0n, acceptedSources: null },
+					{ solver: "0xs1", weight: 1n, acceptedSources: null },
+					{ solver: "0xs2", weight: 1n, acceptedSources: null },
+					{ solver: "0xs3", weight: 1n, acceptedSources: null },
 				]),
 				leg(1, USDC, 660n, [
-					{ solver: "0xs1", weight: 0n, acceptedSources: null },
-					{ solver: "0xs2", weight: 0n, acceptedSources: null },
+					{ solver: "0xs1", weight: 1n, acceptedSources: null },
+					{ solver: "0xs2", weight: 1n, acceptedSources: null },
 				]),
 			],
 			lpBalances: [],
@@ -319,10 +320,7 @@ describe("handlePhantomOrderPrices pool pipeline", () => {
 		})
 
 		const chainRows = [...table("PoolChainLiquidity").values()]
-		expect(chainRows.map((r) => r.id).sort()).toEqual([
-			`cNGN-USDC-${CHAIN}-BUY`,
-			`cNGN-USDC-${CHAIN}-SELL`,
-		])
+		expect(chainRows.map((r) => r.id).sort()).toEqual([`cNGN-USDC-${CHAIN}-BUY`, `cNGN-USDC-${CHAIN}-SELL`])
 
 		const snapshots = [...table("PhantomOrderPriceSnapshotV2").values()]
 		expect(snapshots.map((s) => [s.poolId, s.direction, s.chain])).toEqual([
@@ -495,10 +493,7 @@ describe("handlePhantomOrderPrices pool pipeline", () => {
 		// Each chain keeps its own sample row; the pool's side is their depth-weighted average:
 		// (990000·100 + 1010000·300) / 400 = 1005000.
 		const chainRows = [...table("PoolChainLiquidity").values()]
-		expect(chainRows.map((r) => r.id).sort()).toEqual([
-			`USDC-USDT-${CHAIN2}-SELL`,
-			`USDC-USDT-${CHAIN}-SELL`,
-		])
+		expect(chainRows.map((r) => r.id).sort()).toEqual([`USDC-USDT-${CHAIN2}-SELL`, `USDC-USDT-${CHAIN}-SELL`])
 		const pool = table("LiquidityPool").get("USDC-USDT")
 		expect(pool).toMatchObject({
 			sellRate: 1_005_000n * SCALE,

--- a/sdk/packages/sdk/src/protocols/intents/phantom-aggregation.ts
+++ b/sdk/packages/sdk/src/protocols/intents/phantom-aggregation.ts
@@ -188,10 +188,14 @@ export interface LpBalance {
 	balance: bigint
 }
 
-/** One verified solver behind a leg's quote. */
+/** One verified solver behind a leg's quote, holding inventory to deliver it. */
 export interface PhantomLegBidder {
 	solver: HexString
-	/** The solver's output-token inventory on the destination chain — its weight in the median. */
+	/**
+	 * The solver's output-token inventory on the destination chain — its weight in the median.
+	 * Always greater than zero: a solver quoting a leg it holds none of is dropped, not recorded
+	 * at zero, since it can deliver nothing at any price.
+	 */
 	weight: bigint
 	/**
 	 * Source chains the solver's signed paymasterAndData declaration accepts payment from. Null
@@ -209,8 +213,9 @@ export interface PhantomLegAggregation {
 	lowestPrice: bigint
 	highestPrice: bigint
 	medianPrice: bigint
+	/** Backed quotes behind the price. Quotes from solvers holding no inventory are not counted. */
 	bidCount: number
-	/** The verified solvers quoting this leg; bidCount === bidders.length. */
+	/** The verified, inventory-backed solvers quoting this leg; bidCount === bidders.length. */
 	bidders: PhantomLegBidder[]
 }
 
@@ -708,33 +713,40 @@ export async function aggregatePhantomBids(params: {
 	// lowestPrice and highestPrice carry that same value rather than the raw min/max of the bid set,
 	// so consumers cannot read an outlier bid as if it were a tradeable bound.
 	//
-	// A leg whose every quote carries zero weight is dropped rather than priced. The weight is the
-	// solver's inventory in THAT leg's output token on the destination chain, so all-zero means no
-	// bidder can deliver the leg at any price — there is nothing to weight the median by, and
-	// weightedMedian would fall back to picking a quote by position, letting whoever quotes the
-	// extreme set the published rate on zero capital. An unbacked quote is closer to no quote than
-	// to a price, so it is reported as one: no snapshot, and the leg's depth zeroes out downstream.
+	// A quote's weight is the solver's inventory in THAT leg's output token on the destination
+	// chain, so a zero-weight quote is one its solver cannot deliver at any price. Those are
+	// dropped outright rather than merely down-weighted: they must not reach weightedMedian (with
+	// nothing to weight by it picks a quote by position, letting whoever quotes the extreme set the
+	// rate on zero capital), and they must not reach bidCount or `bidders`, where they would inflate
+	// the solver count behind a price and mint zero-capacity PoolBidder/PoolRoute rows downstream.
+	// A leg left with no backed quote at all is therefore absent entirely, exactly as if nobody had
+	// quoted it — no snapshot, and its depth zeroes out downstream.
 	const legs = [...quotesByLeg.entries()]
 		.sort(([a], [b]) => a - b)
-		.filter(([legIndex, { outputToken, quotes }]) => {
-			if (quotes.some((quote) => quote.weight > 0n)) return true
-			logger?.warn(
-				{ commitment, chain, legIndex, outputToken, quotes: quotes.length },
-				"Dropping phantom leg: no bidder holds the output token on this chain, so no quote is backed",
-			)
-			return false
-		})
-		.map(([legIndex, { outputToken, quotes, bidders }]) => {
-			const medianPrice = weightedMedian(quotes)
-			return {
-				legIndex,
-				outputToken,
-				lowestPrice: medianPrice,
-				highestPrice: medianPrice,
-				medianPrice,
-				bidCount: quotes.length,
-				bidders,
+		.flatMap(([legIndex, { outputToken, quotes, bidders }]) => {
+			// quotes and bidders are pushed in lockstep above, so the same predicate keeps them aligned.
+			const backedQuotes = quotes.filter((quote) => quote.weight > 0n)
+			const backedBidders = bidders.filter((bidder) => bidder.weight > 0n)
+			if (backedQuotes.length === 0) {
+				logger?.warn(
+					{ commitment, chain, legIndex, outputToken, quotes: quotes.length },
+					"Dropping phantom leg: no bidder holds the output token on this chain, so no quote is backed",
+				)
+				return []
 			}
+
+			const medianPrice = weightedMedian(backedQuotes)
+			return [
+				{
+					legIndex,
+					outputToken,
+					lowestPrice: medianPrice,
+					highestPrice: medianPrice,
+					medianPrice,
+					bidCount: backedQuotes.length,
+					bidders: backedBidders,
+				},
+			]
 		})
 
 	return { legs, lpBalances }

--- a/sdk/packages/sdk/src/protocols/intents/phantom-aggregation.ts
+++ b/sdk/packages/sdk/src/protocols/intents/phantom-aggregation.ts
@@ -216,7 +216,11 @@ export interface PhantomLegAggregation {
 
 /** The aggregated result for a single phantom order's bid window. */
 export interface PhantomAggregation {
-	/** One entry per leg that at least one solver quoted; legs nobody quoted are absent. */
+	/**
+	 * One entry per leg that at least one solver quoted AND at least one of those quotes is backed
+	 * by output-token inventory on the destination chain. Legs nobody quoted are absent, and so are
+	 * legs every bidder quoted on zero inventory — neither is a price anyone could trade against.
+	 */
 	legs: PhantomLegAggregation[]
 	lpBalances: LpBalance[]
 }
@@ -229,8 +233,14 @@ export interface AggregationLogger {
 // the solver's total balance for the output token across native + vault venues — so a solver that
 // can actually deliver size moves the price more than one quoting on thin liquidity. Returns the
 // lower weighted median: the smallest price whose cumulative weight reaches half of the total.
-// Zero-weight quotes contribute nothing; if every weight is zero it falls back to the unweighted
-// median so a price is still reported.
+// Zero-weight quotes contribute nothing.
+//
+// Callers must not hand this an entry set whose weights are all zero: with nothing to weight by it
+// can only pick a quote by position, and for an even-sized set that position is the upper of the
+// two middles — so "the median" becomes "whoever quoted higher", settable by a solver holding no
+// inventory at all. aggregatePhantomBids drops such legs instead of pricing them. The fallback
+// below stays only so an unguarded caller gets a number rather than a crash; treat reaching it as
+// a caller bug.
 export function weightedMedian(entries: { price: bigint; weight: bigint }[]): bigint {
 	const sorted = [...entries].sort((a, b) => (a.price < b.price ? -1 : a.price > b.price ? 1 : 0))
 	const totalWeight = sorted.reduce((acc, e) => (e.weight > 0n ? acc + e.weight : acc), 0n)
@@ -697,8 +707,23 @@ export async function aggregatePhantomBids(params: {
 	// Each leg reports a single price: the liquidity-weighted median of the quotes for that leg.
 	// lowestPrice and highestPrice carry that same value rather than the raw min/max of the bid set,
 	// so consumers cannot read an outlier bid as if it were a tradeable bound.
+	//
+	// A leg whose every quote carries zero weight is dropped rather than priced. The weight is the
+	// solver's inventory in THAT leg's output token on the destination chain, so all-zero means no
+	// bidder can deliver the leg at any price — there is nothing to weight the median by, and
+	// weightedMedian would fall back to picking a quote by position, letting whoever quotes the
+	// extreme set the published rate on zero capital. An unbacked quote is closer to no quote than
+	// to a price, so it is reported as one: no snapshot, and the leg's depth zeroes out downstream.
 	const legs = [...quotesByLeg.entries()]
 		.sort(([a], [b]) => a - b)
+		.filter(([legIndex, { outputToken, quotes }]) => {
+			if (quotes.some((quote) => quote.weight > 0n)) return true
+			logger?.warn(
+				{ commitment, chain, legIndex, outputToken, quotes: quotes.length },
+				"Dropping phantom leg: no bidder holds the output token on this chain, so no quote is backed",
+			)
+			return false
+		})
 		.map(([legIndex, { outputToken, quotes, bidders }]) => {
 			const medianPrice = weightedMedian(quotes)
 			return {

--- a/sdk/packages/sdk/src/tests/phantomAggregation.test.ts
+++ b/sdk/packages/sdk/src/tests/phantomAggregation.test.ts
@@ -485,7 +485,11 @@ describe("aggregatePhantomBids bid verification", () => {
 		expect(result!.legs).toEqual([])
 	})
 
-	it("keeps a leg when at least one bidder is backed, zero-inventory co-bidders included", async () => {
+	// A zero-inventory co-bidder is excluded outright, not merely down-weighted: counting it would
+	// overstate how many solvers stand behind the price, and carrying it into `bidders` would mint
+	// a zero-capacity PoolBidder row and, through its declaration, a PoolRoute advertising a
+	// corridor nobody can actually fill.
+	it("keeps a leg backed by one solver but excludes its zero-inventory co-bidder", async () => {
 		const backed = privateKeyToAccount(SOLVER_KEY).address.toLowerCase()
 		const solver = await signedBidUserOp({ signingKey: SOLVER_KEY })
 		const empty = await signedBidUserOp({ signingKey: IMPOSTOR_KEY })
@@ -495,9 +499,9 @@ describe("aggregatePhantomBids bid verification", () => {
 		)
 
 		expect(result!.legs).toHaveLength(1)
-		// Both bids still count; the empty one just carries no weight into the median.
-		expect(result!.legs[0].bidCount).toBe(2)
-		expect(result!.legs[0].bidders.map((b) => b.weight)).toEqual([SOLVER_BALANCE, 0n])
+		expect(result!.legs[0].bidCount).toBe(1)
+		expect(result!.legs[0].bidders.map((b) => b.solver.toLowerCase())).toEqual([backed])
+		expect(result!.legs[0].bidders.map((b) => b.weight)).toEqual([SOLVER_BALANCE])
 	})
 
 	// One bundled order per configured chain means several aggregations run against the same

--- a/sdk/packages/sdk/src/tests/phantomAggregation.test.ts
+++ b/sdk/packages/sdk/src/tests/phantomAggregation.test.ts
@@ -228,9 +228,17 @@ async function signedBidUserOp(opts: {
 	return { ...userOp, signature: concat([opts.commitment ?? COMMITMENT, solverSignature]) as HexString }
 }
 
+// The account a `balanceOf(address)` eth_call is asking about, lowercased.
+const balanceOfSubject = (data: string) => `0x${data.slice(-40)}`.toLowerCase()
+
 // Stands in for the Hyperbridge node and the destination chain's RPC: serves the given bids, the
-// given account code, and a fixed ERC-20 balance for any eth_call.
-function mockRpc(bids: PackedUserOperation[], codeFor: (account: string) => string): FetchLike {
+// given account code, and an ERC-20 balance for any eth_call — fixed by default, or per-holder
+// when a `balanceFor` is supplied.
+function mockRpc(
+	bids: PackedUserOperation[],
+	codeFor: (account: string) => string,
+	balanceFor: (holder: string) => bigint = () => SOLVER_BALANCE,
+): FetchLike {
 	return async (_url, init) => {
 		const payload = JSON.parse(init.body)
 		const result =
@@ -242,15 +250,19 @@ function mockRpc(bids: PackedUserOperation[], codeFor: (account: string) => stri
 					}))
 				: payload.method === "eth_getCode"
 					? codeFor(payload.params[0])
-					: toHex(SOLVER_BALANCE, { size: 32 })
+					: toHex(balanceFor(balanceOfSubject(payload.params[0].data)), { size: 32 })
 		return { json: async () => ({ id: payload.id, jsonrpc: "2.0", result }) }
 	}
 }
 
 const delegatedTo = (target: string) => () => `0xef0100${target.slice(2)}`.toLowerCase()
 
-function aggregate(bids: PackedUserOperation[], codeFor: (account: string) => string) {
-	setAggregationFetch(mockRpc(bids, codeFor))
+function aggregate(
+	bids: PackedUserOperation[],
+	codeFor: (account: string) => string,
+	balanceFor?: (holder: string) => bigint,
+) {
+	setAggregationFetch(mockRpc(bids, codeFor, balanceFor))
 	return aggregatePhantomBids({
 		nodeUrl: NODE_URL,
 		evmRpcUrls: { [CHAIN]: "http://base.test" },
@@ -458,6 +470,34 @@ describe("aggregatePhantomBids bid verification", () => {
 		const result = await aggregate([userOp], delegatedTo(SOLVER_ACCOUNT))
 
 		expect(result!.legs[0].bidders[0].acceptedSources).toEqual([])
+	})
+
+	// The weight IS the solver's output-token inventory on the destination chain. When every quote
+	// for a leg carries zero weight there is nothing to weight the median by, and weightedMedian
+	// can only pick by position — so on an even-sized set the highest quote wins and any solver
+	// holding nothing sets the published rate for free. Such legs are dropped, not priced.
+	it("drops a leg when no bidder holds the output token on the destination chain", async () => {
+		const userOp = await signedBidUserOp({ signingKey: SOLVER_KEY })
+
+		const result = await aggregate([userOp], delegatedTo(SOLVER_ACCOUNT), () => 0n)
+
+		expect(result).not.toBeNull()
+		expect(result!.legs).toEqual([])
+	})
+
+	it("keeps a leg when at least one bidder is backed, zero-inventory co-bidders included", async () => {
+		const backed = privateKeyToAccount(SOLVER_KEY).address.toLowerCase()
+		const solver = await signedBidUserOp({ signingKey: SOLVER_KEY })
+		const empty = await signedBidUserOp({ signingKey: IMPOSTOR_KEY })
+
+		const result = await aggregate([solver, empty], delegatedTo(SOLVER_ACCOUNT), (holder) =>
+			holder === backed ? SOLVER_BALANCE : 0n,
+		)
+
+		expect(result!.legs).toHaveLength(1)
+		// Both bids still count; the empty one just carries no weight into the median.
+		expect(result!.legs[0].bidCount).toBe(2)
+		expect(result!.legs[0].bidders.map((b) => b.weight)).toEqual([SOLVER_BALANCE, 0n])
 	})
 
 	// One bundled order per configured chain means several aggregations run against the same


### PR DESCRIPTION


A leg's quote weight is the solver's inventory in THAT leg's output token on the destination chain. When every quote for a leg carries zero weight there is nothing to weight the median by, and weightedMedian falls through to picking a quote by position — `sorted[Math.floor(n/2)]`, the upper of the two middles for an even set. With two quotes that is simply "the higher price wins", so a solver holding no inventory at all can set the published rate for free.

This is live on nexus. cNGN liquidity sits entirely on Base, so the USDC->cNGN legs on Ethereum and Polygon have zero weight every window. At blocks 11444817 and 11445117 two solvers quoted that leg at 1393 and 1401; both hold 0.00 cNGN on Ethereum, so the fallback published 1401. The same two solvers on Base, with real cNGN weights of 57,660,896 and 341,249, correctly published 1393. Ten of the eighteen live PoolChainLiquidity rows currently carry a rate with zero backing depth and are exposed to the same thing.

So don't publish a price nobody can trade against: a leg whose every quote is unbacked is now dropped from the aggregation rather than priced. Downstream it reads exactly like a leg nobody quoted — no snapshot row, depth zeroed on the chain-liquidity row while the last known rate is retained, and the bidders behind it (all of whom hold nothing) stop advertising route capacity.

Legs with a mix of backed and unbacked quotes are untouched: they keep every bidder, zero-weight ones included, and the weighted median works as designed.