### PR TITLE
fix(sdk): query available liquidity from indexer routes

### DIFF
--- a/docs/content/developers/sdk/api/intent-gateway.mdx
+++ b/docs/content/developers/sdk/api/intent-gateway.mdx
@@ -234,9 +234,9 @@ For an exact-input Phantom quote, the SDK deducts the gateway fee and computes `
 ### queryAvailableLiquidity(params)
 
 Returns output-token liquidity from the indexer's latest pair-centric pool
-sample. Same-chain queries use the destination pool depth. Cross-chain queries
-use the matching explicit `PoolRoute`, returning zero liquidity when no indexed
-route accepts the source chain.
+sample. The result reports destination capacity, unrestricted capacity, and the
+matching explicit cross-chain route separately. The SDK does not decide whether
+the source chain is covered by the legacy unrestricted-bidder policy.
 
 ```typescript lineNumbers
 import { createQueryClient, IntentGateway } from "@hyperbridge/sdk"
@@ -251,10 +251,10 @@ const liquidity = await gateway.queryAvailableLiquidity({
 })
 
 if (liquidity) {
-  console.log(liquidity.totalLiquidity, "cNGN")
-  console.log("Providers:", liquidity.providerCount)
-  console.log("Route:", liquidity.sourceChain, "→", liquidity.destinationChain)
-  console.log("Measured at:", liquidity.snapshotTime)
+  console.log("Destination:", liquidity.destination.totalLiquidity)
+  console.log("Unrestricted:", liquidity.unrestricted.totalLiquidity)
+  console.log("Explicit route:", liquidity.explicitRoute?.totalLiquidity ?? "none")
+  console.log("Updated at:", liquidity.updatedAt)
 }
 ```
 
@@ -262,18 +262,42 @@ if (liquidity) {
 async queryAvailableLiquidity(params: {
   tokenIn: HexString
   tokenOut: HexString
-}): Promise<AvailableLiquiditySnapshot | undefined>
+}): Promise<AvailableLiquidity | undefined>
 ```
 
-`totalLiquidity` is a decimal string formatted from the indexer's 18-decimal
-normalized pool depth. `providerCount` is the number of bidders represented by
-that pool sample or explicit route. Legacy unrestricted bidders are not included
-in cross-chain results because the indexer deliberately does not assign their
-capacity to source chains. `liquidityByChain` is retained for compatibility and
-contains the same result for the gateway's destination chain.
+Each liquidity value is a decimal string formatted from the indexer's
+18-decimal normalized depth. `destination` is the complete destination-chain
+capacity. `unrestricted` is the subset from bidders without an accepted-source
+declaration. `explicitRoute` is the capacity from bidders that explicitly accept
+the requested source chain, or `null` when there is no such route. Consumers can
+combine the explicit and unrestricted slices when their transport policy allows
+it.
 
 This is indexed availability, not reserved liquidity or a fill guarantee. The
 method returns `undefined` only when the destination has no indexed pool sample.
+
+### queryBuyAndSellRates(params)
+
+Returns both indexed rates for a token pair. Callers provide token symbols and
+chain IDs; token addresses are resolved internally from the SDK configuration.
+
+```typescript lineNumbers
+const rates = await gateway.queryBuyAndSellRates({
+  tokenInSymbol: "USDC",
+  tokenOutSymbol: "cNGN",
+  sourceChainId: 1,
+  destinationChainId: 8453,
+})
+
+if (rates) {
+  console.log("Sell rate:", rates.sellRate)
+  console.log("Buy rate:", rates.buyRate)
+}
+```
+
+`sellRate` is token1 received for one token0. `buyRate` is token0 received for
+one token1. Either rate can be `null` when that side of the pool has not been
+priced. Numeric chain IDs and `EVM-*` state machine IDs are both accepted.
 
 ---
 

--- a/docs/content/developers/sdk/api/intent-gateway.mdx
+++ b/docs/content/developers/sdk/api/intent-gateway.mdx
@@ -278,8 +278,9 @@ method returns `undefined` only when the destination has no indexed pool sample.
 
 ### queryBuyAndSellRates(params)
 
-Returns both indexed rates for a token pair. Callers provide token symbols and
-chain IDs; token addresses are resolved internally from the SDK configuration.
+Returns chain-specific buy and sell rates for a token pair. Callers provide
+token symbols and numeric chain IDs; token addresses and canonical symbol casing
+are resolved internally from the SDK configuration.
 
 ```typescript lineNumbers
 const rates = await gateway.queryBuyAndSellRates({
@@ -290,14 +291,20 @@ const rates = await gateway.queryBuyAndSellRates({
 })
 
 if (rates) {
-  console.log("Sell rate:", rates.sellRate)
+  console.log(`${rates.quoteTokenSymbol} per ${rates.baseTokenSymbol}`)
   console.log("Buy rate:", rates.buyRate)
+  console.log("Sell rate:", rates.sellRate)
 }
 ```
 
-`sellRate` is token1 received for one token0. `buyRate` is token0 received for
-one token1. Either rate can be `null` when that side of the pool has not been
-priced. Numeric chain IDs and `EVM-*` state machine IDs are both accepted.
+Both rates use the less valuable token as the quote currency. For USDC/cNGN,
+both values are therefore cNGN per one USDC. The requested input-to-output rate
+is read on the destination chain and the reverse rate is read on the source
+chain; both are then oriented into the same units. Either rate and its matching
+timestamp can be `null` when that chain and direction have not been priced.
+
+Symbol matching is case-insensitive, so `"cNGN"`, `"cngn"`, and `"CNGN"` all
+resolve to the canonical `"cNGN"` pool symbol.
 
 ---
 

--- a/docs/content/developers/sdk/api/intent-gateway.mdx
+++ b/docs/content/developers/sdk/api/intent-gateway.mdx
@@ -233,9 +233,10 @@ For an exact-input Phantom quote, the SDK deducts the gateway fee and computes `
 
 ### queryAvailableLiquidity(params)
 
-Returns the total output-token liquidity measured in the latest directional
-Phantom snapshot. For `USDC → cNGN`, the result is the amount of cNGN held by
-eligible solvers for that snapshot at its measurement time.
+Returns output-token liquidity from the indexer's latest pair-centric pool
+sample. Same-chain queries use the destination pool depth. Cross-chain queries
+use the matching explicit `PoolRoute`, returning zero liquidity when no indexed
+route accepts the source chain.
 
 ```typescript lineNumbers
 import { createQueryClient, IntentGateway } from "@hyperbridge/sdk"
