### PR TITLE
[ci]: npm trusted publishing (OIDC) for simplex and sdk

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -14,6 +14,10 @@ jobs:
     permissions:
       contents: write
       packages: write
+      # Trusted publishing: OIDC in place of NPM_TOKEN. npm trusts
+      # publish-sdk.yml on polytope-labs/hyperbridge (package Settings ->
+      # Trusted Publisher). Token publishing sunsets ~Jan 2027.
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -40,17 +44,16 @@ jobs:
       - name: Build SDK
         run: pnpm --filter="@hyperbridge/sdk" build
 
-      - name: Authenticate with npm
-        run: |
-          printf "//registry.npmjs.org/:_authToken=%s\n" "${NODE_AUTH_TOKEN}" > ~/.npmrc
-          npm whoami --registry=https://registry.npmjs.org
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # npm >= 11.5 exchanges the Actions OIDC token for npm credentials on its
+      # own; the runner's bundled npm predates that. The sdk has no workspace:*
+      # dependencies, so npm publish alone suffices — no pnpm pack step.
+      - name: OIDC-capable npm
+        run: npm install -g npm@^11
 
       - name: Publish to npm
-        run: pnpm --filter="@hyperbridge/sdk" publish --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          cd packages/sdk
+          npm publish --access public
 
   generate-changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-simplex.yml
+++ b/.github/workflows/publish-simplex.yml
@@ -100,6 +100,15 @@ jobs:
             contents: read
             packages: write
         steps:
+            # Only the Docker Hub overview file: this job otherwise works purely
+            # from downloaded digests, and the description step reads from disk —
+            # publishing it without a checkout was an ENOENT in the first release.
+            - name: Checkout Docker Hub overview
+              uses: actions/checkout@v4
+              with:
+                  sparse-checkout: sdk/packages/simplex/scripts/DOCKERHUB.md
+                  sparse-checkout-cone-mode: false
+
             - name: Download digests
               uses: actions/download-artifact@v4
               with:
@@ -160,6 +169,11 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: read
+            # Trusted publishing: this job authenticates to npm as this workflow
+            # via OIDC — no long-lived token. npm trusts publish-simplex.yml on
+            # polytope-labs/hyperbridge (package Settings -> Trusted Publisher).
+            # Token publishing sunsets ~Jan 2027.
+            id-token: write
         defaults:
             run:
                 working-directory: sdk
@@ -209,13 +223,6 @@ jobs:
             - name: Build simplex
               run: pnpm --filter="@hyperbridge/simplex" build
 
-            - name: Authenticate with npm
-              run: |
-                  printf "//registry.npmjs.org/:_authToken=%s\n" "${NODE_AUTH_TOKEN}" > ~/.npmrc
-                  npm whoami --registry=https://registry.npmjs.org
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
             # pnpm rewrites the `workspace:*` dependency on @hyperbridge/sdk to its
             # concrete version as it packs. That version existing on npm is not enough:
             # the registry copy must MATCH the workspace simplex was built and tested
@@ -235,10 +242,20 @@ jobs:
                     exit 1
                   fi
 
+            # npm >= 11.5 exchanges the Actions OIDC token for npm credentials on
+            # its own; the runner's bundled npm predates that.
+            - name: OIDC-capable npm
+              run: npm install -g npm@^11
+
+            # pnpm pack rewrites the workspace:* dependency on @hyperbridge/sdk to
+            # its concrete version — npm's pack does not — and npm publish carries
+            # the OIDC trusted-publishing exchange. Each tool does the half it is
+            # good at. Provenance comes with trusted publishing automatically.
             - name: Publish to npm
-              run: pnpm --filter="@hyperbridge/simplex" publish --access public --no-git-checks
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+              run: |
+                  cd packages/simplex
+                  pnpm pack --pack-destination /tmp/npm-pkg
+                  npm publish /tmp/npm-pkg/*.tgz --access public
 
     generate-changelog:
         runs-on: ubuntu-latest

--- a/sdk/packages/simplex/README.md
+++ b/sdk/packages/simplex/README.md
@@ -4,7 +4,7 @@ Automated intent solver for the Hyperbridge IntentGateway. Run it as a standalon
 it in your own Node application.
 
 Full documentation:
-[docs.hyperbridge.network/developers/evm/intent-gateway/simplex](https://docs.hyperbridge.network/developers/evm/intent-gateway/simplex)
+[docs.hyperbridge.network/developers/sdk/simplex](https://docs.hyperbridge.network/developers/sdk/simplex/)
 
 ## As a library
 

--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -159,7 +159,7 @@
 		"defi",
 		"intent-gateway"
 	],
-	"homepage": "https://docs.hyperbridge.network/developers/evm/intent-gateway/simplex",
+	"homepage": "https://docs.hyperbridge.network/developers/sdk/simplex/",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/polytope-labs/hyperbridge.git",

--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/simplex",
-	"version": "0.9.7",
+	"version": "0.9.8",
 	"license": "Apache-2.0",
 	"description": "Automated intent filler for the Hyperbridge IntentGateway \u2014 run it as a binary or embed it as a library",
 	"main": "dist/index.js",


### PR DESCRIPTION
Both publish workflows authenticate to npm via **OIDC trusted publishing** instead of `NPM_TOKEN`.

**Why now:** npm's [July changelog](https://github.blog/changelog/2026-07-08-npm-install-time-security-and-gat-bypass2fa-deprecation/) schedules 2FA-bypass tokens to lose account-management bypass in early August 2026 and direct publishing around **January 2027**. Separately, the existing token could not *create* `@hyperbridge/simplex` at all (`E404`-masked 403), which is why 0.9.7's first publish had to be manual. Both packages now list their workflow file as a trusted publisher in npm settings.

**What changed**
- `publish-simplex.yml` / `publish-sdk.yml`: `id-token: write`, auth step removed, OIDC-capable `npm@^11` installed (the runner's bundled npm predates the exchange).
- Simplex publishes via `pnpm pack` → `npm publish <tarball>`: pnpm rewrites the `workspace:*` dep on `@hyperbridge/sdk` to its concrete version (npm's pack ships the literal string and the package installs for nobody); npm carries the OIDC exchange. The sdk has no workspace deps, so `npm publish` alone.
- The `merge` job gains a sparse checkout of `scripts/DOCKERHUB.md` — the Docker Hub description step read from disk in a job that never checked out, an `ENOENT` in the 0.9.7 release.
- Provenance attestations come with trusted publishing automatically.

**After the first successful OIDC release:** `NPM_TOKEN` has no remaining reader and should be deleted from repo secrets.

**Not testable from a PR** — tag workflows run from the tag's commit. The proof is the next `sdk-v*` / `simplex-v*` tag.


**Also riding along:** the npm `homepage` and the README's lead link now point at the library guide (`/developers/sdk/simplex/`) instead of the binary operator page — someone landing from npm is holding the library. Shows on the npm page from the next publish, same event that proves the OIDC flow.

**And the version bump to `0.9.8`** — published manifests are immutable, so the homepage only ships with a new version. Tagging `simplex-v0.9.8` after this merges is one release proving four things: OIDC publish, Docker Hub description, the new homepage, and that `NPM_TOKEN` can be deleted.
