### PR TITLE
[indexer]: Include declared Uniswap V4 positions in the swept LP balance

### DIFF
--- a/sdk/packages/indexer/src/configs/schema.graphql
+++ b/sdk/packages/indexer/src/configs/schema.graphql
@@ -2484,8 +2484,12 @@ type LiquidityProviderBalanceV2 @entity {
 	tokenAddress: String! @index
 
 	"""
-	Provider balance for tokenAddress on `chain`,
-	including raw ERC-20 balance and redeemable ERC-4626 vault positions.
+	Provider balance for tokenAddress on `chain`: raw ERC-20, redeemable ERC-4626 vault positions,
+	and the withdrawable amount held in the Uniswap V4 positions the provider declared in that
+	chain's phantom bid and still owns, valued at the pool price when the snapshot was taken. The
+	V4 share is only visible on the chain whose bid declared it — a bid is per chain, so no other
+	chain's sweep can see those positions — and only for a token some yield-vault entry tracks,
+	since the sweep has no row to attach it to otherwise.
 	"""
 	balance: BigInt! @index
 

--- a/sdk/packages/indexer/src/handlers/events/substrateChains/handlePhantomOrderPrices.handler.ts
+++ b/sdk/packages/indexer/src/handlers/events/substrateChains/handlePhantomOrderPrices.handler.ts
@@ -170,10 +170,21 @@ export const handlePhantomOrderPrices = wrap(async (event: SubstrateEvent): Prom
 		}
 		// One row per provider per (chain, token) per block so liquidity history is preserved.
 		// Every order closing on this block sweeps the same point-in-time balances, so the row is
-		// written by whichever of them runs first and skipped by the rest (and by replays); a
-		// solver first seen by a later order on the block still gets its rows here.
+		// written by whichever of them runs first; a solver first seen by a later order on the
+		// block still gets its rows here.
 		const id = `${lp.chain}-${lp.tokenAddress}-${blockNumber}-${lp.solver}`
-		if (await LiquidityProviderBalanceV2.get(id)) continue
+		const existing = await LiquidityProviderBalanceV2.get(id)
+		if (existing) {
+			// Only the chain whose own bid declared the positions can value them, and that order is
+			// not necessarily the one that wrote this row — every chain's sweep covers every chain,
+			// but sees V4 positions on its own chain alone. Take the larger reading so the stored
+			// value does not depend on which of the block's orders happened to run first.
+			if (lp.balance > existing.balance) {
+				existing.balance = lp.balance
+				await existing.save()
+			}
+			continue
+		}
 		await LiquidityProviderBalanceV2.create({
 			id,
 			providerId: lp.solver,

--- a/sdk/packages/sdk/src/protocols/intents/phantom-aggregation.ts
+++ b/sdk/packages/sdk/src/protocols/intents/phantom-aggregation.ts
@@ -314,6 +314,15 @@ export interface LpBalance {
 	/** State machine id of the chain the balance was measured on (e.g. EVM-8453). */
 	chain: string
 	tokenAddress: HexString
+	/**
+	 * Wallet ERC-20, redeemable ERC-4626 vault shares, and the withdrawable amount held in the
+	 * solver's declared Uniswap V4 positions — the same total the leg weights are built from, so a
+	 * provider's reported inventory and the depth attributed to it cannot disagree.
+	 *
+	 * The V4 share is only ever included on the chain whose bid declared the positions: a bid is
+	 * per chain, so no other chain's sweep can know about them. Consumers must therefore treat the
+	 * larger of two readings for the same (chain, token, block) as the complete one.
+	 */
 	balance: bigint
 }
 
@@ -824,6 +833,8 @@ async function sweepSolverLiquidity(
 	yieldVaults: YieldVaultMap,
 	solver: string,
 	getBalance: ReturnType<typeof memoizedSolverBalance>,
+	/** Verified positions and the chain they sit on; only that chain's tokens can draw on them. */
+	positions: { chain: string; states: V4PositionState[] },
 ): Promise<LpBalance[]> {
 	const balances: LpBalance[] = []
 	for (const [chain, tokens] of Object.entries(yieldVaults)) {
@@ -831,8 +842,24 @@ async function sweepSolverLiquidity(
 		if (!url) continue
 		for (const token of Object.keys(tokens)) {
 			const balance = await getBalance(url, chain, token, solver)
-			if (balance === 0n) continue
-			balances.push({ solver, chain, tokenAddress: token as HexString, balance })
+			const uniswapV4Balance =
+				chain === positions.chain
+					? positions.states.reduce(
+							(total, state) =>
+								total +
+								positionAmountOfToken({
+									info: state.info,
+									liquidity: state.liquidity,
+									sqrtPriceX96: state.sqrtPriceX96,
+									outputToken: token,
+								}),
+							0n,
+						)
+					: 0n
+			// A token the solver neither holds nor has parked in a position is not a row.
+			const total = balance + uniswapV4Balance
+			if (total === 0n) continue
+			balances.push({ solver, chain, tokenAddress: token as HexString, balance: total })
 		}
 	}
 	return balances
@@ -1074,7 +1101,12 @@ async function runAggregation(
 
 			// Full liquidity picture: every configured token on every supported chain. Swept once per
 			// bid rather than per leg, since it measures the solver's whole inventory either way.
-			lpBalances.push(...(await sweepSolverLiquidity(evmRpcUrls, yieldVaults, solver, getBalance)))
+			lpBalances.push(
+				...(await sweepSolverLiquidity(evmRpcUrls, yieldVaults, solver, getBalance, {
+					chain,
+					states: positions,
+				})),
+			)
 		} catch (err) {
 			// A malformed bid is this bid's problem — skip it and price the rest. An unreachable RPC
 			// is the snapshot's problem: continuing would silently price the order from whichever

--- a/sdk/packages/sdk/src/tests/phantomAggregation.test.ts
+++ b/sdk/packages/sdk/src/tests/phantomAggregation.test.ts
@@ -727,6 +727,25 @@ describe("aggregatePhantomBids bid verification", () => {
 			expect(result!.legs[0].bidders[0].weight).toBeGreaterThan(0n)
 		})
 
+		// The sweep is where a provider's inventory is reported, so a position missing from it makes
+		// the same solver look smaller there than the depth attributed to it — the two must agree.
+		it("reports the position in the liquidity sweep, not only in the leg weight", async () => {
+			const userOp = await signedBidUserOp({
+				signingKey: SOLVER_KEY,
+				paymasterAndData: encodePhantomBidDeclaration({ uniswapV4Positions: [TOKEN_ID] }),
+			})
+			setAggregationFetch(v4Rpc([userOp], solverAddress))
+
+			const result = await aggregateWithV4(solverAddress)
+
+			// The mock returns a zero ERC-20 balance for every token, so anything here is the position.
+			const swept = result!.lpBalances.find((lp) => lp.tokenAddress.toLowerCase() === USDT)
+			expect(swept).toBeDefined()
+			expect(swept!.balance).toBeGreaterThan(0n)
+			// And it is the same number the leg was weighted by, so inventory and depth cannot disagree.
+			expect(swept!.balance).toBe(result!.legs[0].bidders[0].weight)
+		})
+
 		// Regression: the Base StateView address was wrong, so slot0 answered "0x", every declared
 		// position resolved to null, and ~168k cNGN of real depth read as zero — silently, for as
 		// long as nobody thought to check. A misconfigured address must say so.


### PR DESCRIPTION


A provider's V4 liquidity was counted in the leg weight but not in the balance sweep, so the same solver looked smaller in LiquidityProviderBalanceV2 than the depth attributed to it in PoolBidder. Anyone checking whether a position was indexed would look at the sweep, see the wallet balance alone, and conclude it was not — which is exactly what happened.

The sweep now adds the withdrawable amount of each token held in the positions that chain's bid declared and the solver still owns, so reported inventory and attributed depth are built from the same total and cannot disagree.

Folded into `balance` rather than reported beside it, so there is one number per (provider, chain, token) as before. No structural schema change — only the field doc, which would otherwise still claim ERC-20 and ERC-4626 are all it covers.

Writes take the larger of two readings for the same row. Every chain's sweep covers every chain, but sees V4 positions on its own chain alone, and all of a block's orders race for the same row — so without this the stored value would depend on which order happened to run first.