### PR TITLE
[runtime]: Reject purchases whose app identifier exceeds AppKey

### DIFF
--- a/evm/src/apps/BandwidthManager.sol
+++ b/evm/src/apps/BandwidthManager.sol
@@ -70,6 +70,11 @@ contract BandwidthManager is HyperApp, ERC165, Ownable {
     /// the round-trip.
     bytes public constant PALLET_BANDWIDTH_MODULE_ID = bytes("BWMARKET");
 
+    /// Must equal the bound on `pallet_bandwidth::AppKey`. The pallet rejects anything longer,
+    /// so checking here fails the purchase before the payer is charged for a message that
+    /// cannot be credited.
+    uint256 public constant MAX_APP_LENGTH = 32;
+
     /// Discriminants for the first byte of an `onAccept` body. Order
     /// must match `pallet_bandwidth::lib.rs::ACTION_*`.
     enum OnAcceptActions {
@@ -149,7 +154,9 @@ contract BandwidthManager is HyperApp, ERC165, Ownable {
         external
         returns (bytes32 commitment)
     {
-        if (app.length == 0 || chain.length == 0 || months == 0) revert InvalidPurchase();
+        if (app.length == 0 || app.length > MAX_APP_LENGTH || chain.length == 0 || months == 0) {
+            revert InvalidPurchase();
+        }
         uint256 price18d = tierPrice[tier];
         if (price18d == 0) revert UnknownTier();
 

--- a/evm/tests/foundry/BandwidthManagerTest.t.sol
+++ b/evm/tests/foundry/BandwidthManagerTest.t.sol
@@ -159,6 +159,33 @@ contract BandwidthManagerTest is Test {
         manager.purchase(hex"", TIER1, 1, APP_CHAIN);
     }
 
+    /// The pallet stores `app` in a 32-byte-bounded key and rejects anything longer, so a
+    /// purchase carrying more can never be credited. The tier price is flat regardless of body
+    /// length, so the excess is payload the buyer pays nothing extra for — reject it here rather
+    /// than take the fee for a message hyperbridge will drop.
+    function testRejectsOversizedApp() public {
+        bytes memory oversized = new bytes(manager.MAX_APP_LENGTH() + 1);
+        vm.expectRevert(BandwidthManager.InvalidPurchase.selector);
+        vm.prank(BUYER);
+        manager.purchase(oversized, TIER1, 1, APP_CHAIN);
+    }
+
+    /// The bound itself stays valid — the rejection is for what exceeds it, not for identifiers
+    /// longer than the 20-byte address the happy path uses.
+    function testAcceptsAppAtMaxLength() public {
+        bytes memory atBound = new bytes(manager.MAX_APP_LENGTH());
+        feeToken.mint(BUYER, TIER1_PRICE_18D);
+
+        vm.startPrank(BUYER);
+        feeToken.approve(address(manager), TIER1_PRICE_18D);
+        vm.recordLogs();
+        manager.purchase(atBound, TIER1, 1, APP_CHAIN);
+        vm.stopPrank();
+
+        BandwidthPurchaseMsg memory body = _findDispatchedBody(vm.getRecordedLogs(), address(host));
+        assertEq(body.app, atBound);
+    }
+
     function testRejectsEmptyAppChain() public {
         vm.expectRevert(BandwidthManager.InvalidPurchase.selector);
         vm.prank(BUYER);

--- a/modules/pallets/bandwidth/src/abi.rs
+++ b/modules/pallets/bandwidth/src/abi.rs
@@ -8,6 +8,7 @@
 use alloc::{format, string::ToString, vec::Vec};
 use alloy_sol_types::SolType;
 use core::str::{self, FromStr};
+use crate::types::AppKey;
 use ismp::host::StateMachine;
 
 pub use ismp_abi::bandwidth_manager::{BandwidthPurchaseMsg, Tier, Withdrawal};
@@ -18,7 +19,7 @@ pub use ismp_abi::bandwidth_manager::{BandwidthPurchaseMsg, Tier, Withdrawal};
 /// at decode time rather than reaching storage.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PurchaseMessage {
-	/// Recipient app on the credit chain. Truncated to `AppKey` later.
+	/// Recipient app on the credit chain. Rejected at decode time if it does not fit `AppKey`.
 	pub app: Vec<u8>,
 	/// Tier discriminant; must map to a `TierIndex` variant.
 	pub tier: u32,
@@ -44,6 +45,18 @@ impl TryFrom<&[u8]> for PurchaseMessage {
 		if months == 0 {
 			return Err(anyhow::anyhow!("months must be >= 1"));
 		}
+		// The app identifier is stored as an `AppKey`, so anything longer is not a longer
+		// identifier — it is bytes that silently disappear. Rejecting here keeps the decoded
+		// message equal to what gets stored, and stops a purchase from carrying payload that
+		// serves no purpose in the subscription it pays for.
+		if abi.app.is_empty() || abi.app.len() > AppKey::bound() {
+			return Err(anyhow::anyhow!(format!(
+				"app identifier must be 1..={} bytes, got {}",
+				AppKey::bound(),
+				abi.app.len()
+			)));
+		}
+
 		let chain_str = str::from_utf8(&abi.chain)
 			.map_err(|err| anyhow::anyhow!(format!("chain is not utf-8: {err}")))?;
 		let chain = StateMachine::from_str(chain_str)

--- a/modules/pallets/testsuite/src/tests/pallet_bandwidth.rs
+++ b/modules/pallets/testsuite/src/tests/pallet_bandwidth.rs
@@ -520,6 +520,63 @@ fn purchase_rejects_zero_months() {
 	});
 }
 
+/// Builds a purchase whose `app` field is arbitrary bytes rather than an address, so the
+/// `AppKey` bound can be probed from either side.
+fn purchase_request_with_app(app: Vec<u8>) -> PostRequest {
+	let mut req = purchase_request(APP_CHAIN, MANAGER, TIER1, APP_CHAIN);
+	req.body =
+		(&PurchaseMessage { app, tier: TIER1.into(), months: 1, chain: APP_CHAIN }).into();
+	req
+}
+
+/// `app` is stored as an `AppKey`, so bytes past its bound are not a longer identifier — they
+/// silently disappear. The tier price is flat regardless of body length, so a purchase carrying
+/// them is paying the same for a message that got longer for no reason; reject it at decode time
+/// instead of truncating.
+#[test]
+fn purchase_rejects_app_identifier_over_the_bound() {
+	new_test_ext().execute_with(|| {
+		jump_to(T0);
+		register_manager(APP_CHAIN);
+		configure_tier(TIER1, TIER1_BYTES, MONTH_SECS);
+
+		dispatch(purchase_request_with_app(vec![0xBB; AppKey::bound() + 1]))
+			.expect_err("app identifier longer than AppKey must be rejected at decode time");
+		assert_eq!(sub_count(APP_CHAIN), 0);
+	});
+}
+
+#[test]
+fn purchase_rejects_empty_app_identifier() {
+	new_test_ext().execute_with(|| {
+		jump_to(T0);
+		register_manager(APP_CHAIN);
+		configure_tier(TIER1, TIER1_BYTES, MONTH_SECS);
+
+		dispatch(purchase_request_with_app(Vec::new()))
+			.expect_err("empty app identifier must be rejected at decode time");
+		assert_eq!(sub_count(APP_CHAIN), 0);
+	});
+}
+
+/// The bound itself stays valid — the rejection is for what exceeds it, not for identifiers
+/// longer than the 20-byte address the happy path uses.
+#[test]
+fn purchase_accepts_app_identifier_at_the_bound() {
+	new_test_ext().execute_with(|| {
+		jump_to(T0);
+		register_manager(APP_CHAIN);
+		configure_tier(TIER1, TIER1_BYTES, MONTH_SECS);
+
+		let app = vec![0xBB; AppKey::bound()];
+		dispatch(purchase_request_with_app(app.clone()))
+			.expect("an app identifier that fits AppKey must be accepted");
+
+		let key = AppKey::truncate_from(app);
+		assert_eq!(Allowance::<Test>::get(APP_CHAIN, key).len(), 1);
+	});
+}
+
 /// The 1024-sub cap evicts the oldest entry. force_credit reuses the
 /// same push path as purchase, so this also covers the purchase cap.
 #[test]


### PR DESCRIPTION
`app` is stored as an `AppKey` (`BoundedVec<u8, ConstU32<32>>`) via `AppKey::truncate_from`, so bytes past the bound were silently discarded rather than rejected. A tier's price is flat per month and does not scale with body length, so those bytes cost the buyer nothing extra while making the delivered message arbitrarily longer — and the credited subscription was keyed on a truncation of what the buyer actually asked for.

Reject at decode time in `PurchaseMessage::try_from`, and mirror the check in `BandwidthManager.purchase` behind `MAX_APP_LENGTH` so the purchase fails before the payer is charged for a message hyperbridge would drop.