@@ -252,7 +253,7 @@ const liquidity = await gateway.queryAvailableLiquidity({
 if (liquidity) {
   console.log(liquidity.totalLiquidity, "cNGN")
   console.log("Providers:", liquidity.providerCount)
-  console.log("Liquidity by chain:", liquidity.liquidityByChain)
+  console.log("Route:", liquidity.sourceChain, "→", liquidity.destinationChain)
   console.log("Measured at:", liquidity.snapshotTime)
 }
 ```
@@ -264,16 +265,15 @@ async queryAvailableLiquidity(params: {
 }): Promise<AvailableLiquiditySnapshot | undefined>
 ```
 
-`totalLiquidity` is a decimal string formatted with the canonical Base output
-token decimals. `liquidityByChain` provides the corresponding `chain`,
-`tokenAddress`, formatted `totalLiquidity`, and `providerCount` for each
-indexed output-token balance group; each group uses its own chain/token
-decimals. The
-indexer aggregates raw ERC-20 balances plus
-redeemable ERC-4626 positions at the snapshot time. This is historical
-availability, not reserved liquidity or a guarantee that the same amount remains
-fillable. The method returns `undefined` when the directional pair has no indexed
-snapshot.
+`totalLiquidity` is a decimal string formatted from the indexer's 18-decimal
+normalized pool depth. `providerCount` is the number of bidders represented by
+that pool sample or explicit route. Legacy unrestricted bidders are not included
+in cross-chain results because the indexer deliberately does not assign their
+capacity to source chains. `liquidityByChain` is retained for compatibility and
+contains the same result for the gateway's destination chain.
+
+This is indexed availability, not reserved liquidity or a fill guarantee. The
+method returns `undefined` only when the destination has no indexed pool sample.
 
 ---
 

--- a/sdk/packages/indexer/src/addresses/pool-tokens.addresses.ts
+++ b/sdk/packages/indexer/src/addresses/pool-tokens.addresses.ts
@@ -3,9 +3,11 @@
 // src/configs/config-mainnet.json / config-testnet.json, reading symbol() and decimals() from
 // the token contracts. Add tokens there, not here.
 
+import { poolSlug, sortPoolSymbols } from "@hyperbridge/sdk/intents-helpers"
 import { POOL_TOKENS } from "./pool-tokens.generated"
 
 export { POOL_TOKENS }
+export { poolSlug, sortPoolSymbols }
 
 export interface PoolToken {
 	/** Canonical symbol casing, shared across chains (e.g. "cNGN"). */
@@ -29,21 +31,4 @@ for (const tokens of Object.values(POOL_TOKENS)) {
 /** Canonical casing for a symbol known to the registry ("CNGN" -> "cNGN"); undefined otherwise. */
 export function canonicalPoolSymbol(symbol: string): string | undefined {
 	return CANONICAL_SYMBOLS.get(symbol.toLowerCase())
-}
-
-/**
- * The two symbols of a pair in canonical pool order: sorted case-insensitively, so both
- * directions of a pair land in the same pool (cNGN/USDC and USDC/cNGN are both cNGN-USDC).
- * Plain code-unit comparison, never locale-sensitive collation — the result is a persisted
- * primary key and must sort identically everywhere.
- */
-export function sortPoolSymbols(symbolA: string, symbolB: string): [string, string] {
-	const [a, b] = [symbolA.toLowerCase(), symbolB.toLowerCase()]
-	return a <= b ? [symbolA, symbolB] : [symbolB, symbolA]
-}
-
-/** Canonical pool slug for a pair: {token0}-{token1} in canonical pool order. */
-export function poolSlug(symbolA: string, symbolB: string): string {
-	const [first, second] = sortPoolSymbols(symbolA, symbolB)
-	return `${first}-${second}`
 }

--- a/sdk/packages/sdk/src/configs/ChainConfigService.ts
+++ b/sdk/packages/sdk/src/configs/ChainConfigService.ts
@@ -2,7 +2,6 @@ import type { ChainConfig, HexString } from "@/types"
 import {
 	chainConfigs,
 	getConfigByStateMachineId,
-	type Chains,
 	hyperbridgeAddress,
 	type ConfiguredAssetSymbol,
 	type Erc4626VaultConfigData,
@@ -21,7 +20,7 @@ export class ChainConfigService {
 	}
 
 	private getConfig(chain: string) {
-		return getConfigByStateMachineId(chain as Chains)
+		return getConfigByStateMachineId(chain)
 	}
 
 	getChainConfig(chain: string): ChainConfig {
@@ -111,11 +110,25 @@ export class ChainConfigService {
 	 * it, so a new asset is added once in `chain.ts` and nowhere else.
 	 */
 	getAssetBySymbol(chain: string, symbol: string): HexString | undefined {
-		const assets = this.getConfig(chain)?.assets
+		return this.getAssetMetadataBySymbol(chain, symbol)?.address
+	}
+
+	/** Resolves a configured token symbol case-insensitively on a specific chain. */
+	getAssetMetadataBySymbol(
+		chain: string,
+		symbol: string,
+	): { symbol: ConfiguredAssetSymbol; address: HexString; decimals?: number } | undefined {
+		const config = this.getConfig(chain)
+		const assets = config?.assets
 		if (!assets) return undefined
 		const target = symbol.trim().toUpperCase()
 		for (const [key, address] of Object.entries(assets)) {
-			if (key.toUpperCase() === target) return address as HexString
+			if (key.toUpperCase() !== target) continue
+			return {
+				symbol: key as ConfiguredAssetSymbol,
+				address: address as HexString,
+				decimals: config.tokenDecimals?.[key as keyof typeof config.tokenDecimals],
+			}
 		}
 		return undefined
 	}

--- a/sdk/packages/sdk/src/configs/chain.ts
+++ b/sdk/packages/sdk/src/configs/chain.ts
@@ -19,7 +19,7 @@ import {
 } from "viem/chains"
 import { defineChain } from "viem"
 import { TronWeb } from "tronweb"
-import { HexString } from "@/types"
+import type { HexString } from "@/types"
 
 /** Convert a Tron base58 address to a 0x-prefixed 20-byte EVM hex address */
 function tronAddress(base58: string): HexString {
@@ -113,7 +113,18 @@ export const tronNile = defineChain({
 // Known Tron chain IDs (mainnet + Nile testnet)
 export const tronChainIds = new Set([728126428, 3448148188])
 
-export type ConfiguredAssetSymbol = "WETH" | "DAI" | "USDC" | "USDT" | "cNGN" | "EXT"
+export type ConfiguredAssetSymbol =
+	| "WETH"
+	| "DAI"
+	| "USDC"
+	| "USDT"
+	| "cNGN"
+	| "EXT"
+	| "ZARP"
+	| "EURC"
+	| "XSGD"
+	| "TRYB"
+	| "USDR"
 
 export interface UniswapV4PoolConfigData {
 	tokens: readonly [ConfiguredAssetSymbol, ConfiguredAssetSymbol]
@@ -989,7 +1000,8 @@ const configsByStateMachineId = Object.fromEntries(
 	Object.values(chainConfigs).map((c) => [c.stateMachineId, c]),
 ) as Record<Chains, ChainConfigData>
 
-export const getConfigByStateMachineId = (id: Chains): ChainConfigData | undefined => configsByStateMachineId[id]
+export const getConfigByStateMachineId = (id: string): ChainConfigData | undefined =>
+	configsByStateMachineId[id as Chains]
 
 export const getChainId = (stateMachineId: string): number | undefined =>
 	configsByStateMachineId[stateMachineId as Chains]?.chainId

--- a/sdk/packages/sdk/src/configs/chain.ts
+++ b/sdk/packages/sdk/src/configs/chain.ts
@@ -126,6 +126,12 @@ export type ConfiguredAssetSymbol =
 	| "TRYB"
 	| "USDR"
 
+/** A configured asset symbol in its canonical, lowercase, or uppercase form. */
+export type ConfiguredAssetSymbolInput =
+	| ConfiguredAssetSymbol
+	| Lowercase<ConfiguredAssetSymbol>
+	| Uppercase<ConfiguredAssetSymbol>
+
 export interface UniswapV4PoolConfigData {
 	tokens: readonly [ConfiguredAssetSymbol, ConfiguredAssetSymbol]
 	fee: number

--- a/sdk/packages/sdk/src/intents-helpers.ts
+++ b/sdk/packages/sdk/src/intents-helpers.ts
@@ -3,6 +3,7 @@
 export { decodeERC7821ExecuteBatch, encodeERC7821ExecuteBatch } from "@/protocols/intents/decode-utils"
 export { decodeUserOpScale, encodeUserOpScale } from "@/chains/intentsCoprocessor"
 export { default as IntentGatewayV2 } from "@/abis/IntentGatewayV2"
+export { poolSlug, sortPoolSymbols } from "@/protocols/intents/liquidity-pool"
 export {
 	aggregatePhantomBids,
 	decodeAcceptedSourceChains,

--- a/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
+++ b/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
@@ -10,7 +10,9 @@ import type {
 	IndexerQueryClient,
 	OrderStatus,
 	OrderWithStatus,
-	AvailableLiquiditySnapshot,
+	AvailableLiquidity,
+	BuyAndSellRates,
+	QueryBuyAndSellRatesParams,
 } from "@/types"
 import type {
 	PackedUserOperation,
@@ -27,6 +29,7 @@ import type { ResumeIntentOrderOptions } from "@/types"
 import type { IEvmChain } from "@/chain"
 import type { IntentsCoprocessor } from "@/chains/intentsCoprocessor"
 import type { IsmpClient } from "@/client"
+import { chainConfigs, getConfigByStateMachineId } from "@/configs/chain"
 import { _queryOrderInternal } from "@/queryClient"
 import type { IntentGatewayContext } from "./types"
 import type { CancelEvent } from "./types"
@@ -37,7 +40,11 @@ import { OrderCanceller } from "./OrderCanceller"
 import { BidManager } from "./BidManager"
 import { GasEstimator } from "./GasEstimator"
 import { OrderStatusChecker } from "./OrderStatusChecker"
-import { LiquidityEngine } from "./LiquidityEngine"
+import {
+	LiquidityEngine,
+	UnsupportedLiquidityAssetError,
+	UnsupportedLiquidityChainError,
+} from "./LiquidityEngine"
 import {
 	type IntentQuoteStrategyHandler,
 	type QuoteIntentParams,
@@ -48,7 +55,13 @@ import {
 	UnsupportedIntentQuoteStrategyError,
 } from "./quote"
 import type { ERC7821Call } from "@/types"
-import { DEFAULT_GRAFFITI, DEFAULT_POLL_INTERVAL, ADDRESS_ZERO, bytes32ToBytes20, sleep } from "@/utils"
+import {
+	DEFAULT_GRAFFITI,
+	DEFAULT_POLL_INTERVAL,
+	ADDRESS_ZERO,
+	bytes32ToBytes20,
+	sleep,
+} from "@/utils"
 import { getFeeToken } from "./utils"
 
 const CROSS_CHAIN_ORDER_FEE_GAS_PRICE_BUMP_PERCENT = 10n
@@ -242,43 +255,66 @@ export class IntentGateway {
 	}
 
 	/**
-	 * Returns the indexed output-token liquidity reachable for this gateway's
-	 * source-to-destination corridor.
+	 * Returns indexed destination liquidity and its source-routing slices.
 	 *
-	 * Pool identity, directional depth, and route attribution come exclusively
-	 * from the indexer's pair-centric liquidity entities. Amounts are decimal
-	 * strings normalized to 18 decimals by the indexer and reflect its latest
-	 * pool sample; they are not live reservations or fill guarantees.
+	 * Destination, unrestricted, and explicit-route capacity come exclusively
+	 * from the indexer's pair-centric liquidity entities. The SDK does not decide
+	 * whether unrestricted bidders cover the source chain. Amounts reflect the
+	 * latest rolling sample; they are not reservations or fill guarantees.
 	 *
 	 * Requires a prior call to {@link withQueryClient}.
 	 */
 	async queryAvailableLiquidity(
 		params: Pick<QuoteIntentParams, "tokenIn" | "tokenOut">,
-	): Promise<AvailableLiquiditySnapshot | undefined> {
+	): Promise<AvailableLiquidity | undefined> {
 		const { queryClient } = this.requireIndexer()
-		const sourceStateMachineId = this.source.config.stateMachineId
-		const destinationStateMachineId = this.dest.config.stateMachineId
+		const sourceStateMachineId = getConfigByStateMachineId(this.source.config.stateMachineId)?.stateMachineId
+		const destinationStateMachineId = getConfigByStateMachineId(this.dest.config.stateMachineId)?.stateMachineId
+		if (!sourceStateMachineId) throw new UnsupportedLiquidityChainError(this.source.config.stateMachineId)
+		if (!destinationStateMachineId) throw new UnsupportedLiquidityChainError(this.dest.config.stateMachineId)
 		const sourceToken = this.source.configService.getAssetMetadataByAddress(sourceStateMachineId, params.tokenIn)
 		const destinationToken = this.dest.configService.getAssetMetadataByAddress(
 			destinationStateMachineId,
 			params.tokenOut,
 		)
-		if (!sourceToken || !destinationToken) {
-			throw new UnsupportedIntentQuotePairError({
-				source: sourceStateMachineId,
-				destination: destinationStateMachineId,
-				tokenIn: params.tokenIn,
-				tokenOut: params.tokenOut,
-				quoteSource: "Indexer liquidity pool",
-			})
-		}
+		if (!sourceToken) throw new UnsupportedLiquidityAssetError(sourceStateMachineId, params.tokenIn)
+		if (!destinationToken) throw new UnsupportedLiquidityAssetError(destinationStateMachineId, params.tokenOut)
 
-		return new LiquidityEngine(queryClient).getAvailableLiquiditySnapshot({
-			sourceChain: sourceStateMachineId,
-			destinationChain: destinationStateMachineId,
+		return new LiquidityEngine(queryClient).getAvailableLiquidity({
+			source: {
+				chain: sourceStateMachineId,
+				...sourceToken,
+			},
+			destination: {
+				chain: destinationStateMachineId,
+				...destinationToken,
+			},
+		})
+	}
+
+	/**
+	 * Returns both indexed rates for a symbol pair without requiring token
+	 * addresses. Chain IDs are numeric IDs for chains configured in the SDK.
+	 */
+	async queryBuyAndSellRates(params: QueryBuyAndSellRatesParams): Promise<BuyAndSellRates | undefined> {
+		const { queryClient } = this.requireIndexer()
+		const sourceChain = chainConfigs[params.sourceChainId]?.stateMachineId
+		const destinationChain = chainConfigs[params.destinationChainId]?.stateMachineId
+		if (!sourceChain) throw new UnsupportedLiquidityChainError(params.sourceChainId)
+		if (!destinationChain) throw new UnsupportedLiquidityChainError(params.destinationChainId)
+		const sourceToken = this.source.configService.getAssetMetadataBySymbol(sourceChain, params.tokenInSymbol)
+		const destinationToken = this.dest.configService.getAssetMetadataBySymbol(
+			destinationChain,
+			params.tokenOutSymbol,
+		)
+		if (!sourceToken) throw new UnsupportedLiquidityAssetError(sourceChain, params.tokenInSymbol)
+		if (!destinationToken) throw new UnsupportedLiquidityAssetError(destinationChain, params.tokenOutSymbol)
+
+		return new LiquidityEngine(queryClient).getBuyAndSellRates({
+			sourceChain,
+			destinationChain,
 			tokenInSymbol: sourceToken.symbol,
 			tokenOutSymbol: destinationToken.symbol,
-			tokenOut: destinationToken.address,
 		})
 	}
 

--- a/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
+++ b/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
@@ -47,7 +47,6 @@ import {
 	UnsupportedIntentQuotePairError,
 	UnsupportedIntentQuoteStrategyError,
 } from "./quote"
-import { PhantomSnapshotPairResolver } from "./quote/phantomSnapshot"
 import type { ERC7821Call } from "@/types"
 import { DEFAULT_GRAFFITI, DEFAULT_POLL_INTERVAL, ADDRESS_ZERO, bytes32ToBytes20, sleep } from "@/utils"
 import { getFeeToken } from "./utils"
@@ -105,8 +104,6 @@ export class IntentGateway {
 	private readonly gasEstimator: GasEstimator
 	/** Quote strategies for pricing orders before placement, keyed by strategy name. */
 	private readonly quoteStrategies: Record<string, IntentQuoteStrategyHandler>
-	/** Resolves order tokens to canonical Phantom snapshot market pairs. */
-	private readonly phantomSnapshotPairResolver: PhantomSnapshotPairResolver
 
 	/**
 	 * Private constructor — use {@link IntentGateway.create} instead.
@@ -155,7 +152,6 @@ export class IntentGateway {
 		this.bidManager = bidManager
 		this.gasEstimator = gasEstimator
 		this._crypto = crypto
-		this.phantomSnapshotPairResolver = new PhantomSnapshotPairResolver(dest.configService)
 		this.quoteStrategies = {
 			phantom_snapshot: new PhantomSnapshotIntentQuoteStrategy(
 				dest.configService,
@@ -246,13 +242,13 @@ export class IntentGateway {
 	}
 
 	/**
-	 * Returns the output-token liquidity measured in the latest directional
-	 * Phantom snapshot for this gateway's source and destination.
+	 * Returns the indexed output-token liquidity reachable for this gateway's
+	 * source-to-destination corridor.
 	 *
-	 * Pair resolution uses the same canonical Base market as {@link quoteIntent}.
-	 * The snapshot itself determines the output token and chain to aggregate. The
-	 * amount is in the token's smallest unit and reflects the indexer's
-	 * `snapshotTime`; it is not a live reservation or fill guarantee.
+	 * Pool identity, directional depth, and route attribution come exclusively
+	 * from the indexer's pair-centric liquidity entities. Amounts are decimal
+	 * strings normalized to 18 decimals by the indexer and reflect its latest
+	 * pool sample; they are not live reservations or fill guarantees.
 	 *
 	 * Requires a prior call to {@link withQueryClient}.
 	 */
@@ -262,20 +258,27 @@ export class IntentGateway {
 		const { queryClient } = this.requireIndexer()
 		const sourceStateMachineId = this.source.config.stateMachineId
 		const destinationStateMachineId = this.dest.config.stateMachineId
-		const pair = this.phantomSnapshotPairResolver.resolve(params, sourceStateMachineId, destinationStateMachineId)
-		if (!pair) {
+		const sourceToken = this.source.configService.getAssetMetadataByAddress(sourceStateMachineId, params.tokenIn)
+		const destinationToken = this.dest.configService.getAssetMetadataByAddress(
+			destinationStateMachineId,
+			params.tokenOut,
+		)
+		if (!sourceToken || !destinationToken) {
 			throw new UnsupportedIntentQuotePairError({
 				source: sourceStateMachineId,
 				destination: destinationStateMachineId,
 				tokenIn: params.tokenIn,
 				tokenOut: params.tokenOut,
-				quoteSource: "Phantom snapshot pair",
+				quoteSource: "Indexer liquidity pool",
 			})
 		}
 
-		return new LiquidityEngine(queryClient, this.dest.configService).getAvailableLiquiditySnapshot({
-			tokenIn: pair.tokenA,
-			tokenOut: pair.tokenB,
+		return new LiquidityEngine(queryClient).getAvailableLiquiditySnapshot({
+			sourceChain: sourceStateMachineId,
+			destinationChain: destinationStateMachineId,
+			tokenInSymbol: sourceToken.symbol,
+			tokenOutSymbol: destinationToken.symbol,
+			tokenOut: destinationToken.address,
 		})
 	}
 

--- a/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
+++ b/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
@@ -293,8 +293,9 @@ export class IntentGateway {
 	}
 
 	/**
-	 * Returns both indexed rates for a symbol pair without requiring token
-	 * addresses. Chain IDs are numeric IDs for chains configured in the SDK.
+	 * Returns chain-specific buy and sell rates in less-valued quote-token units
+	 * without requiring token addresses. Symbols are matched case-insensitively;
+	 * chain IDs are numeric IDs for chains configured in the SDK.
 	 */
 	async queryBuyAndSellRates(params: QueryBuyAndSellRatesParams): Promise<BuyAndSellRates | undefined> {
 		const { queryClient } = this.requireIndexer()

--- a/sdk/packages/sdk/src/protocols/intents/LiquidityEngine.ts
+++ b/sdk/packages/sdk/src/protocols/intents/LiquidityEngine.ts
@@ -1,13 +1,17 @@
-import { formatUnits } from "viem"
 import type { Chains, ConfiguredAssetSymbol } from "@/configs/chain"
 import { AVAILABLE_LIQUIDITY, BUY_AND_SELL_RATES } from "@/queries"
 import type { AvailableLiquidity, BuyAndSellRates, HexString, IndexerQueryClient, LiquiditySlice } from "@/types"
 import { dateStringtoTimestamp, normalizeEvmAddress } from "@/utils"
+import { formatUnits } from "viem"
 import { resolveLiquidityPool } from "./liquidity-pool"
 
-const POOL_DEPTH_DECIMALS = 18
+const INDEXER_FIXED_POINT_DECIMALS = 18
+const POOL_RATE_SCALE = 10n ** 18n
 const SELL = "SELL"
 const BUY = "BUY"
+const USD_STABLE_SYMBOLS = new Set<ConfiguredAssetSymbol>(["USDC", "USDT"])
+
+type PoolDirection = typeof SELL | typeof BUY
 
 interface AvailableLiquidityResponse {
 	poolChainLiquidities: {
@@ -33,13 +37,22 @@ interface PoolRouteNode {
 }
 
 interface BuyAndSellRatesResponse {
-	liquidityPools: {
-		nodes: Array<{
-			sellRate: string | null
-			buyRate: string | null
-			lastUpdatedAt: string
-		}>
-	}
+	direct: RateConnection
+	reverse: RateConnection
+}
+
+interface RateConnection {
+	nodes: ChainRateNode[]
+}
+
+interface ChainRateNode {
+	rate: string
+	lastUpdatedAt: string
+}
+
+interface IndexedRate {
+	scaledRate: bigint
+	updatedAt: Date
 }
 
 export interface LiquidityAsset {
@@ -105,7 +118,14 @@ export class LiquidityEngine {
 		}
 	}
 
-	/** Returns the indexer's merged buy and sell rates for a configured symbol pair. */
+	/**
+	 * Returns chain-specific buy and sell rates in less-valued quote-token units
+	 * per one base token.
+	 *
+	 * The requested direction is read on the destination chain; its reverse is
+	 * read on the source chain. This mirrors where each direction's output token
+	 * must be delivered for a cross-chain trade.
+	 */
 	async getBuyAndSellRates(params: {
 		sourceChain: Chains
 		destinationChain: Chains
@@ -113,22 +133,45 @@ export class LiquidityEngine {
 		tokenOutSymbol: ConfiguredAssetSymbol
 	}): Promise<BuyAndSellRates | undefined> {
 		const pool = resolveLiquidityPool(params.tokenInSymbol, params.tokenOutSymbol)
+		const directDirection: PoolDirection =
+			params.tokenInSymbol.toLowerCase() === pool.token0Symbol.toLowerCase() ? SELL : BUY
+		const reverseDirection: PoolDirection = directDirection === SELL ? BUY : SELL
 		const response = await this.queryClient.request<BuyAndSellRatesResponse>(BUY_AND_SELL_RATES, {
 			poolId: pool.poolId,
+			directChain: params.destinationChain,
+			directDirection,
+			reverseChain: params.sourceChain,
+			reverseDirection,
 		})
-		if (!response?.liquidityPools?.nodes) {
-			throw new InvalidLiquidityIndexerResponseError("liquidityPools connection is missing")
+		if (!response?.direct?.nodes || !response?.reverse?.nodes) {
+			throw new InvalidLiquidityIndexerResponseError("rate connections are missing")
 		}
-		const rates = response.liquidityPools.nodes[0]
-		if (!rates) return undefined
+
+		const direct = readIndexedRate(response.direct.nodes[0], "direct rate")
+		const reverse = readIndexedRate(response.reverse.nodes[0], "reverse rate")
+		if (!direct && !reverse) return undefined
+
+		const quoteTokenSymbol = resolveQuoteTokenSymbol(
+			params.tokenInSymbol,
+			params.tokenOutSymbol,
+			direct?.scaledRate,
+			reverse?.scaledRate,
+		)
+		const quoteIsTokenOut = quoteTokenSymbol === params.tokenOutSymbol
+		const buy = quoteIsTokenOut ? direct : reverse
+		const sell = quoteIsTokenOut ? reverse : direct
 
 		return {
-			...pool,
+			baseTokenSymbol: quoteIsTokenOut ? params.tokenInSymbol : params.tokenOutSymbol,
+			quoteTokenSymbol,
 			sourceChain: params.sourceChain,
 			destinationChain: params.destinationChain,
-			sellRate: rates.sellRate === null ? null : formatIndexerAmount(rates.sellRate, "sellRate"),
-			buyRate: rates.buyRate === null ? null : formatIndexerAmount(rates.buyRate, "buyRate"),
-			lastUpdatedAt: readIndexerDate(rates.lastUpdatedAt, "pool lastUpdatedAt"),
+			buyRate: buy ? formatUnits(buy.scaledRate, INDEXER_FIXED_POINT_DECIMALS) : null,
+			sellRate: sell
+				? formatUnits(reciprocalRate(sell.scaledRate, "sell rate"), INDEXER_FIXED_POINT_DECIMALS)
+				: null,
+			buyRateUpdatedAt: buy?.updatedAt ?? null,
+			sellRateUpdatedAt: sell?.updatedAt ?? null,
 		}
 	}
 }
@@ -165,7 +208,7 @@ function formatIndexerAmount(value: string, label: string): string {
 	try {
 		const amount = BigInt(value)
 		if (amount < 0n) throw new Error()
-		return formatUnits(amount, POOL_DEPTH_DECIMALS)
+		return formatUnits(amount, INDEXER_FIXED_POINT_DECIMALS)
 	} catch {
 		throw new InvalidLiquidityIndexerResponseError(`${label} is not a non-negative integer`)
 	}
@@ -175,4 +218,41 @@ function readIndexerDate(value: string, label: string): Date {
 	const date = new Date(dateStringtoTimestamp(value))
 	if (Number.isNaN(date.getTime())) throw new InvalidLiquidityIndexerResponseError(`${label} is invalid`)
 	return date
+}
+
+function readIndexedRate(node: ChainRateNode | undefined, label: string): IndexedRate | undefined {
+	if (!node) return undefined
+	try {
+		const scaledRate = BigInt(node.rate)
+		if (scaledRate <= 0n) throw new Error()
+		return {
+			scaledRate,
+			updatedAt: readIndexerDate(node.lastUpdatedAt, `${label} lastUpdatedAt`),
+		}
+	} catch (error) {
+		if (error instanceof InvalidLiquidityIndexerResponseError) throw error
+		throw new InvalidLiquidityIndexerResponseError(`${label} is not a positive integer`)
+	}
+}
+
+function resolveQuoteTokenSymbol(
+	tokenInSymbol: ConfiguredAssetSymbol,
+	tokenOutSymbol: ConfiguredAssetSymbol,
+	directRate?: bigint,
+	reverseRate?: bigint,
+): ConfiguredAssetSymbol {
+	const inputIsUsdStable = USD_STABLE_SYMBOLS.has(tokenInSymbol)
+	const outputIsUsdStable = USD_STABLE_SYMBOLS.has(tokenOutSymbol)
+	if (inputIsUsdStable !== outputIsUsdStable) return inputIsUsdStable ? tokenOutSymbol : tokenInSymbol
+
+	if (directRate !== undefined) return directRate >= POOL_RATE_SCALE ? tokenOutSymbol : tokenInSymbol
+	if (reverseRate !== undefined) return reverseRate >= POOL_RATE_SCALE ? tokenInSymbol : tokenOutSymbol
+
+	throw new InvalidLiquidityIndexerResponseError("cannot orient an empty rate pair")
+}
+
+function reciprocalRate(rate: bigint, label: string): bigint {
+	const reciprocal = (POOL_RATE_SCALE * POOL_RATE_SCALE) / rate
+	if (reciprocal <= 0n) throw new InvalidLiquidityIndexerResponseError(`${label} reciprocal underflowed`)
+	return reciprocal
 }

--- a/sdk/packages/sdk/src/protocols/intents/LiquidityEngine.ts
+++ b/sdk/packages/sdk/src/protocols/intents/LiquidityEngine.ts
@@ -1,13 +1,13 @@
 import { formatUnits } from "viem"
-import { AVAILABLE_LIQUIDITY } from "@/queries"
-import type { AvailableLiquiditySnapshot, HexString, IndexerQueryClient } from "@/types"
-import { dateStringtoTimestamp } from "@/utils"
+import type { Chains, ConfiguredAssetSymbol } from "@/configs/chain"
+import { AVAILABLE_LIQUIDITY, BUY_AND_SELL_RATES } from "@/queries"
+import type { AvailableLiquidity, BuyAndSellRates, HexString, IndexerQueryClient, LiquiditySlice } from "@/types"
+import { dateStringtoTimestamp, normalizeEvmAddress } from "@/utils"
+import { resolveLiquidityPool } from "./liquidity-pool"
 
 const POOL_DEPTH_DECIMALS = 18
 const SELL = "SELL"
 const BUY = "BUY"
-
-type PoolDirection = typeof SELL | typeof BUY
 
 interface AvailableLiquidityResponse {
 	poolChainLiquidities: {
@@ -21,17 +21,31 @@ interface AvailableLiquidityResponse {
 interface PoolChainLiquidityNode {
 	depth: string
 	bidCount: number
+	unrestrictedDepth: string
+	unrestrictedBidCount: number
 	lastUpdatedAt: string
 }
 
 interface PoolRouteNode {
 	depth: string
 	bidCount: number
+	lastUpdatedAt: string
 }
 
-interface ResolvedPoolQuery {
-	poolId: string
-	direction: PoolDirection
+interface BuyAndSellRatesResponse {
+	liquidityPools: {
+		nodes: Array<{
+			sellRate: string | null
+			buyRate: string | null
+			lastUpdatedAt: string
+		}>
+	}
+}
+
+export interface LiquidityAsset {
+	chain: Chains
+	symbol: ConfiguredAssetSymbol
+	address: HexString
 }
 
 /** Reads pair-centric, route-aware liquidity directly from Nexus. */
@@ -45,61 +59,120 @@ export class LiquidityEngine {
 	 * configuration; this layer only maps those configured symbols onto the
 	 * indexer's canonical pool and route fields.
 	 *
-	 * Cross-chain queries use only explicitly indexed `PoolRoute` liquidity. The
-	 * indexer's unrestricted slice is intentionally excluded because deciding
-	 * which sources that legacy policy covers is outside the indexer contract.
+	 * Destination, unrestricted, and explicit-route capacity are returned as
+	 * separate values so callers can apply their own source-chain policy.
 	 *
 	 * @returns `undefined` only when the indexer has not published a destination
 	 * pool sample yet.
 	 */
-	async getAvailableLiquiditySnapshot(params: {
-		sourceChain: string
-		destinationChain: string
-		tokenInSymbol: string
-		tokenOutSymbol: string
-		tokenOut: HexString
-	}): Promise<AvailableLiquiditySnapshot | undefined> {
-		const resolved = resolvePoolQuery(params.tokenInSymbol, params.tokenOutSymbol)
+	async getAvailableLiquidity(params: {
+		source: LiquidityAsset
+		destination: LiquidityAsset
+	}): Promise<AvailableLiquidity | undefined> {
+		const pool = resolveLiquidityPool(params.source.symbol, params.destination.symbol)
+		const direction = params.source.symbol.toLowerCase() === pool.token0Symbol.toLowerCase() ? SELL : BUY
 		const variables = {
-			poolId: resolved.poolId,
-			sourceChain: params.sourceChain,
-			destinationChain: params.destinationChain,
-			direction: resolved.direction,
+			poolId: pool.poolId,
+			sourceChain: params.source.chain,
+			destinationChain: params.destination.chain,
+			direction,
 		}
 		const response = await this.queryClient.request<AvailableLiquidityResponse>(AVAILABLE_LIQUIDITY, variables)
+		if (!response?.poolChainLiquidities?.nodes || !response?.poolRoutes?.nodes) {
+			throw new InvalidLiquidityIndexerResponseError("liquidity connections are missing")
+		}
 		const chainLiquidity = response.poolChainLiquidities.nodes[0]
 		if (!chainLiquidity) return undefined
 
-		const liquidity =
-			params.sourceChain === params.destinationChain
-				? chainLiquidity
-				: (response.poolRoutes.nodes[0] ?? { depth: "0", bidCount: 0 })
-		const totalLiquidity = formatUnits(BigInt(liquidity.depth), POOL_DEPTH_DECIMALS)
+		const route = response.poolRoutes.nodes[0]
 		return {
-			poolId: resolved.poolId,
-			direction: resolved.direction,
+			sourceChain: params.source.chain,
+			destinationChain: params.destination.chain,
+			tokenAddress: normalizeEvmAddress(params.destination.address, "destination token"),
+			updatedAt: readIndexerDate(chainLiquidity.lastUpdatedAt, "destination lastUpdatedAt"),
+			destination: readLiquiditySlice(chainLiquidity.depth, chainLiquidity.bidCount, "destination"),
+			unrestricted: readLiquiditySlice(
+				chainLiquidity.unrestrictedDepth,
+				chainLiquidity.unrestrictedBidCount,
+				"unrestricted",
+			),
+			explicitRoute: route
+				? {
+						...readLiquiditySlice(route.depth, route.bidCount, "explicit route"),
+						updatedAt: readIndexerDate(route.lastUpdatedAt, "route lastUpdatedAt"),
+					}
+				: null,
+		}
+	}
+
+	/** Returns the indexer's merged buy and sell rates for a configured symbol pair. */
+	async getBuyAndSellRates(params: {
+		sourceChain: Chains
+		destinationChain: Chains
+		tokenInSymbol: ConfiguredAssetSymbol
+		tokenOutSymbol: ConfiguredAssetSymbol
+	}): Promise<BuyAndSellRates | undefined> {
+		const pool = resolveLiquidityPool(params.tokenInSymbol, params.tokenOutSymbol)
+		const response = await this.queryClient.request<BuyAndSellRatesResponse>(BUY_AND_SELL_RATES, {
+			poolId: pool.poolId,
+		})
+		if (!response?.liquidityPools?.nodes) {
+			throw new InvalidLiquidityIndexerResponseError("liquidityPools connection is missing")
+		}
+		const rates = response.liquidityPools.nodes[0]
+		if (!rates) return undefined
+
+		return {
+			...pool,
 			sourceChain: params.sourceChain,
 			destinationChain: params.destinationChain,
-			totalLiquidity,
-			providerCount: liquidity.bidCount,
-			tokenAddress: params.tokenOut,
-			snapshotTime: new Date(dateStringtoTimestamp(chainLiquidity.lastUpdatedAt)),
-			liquidityByChain: [
-				{
-					chain: params.destinationChain,
-					tokenAddress: params.tokenOut,
-					totalLiquidity,
-					providerCount: liquidity.bidCount,
-				},
-			],
+			sellRate: rates.sellRate === null ? null : formatIndexerAmount(rates.sellRate, "sellRate"),
+			buyRate: rates.buyRate === null ? null : formatIndexerAmount(rates.buyRate, "buyRate"),
+			lastUpdatedAt: readIndexerDate(rates.lastUpdatedAt, "pool lastUpdatedAt"),
 		}
 	}
 }
 
-function resolvePoolQuery(tokenInSymbol: string, tokenOutSymbol: string): ResolvedPoolQuery {
-	const inputIsToken0 = tokenInSymbol.toLowerCase() <= tokenOutSymbol.toLowerCase()
-	return {
-		poolId: inputIsToken0 ? `${tokenInSymbol}-${tokenOutSymbol}` : `${tokenOutSymbol}-${tokenInSymbol}`,
-		direction: inputIsToken0 ? SELL : BUY,
+export class InvalidLiquidityIndexerResponseError extends Error {
+	constructor(reason: string) {
+		super(`Invalid liquidity indexer response: ${reason}`)
+		this.name = "InvalidLiquidityIndexerResponseError"
 	}
+}
+
+export class UnsupportedLiquidityAssetError extends Error {
+	constructor(chain: string, asset: string) {
+		super(`No configured liquidity asset found for ${asset} on ${chain}`)
+		this.name = "UnsupportedLiquidityAssetError"
+	}
+}
+
+export class UnsupportedLiquidityChainError extends Error {
+	constructor(chainId: number | string) {
+		super(`No configured liquidity chain found for chain ID ${chainId}`)
+		this.name = "UnsupportedLiquidityChainError"
+	}
+}
+
+function readLiquiditySlice(depth: string, providerCount: number, label: string): LiquiditySlice {
+	if (!Number.isSafeInteger(providerCount) || providerCount < 0) {
+		throw new InvalidLiquidityIndexerResponseError(`${label} provider count is invalid`)
+	}
+	return { totalLiquidity: formatIndexerAmount(depth, `${label} depth`), providerCount }
+}
+
+function formatIndexerAmount(value: string, label: string): string {
+	try {
+		const amount = BigInt(value)
+		if (amount < 0n) throw new Error()
+		return formatUnits(amount, POOL_DEPTH_DECIMALS)
+	} catch {
+		throw new InvalidLiquidityIndexerResponseError(`${label} is not a non-negative integer`)
+	}
+}
+
+function readIndexerDate(value: string, label: string): Date {
+	const date = new Date(dateStringtoTimestamp(value))
+	if (Number.isNaN(date.getTime())) throw new InvalidLiquidityIndexerResponseError(`${label} is invalid`)
+	return date
 }

--- a/sdk/packages/sdk/src/protocols/intents/LiquidityEngine.ts
+++ b/sdk/packages/sdk/src/protocols/intents/LiquidityEngine.ts
@@ -1,237 +1,105 @@
-import { LATEST_PHANTOM_ORDER_LIQUIDITY_SNAPSHOT, LIQUIDITY_PROVIDER_BALANCES } from "@/queries"
-import { Chains } from "@/configs/chain"
-import type { ChainConfigService } from "@/configs/ChainConfigService"
-import type { AvailableLiquidityByChain, AvailableLiquiditySnapshot, HexString, IndexerQueryClient } from "@/types"
-import { dateStringtoTimestamp, normalizeEvmAddress } from "@/utils"
 import { formatUnits } from "viem"
+import { AVAILABLE_LIQUIDITY } from "@/queries"
+import type { AvailableLiquiditySnapshot, HexString, IndexerQueryClient } from "@/types"
+import { dateStringtoTimestamp } from "@/utils"
 
-interface LiquidityProviderBalancesResponse {
-	liquidityProviderBalances: {
-		aggregates: {
-			sum: { balance: string | null }
-			distinctCount: { providerId: string }
-		} | null
-		groupedAggregates: Array<{
-			keys: string[]
-			sum: { balance: string | null }
-			distinctCount: { providerId: string }
-		}>
+const POOL_DEPTH_DECIMALS = 18
+const SELL = "SELL"
+const BUY = "BUY"
+
+type PoolDirection = typeof SELL | typeof BUY
+
+interface AvailableLiquidityResponse {
+	poolChainLiquidities: {
+		nodes: PoolChainLiquidityNode[]
+	}
+	poolRoutes: {
+		nodes: PoolRouteNode[]
 	}
 }
 
-interface PhantomOrderLiquiditySnapshotsResponse {
-	phantomOrderPriceSnapshots: {
-		nodes: Array<{
-			commitment: string
-			tokenA: string
-			tokenB: string
-			snapshotTime: string
-		}>
-	}
+interface PoolChainLiquidityNode {
+	depth: string
+	bidCount: number
+	lastUpdatedAt: string
 }
 
-const COMMITMENT_PATTERN = /^0x[0-9a-f]{64}$/i
+interface PoolRouteNode {
+	depth: string
+	bidCount: number
+}
 
-/**
- * Owns Phantom liquidity snapshot retrieval and aggregation from Nexus.
- *
- * The indexer performs balance and distinct-provider aggregation; this class
- * validates and maps those aggregate results into the SDK response shape.
- */
+interface ResolvedPoolQuery {
+	poolId: string
+	direction: PoolDirection
+}
+
+/** Reads pair-centric, route-aware liquidity directly from Nexus. */
 export class LiquidityEngine {
-	/**
-	 * @param queryClient - Nexus GraphQL client attached to the gateway.
-	 * @param chainConfigService - Resolves token decimals for formatted results.
-	 */
-	constructor(
-		private readonly queryClient: IndexerQueryClient,
-		private readonly chainConfigService: ChainConfigService,
-	) {}
+	constructor(private readonly queryClient: IndexerQueryClient) {}
 
 	/**
-	 * Retrieves the newest directional Phantom snapshot for a pair and its
-	 * indexed output-token liquidity.
+	 * Returns liquidity reachable from one source chain on one destination.
 	 *
-	 * Nexus filters balances to the canonical output token, then aggregates them
-	 * overall and by chain. The returned amounts are decimal strings: the total
-	 * uses the canonical Base output-token decimals, while each chain group uses
-	 * that chain's token decimals. They describe `snapshotTime`, not live
-	 * reservations or fill guarantees.
+	 * The caller resolves chain-specific token addresses through chain
+	 * configuration; this layer only maps those configured symbols onto the
+	 * indexer's canonical pool and route fields.
 	 *
-	 * @param params - Canonical Phantom-market input and output token addresses.
-	 * @returns The latest snapshot, or `undefined` if Nexus has no snapshot for
-	 * the directional pair.
-	 * @throws {InvalidAvailableLiquiditySnapshotError} If Nexus returns malformed
-	 * or internally inconsistent snapshot data.
+	 * Cross-chain queries use only explicitly indexed `PoolRoute` liquidity. The
+	 * indexer's unrestricted slice is intentionally excluded because deciding
+	 * which sources that legacy policy covers is outside the indexer contract.
+	 *
+	 * @returns `undefined` only when the indexer has not published a destination
+	 * pool sample yet.
 	 */
 	async getAvailableLiquiditySnapshot(params: {
-		tokenIn: HexString
+		sourceChain: string
+		destinationChain: string
+		tokenInSymbol: string
+		tokenOutSymbol: string
 		tokenOut: HexString
 	}): Promise<AvailableLiquiditySnapshot | undefined> {
-		const tokenIn = normalizeEvmAddress(params.tokenIn, "tokenIn")
-		const tokenOut = normalizeEvmAddress(params.tokenOut, "tokenOut")
-		const response = await this.queryClient.request<PhantomOrderLiquiditySnapshotsResponse>(
-			LATEST_PHANTOM_ORDER_LIQUIDITY_SNAPSHOT,
-			{ tokenA: tokenIn, tokenB: tokenOut },
-		)
-		const node = response?.phantomOrderPriceSnapshots?.nodes?.[0]
-		if (!node) return
-
-		const commitment = node.commitment.toLowerCase()
-		if (!COMMITMENT_PATTERN.test(commitment)) {
-			throw new InvalidAvailableLiquiditySnapshotError(commitment || "<missing>", "commitment is not bytes32 hex")
+		const resolved = resolvePoolQuery(params.tokenInSymbol, params.tokenOutSymbol)
+		const variables = {
+			poolId: resolved.poolId,
+			sourceChain: params.sourceChain,
+			destinationChain: params.destinationChain,
+			direction: resolved.direction,
 		}
-		if (node.tokenA.toLowerCase() !== tokenIn || node.tokenB.toLowerCase() !== tokenOut) {
-			throw new InvalidAvailableLiquiditySnapshotError(commitment, "snapshot token pair does not match the query")
-		}
+		const response = await this.queryClient.request<AvailableLiquidityResponse>(AVAILABLE_LIQUIDITY, variables)
+		const chainLiquidity = response.poolChainLiquidities.nodes[0]
+		if (!chainLiquidity) return undefined
 
-		const snapshotTime = new Date(dateStringtoTimestamp(node.snapshotTime))
-		if (Number.isNaN(snapshotTime.getTime())) {
-			throw new InvalidAvailableLiquiditySnapshotError(commitment, "snapshotTime is invalid")
-		}
-
-		const { totalLiquidity, providerCount, liquidityByChain } = await this.querySnapshotLiquidityAggregates({
-			commitment,
-			tokenAddress: tokenOut,
-		})
-
+		const liquidity =
+			params.sourceChain === params.destinationChain
+				? chainLiquidity
+				: (response.poolRoutes.nodes[0] ?? { depth: "0", bidCount: 0 })
+		const totalLiquidity = formatUnits(BigInt(liquidity.depth), POOL_DEPTH_DECIMALS)
 		return {
-			totalLiquidity: this.formatLiquidity(totalLiquidity, Chains.BASE_MAINNET, tokenOut, commitment),
-			providerCount,
-			tokenAddress: tokenOut,
-			snapshotTime,
-			liquidityByChain: liquidityByChain.map((group) => ({
-				...group,
-				totalLiquidity: this.formatLiquidity(group.totalLiquidity, group.chain, group.tokenAddress, commitment),
-			})),
+			poolId: resolved.poolId,
+			direction: resolved.direction,
+			sourceChain: params.sourceChain,
+			destinationChain: params.destinationChain,
+			totalLiquidity,
+			providerCount: liquidity.bidCount,
+			tokenAddress: params.tokenOut,
+			snapshotTime: new Date(dateStringtoTimestamp(chainLiquidity.lastUpdatedAt)),
+			liquidityByChain: [
+				{
+					chain: params.destinationChain,
+					tokenAddress: params.tokenOut,
+					totalLiquidity,
+					providerCount: liquidity.bidCount,
+				},
+			],
 		}
-	}
-
-	/**
-	 * Requests server-side sums and distinct provider counts for one immutable
-	 * snapshot/output-token pair, including chain-level aggregate groups.
-	 *
-	 * `commitment` uniquely identifies the selected snapshot
-	 */
-	private async querySnapshotLiquidityAggregates(params: { commitment: string; tokenAddress: HexString }): Promise<{
-		totalLiquidity: bigint
-		providerCount: number
-		liquidityByChain: RawAvailableLiquidityByChain[]
-	}> {
-		const response = await this.queryClient.request<LiquidityProviderBalancesResponse>(
-			LIQUIDITY_PROVIDER_BALANCES,
-			{ commitment: params.commitment, tokenAddress: params.tokenAddress },
-		)
-		const connection = response?.liquidityProviderBalances
-		const aggregates = connection?.aggregates
-		if (!connection || !aggregates) {
-			throw new InvalidAvailableLiquiditySnapshotError(
-				params.commitment,
-				"liquidityProviderBalances aggregates are missing",
-			)
-		}
-
-		const totalLiquidity = parseSnapshotBigInt(aggregates.sum.balance ?? "0", params.commitment, "total balance")
-		const providerCount = parseProviderCount(aggregates.distinctCount.providerId, params.commitment, "total")
-		const liquidityByChain = connection.groupedAggregates.map((group, index) => {
-			const [chain, tokenAddress] = group.keys
-			if (!chain?.trim() || !tokenAddress) {
-				throw new InvalidAvailableLiquiditySnapshotError(
-					params.commitment,
-					`liquidity group ${index} has invalid keys`,
-				)
-			}
-			const normalizedTokenAddress = normalizeIndexedLiquidityAddress(
-				tokenAddress,
-				params.commitment,
-				`liquidity group ${index} tokenAddress`,
-			)
-			if (normalizedTokenAddress !== params.tokenAddress) {
-				throw new InvalidAvailableLiquiditySnapshotError(
-					params.commitment,
-					`liquidity group ${index} tokenAddress does not match the snapshot output token`,
-				)
-			}
-
-			return {
-				chain: chain.trim(),
-				tokenAddress: normalizedTokenAddress,
-				totalLiquidity: parseSnapshotBigInt(
-					group.sum.balance ?? "0",
-					params.commitment,
-					`liquidity group ${index} balance`,
-				),
-				providerCount: parseProviderCount(
-					group.distinctCount.providerId,
-					params.commitment,
-					`liquidity group ${index}`,
-				),
-			}
-		})
-		const groupedTotal = liquidityByChain.reduce((sum, group) => sum + group.totalLiquidity, 0n)
-		if (groupedTotal !== totalLiquidity) {
-			throw new InvalidAvailableLiquiditySnapshotError(
-				params.commitment,
-				"grouped liquidity does not match the total liquidity",
-			)
-		}
-
-		return { totalLiquidity, providerCount, liquidityByChain }
-	}
-
-	/** Formats a raw amount using the configured decimals for its chain/token. */
-	private formatLiquidity(amount: bigint, chain: string, tokenAddress: HexString, commitment: string): string {
-		const decimals = this.chainConfigService.getAssetMetadataByAddress(chain, tokenAddress)?.decimals
-		if (decimals === undefined) {
-			throw new InvalidAvailableLiquiditySnapshotError(
-				commitment,
-				`token decimals are not configured for ${tokenAddress} on ${chain}`,
-			)
-		}
-		return formatUnits(amount, decimals)
 	}
 }
 
-type RawAvailableLiquidityByChain = Omit<AvailableLiquidityByChain, "totalLiquidity"> & {
-	totalLiquidity: bigint
-}
-
-class InvalidAvailableLiquiditySnapshotError extends Error {
-	/** Creates an error that identifies the invalid snapshot and field/reason. */
-	constructor(commitment: string, reason: string) {
-		super(`Invalid available-liquidity snapshot ${commitment}: ${reason}`)
-		this.name = "InvalidAvailableLiquiditySnapshotError"
-	}
-}
-
-/** Parses a non-negative smallest-unit amount returned by the indexer. */
-function parseSnapshotBigInt(value: string, commitment: string, field: string): bigint {
-	try {
-		const amount = BigInt(value)
-		if (amount < 0n) {
-			throw new InvalidAvailableLiquiditySnapshotError(commitment, `${field} cannot be negative`)
-		}
-		return amount
-	} catch (error) {
-		if (error instanceof InvalidAvailableLiquiditySnapshotError) throw error
-		throw new InvalidAvailableLiquiditySnapshotError(commitment, `${field} is not an integer`)
-	}
-}
-
-/** Parses a safe, non-negative distinct-provider count returned by the indexer. */
-function parseProviderCount(value: string, commitment: string, field: string): number {
-	const count = Number(value)
-	if (!Number.isSafeInteger(count) || count < 0) {
-		throw new InvalidAvailableLiquiditySnapshotError(commitment, `${field} provider count is invalid`)
-	}
-	return count
-}
-
-/** Validates and canonicalizes an EVM address from a Nexus aggregate group. */
-function normalizeIndexedLiquidityAddress(address: string, commitment: string, field: string): HexString {
-	try {
-		return normalizeEvmAddress(address, field)
-	} catch {
-		throw new InvalidAvailableLiquiditySnapshotError(commitment, `${field} is not a valid EVM address`)
+function resolvePoolQuery(tokenInSymbol: string, tokenOutSymbol: string): ResolvedPoolQuery {
+	const inputIsToken0 = tokenInSymbol.toLowerCase() <= tokenOutSymbol.toLowerCase()
+	return {
+		poolId: inputIsToken0 ? `${tokenInSymbol}-${tokenOutSymbol}` : `${tokenOutSymbol}-${tokenInSymbol}`,
+		direction: inputIsToken0 ? SELL : BUY,
 	}
 }

--- a/sdk/packages/sdk/src/protocols/intents/index.ts
+++ b/sdk/packages/sdk/src/protocols/intents/index.ts
@@ -1,4 +1,10 @@
 export { IntentGateway } from "./IntentGateway"
+export {
+	InvalidLiquidityIndexerResponseError,
+	UnsupportedLiquidityAssetError,
+	UnsupportedLiquidityChainError,
+} from "./LiquidityEngine"
+export { poolSlug, sortPoolSymbols } from "./liquidity-pool"
 export { OrderStatusChecker } from "./OrderStatusChecker"
 export {
 	InvalidPhantomSnapshotError,

--- a/sdk/packages/sdk/src/protocols/intents/liquidity-pool.ts
+++ b/sdk/packages/sdk/src/protocols/intents/liquidity-pool.ts
@@ -4,7 +4,12 @@ export interface ResolvedLiquidityPool<Symbol extends string = string> {
 	token1Symbol: Symbol
 }
 
-/** Canonical symbol order used by the SDK and indexer pool IDs. */
+/**
+ * Canonical symbol order used by the SDK and indexer pool IDs.
+ *
+ * Plain code-unit comparison, never locale-sensitive collation — the result is
+ * a persisted primary key and must sort identically everywhere.
+ */
 export function sortPoolSymbols<Symbol extends string>(symbolA: Symbol, symbolB: Symbol): [Symbol, Symbol] {
 	return symbolA.toLowerCase() <= symbolB.toLowerCase() ? [symbolA, symbolB] : [symbolB, symbolA]
 }

--- a/sdk/packages/sdk/src/protocols/intents/liquidity-pool.ts
+++ b/sdk/packages/sdk/src/protocols/intents/liquidity-pool.ts
@@ -1,0 +1,27 @@
+export interface ResolvedLiquidityPool<Symbol extends string = string> {
+	poolId: string
+	token0Symbol: Symbol
+	token1Symbol: Symbol
+}
+
+/** Canonical symbol order used by the SDK and indexer pool IDs. */
+export function sortPoolSymbols<Symbol extends string>(symbolA: Symbol, symbolB: Symbol): [Symbol, Symbol] {
+	return symbolA.toLowerCase() <= symbolB.toLowerCase() ? [symbolA, symbolB] : [symbolB, symbolA]
+}
+
+/** Canonical indexer pool ID for a pair of canonical token symbols. */
+export function poolSlug(symbolA: string, symbolB: string): string {
+	return sortPoolSymbols(symbolA, symbolB).join("-")
+}
+
+export function resolveLiquidityPool<Symbol extends string>(
+	symbolA: Symbol,
+	symbolB: Symbol,
+): ResolvedLiquidityPool<Symbol> {
+	const [token0Symbol, token1Symbol] = sortPoolSymbols(symbolA, symbolB)
+	return {
+		poolId: `${token0Symbol}-${token1Symbol}`,
+		token0Symbol,
+		token1Symbol,
+	}
+}

--- a/sdk/packages/sdk/src/queries.ts
+++ b/sdk/packages/sdk/src/queries.ts
@@ -265,53 +265,43 @@ query LatestPhantomOrderPriceSnapshot($tokenA: String!, $tokenB: String!) {
   }
 }`
 
-export const LATEST_PHANTOM_ORDER_LIQUIDITY_SNAPSHOT = `
-query LatestPhantomOrderLiquiditySnapshot($tokenA: String!, $tokenB: String!) {
-  phantomOrderPriceSnapshots(
+export const AVAILABLE_LIQUIDITY = `
+query AvailableLiquidity(
+  $poolId: String!
+  $sourceChain: String!
+  $destinationChain: String!
+  $direction: String!
+) {
+  poolChainLiquidities(
     filter: {
       and: [
-        { tokenA: { equalTo: $tokenA } }
-        { tokenB: { equalTo: $tokenB } }
+        { poolId: { equalTo: $poolId } }
+        { chain: { equalTo: $destinationChain } }
+        { direction: { equalTo: $direction } }
       ]
     }
-    orderBy: SNAPSHOT_TIME_DESC
     first: 1
   ) {
     nodes {
-      commitment
-      tokenA
-      tokenB
-      snapshotTime
+      depth
+      bidCount
+      lastUpdatedAt
     }
   }
-}`
-
-export const LIQUIDITY_PROVIDER_BALANCES = `
-query LiquidityProviderBalanceAggregates($commitment: String!, $tokenAddress: String!) {
-  liquidityProviderBalances(
+  poolRoutes(
     filter: {
       and: [
-        { commitment: { equalTo: $commitment } }
-        { tokenAddress: { equalTo: $tokenAddress } }
+        { poolId: { equalTo: $poolId } }
+        { sourceChain: { equalTo: $sourceChain } }
+        { chain: { equalTo: $destinationChain } }
+        { direction: { equalTo: $direction } }
       ]
     }
+    first: 1
   ) {
-    aggregates {
-      sum {
-        balance
-      }
-      distinctCount {
-        providerId
-      }
-    }
-    groupedAggregates(groupBy: [CHAIN, TOKEN_ADDRESS]) {
-      keys
-      sum {
-        balance
-      }
-      distinctCount {
-        providerId
-      }
+    nodes {
+      depth
+      bidCount
     }
   }
 }`

--- a/sdk/packages/sdk/src/queries.ts
+++ b/sdk/packages/sdk/src/queries.ts
@@ -285,6 +285,8 @@ query AvailableLiquidity(
     nodes {
       depth
       bidCount
+      unrestrictedDepth
+      unrestrictedBidCount
       lastUpdatedAt
     }
   }
@@ -302,6 +304,18 @@ query AvailableLiquidity(
     nodes {
       depth
       bidCount
+      lastUpdatedAt
+    }
+  }
+}`
+
+export const BUY_AND_SELL_RATES = `
+query BuyAndSellRates($poolId: ID!) {
+  liquidityPools(filter: { id: { equalTo: $poolId } }, first: 1) {
+    nodes {
+      sellRate
+      buyRate
+      lastUpdatedAt
     }
   }
 }`

--- a/sdk/packages/sdk/src/queries.ts
+++ b/sdk/packages/sdk/src/queries.ts
@@ -275,7 +275,7 @@ query AvailableLiquidity(
   poolChainLiquidities(
     filter: {
       and: [
-        { poolId: { equalTo: $poolId } }
+        { poolId: { equalToInsensitive: $poolId } }
         { chain: { equalTo: $destinationChain } }
         { direction: { equalTo: $direction } }
       ]
@@ -293,7 +293,7 @@ query AvailableLiquidity(
   poolRoutes(
     filter: {
       and: [
-        { poolId: { equalTo: $poolId } }
+        { poolId: { equalToInsensitive: $poolId } }
         { sourceChain: { equalTo: $sourceChain } }
         { chain: { equalTo: $destinationChain } }
         { direction: { equalTo: $direction } }
@@ -310,11 +310,40 @@ query AvailableLiquidity(
 }`
 
 export const BUY_AND_SELL_RATES = `
-query BuyAndSellRates($poolId: ID!) {
-  liquidityPools(filter: { id: { equalTo: $poolId } }, first: 1) {
+query BuyAndSellRates(
+  $poolId: String!
+  $directChain: String!
+  $directDirection: String!
+  $reverseChain: String!
+  $reverseDirection: String!
+) {
+  direct: poolChainLiquidities(
+    filter: {
+      and: [
+        { poolId: { equalToInsensitive: $poolId } }
+        { chain: { equalTo: $directChain } }
+        { direction: { equalTo: $directDirection } }
+      ]
+    }
+    first: 1
+  ) {
     nodes {
-      sellRate
-      buyRate
+      rate
+      lastUpdatedAt
+    }
+  }
+  reverse: poolChainLiquidities(
+    filter: {
+      and: [
+        { poolId: { equalToInsensitive: $poolId } }
+        { chain: { equalTo: $reverseChain } }
+        { direction: { equalTo: $reverseDirection } }
+      ]
+    }
+    first: 1
+  ) {
+    nodes {
+      rate
       lastUpdatedAt
     }
   }

--- a/sdk/packages/sdk/src/tests/sequential/intentGateway.test.ts
+++ b/sdk/packages/sdk/src/tests/sequential/intentGateway.test.ts
@@ -1,11 +1,12 @@
 import "log-timestamp"
 
 import { strict as assert } from "node:assert"
-import { decodeFunctionData, type PublicClient } from "viem"
+import { decodeFunctionData, parseUnits, type PublicClient } from "viem"
 import { ABI as IntentGatewayV2ABI } from "@/abis/IntentGatewayV2"
 import type { AvailableLiquiditySnapshot, HexString, Order, TokenInfo } from "@/types"
 import { EvmChain } from "@/chain"
 import { IntentGateway } from "@/protocols/intents/IntentGateway"
+import { LiquidityEngine } from "@/protocols/intents/LiquidityEngine"
 import { DEFAULT_GRAFFITI } from "@/protocols/intents/types"
 import { createQueryClient } from "@/queryClient"
 import {
@@ -87,46 +88,86 @@ describe("Intent quote helper", () => {
 	it("queries live USDC to cNGN liquidity", async () => {
 		const configService = new ChainConfigService()
 		const cNgnAddress = configService.getCNgnAsset(BASE_CHAIN)
-
 		assert(cNgnAddress, "Expected cNGN to be configured on Base")
 
 		const intentGateway = await createLiveBaseIntentGateway(configService)
-
 		const liquidity = await intentGateway.queryAvailableLiquidity({
 			tokenIn: configService.getUsdcAsset(BASE_CHAIN),
 			tokenOut: cNgnAddress,
 		})
 
-		assertAndLogLiquidity("USDC → cNGN", liquidity, cNgnAddress)
+		assertAndLogLiquidity("USDC → cNGN", liquidity, cNgnAddress, "cNGN-USDC", "BUY")
 	}, 120_000)
 
 	it("queries live cNGN to USDC liquidity", async () => {
 		const configService = new ChainConfigService()
 		const cNgnAddress = configService.getCNgnAsset(BASE_CHAIN)
 		const usdcAddress = configService.getUsdcAsset(BASE_CHAIN)
-
 		assert(cNgnAddress, "Expected cNGN to be configured on Base")
-		const intentGateway = await createLiveBaseIntentGateway(configService)
-		const liquidity = await intentGateway.queryAvailableLiquidity({
-			tokenIn: cNgnAddress,
-			tokenOut: usdcAddress,
-		})
 
-		assertAndLogLiquidity("cNGN → USDC", liquidity, usdcAddress)
+		const intentGateway = await createLiveBaseIntentGateway(configService)
+		const liquidity = await intentGateway.queryAvailableLiquidity({ tokenIn: cNgnAddress, tokenOut: usdcAddress })
+
+		assertAndLogLiquidity("cNGN → USDC", liquidity, usdcAddress, "cNGN-USDC", "SELL")
 	}, 120_000)
 
-	it("resolves Base USDT to the canonical USDC to cNGN liquidity snapshot", async () => {
+	it("queries the indexed Base USDT to cNGN pool directly", async () => {
 		const configService = new ChainConfigService()
 		const cNgnAddress = configService.getCNgnAsset(BASE_CHAIN)
-
 		assert(cNgnAddress, "Expected cNGN to be configured on Base")
+
 		const intentGateway = await createLiveBaseIntentGateway(configService)
 		const liquidity = await intentGateway.queryAvailableLiquidity({
 			tokenIn: configService.getUsdtAsset(BASE_CHAIN),
 			tokenOut: cNgnAddress,
 		})
 
-		assertAndLogLiquidity("USDT → cNGN (canonical USDC snapshot)", liquidity, cNgnAddress)
+		assertAndLogLiquidity("USDT → cNGN", liquidity, cNgnAddress, "cNGN-USDT", "BUY")
+	}, 120_000)
+
+	it("uses the indexer's explicit route for a cross-chain source", async () => {
+		const configService = new ChainConfigService()
+		const cNgnAddress = configService.getCNgnAsset(BASE_CHAIN)
+		assert(cNgnAddress, "Expected cNGN to be configured on Base")
+		const sourceUsdc = configService.getUsdcAsset(CHAINS.eth.id)
+		const sourceToken = configService.getAssetMetadataByAddress(CHAINS.eth.id, sourceUsdc)
+		const destinationToken = configService.getAssetMetadataByAddress(BASE_CHAIN, cNgnAddress)
+		assert(sourceToken, "Expected Ethereum USDC metadata")
+		assert(destinationToken, "Expected Base cNGN metadata")
+
+		const engine = new LiquidityEngine(
+			createQueryClient({ url: "https://nexus.indexer.polytope.technology/" }),
+		)
+		const [destinationLiquidity, routeLiquidity] = await Promise.all([
+			engine.getAvailableLiquiditySnapshot({
+				sourceChain: BASE_CHAIN,
+				destinationChain: BASE_CHAIN,
+				tokenInSymbol: sourceToken.symbol,
+				tokenOutSymbol: destinationToken.symbol,
+				tokenOut: destinationToken.address,
+			}),
+			engine.getAvailableLiquiditySnapshot({
+				sourceChain: CHAINS.eth.id,
+				destinationChain: BASE_CHAIN,
+				tokenInSymbol: sourceToken.symbol,
+				tokenOutSymbol: destinationToken.symbol,
+				tokenOut: destinationToken.address,
+			}),
+		])
+
+		logLiquidity("Base destination depth", destinationLiquidity)
+		logLiquidity("Ethereum → Base explicit route", routeLiquidity)
+		assert(destinationLiquidity, "Expected indexed Base destination liquidity")
+		assert(routeLiquidity, "Expected indexed Ethereum → Base route result")
+		assert.equal(routeLiquidity.poolId, "cNGN-USDC")
+		assert.equal(routeLiquidity.direction, "BUY")
+		assert.equal(routeLiquidity.sourceChain, CHAINS.eth.id)
+		assert.equal(routeLiquidity.destinationChain, BASE_CHAIN)
+		assert.equal(routeLiquidity.tokenAddress.toLowerCase(), cNgnAddress.toLowerCase())
+		assert(routeLiquidity.providerCount <= destinationLiquidity.providerCount)
+		assert(
+			parseUnits(routeLiquidity.totalLiquidity, 18) <= parseUnits(destinationLiquidity.totalLiquidity, 18),
+		)
 	}, 120_000)
 
 	it("quotes USDT through the Base USDC Phantom snapshot", async () => {
@@ -403,32 +444,33 @@ async function createLiveBaseIntentGateway(configService: ChainConfigService): P
 	)
 }
 
+function logLiquidity(label: string, liquidity: AvailableLiquiditySnapshot | undefined): void {
+	console.log(`[queryAvailableLiquidity] ${label}`)
+	console.log(
+		liquidity
+			? {
+					...liquidity,
+					snapshotTime: liquidity.snapshotTime.toISOString(),
+				}
+			: undefined,
+	)
+}
+
 function assertAndLogLiquidity(
 	pair: string,
 	liquidity: AvailableLiquiditySnapshot | undefined,
 	expectedTokenAddress: HexString,
+	expectedPoolId: string,
+	expectedDirection: AvailableLiquiditySnapshot["direction"],
 ): asserts liquidity is AvailableLiquiditySnapshot {
-	assert(liquidity, `Expected a live ${pair} Phantom liquidity snapshot from Nexus`)
-	console.log(`Live ${pair} liquidity snapshot from Nexus`)
-	console.log({
-		totalLiquidity: liquidity.totalLiquidity,
-		providerCount: liquidity.providerCount,
-		tokenAddress: liquidity.tokenAddress,
-		snapshotTime: liquidity.snapshotTime.toISOString(),
-		liquidityByChain: liquidity.liquidityByChain,
-	})
+	logLiquidity(pair, liquidity)
+	assert(liquidity, `Expected live ${pair} indexed pool liquidity from Nexus`)
 	assert.notEqual(liquidity.totalLiquidity, "0")
 	assert(liquidity.providerCount > 0)
+	assert.equal(liquidity.poolId, expectedPoolId)
+	assert.equal(liquidity.direction, expectedDirection)
 	assert.equal(liquidity.tokenAddress.toLowerCase(), expectedTokenAddress.toLowerCase())
 	assert(!Number.isNaN(liquidity.snapshotTime.getTime()))
-	assert(liquidity.liquidityByChain.length > 0)
-	assert(
-		liquidity.liquidityByChain.some(
-			(group) =>
-				group.chain === CHAINS.base.id &&
-				group.tokenAddress.toLowerCase() === expectedTokenAddress.toLowerCase(),
-		),
-	)
 }
 
 function buildOrder(

--- a/sdk/packages/sdk/src/tests/sequential/intentGateway.test.ts
+++ b/sdk/packages/sdk/src/tests/sequential/intentGateway.test.ts
@@ -122,7 +122,12 @@ describe("Intent quote helper", () => {
 			tokenOut: cNgnAddress,
 		})
 
-		assertAndLogLiquidity("USDT → cNGN", liquidity, cNgnAddress)
+		logLiquidity("USDT → cNGN", liquidity)
+		assert(liquidity, "Expected an indexed Base USDT → cNGN pool sample")
+		assert.equal(liquidity.tokenAddress, cNgnAddress.toLowerCase())
+		assert(!Number.isNaN(liquidity.updatedAt.getTime()))
+		assert(parseUnits(liquidity.destination.totalLiquidity, 18) >= 0n)
+		assert(liquidity.destination.providerCount >= 0)
 	}, 120_000)
 
 	it("reports destination, unrestricted, and explicit cross-chain liquidity separately", async () => {
@@ -148,17 +153,18 @@ describe("Intent quote helper", () => {
 		assert.equal(liquidity.sourceChain, CHAINS.eth.id)
 		assert.equal(liquidity.destinationChain, BASE_CHAIN)
 		assert.equal(liquidity.tokenAddress, cNgnAddress.toLowerCase())
-		assert(parseUnits(liquidity.unrestricted.totalLiquidity, 18) > 0n)
-		assert(liquidity.unrestricted.providerCount > 0)
+		assert(parseUnits(liquidity.destination.totalLiquidity, 18) > 0n)
 		assert(
 			parseUnits(liquidity.unrestricted.totalLiquidity, 18) <=
 				parseUnits(liquidity.destination.totalLiquidity, 18),
 		)
+		assert(liquidity.unrestricted.providerCount <= liquidity.destination.providerCount)
 		if (liquidity.explicitRoute) {
 			assert(
 				parseUnits(liquidity.explicitRoute.totalLiquidity, 18) <=
 					parseUnits(liquidity.destination.totalLiquidity, 18),
 			)
+			assert(liquidity.explicitRoute.providerCount <= liquidity.destination.providerCount)
 		}
 	}, 120_000)
 
@@ -167,20 +173,19 @@ describe("Intent quote helper", () => {
 		const intentGateway = await createLiveBaseIntentGateway(configService)
 		const rates = await intentGateway.queryBuyAndSellRates({
 			tokenInSymbol: "USDC",
-			tokenOutSymbol: "cNGN",
+			tokenOutSymbol: "cngn",
 			sourceChainId: 1,
 			destinationChainId: 8453,
 		})
 
 		logRates("Ethereum USDC → Base cNGN", rates)
-		assert(rates, "Expected live cNGN-USDC rates from Nexus")
-		assert.equal(rates.poolId, "cNGN-USDC")
-		assert.equal(rates.token0Symbol, "cNGN")
-		assert.equal(rates.token1Symbol, "USDC")
-		assert.equal(rates.sourceChain, CHAINS.eth.id)
-		assert.equal(rates.destinationChain, BASE_CHAIN)
-		assert(rates.sellRate && parseUnits(rates.sellRate, 18) > 0n)
-		assert(rates.buyRate && parseUnits(rates.buyRate, 18) > 0n)
+		assert(rates, "Expected live chain-specific cNGN/USDC rates from Nexus")
+		assert.equal(rates.baseTokenSymbol, "USDC")
+		assert.equal(rates.quoteTokenSymbol, "cNGN")
+		assert(rates.buyRate && parseUnits(rates.buyRate, 18) > 1_000n * 10n ** 18n)
+		assert(rates.sellRate && parseUnits(rates.sellRate, 18) > 1_000n * 10n ** 18n)
+		assert(rates.buyRateUpdatedAt && !Number.isNaN(rates.buyRateUpdatedAt.getTime()))
+		assert(rates.sellRateUpdatedAt && !Number.isNaN(rates.sellRateUpdatedAt.getTime()))
 	}, 120_000)
 
 	it("quotes USDT through the Base USDC Phantom snapshot", async () => {
@@ -474,7 +479,15 @@ function logLiquidity(label: string, liquidity: AvailableLiquidity | undefined):
 
 function logRates(label: string, rates: BuyAndSellRates | undefined): void {
 	console.log(`[queryBuyAndSellRates] ${label}`)
-	console.log(rates ? { ...rates, lastUpdatedAt: rates.lastUpdatedAt.toISOString() } : undefined)
+	console.log(
+		rates
+			? {
+					...rates,
+					buyRateUpdatedAt: rates.buyRateUpdatedAt?.toISOString() ?? null,
+					sellRateUpdatedAt: rates.sellRateUpdatedAt?.toISOString() ?? null,
+				}
+			: undefined,
+	)
 }
 
 function assertAndLogLiquidity(

--- a/sdk/packages/sdk/src/tests/sequential/intentGateway.test.ts
+++ b/sdk/packages/sdk/src/tests/sequential/intentGateway.test.ts
@@ -3,7 +3,7 @@ import "log-timestamp"
 import { strict as assert } from "node:assert"
 import { decodeFunctionData, parseUnits, type PublicClient } from "viem"
 import { ABI as IntentGatewayV2ABI } from "@/abis/IntentGatewayV2"
-import type { AvailableLiquiditySnapshot, HexString, Order, TokenInfo } from "@/types"
+import type { AvailableLiquidity, BuyAndSellRates, HexString, Order, TokenInfo } from "@/types"
 import { EvmChain } from "@/chain"
 import { IntentGateway } from "@/protocols/intents/IntentGateway"
 import { LiquidityEngine } from "@/protocols/intents/LiquidityEngine"
@@ -96,7 +96,7 @@ describe("Intent quote helper", () => {
 			tokenOut: cNgnAddress,
 		})
 
-		assertAndLogLiquidity("USDC → cNGN", liquidity, cNgnAddress, "cNGN-USDC", "BUY")
+		assertAndLogLiquidity("USDC → cNGN", liquidity, cNgnAddress)
 	}, 120_000)
 
 	it("queries live cNGN to USDC liquidity", async () => {
@@ -108,7 +108,7 @@ describe("Intent quote helper", () => {
 		const intentGateway = await createLiveBaseIntentGateway(configService)
 		const liquidity = await intentGateway.queryAvailableLiquidity({ tokenIn: cNgnAddress, tokenOut: usdcAddress })
 
-		assertAndLogLiquidity("cNGN → USDC", liquidity, usdcAddress, "cNGN-USDC", "SELL")
+		assertAndLogLiquidity("cNGN → USDC", liquidity, usdcAddress)
 	}, 120_000)
 
 	it("queries the indexed Base USDT to cNGN pool directly", async () => {
@@ -122,10 +122,10 @@ describe("Intent quote helper", () => {
 			tokenOut: cNgnAddress,
 		})
 
-		assertAndLogLiquidity("USDT → cNGN", liquidity, cNgnAddress, "cNGN-USDT", "BUY")
+		assertAndLogLiquidity("USDT → cNGN", liquidity, cNgnAddress)
 	}, 120_000)
 
-	it("uses the indexer's explicit route for a cross-chain source", async () => {
+	it("reports destination, unrestricted, and explicit cross-chain liquidity separately", async () => {
 		const configService = new ChainConfigService()
 		const cNgnAddress = configService.getCNgnAsset(BASE_CHAIN)
 		assert(cNgnAddress, "Expected cNGN to be configured on Base")
@@ -138,36 +138,49 @@ describe("Intent quote helper", () => {
 		const engine = new LiquidityEngine(
 			createQueryClient({ url: "https://nexus.indexer.polytope.technology/" }),
 		)
-		const [destinationLiquidity, routeLiquidity] = await Promise.all([
-			engine.getAvailableLiquiditySnapshot({
-				sourceChain: BASE_CHAIN,
-				destinationChain: BASE_CHAIN,
-				tokenInSymbol: sourceToken.symbol,
-				tokenOutSymbol: destinationToken.symbol,
-				tokenOut: destinationToken.address,
-			}),
-			engine.getAvailableLiquiditySnapshot({
-				sourceChain: CHAINS.eth.id,
-				destinationChain: BASE_CHAIN,
-				tokenInSymbol: sourceToken.symbol,
-				tokenOutSymbol: destinationToken.symbol,
-				tokenOut: destinationToken.address,
-			}),
-		])
+		const liquidity = await engine.getAvailableLiquidity({
+			source: { chain: CHAINS.eth.id, ...sourceToken },
+			destination: { chain: BASE_CHAIN, ...destinationToken },
+		})
 
-		logLiquidity("Base destination depth", destinationLiquidity)
-		logLiquidity("Ethereum → Base explicit route", routeLiquidity)
-		assert(destinationLiquidity, "Expected indexed Base destination liquidity")
-		assert(routeLiquidity, "Expected indexed Ethereum → Base route result")
-		assert.equal(routeLiquidity.poolId, "cNGN-USDC")
-		assert.equal(routeLiquidity.direction, "BUY")
-		assert.equal(routeLiquidity.sourceChain, CHAINS.eth.id)
-		assert.equal(routeLiquidity.destinationChain, BASE_CHAIN)
-		assert.equal(routeLiquidity.tokenAddress.toLowerCase(), cNgnAddress.toLowerCase())
-		assert(routeLiquidity.providerCount <= destinationLiquidity.providerCount)
+		logLiquidity("Ethereum USDC → Base cNGN", liquidity)
+		assert(liquidity, "Expected indexed Base destination liquidity")
+		assert.equal(liquidity.sourceChain, CHAINS.eth.id)
+		assert.equal(liquidity.destinationChain, BASE_CHAIN)
+		assert.equal(liquidity.tokenAddress, cNgnAddress.toLowerCase())
+		assert(parseUnits(liquidity.unrestricted.totalLiquidity, 18) > 0n)
+		assert(liquidity.unrestricted.providerCount > 0)
 		assert(
-			parseUnits(routeLiquidity.totalLiquidity, 18) <= parseUnits(destinationLiquidity.totalLiquidity, 18),
+			parseUnits(liquidity.unrestricted.totalLiquidity, 18) <=
+				parseUnits(liquidity.destination.totalLiquidity, 18),
 		)
+		if (liquidity.explicitRoute) {
+			assert(
+				parseUnits(liquidity.explicitRoute.totalLiquidity, 18) <=
+					parseUnits(liquidity.destination.totalLiquidity, 18),
+			)
+		}
+	}, 120_000)
+
+	it("queries buy and sell rates using only symbols and chain IDs", async () => {
+		const configService = new ChainConfigService()
+		const intentGateway = await createLiveBaseIntentGateway(configService)
+		const rates = await intentGateway.queryBuyAndSellRates({
+			tokenInSymbol: "USDC",
+			tokenOutSymbol: "cNGN",
+			sourceChainId: 1,
+			destinationChainId: 8453,
+		})
+
+		logRates("Ethereum USDC → Base cNGN", rates)
+		assert(rates, "Expected live cNGN-USDC rates from Nexus")
+		assert.equal(rates.poolId, "cNGN-USDC")
+		assert.equal(rates.token0Symbol, "cNGN")
+		assert.equal(rates.token1Symbol, "USDC")
+		assert.equal(rates.sourceChain, CHAINS.eth.id)
+		assert.equal(rates.destinationChain, BASE_CHAIN)
+		assert(rates.sellRate && parseUnits(rates.sellRate, 18) > 0n)
+		assert(rates.buyRate && parseUnits(rates.buyRate, 18) > 0n)
 	}, 120_000)
 
 	it("quotes USDT through the Base USDC Phantom snapshot", async () => {
@@ -444,33 +457,40 @@ async function createLiveBaseIntentGateway(configService: ChainConfigService): P
 	)
 }
 
-function logLiquidity(label: string, liquidity: AvailableLiquiditySnapshot | undefined): void {
+function logLiquidity(label: string, liquidity: AvailableLiquidity | undefined): void {
 	console.log(`[queryAvailableLiquidity] ${label}`)
 	console.log(
 		liquidity
 			? {
 					...liquidity,
-					snapshotTime: liquidity.snapshotTime.toISOString(),
+					updatedAt: liquidity.updatedAt.toISOString(),
+					explicitRoute: liquidity.explicitRoute
+						? { ...liquidity.explicitRoute, updatedAt: liquidity.explicitRoute.updatedAt.toISOString() }
+						: null,
 				}
 			: undefined,
 	)
 }
 
+function logRates(label: string, rates: BuyAndSellRates | undefined): void {
+	console.log(`[queryBuyAndSellRates] ${label}`)
+	console.log(rates ? { ...rates, lastUpdatedAt: rates.lastUpdatedAt.toISOString() } : undefined)
+}
+
 function assertAndLogLiquidity(
 	pair: string,
-	liquidity: AvailableLiquiditySnapshot | undefined,
+	liquidity: AvailableLiquidity | undefined,
 	expectedTokenAddress: HexString,
-	expectedPoolId: string,
-	expectedDirection: AvailableLiquiditySnapshot["direction"],
-): asserts liquidity is AvailableLiquiditySnapshot {
+): asserts liquidity is AvailableLiquidity {
 	logLiquidity(pair, liquidity)
 	assert(liquidity, `Expected live ${pair} indexed pool liquidity from Nexus`)
-	assert.notEqual(liquidity.totalLiquidity, "0")
-	assert(liquidity.providerCount > 0)
-	assert.equal(liquidity.poolId, expectedPoolId)
-	assert.equal(liquidity.direction, expectedDirection)
-	assert.equal(liquidity.tokenAddress.toLowerCase(), expectedTokenAddress.toLowerCase())
-	assert(!Number.isNaN(liquidity.snapshotTime.getTime()))
+	assert.notEqual(liquidity.destination.totalLiquidity, "0")
+	assert(liquidity.destination.providerCount > 0)
+	assert.equal(liquidity.tokenAddress, expectedTokenAddress.toLowerCase())
+	assert(!Number.isNaN(liquidity.updatedAt.getTime()))
+	assert(
+		parseUnits(liquidity.unrestricted.totalLiquidity, 18) <= parseUnits(liquidity.destination.totalLiquidity, 18),
+	)
 }
 
 function buildOrder(

--- a/sdk/packages/sdk/src/types/index.ts
+++ b/sdk/packages/sdk/src/types/index.ts
@@ -8,7 +8,7 @@ import type { Account } from "viem/accounts"
 export type { Account as ViemAccount } from "viem/accounts"
 import type HandlerV2 from "@/abis/handlerV2"
 import type { IChain } from "@/chain"
-import type { Chains, ConfiguredAssetSymbol } from "@/configs/chain"
+import type { Chains, ConfiguredAssetSymbol, ConfiguredAssetSymbolInput } from "@/configs/chain"
 import { Struct, Vector, Bytes, u8 } from "scale-ts"
 
 export type EstimateGasCallData = ContractFunctionArgs<
@@ -1176,24 +1176,28 @@ export interface AvailableLiquidity {
 	explicitRoute: (LiquiditySlice & { updatedAt: Date }) | null
 }
 
-/** Buy and sell rates for an indexed symbol pair, normalized from 18 decimals. */
+/**
+ * Chain-specific buy and sell rates expressed as quote-token units per one
+ * base token. The quote token is the less valuable currency when the indexed
+ * rates establish an ordering (for example, cNGN in a USDC/cNGN pair).
+ */
 export interface BuyAndSellRates {
-	poolId: string
-	token0Symbol: ConfiguredAssetSymbol
-	token1Symbol: ConfiguredAssetSymbol
+	baseTokenSymbol: ConfiguredAssetSymbol
+	quoteTokenSymbol: ConfiguredAssetSymbol
 	sourceChain: Chains
 	destinationChain: Chains
-	/** Token1 received for one token0. */
-	sellRate: string | null
-	/** Token0 received for one token1. */
+	/** Quote-token units received when buying the quote token with one base token. */
 	buyRate: string | null
-	lastUpdatedAt: Date
+	/** Quote-token units sold to receive one base token. */
+	sellRate: string | null
+	buyRateUpdatedAt: Date | null
+	sellRateUpdatedAt: Date | null
 }
 
 /** Symbol-only input for querying an indexed pool's rates. */
 export interface QueryBuyAndSellRatesParams {
-	tokenInSymbol: ConfiguredAssetSymbol
-	tokenOutSymbol: ConfiguredAssetSymbol
+	tokenInSymbol: ConfiguredAssetSymbolInput
+	tokenOutSymbol: ConfiguredAssetSymbolInput
 	sourceChainId: Chain["id"]
 	destinationChainId: Chain["id"]
 }

--- a/sdk/packages/sdk/src/types/index.ts
+++ b/sdk/packages/sdk/src/types/index.ts
@@ -1,13 +1,14 @@
 import type { ConsolaInstance } from "consola"
 import type Decimal from "decimal.js"
 import type { GraphQLClient } from "graphql-request"
-import type { ContractFunctionArgs, Hex, Log, PublicClient, TransactionReceipt } from "viem"
+import type { Chain, ContractFunctionArgs, Hex, Log, PublicClient, TransactionReceipt } from "viem"
 import type { Account } from "viem/accounts"
 
 /** Re-export: use this type when wiring a viem `Account` next to `SigningAccount` so you stay aligned with the SDK’s viem resolution. */
 export type { Account as ViemAccount } from "viem/accounts"
 import type HandlerV2 from "@/abis/handlerV2"
 import type { IChain } from "@/chain"
+import type { Chains, ConfiguredAssetSymbol } from "@/configs/chain"
 import { Struct, Vector, Bytes, u8 } from "scale-ts"
 
 export type EstimateGasCallData = ContractFunctionArgs<
@@ -1153,31 +1154,48 @@ export interface PhantomOrderPriceSnapshotsResponse {
 	}
 }
 
-/**
- * Solver liquidity from the indexer's latest pair sample.
- *
- * Liquidity amounts are decimal strings from the indexer's 18-decimal
- * normalized pool depths. Cross-chain results include only bidders represented
- * by an explicit indexed route. Amounts are upper bounds, not reserved fills.
- */
-export interface AvailableLiquiditySnapshot {
-	poolId: string
-	direction: "SELL" | "BUY"
-	sourceChain: string
-	destinationChain: string
+/** One independently reported slice of indexed liquidity. */
+export interface LiquiditySlice {
 	totalLiquidity: string
 	providerCount: number
-	tokenAddress: HexString
-	snapshotTime: Date
-	liquidityByChain: AvailableLiquidityByChain[]
 }
 
-/** Destination-chain representation retained for API compatibility. */
-export interface AvailableLiquidityByChain {
-	chain: string
+/**
+ * Indexed destination capacity and its source-routing slices.
+ *
+ * The SDK reports the indexer's facts separately and does not decide whether a
+ * source chain is covered by the legacy unrestricted-bidder policy.
+ */
+export interface AvailableLiquidity {
+	sourceChain: Chains
+	destinationChain: Chains
 	tokenAddress: HexString
-	totalLiquidity: string
-	providerCount: number
+	updatedAt: Date
+	destination: LiquiditySlice
+	unrestricted: LiquiditySlice
+	explicitRoute: (LiquiditySlice & { updatedAt: Date }) | null
+}
+
+/** Buy and sell rates for an indexed symbol pair, normalized from 18 decimals. */
+export interface BuyAndSellRates {
+	poolId: string
+	token0Symbol: ConfiguredAssetSymbol
+	token1Symbol: ConfiguredAssetSymbol
+	sourceChain: Chains
+	destinationChain: Chains
+	/** Token1 received for one token0. */
+	sellRate: string | null
+	/** Token0 received for one token1. */
+	buyRate: string | null
+	lastUpdatedAt: Date
+}
+
+/** Symbol-only input for querying an indexed pool's rates. */
+export interface QueryBuyAndSellRatesParams {
+	tokenInSymbol: ConfiguredAssetSymbol
+	tokenOutSymbol: ConfiguredAssetSymbol
+	sourceChainId: Chain["id"]
+	destinationChainId: Chain["id"]
 }
 
 export interface TokenPrice {

--- a/sdk/packages/sdk/src/types/index.ts
+++ b/sdk/packages/sdk/src/types/index.ts
@@ -1154,12 +1154,17 @@ export interface PhantomOrderPriceSnapshotsResponse {
 }
 
 /**
- * Total solver liquidity measured at one immutable Phantom price snapshot.
+ * Solver liquidity from the indexer's latest pair sample.
  *
- * Liquidity amounts are decimal strings formatted with the configured decimals
- * for their respective `tokenAddress` and chain.
+ * Liquidity amounts are decimal strings from the indexer's 18-decimal
+ * normalized pool depths. Cross-chain results include only bidders represented
+ * by an explicit indexed route. Amounts are upper bounds, not reserved fills.
  */
 export interface AvailableLiquiditySnapshot {
+	poolId: string
+	direction: "SELL" | "BUY"
+	sourceChain: string
+	destinationChain: string
 	totalLiquidity: string
 	providerCount: number
 	tokenAddress: HexString
@@ -1167,7 +1172,7 @@ export interface AvailableLiquiditySnapshot {
 	liquidityByChain: AvailableLiquidityByChain[]
 }
 
-/** Liquidity for one chain/token balance group in an availability snapshot. */
+/** Destination-chain representation retained for API compatibility. */
 export interface AvailableLiquidityByChain {
 	chain: string
 	tokenAddress: HexString


### PR DESCRIPTION
## Summary

- Update `queryAvailableLiquidity` to use the latest indexer data
- Support same-chain and cross-chain liquidity queries
- Remove outdated Uniswap and snapshot logic
- Use configured token addresses
- Add live tests with result logging

## Testing

- Node and browser builds pass
- Live liquidity tests pass for USDC, USDT, cNGN, and cross-chain routes