### PR TITLE
[indexer]: fix the Base Uniswap V4 StateView address

### DIFF
--- a/sdk/packages/indexer/src/addresses/uniswap-v4.addresses.ts
+++ b/sdk/packages/indexer/src/addresses/uniswap-v4.addresses.ts
@@ -15,6 +15,6 @@ export interface UniswapV4Deployment {
 export const UNISWAP_V4_ADDRESSES: Record<string, UniswapV4Deployment> = {
 	"EVM-8453": {
 		positionManager: "0x7c5f5a4bbd8fd63184577525326123b519429bdc",
-		stateView: "0xd13dd3d6e93f276fafc9db9e6bb47c1180aee0c4",
+		stateView: "0xa3c0c9b65bad0b08107aa264b0f3db444b867a71",
 	},
 }

--- a/sdk/packages/sdk/src/protocols/intents/phantom-aggregation.ts
+++ b/sdk/packages/sdk/src/protocols/intents/phantom-aggregation.ts
@@ -712,6 +712,7 @@ async function readV4Position(
 	contracts: UniswapV4Contracts,
 	tokenId: bigint,
 	keccak: (hex: HexString) => HexString,
+	logger?: AggregationLogger,
 ): Promise<V4PositionState | null> {
 	const call = async (to: string, data: string): Promise<string | null> => {
 		const result = await rpcCall(evmRpcUrl, {
@@ -733,13 +734,31 @@ async function readV4Position(
 		call(contracts.positionManager, `${SELECTOR_POOL_AND_POSITION_INFO}${arg}`),
 		call(contracts.positionManager, `${SELECTOR_POSITION_LIQUIDITY}${arg}`),
 	])
-	if (!ownerData || !infoData || !liquidityData) return null
+	// An empty ownerOf is a tokenId that was never minted or has been burned — a solver may name a
+	// stale position, which is its problem and not ours.
+	if (!ownerData) return null
+	if (!infoData || !liquidityData) {
+		logger?.warn(
+			{ tokenId: tokenId.toString(), positionManager: contracts.positionManager },
+			"Uniswap V4 position exists but its pool info or liquidity did not read back — check the configured PositionManager",
+		)
+		return null
+	}
 
 	const info = decodePoolAndPositionInfo(infoData)
 	// The pool id is keccak of the PoolKey exactly as the chain returned it, so no re-encoding of
 	// ours can disagree with the hash the pool was registered under.
 	const slot0Data = await call(contracts.stateView, `${SELECTOR_GET_SLOT0}${keccak(info.poolKeyEncoded).slice(2)}`)
-	if (!slot0Data) return null
+	// The position resolved, so its pool exists — an empty slot0 means the call went somewhere that
+	// is not a StateView, i.e. a misconfigured address. Silence here is what let a wrong address
+	// zero out every declared position indefinitely instead of failing where someone would see it.
+	if (!slot0Data) {
+		logger?.warn(
+			{ tokenId: tokenId.toString(), stateView: contracts.stateView, evmRpcUrl },
+			"Uniswap V4 slot0 read returned nothing for a live position — the configured StateView address is wrong",
+		)
+		return null
+	}
 
 	return {
 		owner: `0x${ownerData.slice(-40)}`.toLowerCase(),
@@ -750,13 +769,13 @@ async function readV4Position(
 }
 
 /** Promise-caching position reader: one set of reads per position, reused across every leg. */
-function memoizedV4Position(keccak: (hex: HexString) => HexString) {
+function memoizedV4Position(keccak: (hex: HexString) => HexString, logger?: AggregationLogger) {
 	const cache = new Map<string, Promise<V4PositionState | null>>()
 	return (evmRpcUrl: string, chain: string, contracts: UniswapV4Contracts, tokenId: bigint) => {
 		const key = `${chain}|${tokenId}`
 		let pending = cache.get(key)
 		if (!pending) {
-			pending = readV4Position(evmRpcUrl, contracts, tokenId, keccak).catch((err) => {
+			pending = readV4Position(evmRpcUrl, contracts, tokenId, keccak, logger).catch((err) => {
 				cache.delete(key)
 				throw err
 			})
@@ -930,7 +949,7 @@ async function runAggregation(
 
 	// One set of reads per declared position, reused by every leg it backs.
 	const v4Contracts = params.uniswapV4?.[chain]
-	const readPosition = memoizedV4Position(params.keccak ?? keccak256)
+	const readPosition = memoizedV4Position(params.keccak ?? keccak256, logger)
 
 	// Balances repeat across legs and the sweep; one memo serves the whole run.
 	const getBalance = params.getBalance ?? memoizedSolverBalance(yieldVaults)

--- a/sdk/packages/sdk/src/tests/phantomAggregation.test.ts
+++ b/sdk/packages/sdk/src/tests/phantomAggregation.test.ts
@@ -727,6 +727,40 @@ describe("aggregatePhantomBids bid verification", () => {
 			expect(result!.legs[0].bidders[0].weight).toBeGreaterThan(0n)
 		})
 
+		// Regression: the Base StateView address was wrong, so slot0 answered "0x", every declared
+		// position resolved to null, and ~168k cNGN of real depth read as zero — silently, for as
+		// long as nobody thought to check. A misconfigured address must say so.
+		it("warns rather than silently skipping when slot0 reads back empty", async () => {
+			const userOp = await signedBidUserOp({
+				signingKey: SOLVER_KEY,
+				paymasterAndData: encodePhantomBidDeclaration({ uniswapV4Positions: [TOKEN_ID] }),
+			})
+			const base = v4Rpc([userOp], solverAddress)
+			// Everything resolves except the StateView, exactly as a wrong address behaves.
+			setAggregationFetch(async (url, init) => {
+				const payload = JSON.parse(init.body)
+				if (payload.method === "eth_call" && payload.params[0].to === STATE_VIEW) {
+					return { json: async () => ({ id: payload.id, jsonrpc: "2.0", result: "0x" }) }
+				}
+				return base(url, init)
+			})
+			const warnings: string[] = []
+
+			await aggregatePhantomBids({
+				nodeUrl: NODE_URL,
+				evmRpcUrls: { [CHAIN]: "http://base.test" },
+				chain: CHAIN,
+				gatewayAddress: GATEWAY,
+				commitment: COMMITMENT,
+				yieldVaults: { [CHAIN]: { [USDT]: [] } },
+				solverAccount: SOLVER_ACCOUNT,
+				uniswapV4: { [CHAIN]: { positionManager: POSITION_MANAGER, stateView: STATE_VIEW } },
+				logger: { warn: (_payload, message) => warnings.push(message) },
+			})
+
+			expect(warnings.some((w) => w.includes("StateView"))).toBe(true)
+		})
+
 		// The declaration is a pointer, not a claim — pointing at liquidity you do not own is the
 		// obvious way to fake depth, so ownership is checked against the signer on-chain.
 		it("ignores a declared position owned by someone else", async () => {


### PR DESCRIPTION
The address shipped for Base was BSC's — copied from the wrong chain's block in the SDK registry, which had Base right all along. Nothing is deployed at it on Base, so getSlot0 answered "0x", every declared position resolved to null, and the liquidity behind them counted as zero.

Confirmed against the live filler that prompted this. Its bid does carry the declaration — paymasterAndData 0x020001032c58c7 decodes to v2, no accepted sources, one position: tokenId 2906311 — and the position is real, owned by that solver, and holds 168,110.80 cNGN and 67.04 USDC in the cNGN/USDC pool at the current tick. None of it was being counted.

The second half of the bug is that a wrong address produced silence. readV4Position returned null for any empty call, so a misconfiguration was indistinguishable from a burned tokenId and could sit there indefinitely. An empty ownerOf still means the position was never minted or is gone — the solver's problem, not ours — but an empty slot0 for a position that just resolved means the call went somewhere that is not a StateView, and now says so. Same for pool info or liquidity failing to read back behind a live ownerOf.