### PR TITLE
[simplex]: Make phantom bid polling and extrinsic submission more resillent

### DIFF
--- a/sdk/packages/sdk/src/chains/intentsCoprocessor.ts
+++ b/sdk/packages/sdk/src/chains/intentsCoprocessor.ts
@@ -1,5 +1,5 @@
-import { ApiPromise, Keyring, WsProvider } from "@polkadot/api"
-import type { SubmittableExtrinsic } from "@polkadot/api/types"
+import { ApiPromise, HttpProvider, Keyring, WsProvider } from "@polkadot/api"
+import type { ApiOptions, SubmittableExtrinsic } from "@polkadot/api/types"
 import type { KeyringPair } from "@polkadot/keyring/types"
 import { hexToU8a, u8aToHex, u8aConcat } from "@polkadot/util"
 import { decodeAddress, keccakAsU8a } from "@polkadot/util-crypto"
@@ -14,6 +14,47 @@ import IntentGatewayV2 from "@/abis/IntentGatewayV2"
 const OFFCHAIN_BID_PREFIX = new TextEncoder().encode("intents::bid::")
 /** Offchain storage key prefix for phantom orders */
 const OFFCHAIN_PHANTOM_PREFIX = new TextEncoder().encode("intents::phantom::order::")
+
+/** Hyperbridge runtimes hash with keccak, so the registry needs the hasher for both spec names. */
+const HYPERBRIDGE_TYPES_BUNDLE: ApiOptions["typesBundle"] = {
+	spec: {
+		nexus: { hasher: keccakAsU8a },
+		gargantua: { hasher: keccakAsU8a },
+	},
+}
+
+/** Base tip (0.001 BRIDGE) added to every submission to lift it above untipped traffic. */
+const BASE_TIP = 1_000_000_000n
+
+/** How long the HTTP api has to come up (metadata included) before the attempt is abandoned. */
+const HTTP_CONNECT_TIMEOUT_MS = 20_000
+
+/** Rejects after `ms`, without holding a node process open on its own. */
+function rejectAfter(ms: number, message: string): Promise<never> {
+	return new Promise((_resolve, reject) => {
+		const timer = setTimeout(() => reject(new Error(message)), ms)
+		;(timer as unknown as { unref?: () => void }).unref?.()
+	})
+}
+
+/**
+ * Maps a websocket endpoint onto the HTTP endpoint of the same node — substrate serves both on the
+ * same host and port, so the scheme is the only difference. Throws for anything that is not a
+ * `ws(s)://` url rather than guessing at an endpoint.
+ *
+ * The HTTP endpoint is always derived, never configured, because it must be the *same node* as the
+ * websocket: phantom orders are read out of that node's offchain worker storage, which is
+ * node-local and not replicated, so a separately configured host would return nothing for orders
+ * the events said exist.
+ */
+export function deriveHttpUrl(wsUrl: string): string {
+	if (wsUrl.startsWith("wss://")) return `https://${wsUrl.slice("wss://".length)}`
+	if (wsUrl.startsWith("ws://")) return `http://${wsUrl.slice("ws://".length)}`
+	throw new Error(`Cannot derive an HTTP endpoint from a non-websocket url: ${wsUrl}`)
+}
+
+/** Builds the extrinsic to submit against whichever api is live at signing time. */
+type ExtrinsicBuilder = (api: ApiPromise) => SubmittableExtrinsic<"promise">
 
 /** SCALE codec for Bid { filler: AccountId, user_op: Vec<u8> } */
 const BidCodec = Struct({ filler: Bytes(32), user_op: Vector(u8) })
