### PR TITLE
[sdk]: 2.8.4

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -95,7 +95,8 @@ jobs:
             COMMIT_RANGE="${PREVIOUS_TAG}..${CURRENT_TAG}"
           fi
 
-          CHANGELOG=$(git log --pretty=format:"* %s (%h)" $COMMIT_RANGE --reverse | grep -i "sdk")
+          CHANGELOG=$(git log --pretty=format:"* %s (%h)" $COMMIT_RANGE --reverse | grep -i "sdk" || true)
+          if [ -z "$CHANGELOG" ]; then CHANGELOG="* No sdk-specific commits in this range."; fi
 
           echo "# Changelog for ${CLEAN_TAG}" > CHANGELOG.md
           echo "" >> CHANGELOG.md

--- a/.github/workflows/publish-simplex.yml
+++ b/.github/workflows/publish-simplex.yml
@@ -292,7 +292,8 @@ jobs:
                     COMMIT_RANGE="${PREVIOUS_TAG}..${CURRENT_TAG}"
                   fi
 
-                  CHANGELOG=$(git log --pretty=format:"* %s (%h)" $COMMIT_RANGE --reverse | grep -i "simplex")
+                  CHANGELOG=$(git log --pretty=format:"* %s (%h)" $COMMIT_RANGE --reverse | grep -i "simplex" || true)
+                  if [ -z "$CHANGELOG" ]; then CHANGELOG="* No simplex-specific commits in this range."; fi
 
                   echo "changelog<<EOF" >> $GITHUB_OUTPUT
                   echo "## What's Changed" >> $GITHUB_OUTPUT

--- a/sdk/packages/sdk/package.json
+++ b/sdk/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/sdk",
-	"version": "2.8.3",
+	"version": "2.8.4",
 	"description": "The hyperclient SDK provides utilities for querying proofs and statuses for cross-chain requests from HyperBridge.",
 	"type": "module",
 	"types": "./dist/node/index.d.ts",


### PR DESCRIPTION
One line: `packages/sdk` changed since `sdk-v2.8.3` was published (#1130's liquidity-engine rework), so npm's 2.8.3 no longer matches the tree. The simplex release guard refuses to pin a drifted sdk, so the sdk goes first.

Tagging `sdk-v2.8.4` after merge doubles as the first run of #1139's OIDC publish path. `simplex-v0.9.8` follows it.