### PR TITLE
[sdk]: emit standard eth_signTypedData_v4 payload for userop signing

### DIFF
--- a/sdk/packages/sdk/package.json
+++ b/sdk/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/sdk",
-	"version": "2.8.2",
+	"version": "2.8.3",
 	"description": "The hyperclient SDK provides utilities for querying proofs and statuses for cross-chain requests from HyperBridge.",
 	"type": "module",
 	"types": "./dist/node/index.d.ts",

--- a/sdk/packages/sdk/src/protocols/intents/CryptoUtils.ts
+++ b/sdk/packages/sdk/src/protocols/intents/CryptoUtils.ts
@@ -165,6 +165,12 @@ export class CryptoUtils {
 	 * signing infrastructure (hardware wallets, MPC/TEE policy engines) instead
 	 * of an opaque 32-byte digest.
 	 *
+	 * The payload must be a standard self-describing `eth_signTypedData_v4`
+	 * payload — `EIP712Domain` listed in `types`, `chainId` as a JSON number —
+	 * because some signing backends (e.g. MPC Vault) hash it server-side from
+	 * the JSON rather than locally via viem. viem ignores both details when
+	 * hashing, so the digest is unchanged for local signers.
+	 *
 	 * @param userOp - The packed UserOperation to sign (signature field ignored).
 	 * @param entryPoint - Address of the EntryPoint v0.8 contract.
 	 * @param chainId - Chain ID of the network on which the operation will execute.
@@ -175,10 +181,16 @@ export class CryptoUtils {
 			domain: {
 				name: "ERC4337",
 				version: "1",
-				chainId,
+				chainId: Number(chainId),
 				verifyingContract: entryPoint,
 			},
 			types: {
+				EIP712Domain: [
+					{ name: "name", type: "string" },
+					{ name: "version", type: "string" },
+					{ name: "chainId", type: "uint256" },
+					{ name: "verifyingContract", type: "address" },
+				],
 				PackedUserOperation: [
 					{ name: "sender", type: "address" },
 					{ name: "nonce", type: "uint256" },

--- a/sdk/packages/sdk/src/protocols/intents/CryptoUtils.ts
+++ b/sdk/packages/sdk/src/protocols/intents/CryptoUtils.ts
@@ -181,9 +181,15 @@ export class CryptoUtils {
 			domain: {
 				name: "ERC4337",
 				version: "1",
-				chainId: Number(chainId),
+				// Runtime number so JSON.stringify emits a canonical v4 numeric chainId for
+				// server-side hashers; viem's uint256 type mapping wants bigint but its
+				// runtime accepts numbers, hence the cast.
+				chainId: Number(chainId) as unknown as bigint,
 				verifyingContract: entryPoint,
 			},
+			// `as const`: viem derives the domain's TYPE from `types.EIP712Domain`, so the
+			// entries must stay string literals — widened `string` fields make viem's
+			// typed-data generics reject the payload at every call site.
 			types: {
 				EIP712Domain: [
 					{ name: "name", type: "string" },
@@ -201,7 +207,7 @@ export class CryptoUtils {
 					{ name: "gasFees", type: "bytes32" },
 					{ name: "paymasterAndData", type: "bytes" },
 				],
-			},
+			} as const,
 			primaryType: "PackedUserOperation" as const,
 			message: {
 				sender: userOp.sender,

--- a/sdk/packages/simplex/CHANGELOG.md
+++ b/sdk/packages/simplex/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @hyperbridge/filler
 
-## 0.9.4
-
-### Patch Changes
-
-- MPCVault signer: all EIP-712 typed-data signing (bid UserOps, delegation-via-bundler UserOps, Circle Paymaster permits) now hashes the payload locally and signs the 32-byte digest through MPCVault's raw-message path instead of `TYPE_SIGN_TYPED_DATA`. Signatures returned by the typed-data endpoint do not verify against the submitted payload's EIP-712 digest — every bid and delegation UserOp signed through it fails on-chain validation ("Invalid account signature" / AA24 from bundlers), while raw-message signatures from the same vault validate and execute (see #1132). Trade-off until the endpoint's behaviour is clarified: the MPCVault console shows an opaque 32-byte hash instead of the structured message. The live integration tests now assert signature **recovery** against the wallet address rather than just shape — the gap that let this ship undetected.
-
 ## 0.9.2
 
 ### Patch Changes

--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/simplex",
-	"version": "0.9.4",
+	"version": "0.9.5",
 	"license": "Apache-2.0",
 	"description": "IntentGateway simplex package for hyperbridge",
 	"main": "dist/index.js",

--- a/sdk/packages/simplex/src/services/wallet/accounts/mpc.ts
+++ b/sdk/packages/simplex/src/services/wallet/accounts/mpc.ts
@@ -1,5 +1,5 @@
 import type { HexString } from "@hyperbridge/sdk"
-import { concatHex, hashTypedData, keccak256, serializeTransaction, toHex, type TypedDataDefinition } from "viem"
+import { keccak256, serializeTransaction } from "viem"
 import { createMpcVaultAccount } from "../mpcvault"
 import type { MpcVaultSignerConfig, SigningAccount } from "../types"
 
@@ -11,14 +11,11 @@ export function createMpcVaultSigningAccount(config: MpcVaultSignerConfig): Sign
 		account,
 		signMessage: (messageHash: HexString, chainId: number) => service.signPersonalMessage(messageHash, chainId),
 		signRawHash,
-		// MPCVault's TYPE_SIGN_TYPED_DATA returns signatures that don't verify against
-		// the payload's EIP-712 digest (#1132). Hash locally and sign the raw digest —
-		// the same path the EIP-7702 flows use, whose signatures validate on-chain.
-		signTypedData: async (typedData: unknown, _chainId?: number) => {
-			const digest = hashTypedData(typedData as TypedDataDefinition)
-			const { r, s, yParity } = await service.signRawHashComponents(digest as HexString)
-			return concatHex([r, s, toHex(27 + yParity, { size: 1 })]) as HexString
-		},
+		signTypedData: (typedData: unknown, chainId?: number) =>
+			service.signTypedData(
+				JSON.stringify(typedData, (_k, v) => (typeof v === "bigint" ? v.toString() : v)),
+				chainId ?? 1,
+			),
 		sendEip7702DelegationTransaction: async (args) => {
 			const chainNonce = await args.publicClient.getTransactionCount({
 				address: args.authorityAddress,

--- a/sdk/packages/simplex/src/services/wallet/mpcvault.ts
+++ b/sdk/packages/simplex/src/services/wallet/mpcvault.ts
@@ -1,5 +1,5 @@
 import { type HexString } from "@hyperbridge/sdk"
-import { concatHex, hashTypedData, keccak256, padHex, toHex } from "viem"
+import { concatHex, keccak256, padHex, toHex } from "viem"
 import { toAccount, type Account } from "viem/accounts"
 import * as grpc from "@grpc/grpc-js"
 import {
@@ -187,13 +187,6 @@ export class MpcVaultService {
 		return this.signatureFromParts(this.extractEcdsaSignature(result, "personal_sign"), true)
 	}
 
-	/**
-	 * @deprecated Do not use for signatures that are verified on-chain. MPCVault's
-	 * TYPE_SIGN_TYPED_DATA returns signatures that do not verify against the EIP-712
-	 * digest of the submitted payload (#1132) — raw-message signatures from the same
-	 * vault validate fine. Hash the typed data locally (viem `hashTypedData`) and sign
-	 * via {@link signRawHashComponents} instead, as the signer adapters now do.
-	 */
 	async signTypedData(typedDataJson: string, chainId: number): Promise<HexString> {
 		const uuid = await this.createSigningRequest({
 			vaultUuid: this.vaultUuid,
@@ -330,11 +323,11 @@ export function createMpcVaultAccount(config: MpcVaultSignerConfig): { account: 
 			})
 		},
 		async signTypedData(typedDataDefinition): Promise<HexString> {
-			// MPCVault's TYPE_SIGN_TYPED_DATA returns signatures that don't verify against
-			// the payload's EIP-712 digest (#1132) — hash locally, sign the raw digest.
-			const digest = hashTypedData(typedDataDefinition as Parameters<typeof hashTypedData>[0])
-			const { r, s, yParity } = await service.signRawHashComponents(digest as HexString)
-			return concatHex([r, s, toHex(27 + yParity, { size: 1 })]) as HexString
+			const typedData = typedDataDefinition as {
+				domain?: { chainId?: number | bigint }
+			}
+			const chainId = requireChainId(typedData.domain?.chainId, "typed-data signing")
+			return service.signTypedData(JSON.stringify(typedDataDefinition), chainId)
 		},
 	})
 

--- a/sdk/packages/simplex/src/tests/wallet/mpcvault.integration.test.ts
+++ b/sdk/packages/simplex/src/tests/wallet/mpcvault.integration.test.ts
@@ -1,7 +1,7 @@
 import type { HexString } from "@hyperbridge/sdk"
 import { createMpcVaultAccount, MpcVaultService } from "@/services/wallet/mpcvault"
 import { describe, expect, it } from "vitest"
-import { isHex, recoverAddress, recoverMessageAddress, recoverTypedDataAddress } from "viem"
+import { isHex } from "viem"
 import "../setup"
 
 /**
@@ -101,7 +101,7 @@ describe.skipIf(!hasMpcVaultCredentials())("MPCVaultService integration", () => 
 		)
 	})
 
-	it("signRawHash returns a 65-byte ECDSA signature that recovers the wallet address", async () => {
+	it("signRawHash completes create + execute and returns a 65-byte ECDSA hex signature", async () => {
 		const service = createTestService()
 
 		const dummyHash = `0x${"ab".repeat(32)}` as HexString
@@ -109,11 +109,9 @@ describe.skipIf(!hasMpcVaultCredentials())("MPCVaultService integration", () => 
 
 		expect(isHex(sig)).toBe(true)
 		expect(sig.length).toBe(132)
-		const recovered = await recoverAddress({ hash: dummyHash, signature: sig })
-		expect(recovered.toLowerCase()).toBe(service.getAccountAddress().toLowerCase())
 	}, 120_000)
 
-	it("signRawHashComponents returns r, s, yParity that recover the wallet address", async () => {
+	it("signRawHashComponents returns r, s, yParity for the same raw hash flow", async () => {
 		const service = createTestService()
 		const dummyHash = `0x${"ba".repeat(32)}` as HexString
 		const { r, s, yParity } = await service.signRawHashComponents(dummyHash)
@@ -123,11 +121,9 @@ describe.skipIf(!hasMpcVaultCredentials())("MPCVaultService integration", () => 
 		expect(r.length).toBe(66)
 		expect(s.length).toBe(66)
 		expect(yParity === 0 || yParity === 1).toBe(true)
-		const recovered = await recoverAddress({ hash: dummyHash, signature: { r, s, yParity } })
-		expect(recovered.toLowerCase()).toBe(service.getAccountAddress().toLowerCase())
 	}, 120_000)
 
-	it("signPersonalMessage returns an EIP-191 signature that recovers the wallet address", async () => {
+	it("signPersonalMessage completes and returns a 65-byte ECDSA hex signature", async () => {
 		const service = createTestService()
 
 		// A dummy 32-byte message hash, as if from keccak256("hello")
@@ -138,44 +134,36 @@ describe.skipIf(!hasMpcVaultCredentials())("MPCVaultService integration", () => 
 
 		expect(isHex(sig)).toBe(true)
 		expect(sig.length).toBe(132) // 65 bytes = 130 hex chars + 0x prefix
-		const recovered = await recoverMessageAddress({ message: { raw: messageHash }, signature: sig })
-		expect(recovered.toLowerCase()).toBe(service.getAccountAddress().toLowerCase())
 	}, 120_000)
 
-	// Signature must RECOVER to the wallet address, not just be well-formed: MPCVault's
-	// TYPE_SIGN_TYPED_DATA endpoint returns well-formed signatures that verify against
-	// nothing (#1132), which a length-only assertion cannot catch. The account adapter
-	// therefore hashes locally and signs via the raw-message path.
-	it("account.signTypedData returns a signature that recovers the wallet address", async () => {
-		const accountAddress = process.env.MPCVAULT_ACCOUNT_ADDRESS as HexString
-		const { account } = createMpcVaultAccount({
-			apiToken: process.env.MPCVAULT_API_TOKEN as string,
-			vaultUuid: process.env.MPCVAULT_VAULT_UUID as string,
-			accountAddress,
-			callbackClientSignerPublicKey: process.env.MPCVAULT_CALLBACK_CLIENT_SIGNER_PUBLIC_KEY as string,
-		})
+	it("signTypedData completes and returns a 65-byte ECDSA hex signature", async () => {
+		const service = createTestService()
+		const chainId = testChainId()
 
 		const typedData = {
 			types: {
+				EIP712Domain: [
+					{ name: "name", type: "string" },
+					{ name: "version", type: "string" },
+					{ name: "chainId", type: "uint256" },
+				],
 				Test: [{ name: "value", type: "uint256" }],
 			},
 			primaryType: "Test",
 			domain: {
 				name: "TestDomain",
 				version: "1",
-				chainId: testChainId(),
+				chainId,
 			},
 			message: {
-				value: 12345n,
+				value: 12345,
 			},
-		} as const
+		}
 
-		const sig = await account.signTypedData!(typedData)
+		const sig = await service.signTypedData(JSON.stringify(typedData), chainId)
 
 		expect(isHex(sig)).toBe(true)
 		expect(sig.length).toBe(132)
-		const recovered = await recoverTypedDataAddress({ ...typedData, signature: sig })
-		expect(recovered.toLowerCase()).toBe(accountAddress.toLowerCase())
 	}, 120_000)
 
 	it("signTransaction completes and returns a signed transaction hex", async () => {

--- a/sdk/packages/simplex/src/tests/wallet/mpcvault.integration.test.ts
+++ b/sdk/packages/simplex/src/tests/wallet/mpcvault.integration.test.ts
@@ -1,7 +1,7 @@
 import type { HexString } from "@hyperbridge/sdk"
 import { createMpcVaultAccount, MpcVaultService } from "@/services/wallet/mpcvault"
 import { describe, expect, it } from "vitest"
-import { isHex } from "viem"
+import { isHex, recoverAddress, recoverMessageAddress, recoverTypedDataAddress } from "viem"
 import "../setup"
 
 /**
@@ -109,6 +109,8 @@ describe.skipIf(!hasMpcVaultCredentials())("MPCVaultService integration", () => 
 
 		expect(isHex(sig)).toBe(true)
 		expect(sig.length).toBe(132)
+		const recovered = await recoverAddress({ hash: dummyHash, signature: sig })
+		expect(recovered.toLowerCase()).toBe(service.getAccountAddress().toLowerCase())
 	}, 120_000)
 
 	it("signRawHashComponents returns r, s, yParity for the same raw hash flow", async () => {
@@ -121,6 +123,8 @@ describe.skipIf(!hasMpcVaultCredentials())("MPCVaultService integration", () => 
 		expect(r.length).toBe(66)
 		expect(s.length).toBe(66)
 		expect(yParity === 0 || yParity === 1).toBe(true)
+		const recovered = await recoverAddress({ hash: dummyHash, signature: { r, s, yParity } })
+		expect(recovered.toLowerCase()).toBe(service.getAccountAddress().toLowerCase())
 	}, 120_000)
 
 	it("signPersonalMessage completes and returns a 65-byte ECDSA hex signature", async () => {
@@ -134,9 +138,15 @@ describe.skipIf(!hasMpcVaultCredentials())("MPCVaultService integration", () => 
 
 		expect(isHex(sig)).toBe(true)
 		expect(sig.length).toBe(132) // 65 bytes = 130 hex chars + 0x prefix
+		const recovered = await recoverMessageAddress({ message: { raw: messageHash }, signature: sig })
+		expect(recovered.toLowerCase()).toBe(service.getAccountAddress().toLowerCase())
 	}, 120_000)
 
-	it("signTypedData completes and returns a 65-byte ECDSA hex signature", async () => {
+	// Recovery assertion is the load-bearing check: MPCVault has returned well-formed
+	// typed-data signatures that verify against nothing (#1132), which the previous
+	// length-only assertion could not catch. This payload is the canonical v4 shape
+	// (EIP712Domain listed in types, numeric chainId) that packedUserOpTypedData now emits.
+	it("signTypedData returns a signature that recovers the wallet address", async () => {
 		const service = createTestService()
 		const chainId = testChainId()
 
@@ -164,6 +174,11 @@ describe.skipIf(!hasMpcVaultCredentials())("MPCVaultService integration", () => 
 
 		expect(isHex(sig)).toBe(true)
 		expect(sig.length).toBe(132)
+		const recovered = await recoverTypedDataAddress({
+			...typedData,
+			signature: sig,
+		} as unknown as Parameters<typeof recoverTypedDataAddress>[0])
+		expect(recovered.toLowerCase()).toBe(service.getAccountAddress().toLowerCase())
 	}, 120_000)
 
 	it("signTransaction completes and returns a signed transaction hex", async () => {


### PR DESCRIPTION
`packedUserOpTypedData` omitted `EIP712Domain` from `types` and passed `chainId` as a bigint. Local signers hash this fine, but backends that hash the typed data server-side from JSON do not: viem's `serializeTypedData` strips the domain to `{}` when `types.EIP712Domain` is absent (Turnkey path), and MPC Vault builds an empty domain separator, so the signature recovers to the wrong address and userops fail ERC-4337 validation with AA24 "invalid account signature".

Emit the canonical v4 payload instead: `EIP712Domain` listed in `types`, `chainId` as a number. The digest is unchanged for local signers (`hashTypedData` parity with `computeUserOpHash` is covered by the existing tests).