@@ -132,6 +173,9 @@ export class IntentsCoprocessor {
 	/** Cached result of whether the node exposes intents_* RPC methods */
 	private hasIntentsRpc: boolean | null = null
 
+	/** The HTTP-backed api, connected on first use. Cleared after a failed attempt so it retries. */
+	private httpApi: Promise<ApiPromise> | null = null
+
 	// Serialises every extrinsic submission on this instance's substrate account. All submit/retract
 	// methods funnel through signAndSendExtrinsic, each using the API's auto-nonce; fired in parallel
 	// (bids for orders on different chains, or several phantom orders in one interval) they would grab
@@ -149,12 +193,7 @@ export class IntentsCoprocessor {
 	static async connect(wsUrl: string, substratePrivateKey?: string): Promise<IntentsCoprocessor> {
 		const api = await ApiPromise.create({
 			provider: new WsProvider(wsUrl),
-			typesBundle: {
-				spec: {
-					nexus: { hasher: keccakAsU8a },
-					gargantua: { hasher: keccakAsU8a },
-				},
-			},
+			typesBundle: HYPERBRIDGE_TYPES_BUNDLE,
 		})
 		return new IntentsCoprocessor(api, substratePrivateKey, true)
 	}
@@ -190,13 +229,83 @@ export class IntentsCoprocessor {
 	) {}
 
 	/**
+	 * The websocket API, exposed so callers share this one connection instead of opening a second
+	 * socket to the same node.
+	 */
+	get apiConnection(): ApiPromise {
+		return this.api
+	}
+
+	/** Whether the underlying websocket is currently up. */
+	get isConnected(): boolean {
+		return this.api.isConnected
+	}
+
+	/**
 	 * Disconnects the underlying API connection if this instance owns it.
-	 * Only disconnects if created via `connect()`, not when using shared connections.
+	 * Only disconnects the websocket if created via `connect()`, not when using shared connections.
+	 * The HTTP api is always created here, so it is always ours to close.
 	 */
 	async disconnect(): Promise<void> {
+		const http = this.httpApi
+		this.httpApi = null
+		if (http) {
+			// A creation that never settled must not turn shutdown into an unhandled rejection.
+			await http.then((api) => api.disconnect()).catch(() => {})
+		}
 		if (this.ownsConnection) {
 			await this.api.disconnect()
 		}
+	}
+
+	/**
+	 * The HTTP api for this node, connected on first use. Every coprocessor has one — the endpoint
+	 * is derived from the websocket's own endpoint, so there is nothing to configure and nothing to
+	 * be absent.
+	 *
+	 * The connection attempt is bounded on both sides. `isReadyOrError` rejects on a failed
+	 * handshake, where plain `isReady` would simply never resolve, and the timeout covers an
+	 * endpoint that accepts the request and then goes quiet. An unbounded wait here would hang the
+	 * poll tick awaiting it, which is precisely the silent stall that polling exists to avoid. A
+	 * failed attempt is not cached, so the next call tries again.
+	 */
+	private async http(): Promise<ApiPromise> {
+		if (!this.httpApi) {
+			const httpUrl = deriveHttpUrl(this.wsEndpoint())
+			const api = new ApiPromise({
+				provider: new HttpProvider(httpUrl),
+				typesBundle: HYPERBRIDGE_TYPES_BUNDLE,
+				// A second connection to the node the ws api already reported on; its init warnings
+				// would just be duplicates.
+				noInitWarn: true,
+			})
+			this.httpApi = Promise.race([
+				api.isReadyOrError,
+				rejectAfter(HTTP_CONNECT_TIMEOUT_MS, `HTTP RPC ${httpUrl} did not become ready`),
+			]).catch(async (err) => {
+				// Nothing else holds this half-open api; leaving it would keep retrying underneath.
+				await api.disconnect().catch(() => {})
+				this.httpApi = null
+				// polkadot-js reports a failed init as a bare "fetch failed", which says nothing
+				// about where it was fetching from.
+				throw new Error(`HTTP RPC ${httpUrl} is unavailable: ${err instanceof Error ? err.message : err}`)
+			})
+		}
+		return await this.httpApi
+	}
+
+	/**
+	 * The endpoint the websocket provider is connected to. Read from the provider rather than
+	 * remembered from a constructor argument, so it is the one endpoint in use no matter which
+	 * factory built this instance.
+	 */
+	private wsEndpoint(): string {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const endpoint = ((this.api as any)._rpcCore?.provider as { endpoint?: string } | undefined)?.endpoint
+		if (!endpoint) {
+			throw new Error("Cannot determine the Hyperbridge websocket endpoint to derive an HTTP endpoint from")
+		}
+		return endpoint
 	}
 
 	/**
@@ -228,16 +337,50 @@ export class IntentsCoprocessor {
 	 * concurrent calls never collide on the substrate account nonce — each extrinsic reaches a block
 	 * (or is confirmed still pooled and returned as `pending`) before the next is signed; auto-nonce
 	 * via `system.accountNextIndex` counts pooled extrinsics, so a pending one is never re-used.
+	 *
+	 * The extrinsic is built rather than passed in because the api it is built on decides where it
+	 * is signed and sent: a websocket that is down when the queue reaches this submission diverts it
+	 * to {@link sendViaHttp}, which needs the call bound to the HTTP api instead.
 	 */
 	private async signAndSendExtrinsic(
-		extrinsic: SubmittableExtrinsic<"promise">,
+		build: ExtrinsicBuilder,
 		maxRetries: number = 3,
 		timeoutMs: number = 30_000,
 	): Promise<BidSubmissionResult> {
-		const result = await this.submissionQueue.add(() =>
-			this.sendExtrinsicWithRetries(extrinsic, maxRetries, timeoutMs),
-		)
+		const result = await this.submissionQueue.add(async () => {
+			// Checked here, not at call time: the queue may have held this submission for a while.
+			if (!this.api.isConnected) {
+				try {
+					return await this.sendViaHttp(await this.http(), build)
+				} catch (err) {
+					return { success: false, error: err instanceof Error ? err.message : String(err) }
+				}
+			}
+			return await this.sendExtrinsicWithRetries(build(this.api), maxRetries, timeoutMs)
+		})
 		return result ?? { success: false, error: "Submission queue returned no result" }
+	}
+
+	/**
+	 * Last-resort submission for when the websocket is down at signing time. A bid is only worth
+	 * anything inside its window, so waiting for a reconnect usually means not bidding at all.
+	 *
+	 * HTTP has no subscriptions, so this is `author_submitExtrinsic`: the node accepts the extrinsic
+	 * into its pool and returns its hash, and nothing further is observable from here. That is
+	 * exactly the `pending` contract — in flight, outcome unknown, do not re-sign — so the result
+	 * says so rather than claiming a success it cannot see.
+	 *
+	 * Only reached when the socket was already down before signing. A submission that got as far as
+	 * the pool over the websocket is never retried here: that is the duplicate-nonce race the
+	 * `pending` result exists to prevent.
+	 */
+	private async sendViaHttp(api: ApiPromise, build: ExtrinsicBuilder): Promise<BidSubmissionResult> {
+		try {
+			const hash = await build(api).signAndSend(this.getKeyPair(), { tip: BASE_TIP })
+			return { success: false, pending: true, extrinsicHash: hash.toHex() as HexString }
+		} catch (err) {
+			return this.classifySubmissionError(err instanceof Error ? err : new Error(String(err)))
+		}
 	}
 
 	/**
@@ -257,11 +400,10 @@ export class IntentsCoprocessor {
 		timeoutMs: number,
 	): Promise<BidSubmissionResult> {
 		const keyPair = this.getKeyPair()
-		const baseTip = 1_000_000_000n // 0.001 BRIDGE tip to increase priority
 		let attempt = 0
 
 		while (attempt < maxRetries) {
-			const currentTip = baseTip * BigInt(2 ** attempt) // Double tip on each retry
+			const currentTip = BASE_TIP * BigInt(2 ** attempt) // Double tip on each retry
 			attempt++
 
 			try {
@@ -443,8 +585,7 @@ export class IntentsCoprocessor {
 	 */
 	async submitBid(commitment: HexString, userOp: HexString): Promise<BidSubmissionResult> {
 		try {
-			const extrinsic = this.api.tx.intentsCoprocessor.placeBid(commitment, userOp)
-			return await this.signAndSendExtrinsic(extrinsic)
+			return await this.signAndSendExtrinsic((api) => api.tx.intentsCoprocessor.placeBid(commitment, userOp))
 		} catch (error) {
 			return {
 				success: false,
@@ -463,8 +604,7 @@ export class IntentsCoprocessor {
 	 */
 	async retractBid(commitment: HexString): Promise<BidSubmissionResult> {
 		try {
-			const extrinsic = this.api.tx.intentsCoprocessor.retractBid(commitment)
-			return await this.signAndSendExtrinsic(extrinsic)
+			return await this.signAndSendExtrinsic((api) => api.tx.intentsCoprocessor.retractBid(commitment))
 		} catch (error) {
 			return {
 				success: false,
@@ -499,11 +639,12 @@ export class IntentsCoprocessor {
 		userOp: HexString,
 	): Promise<BidSubmissionResult> {
 		try {
-			const batch = this.api.tx.utility.batch([
-				this.api.tx.intentsCoprocessor.placeBid(bidCommitment, userOp),
-				this.api.tx.intentsCoprocessor.retractBid(retractCommitment),
-			])
-			return await this.signAndSendExtrinsic(batch)
+			return await this.signAndSendExtrinsic((api) =>
+				api.tx.utility.batch([
+					api.tx.intentsCoprocessor.placeBid(bidCommitment, userOp),
+					api.tx.intentsCoprocessor.retractBid(retractCommitment),
+				]),
+			)
 		} catch (error) {
 			return {
 				success: false,
@@ -628,7 +769,8 @@ export class IntentsCoprocessor {
 	 */
 	async fetchPhantomOrder(commitment: HexString): Promise<Order | null> {
 		const key = u8aConcat(OFFCHAIN_PHANTOM_PREFIX, hexToU8a(commitment))
-		const result = await this.api.rpc.offchain.localStorageGet("PERSISTENT", u8aToHex(key))
+		const api = await this.http()
+		const result = await api.rpc.offchain.localStorageGet("PERSISTENT", u8aToHex(key))
 		if (!result || result.isNone) return null
 
 		const rawHex = result.unwrap().toHex() as HexString
@@ -681,8 +823,9 @@ export class IntentsCoprocessor {
 	 * Reads the PhantomOrderRegistered events emitted in a single block.
 	 */
 	async getPhantomOrdersInBlock(blockNumber: number): Promise<PhantomOrderEvent[]> {
-		const blockHash = await this.api.rpc.chain.getBlockHash(blockNumber)
-		const apiAt = await this.api.at(blockHash)
+		const api = await this.http()
+		const blockHash = await api.rpc.chain.getBlockHash(blockNumber)
+		const apiAt = await api.at(blockHash)
 		const records = await apiAt.query.system.events()
 
 		const orders: PhantomOrderEvent[] = []
@@ -719,6 +862,12 @@ export class IntentsCoprocessor {
 	 * cannot drop them, because the cursor only advances past a block whose events were actually
 	 * read. Recovery replays the backlog.
 	 *
+	 * Every read here goes over HTTP, never the websocket. Polling is a sequence of independent
+	 * one-shot requests with no state to lose between them, which is exactly what a stateless
+	 * transport does well: a request either answers or fails loudly on this tick, instead of a
+	 * socket that looks alive while delivering nothing. It also means a websocket outage does not
+	 * pause phantom bidding at all — the two transports fail independently.
+	 *
 	 * Returns a function that stops polling.
 	 */
 	pollPhantomOrders(
@@ -737,7 +886,7 @@ export class IntentsCoprocessor {
 			if (inFlight || stopped) return
 			inFlight = true
 			try {
-				const head = (await this.api.rpc.chain.getHeader()).number.toNumber()
+				const head = (await (await this.http()).rpc.chain.getHeader()).number.toNumber()
 
 				if (cursor === null) {
 					// Start just below the head so the head itself is scanned, less any lookback.

--- a/sdk/packages/sdk/src/chains/intentsCoprocessor.ts
+++ b/sdk/packages/sdk/src/chains/intentsCoprocessor.ts
@@ -145,6 +145,48 @@ export interface PhantomOrderEvent {
 	legs: PhantomOrderLeg[]
 }
 
+/** One phantom bid to place, and the bid it replaces on the same chain. */
+export interface PhantomBid {
+	/** The phantom order commitment being bid on. */
+	commitment: HexString
+	/** The SCALE-encoded PackedUserOperation backing the quote. */
+	userOp: HexString
+	/**
+	 * A live bid from a previous interval on the same chain, retracted alongside this one to
+	 * reclaim its deposit. Best-effort: a retraction that fails never affects the bid.
+	 */
+	retractCommitment?: HexString
+}
+
+/** What became of one bid in a batch. */
+export interface PhantomBidOutcome {
+	commitment: HexString
+	success: boolean
+	/** The dispatch error that rejected this bid, when it failed. */
+	error?: string
+}
+
+export interface PhantomBidBatchResult {
+	/** One entry per submitted bid, in the order they were given. */
+	bids: PhantomBidOutcome[]
+	/** The block and extrinsic the bids landed in. */
+	blockHash?: HexString
+	extrinsicHash?: HexString
+	/**
+	 * The batch reached the pool but its inclusion was not observed, so no per-bid outcome is
+	 * known. Same contract as {@link BidSubmissionResult.pending}: in flight, do not re-sign.
+	 */
+	pending?: boolean
+	/** Set when the batch never landed at all, or when its item events could not be attributed. */
+	error?: string
+}
+
+/** A submission result plus the extrinsic's own events, for callers that read per-item outcomes. */
+interface SubmissionOutcome extends BidSubmissionResult {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	events?: { event: { section: string; method: string; data: any } }[]
+}
+
 export interface PollPhantomOrdersOptions {
 	/** How often to check for a new head. Defaults to 6s, roughly one block. */
 	intervalMs?: number
@@ -353,7 +395,7 @@ export class IntentsCoprocessor {
 		build: ExtrinsicBuilder,
 		maxRetries: number = 3,
 		timeoutMs: number = 30_000,
-	): Promise<BidSubmissionResult> {
+	): Promise<SubmissionOutcome> {
 		const result = await this.submissionQueue.add(async () => {
 			// Checked here, not at call time: the queue may have held this submission for a while.
 			if (!this.api.isConnected) {
@@ -405,7 +447,7 @@ export class IntentsCoprocessor {
 		extrinsic: SubmittableExtrinsic<"promise">,
 		maxRetries: number,
 		timeoutMs: number,
-	): Promise<BidSubmissionResult> {
+	): Promise<SubmissionOutcome> {
 		const keyPair = this.getKeyPair()
 		let attempt = 0
 
@@ -464,8 +506,8 @@ export class IntentsCoprocessor {
 		keyPair: KeyringPair,
 		tip: bigint,
 		timeoutMs: number,
-	): Promise<BidSubmissionResult> {
-		return new Promise<BidSubmissionResult>((resolve) => {
+	): Promise<SubmissionOutcome> {
+		return new Promise<SubmissionOutcome>((resolve) => {
 			let resolved = false
 			let unsubscribe: (() => void) | null = null
 			let enteredPool = false
@@ -502,16 +544,9 @@ export class IntentsCoprocessor {
 					if (result.dispatchError && (result.status.isInBlock || result.status.isFinalized)) {
 						resolved = true
 						clearTimeout(timeoutId)
-						let errorMsg: string
-						if (result.dispatchError.isModule) {
-							const decoded = this.api.registry.findMetaError(result.dispatchError.asModule)
-							errorMsg = `Dispatch error: ${decoded.section}::${decoded.name}`
-						} else {
-							errorMsg = `Dispatch error: ${result.dispatchError.toString()}`
-						}
 						resolve({
 							success: false,
-							error: errorMsg,
+							error: `Dispatch error: ${this.describeDispatchError(result.dispatchError)}`,
 						})
 					} else if (
 						result.status.isDropped ||
@@ -544,14 +579,10 @@ export class IntentsCoprocessor {
 							// eslint-disable-next-line @typescript-eslint/no-explicit-any
 							const [indexCodec, dispatchError] = interrupted.event.data as any
 							if (Number(indexCodec.toString()) === 0) {
-								let errorMsg: string
-								if (dispatchError?.isModule) {
-									const decoded = this.api.registry.findMetaError(dispatchError.asModule)
-									errorMsg = `Dispatch error: ${decoded.section}::${decoded.name}`
-								} else {
-									errorMsg = `Dispatch error: batch interrupted (${dispatchError?.toString()})`
-								}
-								resolve({ success: false, error: errorMsg })
+								resolve({
+									success: false,
+									error: `Dispatch error: ${this.describeDispatchError(dispatchError)}`,
+								})
 								return
 							}
 						}
@@ -563,6 +594,8 @@ export class IntentsCoprocessor {
 								: result.status.asFinalized
 							).toHex() as HexString,
 							extrinsicHash: extrinsic.hash.toHex() as HexString,
+							// Carried so a batch caller can attribute each item's outcome.
+							events: result.events,
 						})
 					}
 				})
@@ -658,6 +691,115 @@ export class IntentsCoprocessor {
 				error: error instanceof Error ? error.message : "Unknown error",
 			}
 		}
+	}
+
+	/**
+	 * Places every phantom bid of one interval in a single extrinsic, retracting each chain's
+	 * previous bid alongside it.
+	 *
+	 * The pallet registers one phantom order per configured chain in the same block, so this is the
+	 * whole interval's set. Submitting them one at a time costs a block per chain: submissions are
+	 * serialised on the account nonce and each waits for inclusion, so the last chain's bid is many
+	 * blocks behind the first, against a bid window measured in tens of blocks. Batched, every bid
+	 * lands in the same block.
+	 *
+	 * Uses `utility.force_batch`, not `utility.batch`. `batch` stops at the first failing call, so
+	 * one rejected bid — a closed window, a duplicate, an insufficient deposit — would silently
+	 * drop every bid after it. `force_batch` runs them all and reports each outcome. It needs no
+	 * special origin: any signed account may call it, exactly like `batch`.
+	 *
+	 * @param bids - The bids to place; an empty list is a no-op
+	 * @returns Per-bid outcomes, in the order given
+	 */
+	async submitPhantomBids(bids: PhantomBid[]): Promise<PhantomBidBatchResult> {
+		if (bids.length === 0) return { bids: [] }
+
+		// Call order is the only key the item events give us, so record where each bid's placeBid
+		// sits as the calls are built.
+		const placeIndexByBid: number[] = []
+		let callCount = 0
+		for (const bid of bids) {
+			placeIndexByBid.push(callCount)
+			callCount += bid.retractCommitment ? 2 : 1
+		}
+
+		const outcome = await this.signAndSendExtrinsic((api) =>
+			api.tx.utility.forceBatch(
+				bids.flatMap((bid) => {
+					const calls = [api.tx.intentsCoprocessor.placeBid(bid.commitment, bid.userOp)]
+					// Placed first so the pairing reads the same as the call order; with force_batch
+					// the ordering no longer decides whether the bid survives a failed retraction.
+					if (bid.retractCommitment) {
+						calls.push(api.tx.intentsCoprocessor.retractBid(bid.retractCommitment))
+					}
+					return calls
+				}),
+			),
+		)
+
+		if (!outcome.success) {
+			// Nothing landed, so there is nothing to attribute: every bid shares the batch's fate.
+			return {
+				bids: bids.map((bid) => ({ commitment: bid.commitment, success: false, error: outcome.error })),
+				pending: outcome.pending,
+				extrinsicHash: outcome.extrinsicHash,
+				error: outcome.error,
+			}
+		}
+
+		const items = this.readForceBatchItems(outcome.events ?? [], callCount)
+
+		return {
+			bids: bids.map((bid, index) => {
+				const error = items.errors[placeIndexByBid[index]]
+				return { commitment: bid.commitment, success: !error, error }
+			}),
+			blockHash: outcome.blockHash,
+			extrinsicHash: outcome.extrinsicHash,
+			error: items.error,
+		}
+	}
+
+	/**
+	 * Reads one outcome per call out of a force_batch's events.
+	 *
+	 * `ItemFailed` carries no index — pallet-utility emits exactly one `ItemCompleted` or
+	 * `ItemFailed` per call, in call order, so the k-th item event belongs to call k.
+	 *
+	 * A count that does not match the calls submitted means the events are not the ones assumed
+	 * here, and every attribution after the discrepancy would be off by one. The bids are then
+	 * reported as placed: a bid wrongly recorded as landed is retracted next interval and the
+	 * retraction harmlessly fails with `BidNotFound`, whereas one wrongly recorded as failed is
+	 * never retracted at all and leaves its deposit reserved.
+	 */
+	private readForceBatchItems(
+		events: NonNullable<SubmissionOutcome["events"]>,
+		callCount: number,
+	): { errors: (string | undefined)[]; error?: string } {
+		const errors: (string | undefined)[] = []
+		for (const { event } of events) {
+			if (event.section !== "utility") continue
+			if (event.method === "ItemCompleted") errors.push(undefined)
+			else if (event.method === "ItemFailed") errors.push(this.describeDispatchError(event.data[0]))
+		}
+
+		if (errors.length !== callCount) {
+			return {
+				errors: new Array(callCount).fill(undefined),
+				error: `force_batch reported ${errors.length} item events for ${callCount} calls; outcomes not attributed`,
+			}
+		}
+		return { errors }
+	}
+
+	/** Renders a DispatchError as `pallet::Error`, falling back to its raw form. */
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	private describeDispatchError(dispatchError: any): string {
+		if (dispatchError?.isModule) {
+			const decoded = this.api.registry.findMetaError(dispatchError.asModule)
+			return `${decoded.section}::${decoded.name}`
+		}
+		return dispatchError?.toString() ?? "unknown dispatch error"
 	}
 
 	/**
@@ -858,7 +1000,13 @@ export class IntentsCoprocessor {
 	}
 
 	/**
-	 * Polls for newly registered phantom orders, invoking the callback once per order.
+	 * Polls for newly registered phantom orders, invoking the callback once per block that carries
+	 * any, with all of that block's orders.
+	 *
+	 * Per block rather than per order because that is how the pallet writes them: one order per
+	 * configured chain, all registered in the same `on_initialize`. Delivering them together lets a
+	 * caller bid on the whole interval in one extrinsic (see {@link submitPhantomBids}) instead of
+	 * one per chain.
 	 *
 	 * Each tick reads the current head and scans every block between the last one processed and that
 	 * head, so the block cursor — not the connection — determines what has been seen. This replaced a
@@ -880,7 +1028,7 @@ export class IntentsCoprocessor {
 	 * Returns a function that stops polling.
 	 */
 	pollPhantomOrders(
-		callback: (event: PhantomOrderEvent) => void,
+		callback: (events: PhantomOrderEvent[]) => void,
 		options: PollPhantomOrdersOptions = {},
 	): () => void {
 		const { intervalMs = 6_000, maxBlocksPerPoll = 500, lookbackBlocks = 0, onError } = options
@@ -907,7 +1055,7 @@ export class IntentsCoprocessor {
 				for (let blockNumber = cursor + 1; blockNumber <= to; blockNumber++) {
 					if (stopped) return
 					const orders = await this.getPhantomOrdersInBlock(blockNumber)
-					for (const order of orders) callback(order)
+					if (orders.length > 0) callback(orders)
 					// Advance per block, not per range: a failure partway through re-scans only the
 					// blocks that were never read, and never re-delivers ones that were.
 					cursor = blockNumber

--- a/sdk/packages/sdk/src/chains/intentsCoprocessor.ts
+++ b/sdk/packages/sdk/src/chains/intentsCoprocessor.ts
@@ -229,16 +229,23 @@ export class IntentsCoprocessor {
 	) {}
 
 	/**
+	 * The API every RPC query runs on: HTTP, connected to the same node as the websocket. Exposed so
+	 * callers query through this connection rather than opening one of their own.
+	 *
+	 * The split is by what each transport is for. Queries are one-shot request/response, which HTTP
+	 * serves without holding any state that can silently rot between calls. The websocket earns its
+	 * keep only where subscriptions do — watching a submitted extrinsic to inclusion.
+	 */
+	async queryApi(): Promise<ApiPromise> {
+		return await this.http()
+	}
+
+	/**
 	 * The websocket API, exposed so callers share this one connection instead of opening a second
-	 * socket to the same node.
+	 * socket to the same node. Only needed for subscriptions; use {@link queryApi} to read.
 	 */
 	get apiConnection(): ApiPromise {
 		return this.api
-	}
-
-	/** Whether the underlying websocket is currently up. */
-	get isConnected(): boolean {
-		return this.api.isConnected
 	}
 
 	/**
@@ -661,8 +668,9 @@ export class IntentsCoprocessor {
 	 * @returns Array of BidStorageEntry objects
 	 */
 	async getBidStorageEntries(commitment: HexString): Promise<BidStorageEntry[]> {
+		const api = await this.http()
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const entries = await (this.api.query.intentsCoprocessor.bids as any).entries(commitment)
+		const entries = await (api.query.intentsCoprocessor.bids as any).entries(commitment)
 
 		return entries.map(([storageKey, depositValue]: [any, any]) => ({
 			commitment,
@@ -696,9 +704,9 @@ export class IntentsCoprocessor {
 	 * Single round-trip but does not include deposit amounts.
 	 */
 	private async getBidsViaRpc(commitment: HexString): Promise<FillerBid[]> {
-		const result: RpcBidInfo[] = await (this.api as any)._rpcCore.provider.send("intents_getBidsForOrder", [
-			commitment,
-		])
+		const api = await this.http()
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const result: RpcBidInfo[] = await (api as any)._rpcCore.provider.send("intents_getBidsForOrder", [commitment])
 
 		return result.map((entry) => {
 			const userOp = decodeUserOpScale(entry.user_op as HexString)
@@ -712,8 +720,9 @@ export class IntentsCoprocessor {
 	 * Slower but works on all nodes and includes deposit amounts.
 	 */
 	private async getBidsViaStorage(commitment: HexString): Promise<FillerBid[]> {
+		const api = await this.http()
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const entries = await (this.api.query.intentsCoprocessor.bids as any).entries(commitment)
+		const entries = await (api.query.intentsCoprocessor.bids as any).entries(commitment)
 
 		if (entries.length === 0) return []
 
@@ -725,7 +734,7 @@ export class IntentsCoprocessor {
 				const offchainKey = this.buildOffchainBidKey(commitment, filler)
 				const offchainKeyHex = u8aToHex(offchainKey)
 
-				const offchainResult = await this.api.rpc.offchain.localStorageGet("PERSISTENT", offchainKeyHex)
+				const offchainResult = await api.rpc.offchain.localStorageGet("PERSISTENT", offchainKeyHex)
 
 				if (!offchainResult || offchainResult.isNone) return null
 

--- a/sdk/packages/sdk/src/tests/intentsCoprocessorBatch.test.ts
+++ b/sdk/packages/sdk/src/tests/intentsCoprocessorBatch.test.ts
@@ -55,6 +55,8 @@ function mockApi(events: unknown[], capturedBatch: { calls: any[] | null }) {
 		},
 	}
 	return {
+		// A live socket: submission only diverts to the HTTP fallback when this is false.
+		isConnected: true,
 		tx: {
 			utility: {
 				batch: (calls: any[]) => {

--- a/sdk/packages/sdk/src/tests/intentsCoprocessorHttpFallback.test.ts
+++ b/sdk/packages/sdk/src/tests/intentsCoprocessorHttpFallback.test.ts
@@ -174,6 +174,80 @@ describe("HTTP submission fallback", () => {
 	})
 })
 
+describe("RPC queries", () => {
+	/** A websocket that fails loudly on any use: queries must never reach it. */
+	const tripwireWebsocket = () =>
+		new Proxy(
+			{ isConnected: true },
+			{
+				get: (target, prop) => {
+					if (prop === "isConnected") return true
+					throw new Error("queries must not touch the websocket")
+				},
+			},
+		) as any
+
+	/** An HTTP api serving one bid, both through the custom RPC and through raw storage. */
+	function httpNode() {
+		const calls: string[] = []
+		const filler = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+		return {
+			calls,
+			api: {
+				_rpcCore: {
+					provider: {
+						send: async (method: string) => {
+							calls.push(method)
+							throw new Error("intents RPC not available on this node")
+						},
+					},
+				},
+				query: {
+					intentsCoprocessor: {
+						bids: {
+							entries: async () => {
+								calls.push("bids.entries")
+								return [[{ args: [null, { toString: () => filler }] }, { toString: () => "42" }]]
+							},
+						},
+					},
+				},
+				rpc: {
+					offchain: {
+						localStorageGet: async () => {
+							calls.push("offchain.localStorageGet")
+							return { isNone: true }
+						},
+					},
+				},
+			} as any,
+		}
+	}
+
+	it("reads bid storage entries over HTTP", async () => {
+		const node = httpNode()
+		const coproc = IntentsCoprocessor.fromApi(tripwireWebsocket(), "//Alice")
+		;(coproc as any).httpApi = Promise.resolve(node.api)
+
+		const entries = await coproc.getBidStorageEntries(COMMITMENT)
+
+		expect(entries).toEqual([{ commitment: COMMITMENT, filler: expect.any(String), deposit: 42n }])
+		expect(node.calls).toEqual(["bids.entries"])
+	})
+
+	// Both routes — the custom RPC and the storage fallback it degrades to — stay on HTTP.
+	it("reads bids over HTTP through the RPC and the storage fallback alike", async () => {
+		const node = httpNode()
+		const coproc = IntentsCoprocessor.fromApi(tripwireWebsocket(), "//Alice")
+		;(coproc as any).httpApi = Promise.resolve(node.api)
+
+		const bids = await coproc.getBidsForOrder(COMMITMENT)
+
+		expect(bids).toEqual([])
+		expect(node.calls).toEqual(["intents_getBidsForOrder", "bids.entries", "offchain.localStorageGet"])
+	})
+})
+
 describe("deriveHttpUrl", () => {
 	it("maps a websocket endpoint onto HTTP on the same host and port", () => {
 		expect(deriveHttpUrl("wss://nexus.rpc.example.com")).toBe("https://nexus.rpc.example.com")

--- a/sdk/packages/sdk/src/tests/intentsCoprocessorHttpFallback.test.ts
+++ b/sdk/packages/sdk/src/tests/intentsCoprocessorHttpFallback.test.ts
@@ -1,0 +1,188 @@
+import { beforeAll, describe, expect, it } from "vitest"
+import { cryptoWaitReady } from "@polkadot/util-crypto"
+import { IntentsCoprocessor, deriveHttpUrl } from "@/chains/intentsCoprocessor"
+import type { HexString } from "@/types"
+
+/**
+ * A bid is only worth anything inside its window, so a websocket that is down when the bid is ready
+ * to sign means, in practice, not bidding at all. HTTP is the last resort for exactly that moment:
+ * `author_submitExtrinsic` gets the extrinsic into the node's pool, and — having no subscription to
+ * watch it with — the result says `pending`, which is the existing contract for "in flight, outcome
+ * unknown, do not re-sign".
+ */
+
+const COMMITMENT = "0x4380111111111111111111111111111111111111111111111111111111114818" as HexString
+const USER_OP = "0xdeadbeef" as HexString
+
+const inBlockStatus = {
+	isFuture: false,
+	isReady: false,
+	isBroadcast: false,
+	isRetracted: false,
+	isInBlock: true,
+	isFinalized: false,
+	isDropped: false,
+	isInvalid: false,
+	isUsurped: false,
+	isFinalityTimeout: false,
+	asInBlock: { toHex: () => "0xwsblockhash" },
+	type: "InBlock",
+}
+
+/** The exact shape of a pool rejection as polkadot-js surfaces it: an RpcError with a code. */
+function rpcError(code: number, message: string): Error {
+	const err = new Error(message) as Error & { code: number }
+	err.code = code
+	return err
+}
+
+interface Submission {
+	via: "ws" | "http"
+	tip: bigint
+}
+
+/**
+ * A websocket api that watches submissions to inclusion, and an HTTP api that only accepts them
+ * into the pool. `httpResult` decides what the HTTP node does with the extrinsic it is handed.
+ */
+function mockNode(options: { wsConnected: boolean; httpResult?: () => Promise<unknown> }) {
+	const submissions: Submission[] = []
+
+	const wsSendable = {
+		hash: { toHex: () => "0xwsextrinsichash" },
+		signAndSend: (_keyPair: unknown, opts: { tip: bigint }, cb: (result: unknown) => void) => {
+			submissions.push({ via: "ws", tip: opts.tip })
+			queueMicrotask(() => cb({ dispatchError: undefined, status: inBlockStatus, events: [] }))
+			return Promise.resolve(() => {})
+		},
+	}
+
+	const httpSendable = {
+		hash: { toHex: () => "0xhttpextrinsichash" },
+		// No callback overload: HTTP has no subscriptions, so this resolves to the extrinsic hash.
+		signAndSend: (_keyPair: unknown, opts: { tip: bigint }) => {
+			submissions.push({ via: "http", tip: opts.tip })
+			return options.httpResult?.() ?? Promise.resolve({ toHex: () => "0xhttpextrinsichash" })
+		},
+	}
+
+	const txFor = (sendable: unknown) => ({
+		intentsCoprocessor: {
+			placeBid: () => sendable,
+			retractBid: () => sendable,
+		},
+		utility: { batch: () => sendable },
+	})
+
+	const registry = { findMetaError: () => ({ section: "intentsCoprocessor", name: "BidNotFound" }) }
+
+	return {
+		submissions,
+		wsApi: { isConnected: options.wsConnected, tx: txFor(wsSendable), registry } as any,
+		httpApi: { isConnected: true, tx: txFor(httpSendable), registry } as any,
+	}
+}
+
+/** Builds a coprocessor with the HTTP api already connected, so no real endpoint is dialled. */
+function coprocessorWithHttp(node: ReturnType<typeof mockNode>): IntentsCoprocessor {
+	const coproc = IntentsCoprocessor.fromApi(node.wsApi, "//Alice")
+	;(coproc as any).httpApi = Promise.resolve(node.httpApi)
+	return coproc
+}
+
+describe("HTTP submission fallback", () => {
+	beforeAll(async () => {
+		await cryptoWaitReady()
+	})
+
+	it("submits over HTTP when the websocket is disconnected, reporting the extrinsic as pending", async () => {
+		const node = mockNode({ wsConnected: false })
+		const coproc = coprocessorWithHttp(node)
+
+		const result = await coproc.submitBid(COMMITMENT, USER_OP)
+
+		expect(node.submissions.map((s) => s.via)).toEqual(["http"])
+		expect(result.success).toBe(false)
+		// Unwatchable, not failed: the caller must confirm later rather than re-sign the nonce.
+		expect(result.pending).toBe(true)
+		expect(result.extrinsicHash).toBe("0xhttpextrinsichash")
+	})
+
+	it("keeps using the websocket while it is connected", async () => {
+		const node = mockNode({ wsConnected: true })
+		const coproc = coprocessorWithHttp(node)
+
+		const result = await coproc.submitBid(COMMITMENT, USER_OP)
+
+		expect(node.submissions.map((s) => s.via)).toEqual(["ws"])
+		expect(result.success).toBe(true)
+		expect(result.blockHash).toBe("0xwsblockhash")
+	})
+
+	it("routes a batched bid+retraction over HTTP too, built against the HTTP api", async () => {
+		const node = mockNode({ wsConnected: false })
+		const coproc = coprocessorWithHttp(node)
+
+		const result = await coproc.submitBidWithRetraction(COMMITMENT, COMMITMENT, USER_OP)
+
+		expect(node.submissions.map((s) => s.via)).toEqual(["http"])
+		expect(result.pending).toBe(true)
+	})
+
+	// The fallback must fail fast rather than hang: a caller blocked forever on an unreachable
+	// endpoint is worse than the websocket outage it was meant to cover.
+	it("gives up with an error when the derived HTTP endpoint cannot be reached", async () => {
+		const node = mockNode({ wsConnected: false })
+		// Port 1 is never listening, so the connection is refused instead of left open.
+		node.wsApi._rpcCore = { provider: { endpoint: "ws://127.0.0.1:1" } }
+		const coproc = IntentsCoprocessor.fromApi(node.wsApi, "//Alice")
+
+		const result = await coproc.submitBid(COMMITMENT, USER_OP)
+
+		expect(node.submissions).toEqual([])
+		expect(result.success).toBe(false)
+		expect(result.error).toContain("127.0.0.1:1")
+	})
+
+	// Same rule as the websocket path: a copy already pooled is in flight, not failed.
+	it("reports a pooled duplicate rejected over HTTP as pending", async () => {
+		const node = mockNode({
+			wsConnected: false,
+			httpResult: () => Promise.reject(rpcError(1014, "1014: Priority is too low")),
+		})
+		const coproc = coprocessorWithHttp(node)
+
+		const result = await coproc.submitBid(COMMITMENT, USER_OP)
+
+		expect(result.success).toBe(false)
+		expect(result.pending).toBe(true)
+	})
+
+	it("returns a terminal failure when the HTTP node rejects the extrinsic outright", async () => {
+		const node = mockNode({
+			wsConnected: false,
+			httpResult: () => Promise.reject(rpcError(1010, "1010: Invalid Transaction: Inability to pay some fees")),
+		})
+		const coproc = coprocessorWithHttp(node)
+
+		const result = await coproc.submitBid(COMMITMENT, USER_OP)
+
+		expect(result.success).toBe(false)
+		expect(result.pending).toBeUndefined()
+		// One shot: HTTP is the fallback, and a node that refused the extrinsic said so definitively.
+		expect(node.submissions).toHaveLength(1)
+	})
+})
+
+describe("deriveHttpUrl", () => {
+	it("maps a websocket endpoint onto HTTP on the same host and port", () => {
+		expect(deriveHttpUrl("wss://nexus.rpc.example.com")).toBe("https://nexus.rpc.example.com")
+		expect(deriveHttpUrl("ws://127.0.0.1:9944")).toBe("http://127.0.0.1:9944")
+		expect(deriveHttpUrl("wss://example.com:443/rpc")).toBe("https://example.com:443/rpc")
+	})
+
+	it("throws for anything that is not a websocket url, rather than guessing", () => {
+		expect(() => deriveHttpUrl("https://example.com")).toThrow()
+		expect(() => deriveHttpUrl("")).toThrow()
+	})
+})

--- a/sdk/packages/sdk/src/tests/intentsCoprocessorPending.test.ts
+++ b/sdk/packages/sdk/src/tests/intentsCoprocessorPending.test.ts
@@ -57,6 +57,8 @@ function mockApi(behaviour: (attempt: number, cb: (result: unknown) => void) => 
 		},
 	}
 	const api = {
+		// A live socket: submission only diverts to the HTTP fallback when this is false.
+		isConnected: true,
 		tx: {
 			intentsCoprocessor: {
 				retractBid: () => sendable,
@@ -71,8 +73,11 @@ function mockApi(behaviour: (attempt: number, cb: (result: unknown) => void) => 
 
 /** Runs retractBid with a short watch timeout so timeout paths don't take 30s. */
 async function retractWithShortTimeout(coproc: IntentsCoprocessor, timeoutMs: number): Promise<BidSubmissionResult> {
-	const extrinsic = (coproc as any).api.tx.intentsCoprocessor.retractBid(COMMITMENT)
-	return await (coproc as any).signAndSendExtrinsic(extrinsic, 3, timeoutMs)
+	return await (coproc as any).signAndSendExtrinsic(
+		(api: any) => api.tx.intentsCoprocessor.retractBid(COMMITMENT),
+		3,
+		timeoutMs,
+	)
 }
 
 describe("in-flight extrinsic handling", () => {

--- a/sdk/packages/sdk/src/tests/pollPhantomOrders.test.ts
+++ b/sdk/packages/sdk/src/tests/pollPhantomOrders.test.ts
@@ -47,20 +47,23 @@ interface Harness {
 	setHead: (n: number) => void
 	/** Registers an order in a block; blocks without one still scan clean. */
 	putOrder: (blockNumber: number, commitment: string) => void
-	/** Makes the next `count` head reads throw, simulating a dropped connection. */
+	/** Makes the next `count` head reads throw, simulating an HTTP endpoint that is not answering. */
 	failHeadReads: (count: number) => void
+	/** True once anything has touched the websocket api — polling never should. */
+	touchedWebsocket: () => boolean
 }
 
 function harness(initialHead: number): Harness {
 	let head = initialHead
 	let headFailures = 0
+	let websocketTouched = false
 	const ordersByBlock = new Map<number, string>()
 	const scanned: number[] = []
 
 	const getHeader = vi.fn(async () => {
 		if (headFailures > 0) {
 			headFailures -= 1
-			throw new Error("websocket disconnected")
+			throw new Error("rpc unavailable")
 		}
 		return { number: { toNumber: () => head } }
 	})
@@ -75,8 +78,24 @@ function harness(initialHead: number): Harness {
 		return { query: { system: { events: async () => records } } }
 	})
 
+	// Polling is HTTP-only, so the websocket stands in as a tripwire: any read routed to it shows
+	// up as a touch rather than quietly succeeding.
+	const websocket = new Proxy(
+		{},
+		{
+			get: () => {
+				websocketTouched = true
+				throw new Error("polling must not touch the websocket")
+			},
+		},
+	)
+
 	const coprocessor = Object.create(IntentsCoprocessor.prototype) as IntentsCoprocessor
-	Object.assign(coprocessor, { api: { rpc: { chain: { getHeader, getBlockHash } }, at } })
+	Object.assign(coprocessor, {
+		api: websocket,
+		// Pre-resolved so nothing tries to open a real connection.
+		httpApi: Promise.resolve({ rpc: { chain: { getHeader, getBlockHash } }, at }),
+	})
 
 	return {
 		coprocessor,
@@ -88,6 +107,7 @@ function harness(initialHead: number): Harness {
 		failHeadReads: (count) => {
 			headFailures = count
 		},
+		touchedWebsocket: () => websocketTouched,
 	}
 }
 
@@ -161,6 +181,24 @@ describe("pollPhantomOrders", () => {
 
 		expect(seen.map((e) => e.commitment)).toEqual([COMMITMENT_B])
 		expect(h.scanned).toEqual([100, 101, 102, 103])
+	})
+
+	// Every read goes over HTTP, so the websocket's state — connected or not — is irrelevant to
+	// polling, and a socket outage cannot pause phantom bidding. The harness's websocket throws on
+	// any access, so every other test in this file asserts the same thing implicitly.
+	it("never reads over the websocket", async () => {
+		const h = harness(100)
+		h.putOrder(101, COMMITMENT_A)
+		const seen: PhantomOrderEvent[] = []
+
+		const stop = h.coprocessor.pollPhantomOrders((e) => seen.push(e), { intervalMs: 1000 })
+		await tick(0)
+		h.setHead(101)
+		await tick(1000)
+		stop()
+
+		expect(seen.map((e) => e.commitment)).toEqual([COMMITMENT_A])
+		expect(h.touchedWebsocket()).toBe(false)
 	})
 
 	it("caps how many blocks a single poll scans and catches up over later ticks", async () => {

--- a/sdk/packages/sdk/src/tests/pollPhantomOrders.test.ts
+++ b/sdk/packages/sdk/src/tests/pollPhantomOrders.test.ts
@@ -45,7 +45,7 @@ interface Harness {
 	/** Blocks scanned, in order. */
 	scanned: number[]
 	setHead: (n: number) => void
-	/** Registers an order in a block; blocks without one still scan clean. */
+	/** Registers an order in a block; a block can carry several, as the pallet writes them. */
 	putOrder: (blockNumber: number, commitment: string) => void
 	/** Makes the next `count` head reads throw, simulating an HTTP endpoint that is not answering. */
 	failHeadReads: (count: number) => void
@@ -57,7 +57,7 @@ function harness(initialHead: number): Harness {
 	let head = initialHead
 	let headFailures = 0
 	let websocketTouched = false
-	const ordersByBlock = new Map<number, string>()
+	const ordersByBlock = new Map<number, string[]>()
 	const scanned: number[] = []
 
 	const getHeader = vi.fn(async () => {
@@ -73,8 +73,8 @@ function harness(initialHead: number): Harness {
 	const at = vi.fn(async (blockHash: string) => {
 		const blockNumber = Number(blockHash.replace("0xblock", ""))
 		scanned.push(blockNumber)
-		const commitment = ordersByBlock.get(blockNumber)
-		const records = commitment ? [unrelatedEvent, registeredEvent(commitment)] : [unrelatedEvent]
+		const commitments = ordersByBlock.get(blockNumber) ?? []
+		const records = [unrelatedEvent, ...commitments.map(registeredEvent)]
 		return { query: { system: { events: async () => records } } }
 	})
 
@@ -103,7 +103,8 @@ function harness(initialHead: number): Harness {
 		setHead: (n) => {
 			head = n
 		},
-		putOrder: (blockNumber, commitment) => ordersByBlock.set(blockNumber, commitment),
+		putOrder: (blockNumber, commitment) =>
+			ordersByBlock.set(blockNumber, [...(ordersByBlock.get(blockNumber) ?? []), commitment]),
 		failHeadReads: (count) => {
 			headFailures = count
 		},
@@ -123,7 +124,7 @@ describe("pollPhantomOrders", () => {
 		h.putOrder(100, COMMITMENT_A)
 		const seen: PhantomOrderEvent[] = []
 
-		const stop = h.coprocessor.pollPhantomOrders((e) => seen.push(e), { intervalMs: 1000 })
+		const stop = h.coprocessor.pollPhantomOrders((orders) => seen.push(...orders), { intervalMs: 1000 })
 		await tick(0)
 		stop()
 
@@ -135,6 +136,34 @@ describe("pollPhantomOrders", () => {
 				legs: [{ tokenA: TOKEN_A, tokenB: TOKEN_B, standardAmount: 1000000n }],
 			},
 		])
+	})
+
+	// The pallet registers every configured chain's order in one block, and bidding on them takes
+	// one extrinsic — so they have to arrive together, not one callback at a time.
+	it("delivers a block's orders in a single callback", async () => {
+		const h = harness(100)
+		h.putOrder(100, COMMITMENT_A)
+		h.putOrder(100, COMMITMENT_B)
+		const batches: PhantomOrderEvent[][] = []
+
+		const stop = h.coprocessor.pollPhantomOrders((orders) => batches.push(orders), { intervalMs: 1000 })
+		await tick(0)
+		stop()
+
+		expect(batches).toHaveLength(1)
+		expect(batches[0].map((e) => e.commitment)).toEqual([COMMITMENT_A, COMMITMENT_B])
+	})
+
+	it("does not call back for a block with no orders", async () => {
+		const h = harness(100)
+		const batches: PhantomOrderEvent[][] = []
+
+		const stop = h.coprocessor.pollPhantomOrders((orders) => batches.push(orders), { intervalMs: 1000 })
+		await tick(0)
+		stop()
+
+		expect(h.scanned).toEqual([100])
+		expect(batches).toEqual([])
 	})
 
 	it("scans each block exactly once as the head advances", async () => {
@@ -165,7 +194,7 @@ describe("pollPhantomOrders", () => {
 		const seen: PhantomOrderEvent[] = []
 		const onError = vi.fn()
 
-		const stop = h.coprocessor.pollPhantomOrders((e) => seen.push(e), { intervalMs: 1000, onError })
+		const stop = h.coprocessor.pollPhantomOrders((orders) => seen.push(...orders), { intervalMs: 1000, onError })
 		await tick(0)
 
 		// Two ticks fail while the chain moves on and registers an order at 102.
@@ -191,7 +220,7 @@ describe("pollPhantomOrders", () => {
 		h.putOrder(101, COMMITMENT_A)
 		const seen: PhantomOrderEvent[] = []
 
-		const stop = h.coprocessor.pollPhantomOrders((e) => seen.push(e), { intervalMs: 1000 })
+		const stop = h.coprocessor.pollPhantomOrders((orders) => seen.push(...orders), { intervalMs: 1000 })
 		await tick(0)
 		h.setHead(101)
 		await tick(1000)
@@ -221,7 +250,10 @@ describe("pollPhantomOrders", () => {
 		h.putOrder(98, COMMITMENT_A)
 		const seen: PhantomOrderEvent[] = []
 
-		const stop = h.coprocessor.pollPhantomOrders((e) => seen.push(e), { intervalMs: 1000, lookbackBlocks: 3 })
+		const stop = h.coprocessor.pollPhantomOrders((orders) => seen.push(...orders), {
+			intervalMs: 1000,
+			lookbackBlocks: 3,
+		})
 		await tick(0)
 		stop()
 

--- a/sdk/packages/sdk/src/tests/submitPhantomBids.test.ts
+++ b/sdk/packages/sdk/src/tests/submitPhantomBids.test.ts
@@ -1,0 +1,200 @@
+import { beforeAll, describe, expect, it } from "vitest"
+import { cryptoWaitReady } from "@polkadot/util-crypto"
+import { IntentsCoprocessor } from "@/chains/intentsCoprocessor"
+import type { HexString } from "@/types"
+
+/**
+ * One interval's phantom bids ride in a single `utility.force_batch`.
+ *
+ * `force_batch`, not `batch`: `batch` stops at the first failing call, so one rejected bid — a
+ * closed window, a duplicate, an insufficient deposit — would silently drop every bid after it.
+ * `force_batch` runs them all, and reports each outcome as an `ItemCompleted` or `ItemFailed`
+ * event. Those events carry no index: pallet-utility emits exactly one per call, in call order,
+ * so attribution is positional. These tests pin that mapping, because an off-by-one here records
+ * a bid as landed when it was not (or the reverse, which strands its deposit).
+ */
+
+const COMMITMENT_A = `0x${"aa".repeat(32)}` as HexString
+const COMMITMENT_B = `0x${"bb".repeat(32)}` as HexString
+const COMMITMENT_C = `0x${"cc".repeat(32)}` as HexString
+const PREV_A = `0x${"11".repeat(32)}` as HexString
+const USER_OP = "0xdeadbeef" as HexString
+
+const inBlockStatus = {
+	isFuture: false,
+	isReady: false,
+	isBroadcast: false,
+	isRetracted: false,
+	isInBlock: true,
+	isFinalized: false,
+	isDropped: false,
+	isInvalid: false,
+	isUsurped: false,
+	isFinalityTimeout: false,
+	asInBlock: { toHex: () => "0xblockhash" },
+	type: "InBlock",
+}
+
+const itemCompleted = { event: { section: "utility", method: "ItemCompleted", data: [] } }
+/** `ItemFailed` carries the DispatchError only — no index. */
+const itemFailed = (name: string) => ({
+	event: {
+		section: "utility",
+		method: "ItemFailed",
+		data: [{ isModule: true, asModule: { name } }],
+	},
+})
+const unrelatedEvent = { event: { section: "balances", method: "Transfer", data: [] } }
+
+/** A terminal pool status: the extrinsic is gone and never reached a block. */
+const droppedStatus = { ...inBlockStatus, isInBlock: false, isDropped: true, type: "Dropped" }
+
+/**
+ * A mock node that reports `events` for the batch it is handed, and records the calls that went
+ * into it. `dropped` makes the extrinsic die in the pool instead of reaching a block.
+ */
+function mockNode(options: { events?: unknown[]; dropped?: boolean } = {}) {
+	const batches: { call: string; args: unknown[] }[][] = []
+
+	const sendable = {
+		hash: { toHex: () => "0xextrinsichash" },
+		signAndSend: (_keyPair: unknown, _opts: unknown, cb: (result: unknown) => void) => {
+			queueMicrotask(() =>
+				cb({
+					dispatchError: undefined,
+					status: options.dropped ? droppedStatus : inBlockStatus,
+					events: [unrelatedEvent, ...(options.events ?? [])],
+				}),
+			)
+			return Promise.resolve(() => {})
+		},
+	}
+
+	const api = {
+		isConnected: true,
+		tx: {
+			utility: {
+				forceBatch: (calls: { call: string; args: unknown[] }[]) => {
+					batches.push(calls)
+					return sendable
+				},
+				// Present so a stray `batch` would be visible rather than throwing something opaque.
+				batch: () => {
+					throw new Error("phantom bids must use force_batch")
+				},
+			},
+			intentsCoprocessor: {
+				placeBid: (commitment: HexString, userOp: HexString) => ({
+					call: "placeBid",
+					args: [commitment, userOp],
+				}),
+				retractBid: (commitment: HexString) => ({ call: "retractBid", args: [commitment] }),
+			},
+		},
+		registry: {
+			findMetaError: (module: { name: string }) => ({ section: "intentsCoprocessor", name: module.name }),
+		},
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	} as any
+
+	return { batches, api }
+}
+
+describe("submitPhantomBids", () => {
+	beforeAll(async () => {
+		await cryptoWaitReady()
+	})
+
+	it("places every bid and its retraction in one force_batch", async () => {
+		const node = mockNode({ events: [itemCompleted, itemCompleted, itemCompleted] })
+		const coproc = IntentsCoprocessor.fromApi(node.api, "//Alice")
+
+		const result = await coproc.submitPhantomBids([
+			{ commitment: COMMITMENT_A, userOp: USER_OP, retractCommitment: PREV_A },
+			{ commitment: COMMITMENT_B, userOp: USER_OP },
+		])
+
+		expect(node.batches).toHaveLength(1)
+		expect(node.batches[0].map((c) => c.call)).toEqual(["placeBid", "retractBid", "placeBid"])
+		expect(node.batches[0].map((c) => c.args[0])).toEqual([COMMITMENT_A, PREV_A, COMMITMENT_B])
+		expect(result.bids).toEqual([
+			{ commitment: COMMITMENT_A, success: true, error: undefined },
+			{ commitment: COMMITMENT_B, success: true, error: undefined },
+		])
+		expect(result.blockHash).toBe("0xblockhash")
+	})
+
+	// The whole point of force_batch: one rejected bid must not take the others down with it.
+	it("attributes a failed item to its own bid and leaves the rest placed", async () => {
+		const node = mockNode({
+			events: [itemCompleted, itemFailed("PhantomOrderBidWindowClosed"), itemCompleted],
+		})
+		const coproc = IntentsCoprocessor.fromApi(node.api, "//Alice")
+
+		const result = await coproc.submitPhantomBids([
+			{ commitment: COMMITMENT_A, userOp: USER_OP },
+			{ commitment: COMMITMENT_B, userOp: USER_OP },
+			{ commitment: COMMITMENT_C, userOp: USER_OP },
+		])
+
+		expect(result.bids.map((b) => b.success)).toEqual([true, false, true])
+		expect(result.bids[1].error).toContain("PhantomOrderBidWindowClosed")
+	})
+
+	// A retraction is best-effort: the previous interval's bid may already be gone.
+	it("keeps a bid placed when only its retraction failed", async () => {
+		const node = mockNode({ events: [itemCompleted, itemFailed("BidNotFound"), itemCompleted] })
+		const coproc = IntentsCoprocessor.fromApi(node.api, "//Alice")
+
+		const result = await coproc.submitPhantomBids([
+			{ commitment: COMMITMENT_A, userOp: USER_OP, retractCommitment: PREV_A },
+			{ commitment: COMMITMENT_B, userOp: USER_OP },
+		])
+
+		expect(result.bids.map((b) => b.success)).toEqual([true, true])
+	})
+
+	it("marks every bid failed when the batch itself never lands", async () => {
+		const node = mockNode({ dropped: true })
+		const coproc = IntentsCoprocessor.fromApi(node.api, "//Alice")
+
+		const result = await coproc.submitPhantomBids([
+			{ commitment: COMMITMENT_A, userOp: USER_OP },
+			{ commitment: COMMITMENT_B, userOp: USER_OP },
+		])
+
+		// Nothing landed, so there is nothing to attribute — every bid shares the batch's fate.
+		expect(result.bids).toEqual([
+			{ commitment: COMMITMENT_A, success: false, error: result.error },
+			{ commitment: COMMITMENT_B, success: false, error: result.error },
+		])
+		expect(result.error).toBeTruthy()
+	})
+
+	/**
+	 * Off-by-one insurance. If the item events cannot be lined up with the calls, reporting bids as
+	 * placed is the safe direction: the next interval retracts them and a retraction of a bid that
+	 * never existed fails harmlessly, whereas a bid wrongly recorded as failed is never retracted
+	 * and leaves its deposit reserved.
+	 */
+	it("does not attribute outcomes when the item events do not line up with the calls", async () => {
+		const node = mockNode({ events: [itemCompleted] })
+		const coproc = IntentsCoprocessor.fromApi(node.api, "//Alice")
+
+		const result = await coproc.submitPhantomBids([
+			{ commitment: COMMITMENT_A, userOp: USER_OP },
+			{ commitment: COMMITMENT_B, userOp: USER_OP },
+		])
+
+		expect(result.bids.map((b) => b.success)).toEqual([true, true])
+		expect(result.error).toContain("not attributed")
+	})
+
+	it("is a no-op for an empty list", async () => {
+		const node = mockNode()
+		const coproc = IntentsCoprocessor.fromApi(node.api, "//Alice")
+
+		expect(await coproc.submitPhantomBids([])).toEqual({ bids: [] })
+		expect(node.batches).toEqual([])
+	})
+})

--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/simplex",
-	"version": "0.9.3",
+	"version": "0.9.4",
 	"license": "Apache-2.0",
 	"description": "IntentGateway simplex package for hyperbridge",
 	"main": "dist/index.js",

--- a/sdk/packages/simplex/src/core/boot.ts
+++ b/sdk/packages/simplex/src/core/boot.ts
@@ -488,7 +488,7 @@ export async function bootFiller(config: FillerTomlConfig, options: BootOptions)
 		configService,
 		fillerAddress: runtimeSigner.account.address,
 		token1,
-		hyperbridgeWsUrl: config.simplex.hyperbridgeWsUrl,
+		hyperbridge: intentFiller.hyperbridgeConnection,
 		substratePrivateKey: config.simplex.substratePrivateKey,
 	})
 

--- a/sdk/packages/simplex/src/core/filler.ts
+++ b/sdk/packages/simplex/src/core/filler.ts
@@ -50,6 +50,13 @@ export class IntentFiller {
 	// retracts exactly the one it replaces.
 	private lastPhantomCommitmentByChain = new Map<string, HexString>()
 	private hyperbridge: Promise<IntentsCoprocessor> | undefined = undefined
+	/**
+	 * The filler's Hyperbridge connection, so other services can share it rather than opening a
+	 * second socket to the same node.
+	 */
+	get hyperbridgeConnection(): Promise<IntentsCoprocessor> | undefined {
+		return this.hyperbridge
+	}
 	private config: FillerConfig
 	private configService: FillerConfigService
 	private signer: SigningAccount

--- a/sdk/packages/simplex/src/core/filler.ts
+++ b/sdk/packages/simplex/src/core/filler.ts
@@ -8,6 +8,7 @@ import {
 	retryPromise,
 	type HexString,
 	IntentsCoprocessor,
+	type PhantomBid,
 	type PhantomOrderEvent,
 	orderCommitment,
 	bytes32ToBytes20,
@@ -28,6 +29,15 @@ import { getLogger } from "@/services/Logger"
 import type { SigningAccount } from "@/services/wallet"
 import { hasPaymaster } from "@/services/paymaster"
 import { Decimal } from "decimal.js"
+
+/** One chain's phantom bid, quoted and built, waiting to ride in the interval's batch. */
+interface PreparedPhantomBid {
+	chain: string
+	/** Legs that got a non-zero quote, and how many the order carried — for logging only. */
+	quotedLegs: number
+	legs: number
+	bid: PhantomBid
+}
 
 export class IntentFiller {
 	public monitor: EventMonitor
@@ -868,16 +878,16 @@ export class IntentFiller {
 		this.hyperbridge
 			.then((coprocessor) => {
 				this.stopPhantomPolling = coprocessor.pollPhantomOrders(
-					(order) => {
+					(orders) => {
 						// The queued promise is nobody's return value, so an escaping throw would be an
 						// unhandled rejection — which this process has no handler for and Node turns into
 						// an exit. Contain it here so a bad phantom order can never take the filler down.
 						void this.globalQueue
-							.add(() => this.handlePhantomOrder(order, coprocessor))
+							.add(() => this.handlePhantomOrders(orders, coprocessor))
 							.catch((err) =>
 								this.logger.error(
-									{ err, chain: order.chain, commitment: order.commitment },
-									"Unhandled error while processing a phantom order",
+									{ err, chains: orders.map((order) => order.chain) },
+									"Unhandled error while processing phantom orders",
 								),
 							)
 					},
@@ -922,7 +932,15 @@ export class IntentFiller {
 		return null
 	}
 
-	private async handlePhantomOrder(event: PhantomOrderEvent, coprocessor: IntentsCoprocessor): Promise<void> {
+	/**
+	 * Quotes and builds one chain's phantom bid, ready to be batched with the rest of the interval's.
+	 * Returns null when the chain is skipped, nothing quoted, or the userOp could not be built —
+	 * one chain dropping out never costs the others their bid.
+	 */
+	private async preparePhantomBid(
+		event: PhantomOrderEvent,
+		coprocessor: IntentsCoprocessor,
+	): Promise<PreparedPhantomBid | null> {
 		// A phantom bid is a public quote — it advertises that this filler stands ready to fill that
 		// chain's pairs at the quoted rate. The pallet registers one order per chain *it* knows about,
 		// which is a superset of what any single operator runs, and the strategies price legs off the
@@ -933,17 +951,17 @@ export class IntentFiller {
 		const chainId = getChainId(event.chain)
 		if (chainId === undefined || !this.configService.getConfiguredChainIds().includes(chainId)) {
 			this.logger.debug({ chain: event.chain }, "Phantom order chain is not configured, skipping")
-			return
+			return null
 		}
 		if (this.isChainWatchOnly(chainId)) {
 			this.logger.debug({ chain: event.chain }, "Phantom order chain is watch-only, skipping")
-			return
+			return null
 		}
 
 		const entryPointAddress = this.configService.getEntryPointAddress(`EVM-${chainId}`)
 		if (!entryPointAddress) {
 			this.logger.debug({ chain: event.chain }, "No entry point configured for phantom order chain, skipping")
-			return
+			return null
 		}
 
 		// Fetch the exact ABI-encoded order the pallet committed to from offchain storage. The read
@@ -958,14 +976,14 @@ export class IntentFiller {
 				"Could not read the phantom order from offchain storage — the Hyperbridge node must run with " +
 					"--enable-offchain-indexing=true and expose offchain_localStorageGet (--rpc-methods=unsafe)",
 			)
-			return
+			return null
 		}
 		if (!phantomOrder) {
 			this.logger.warn(
 				{ commitment: event.commitment, chain: event.chain },
 				"Phantom order not found in offchain storage — node may not be an offchain worker or order expired",
 			)
-			return
+			return null
 		}
 
 		// Every leg of every configured pair rides in this one order, so quote leg by leg —
@@ -982,7 +1000,7 @@ export class IntentFiller {
 
 		if (fillerOutputs.every((output) => output.amount === 0n)) {
 			this.logger.debug({ chain: event.chain }, "No strategy quoted any leg of the phantom order")
-			return
+			return null
 		}
 
 		const solverAccountAddress = this.signer.account.address as HexString
@@ -1001,43 +1019,84 @@ export class IntentFiller {
 
 			// Use event.commitment directly — re-deriving it from the decoded order risks parity
 			// divergence if the encode round-trip doesn't perfectly reproduce the pallet's bytes.
-			// When the previous interval's bid on this chain is still live, retract it and place the
-			// new bid in one utility.batch so the old deposit is reclaimed even if the new bid fails.
+			// When the previous interval's bid on this chain is still live it rides along as a
+			// retraction, so the old deposit comes back in the same extrinsic.
 			const prevCommitment = this.lastPhantomCommitmentByChain.get(event.chain)
-			const result =
-				prevCommitment && prevCommitment !== event.commitment
-					? await coprocessor.submitBidWithRetraction(prevCommitment, event.commitment, userOp)
-					: await coprocessor.submitBid(event.commitment, userOp)
-			if (result.success) {
-				this.lastPhantomCommitmentByChain.set(event.chain, event.commitment)
-				this.logger.info(
-					{
-						commitment: event.commitment,
-						chain: event.chain,
-						quotedLegs: fillerOutputs.filter((output) => output.amount > 0n).length,
-						legs: fillerOutputs.length,
-						txHash: result.extrinsicHash,
-						blockHash: result.blockHash,
-					},
-					"Phantom bid submitted",
-				)
-			} else if (result.pending) {
+			return {
+				chain: event.chain,
+				quotedLegs: fillerOutputs.filter((output) => output.amount > 0n).length,
+				legs: fillerOutputs.length,
+				bid: {
+					commitment: event.commitment,
+					userOp,
+					retractCommitment:
+						prevCommitment && prevCommitment !== event.commitment ? prevCommitment : undefined,
+				},
+			}
+		} catch (err) {
+			this.logger.error({ err, chain: event.chain }, "Failed to prepare phantom bid")
+			return null
+		}
+	}
+
+	/**
+	 * Bids on every phantom order registered in one block, in a single extrinsic.
+	 *
+	 * The pallet registers one order per configured chain in the same block, so this is the whole
+	 * interval's set. Quoting stays per chain and runs concurrently; only the submission is shared.
+	 * One bid per chain used to mean one extrinsic per chain, each waiting for inclusion behind the
+	 * last because submissions are serialised on the account nonce — so the final chain's bid was
+	 * many blocks behind the first, against a bid window measured in tens of blocks.
+	 */
+	private async handlePhantomOrders(events: PhantomOrderEvent[], coprocessor: IntentsCoprocessor): Promise<void> {
+		const prepared = (await Promise.all(events.map((event) => this.preparePhantomBid(event, coprocessor)))).filter(
+			(entry): entry is PreparedPhantomBid => entry !== null,
+		)
+		if (prepared.length === 0) return
+
+		const result = await coprocessor.submitPhantomBids(prepared.map((entry) => entry.bid))
+
+		const landed: string[] = []
+		prepared.forEach((entry, index) => {
+			const outcome = result.bids[index]
+			if (outcome?.success) {
+				landed.push(entry.chain)
+				this.lastPhantomCommitmentByChain.set(entry.chain, entry.bid.commitment)
+				return
+			}
+			if (result.pending) {
 				// The extrinsic reached the tx pool but inclusion wasn't observed — it will almost
 				// certainly land. Record the commitment so the next interval's batch retracts it;
 				// if it never lands, that retraction degrades to a harmless trailing BidNotFound.
-				this.lastPhantomCommitmentByChain.set(event.chain, event.commitment)
-				this.logger.info(
-					{ commitment: event.commitment, chain: event.chain, error: result.error },
-					"Phantom bid in flight, inclusion not yet observed",
-				)
-			} else {
-				this.logger.warn(
-					{ commitment: event.commitment, chain: event.chain, error: result.error },
-					"Phantom bid rejected",
-				)
+				this.lastPhantomCommitmentByChain.set(entry.chain, entry.bid.commitment)
+				return
 			}
-		} catch (err) {
-			this.logger.error({ err, chain: event.chain }, "Failed to prepare or submit phantom bid")
+			this.logger.warn(
+				{ commitment: entry.bid.commitment, chain: entry.chain, error: outcome?.error ?? result.error },
+				"Phantom bid rejected",
+			)
+		})
+
+		if (result.pending) {
+			this.logger.info(
+				{ bids: prepared.length, chains: prepared.map((entry) => entry.chain), error: result.error },
+				"Phantom bids in flight, inclusion not yet observed",
+			)
+			return
 		}
+
+		this.logger.info(
+			{
+				bids: prepared.length,
+				landed: landed.length,
+				chains: landed,
+				quotedLegs: prepared.reduce((sum, entry) => sum + entry.quotedLegs, 0),
+				legs: prepared.reduce((sum, entry) => sum + entry.legs, 0),
+				txHash: result.extrinsicHash,
+				blockHash: result.blockHash,
+				error: result.error,
+			},
+			landed.length > 0 ? "Phantom bids submitted" : "Phantom bid batch landed no bids",
+		)
 	}
 }

--- a/sdk/packages/simplex/src/services/BalanceProvider.ts
+++ b/sdk/packages/simplex/src/services/BalanceProvider.ts
@@ -1,4 +1,5 @@
 import { formatUnits } from "viem"
+import type { IntentsCoprocessor } from "@hyperbridge/sdk"
 import { ERC20_ABI } from "@/config/abis/ERC20"
 import type { ChainClientManager } from "./ChainClientManager"
 import type { FillerConfigService } from "./FillerConfigService"
@@ -47,7 +48,12 @@ export interface BalanceProviderOptions {
 	fillerAddress: string
 	/** Exotic token addresses per state machine id — every cross-asset pair's token1 on that chain. */
 	token1: Record<string, string[]>
-	hyperbridgeWsUrl?: string
+	/**
+	 * The filler's Hyperbridge connection, reused rather than dialled again. A second socket to the
+	 * same node doubles the reconnect traffic during an outage for a balance read that is only
+	 * needed once a minute.
+	 */
+	hyperbridge?: Promise<IntentsCoprocessor>
 	substratePrivateKey?: string
 	refreshIntervalMs?: number
 }
@@ -62,8 +68,6 @@ export class BalanceProvider {
 	private initialTimeout?: NodeJS.Timeout
 	private refreshInterval?: NodeJS.Timeout
 	private hyperbridgeInterval?: NodeJS.Timeout
-	// biome-ignore lint/suspicious/noExplicitAny: polkadot API type
-	private polkadotApi?: any
 	private logger = getLogger("balances")
 	private options: BalanceProviderOptions
 	private intervalMs: number
@@ -77,9 +81,9 @@ export class BalanceProvider {
 		this.initialTimeout = setTimeout(() => void this.refresh(), 5_000)
 		this.refreshInterval = setInterval(() => void this.refresh(), this.intervalMs)
 
-		if (this.options.hyperbridgeWsUrl && this.options.substratePrivateKey) {
-			this.initPolkadotApi().catch((err) => {
-				this.logger.warn({ err }, "Failed to initialize Polkadot API for Hyperbridge balance")
+		if (this.options.hyperbridge && this.options.substratePrivateKey) {
+			this.trackHyperbridgeBalance().catch((err) => {
+				this.logger.warn({ err }, "Failed to start Hyperbridge balance tracking")
 			})
 		}
 	}
@@ -88,10 +92,7 @@ export class BalanceProvider {
 		if (this.initialTimeout) clearTimeout(this.initialTimeout)
 		if (this.refreshInterval) clearInterval(this.refreshInterval)
 		if (this.hyperbridgeInterval) clearInterval(this.hyperbridgeInterval)
-		if (this.polkadotApi) {
-			this.polkadotApi.disconnect().catch(() => {})
-			this.polkadotApi = undefined
-		}
+		// The Hyperbridge connection belongs to the filler; it is not ours to close.
 	}
 
 	getSnapshot(): BalanceSnapshot {
@@ -187,19 +188,23 @@ export class BalanceProvider {
 		return row
 	}
 
-	private async initPolkadotApi(): Promise<void> {
-		const { ApiPromise, WsProvider } = await import("@polkadot/api")
-
-		const provider = new WsProvider(this.options.hyperbridgeWsUrl!)
-		this.polkadotApi = await ApiPromise.create({ provider })
-
+	private async trackHyperbridgeBalance(): Promise<void> {
+		const coprocessor = await this.options.hyperbridge!
 		const keypair = await deriveSubstrateKeyPair(this.options.substratePrivateKey!)
 		const address = keypair.address
 
 		const fetchBalance = async () => {
+			// Reading through a socket that is down only produces `WebSocket is not connected`. The
+			// last snapshot stays put and the next tick picks up once the connection is back.
+			if (!coprocessor.isConnected) {
+				this.logger.debug("Skipped Hyperbridge balance fetch, connection is down")
+				return
+			}
 			try {
-				const account = await this.polkadotApi.query.system.account(address)
-				const decimals = (this.polkadotApi.registry.chainDecimals as number[])[0] ?? 12
+				const api = coprocessor.apiConnection
+				// biome-ignore lint/suspicious/noExplicitAny: polkadot API type
+				const account = (await api.query.system.account(address)) as any
+				const decimals = (api.registry.chainDecimals as number[])[0] ?? 12
 
 				const free = parseFloat(formatUnits(BigInt(account.data.free.toString()), decimals))
 				const reserved = parseFloat(formatUnits(BigInt(account.data.reserved.toString()), decimals))

--- a/sdk/packages/simplex/src/services/BalanceProvider.ts
+++ b/sdk/packages/simplex/src/services/BalanceProvider.ts
@@ -194,14 +194,10 @@ export class BalanceProvider {
 		const address = keypair.address
 
 		const fetchBalance = async () => {
-			// Reading through a socket that is down only produces `WebSocket is not connected`. The
-			// last snapshot stays put and the next tick picks up once the connection is back.
-			if (!coprocessor.isConnected) {
-				this.logger.debug("Skipped Hyperbridge balance fetch, connection is down")
-				return
-			}
 			try {
-				const api = coprocessor.apiConnection
+				// Queried over HTTP, so a websocket outage does not stall the balance read; a failed
+				// request leaves the last snapshot in place and the next tick picks it up.
+				const api = await coprocessor.queryApi()
 				// biome-ignore lint/suspicious/noExplicitAny: polkadot API type
 				const account = (await api.query.system.account(address)) as any
 				const decimals = (api.registry.chainDecimals as number[])[0] ?? 12

--- a/sdk/packages/simplex/src/tests/core/phantom-bid-chain-gating.test.ts
+++ b/sdk/packages/simplex/src/tests/core/phantom-bid-chain-gating.test.ts
@@ -41,7 +41,7 @@ function build(watchOnly: Record<number, boolean> = {}) {
 	const fetchPhantomOrder = vi.fn(async () => null)
 	const coprocessor = { fetchPhantomOrder } as any
 
-	const handle = (chain: string) => (filler as any).handlePhantomOrder(event(chain), coprocessor)
+	const handle = (chain: string) => (filler as any).preparePhantomBid(event(chain), coprocessor)
 
 	return { handle, fetchPhantomOrder }
 }


### PR DESCRIPTION
This PR switches to http for polling and adds http as a backup for extrinsic submission when the websocket is disconnected at the point of extrinsic submission.