### PR TITLE
[simplex]: route MPCVault typed-data signing through raw message hashes

### DIFF
--- a/sdk/packages/simplex/CHANGELOG.md
+++ b/sdk/packages/simplex/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @hyperbridge/filler
 
+## 0.9.4
+
+### Patch Changes
+
+- MPCVault signer: all EIP-712 typed-data signing (bid UserOps, delegation-via-bundler UserOps, Circle Paymaster permits) now hashes the payload locally and signs the 32-byte digest through MPCVault's raw-message path instead of `TYPE_SIGN_TYPED_DATA`. Signatures returned by the typed-data endpoint do not verify against the submitted payload's EIP-712 digest — every bid and delegation UserOp signed through it fails on-chain validation ("Invalid account signature" / AA24 from bundlers), while raw-message signatures from the same vault validate and execute (see #1132). Trade-off until the endpoint's behaviour is clarified: the MPCVault console shows an opaque 32-byte hash instead of the structured message. The live integration tests now assert signature **recovery** against the wallet address rather than just shape — the gap that let this ship undetected.
+
 ## 0.9.2
 
 ### Patch Changes

--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/simplex",
-	"version": "0.9.3",
+	"version": "0.9.4",
 	"license": "Apache-2.0",
 	"description": "IntentGateway simplex package for hyperbridge",
 	"main": "dist/index.js",

--- a/sdk/packages/simplex/src/services/wallet/accounts/mpc.ts
+++ b/sdk/packages/simplex/src/services/wallet/accounts/mpc.ts
@@ -1,5 +1,5 @@
 import type { HexString } from "@hyperbridge/sdk"
-import { keccak256, serializeTransaction } from "viem"
+import { concatHex, hashTypedData, keccak256, serializeTransaction, toHex, type TypedDataDefinition } from "viem"
 import { createMpcVaultAccount } from "../mpcvault"
 import type { MpcVaultSignerConfig, SigningAccount } from "../types"
 
@@ -11,11 +11,14 @@ export function createMpcVaultSigningAccount(config: MpcVaultSignerConfig): Sign
 		account,
 		signMessage: (messageHash: HexString, chainId: number) => service.signPersonalMessage(messageHash, chainId),
 		signRawHash,
-		signTypedData: (typedData: unknown, chainId?: number) =>
-			service.signTypedData(
-				JSON.stringify(typedData, (_k, v) => (typeof v === "bigint" ? v.toString() : v)),
-				chainId ?? 1,
-			),
+		// MPCVault's TYPE_SIGN_TYPED_DATA returns signatures that don't verify against
+		// the payload's EIP-712 digest (#1132). Hash locally and sign the raw digest —
+		// the same path the EIP-7702 flows use, whose signatures validate on-chain.
+		signTypedData: async (typedData: unknown, _chainId?: number) => {
+			const digest = hashTypedData(typedData as TypedDataDefinition)
+			const { r, s, yParity } = await service.signRawHashComponents(digest as HexString)
+			return concatHex([r, s, toHex(27 + yParity, { size: 1 })]) as HexString
+		},
 		sendEip7702DelegationTransaction: async (args) => {
 			const chainNonce = await args.publicClient.getTransactionCount({
 				address: args.authorityAddress,

--- a/sdk/packages/simplex/src/services/wallet/mpcvault.ts
+++ b/sdk/packages/simplex/src/services/wallet/mpcvault.ts
@@ -1,5 +1,5 @@
 import { type HexString } from "@hyperbridge/sdk"
-import { concatHex, keccak256, padHex, toHex } from "viem"
+import { concatHex, hashTypedData, keccak256, padHex, toHex } from "viem"
 import { toAccount, type Account } from "viem/accounts"
 import * as grpc from "@grpc/grpc-js"
 import {
@@ -187,6 +187,13 @@ export class MpcVaultService {
 		return this.signatureFromParts(this.extractEcdsaSignature(result, "personal_sign"), true)
 	}
 
+	/**
+	 * @deprecated Do not use for signatures that are verified on-chain. MPCVault's
+	 * TYPE_SIGN_TYPED_DATA returns signatures that do not verify against the EIP-712
+	 * digest of the submitted payload (#1132) — raw-message signatures from the same
+	 * vault validate fine. Hash the typed data locally (viem `hashTypedData`) and sign
+	 * via {@link signRawHashComponents} instead, as the signer adapters now do.
+	 */
 	async signTypedData(typedDataJson: string, chainId: number): Promise<HexString> {
 		const uuid = await this.createSigningRequest({
 			vaultUuid: this.vaultUuid,
@@ -323,11 +330,11 @@ export function createMpcVaultAccount(config: MpcVaultSignerConfig): { account: 
 			})
 		},
 		async signTypedData(typedDataDefinition): Promise<HexString> {
-			const typedData = typedDataDefinition as {
-				domain?: { chainId?: number | bigint }
-			}
-			const chainId = requireChainId(typedData.domain?.chainId, "typed-data signing")
-			return service.signTypedData(JSON.stringify(typedDataDefinition), chainId)
+			// MPCVault's TYPE_SIGN_TYPED_DATA returns signatures that don't verify against
+			// the payload's EIP-712 digest (#1132) — hash locally, sign the raw digest.
+			const digest = hashTypedData(typedDataDefinition as Parameters<typeof hashTypedData>[0])
+			const { r, s, yParity } = await service.signRawHashComponents(digest as HexString)
+			return concatHex([r, s, toHex(27 + yParity, { size: 1 })]) as HexString
 		},
 	})
 

--- a/sdk/packages/simplex/src/tests/wallet/mpcvault.integration.test.ts
+++ b/sdk/packages/simplex/src/tests/wallet/mpcvault.integration.test.ts
@@ -1,7 +1,7 @@
 import type { HexString } from "@hyperbridge/sdk"
 import { createMpcVaultAccount, MpcVaultService } from "@/services/wallet/mpcvault"
 import { describe, expect, it } from "vitest"
-import { isHex } from "viem"
+import { isHex, recoverAddress, recoverMessageAddress, recoverTypedDataAddress } from "viem"
 import "../setup"
 
 /**
@@ -101,7 +101,7 @@ describe.skipIf(!hasMpcVaultCredentials())("MPCVaultService integration", () => 
 		)
 	})
 
-	it("signRawHash completes create + execute and returns a 65-byte ECDSA hex signature", async () => {
+	it("signRawHash returns a 65-byte ECDSA signature that recovers the wallet address", async () => {
 		const service = createTestService()
 
 		const dummyHash = `0x${"ab".repeat(32)}` as HexString
@@ -109,9 +109,11 @@ describe.skipIf(!hasMpcVaultCredentials())("MPCVaultService integration", () => 
 
 		expect(isHex(sig)).toBe(true)
 		expect(sig.length).toBe(132)
+		const recovered = await recoverAddress({ hash: dummyHash, signature: sig })
+		expect(recovered.toLowerCase()).toBe(service.getAccountAddress().toLowerCase())
 	}, 120_000)
 
-	it("signRawHashComponents returns r, s, yParity for the same raw hash flow", async () => {
+	it("signRawHashComponents returns r, s, yParity that recover the wallet address", async () => {
 		const service = createTestService()
 		const dummyHash = `0x${"ba".repeat(32)}` as HexString
 		const { r, s, yParity } = await service.signRawHashComponents(dummyHash)
@@ -121,9 +123,11 @@ describe.skipIf(!hasMpcVaultCredentials())("MPCVaultService integration", () => 
 		expect(r.length).toBe(66)
 		expect(s.length).toBe(66)
 		expect(yParity === 0 || yParity === 1).toBe(true)
+		const recovered = await recoverAddress({ hash: dummyHash, signature: { r, s, yParity } })
+		expect(recovered.toLowerCase()).toBe(service.getAccountAddress().toLowerCase())
 	}, 120_000)
 
-	it("signPersonalMessage completes and returns a 65-byte ECDSA hex signature", async () => {
+	it("signPersonalMessage returns an EIP-191 signature that recovers the wallet address", async () => {
 		const service = createTestService()
 
 		// A dummy 32-byte message hash, as if from keccak256("hello")
@@ -134,36 +138,44 @@ describe.skipIf(!hasMpcVaultCredentials())("MPCVaultService integration", () => 
 
 		expect(isHex(sig)).toBe(true)
 		expect(sig.length).toBe(132) // 65 bytes = 130 hex chars + 0x prefix
+		const recovered = await recoverMessageAddress({ message: { raw: messageHash }, signature: sig })
+		expect(recovered.toLowerCase()).toBe(service.getAccountAddress().toLowerCase())
 	}, 120_000)
 
-	it("signTypedData completes and returns a 65-byte ECDSA hex signature", async () => {
-		const service = createTestService()
-		const chainId = testChainId()
+	// Signature must RECOVER to the wallet address, not just be well-formed: MPCVault's
+	// TYPE_SIGN_TYPED_DATA endpoint returns well-formed signatures that verify against
+	// nothing (#1132), which a length-only assertion cannot catch. The account adapter
+	// therefore hashes locally and signs via the raw-message path.
+	it("account.signTypedData returns a signature that recovers the wallet address", async () => {
+		const accountAddress = process.env.MPCVAULT_ACCOUNT_ADDRESS as HexString
+		const { account } = createMpcVaultAccount({
+			apiToken: process.env.MPCVAULT_API_TOKEN as string,
+			vaultUuid: process.env.MPCVAULT_VAULT_UUID as string,
+			accountAddress,
+			callbackClientSignerPublicKey: process.env.MPCVAULT_CALLBACK_CLIENT_SIGNER_PUBLIC_KEY as string,
+		})
 
 		const typedData = {
 			types: {
-				EIP712Domain: [
-					{ name: "name", type: "string" },
-					{ name: "version", type: "string" },
-					{ name: "chainId", type: "uint256" },
-				],
 				Test: [{ name: "value", type: "uint256" }],
 			},
 			primaryType: "Test",
 			domain: {
 				name: "TestDomain",
 				version: "1",
-				chainId,
+				chainId: testChainId(),
 			},
 			message: {
-				value: 12345,
+				value: 12345n,
 			},
-		}
+		} as const
 
-		const sig = await service.signTypedData(JSON.stringify(typedData), chainId)
+		const sig = await account.signTypedData!(typedData)
 
 		expect(isHex(sig)).toBe(true)
 		expect(sig.length).toBe(132)
+		const recovered = await recoverTypedDataAddress({ ...typedData, signature: sig })
+		expect(recovered.toLowerCase()).toBe(accountAddress.toLowerCase())
 	}, 120_000)
 
 	it("signTransaction completes and returns a signed transaction hex", async () => {


### PR DESCRIPTION
## Summary

Hotfix for #1132: signatures returned by MPCVault's `TYPE_SIGN_TYPED_DATA` endpoint do not verify against the EIP-712 digest of the submitted payload — every bid UserOp and delegation-via-bundler UserOp signed through it fails on-chain validation ("Invalid account signature" / AA24 from bundlers). Raw-message signatures from the same vault validate and execute on-chain (54/54 of the pre-typed-data-era bid signatures recover the solver EOA; the EIP-7702 delegation direct tx and authorization landed on Base the same day the typed-data path was failing).

The MPC signer now hashes typed data locally (viem `hashTypedData`) and signs the 32-byte digest through the raw-message path (`raw_message` + `ECDSA_HASH_FUNCTION_USE_MESSAGE_DIRECTLY`), assembling the signature as `r ‖ s ‖ (27 + yParity)`. This covers bid UserOps, delegation-via-bundler UserOps, and Circle Paymaster permits — everything that flows through `signTypedData`.

## Changes

- `services/wallet/accounts/mpc.ts`: `signTypedData` hashes locally and signs via `signRawHashComponents`; explicit `27 + yParity` v-byte (the raw path's V return convention is unverified, so no reliance on `signatureFromParts` normalization).
- `services/wallet/mpcvault.ts`: same routing for the viem account's `signTypedData`; `MpcVaultService.signTypedData` marked `@deprecated` with a pointer to #1132.
- `tests/wallet/mpcvault.integration.test.ts`: every signing test now asserts **recovery** against the wallet address instead of signature shape — the length-only assertion is the gap that let the broken endpoint ship undetected.
- `@hyperbridge/simplex` 0.9.2 → 0.9.3.

## Trade-off

The MPCVault console now displays an opaque 32-byte digest for typed-data signings instead of the structured message. Restoring the structured path is gated on the #1132 investigation (live A/B probe with and without `types.EIP712Domain`, `GetSigningRequestDetails` on a failed request, client-signer binary analysis).
