### PR TITLE
[sdk]: repository points at the monorepo

### DIFF
--- a/sdk/packages/sdk/package.json
+++ b/sdk/packages/sdk/package.json
@@ -52,7 +52,8 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/polytope-labs/hyperbridge-sdk.git"
+		"url": "git+https://github.com/polytope-labs/hyperbridge.git",
+		"directory": "sdk/packages/sdk"
 	},
 	"license": "Apache-2.0",
 	"author": "Polytope Labs",


### PR DESCRIPTION
The first OIDC publish of `sdk-v2.8.4` was rejected by provenance validation (`E422`): the manifest's `repository.url` still points at the pre-monorepo `hyperbridge-sdk` repo, and attested publishes require it to match the repo that built the package. Token publishes never checked this; the attestation is working as designed on our own stale metadata.

Auth and signing worked — the provenance statement is in the [transparency log](https://search.sigstore.dev/?logIndex=2498122738) — so this is the last blocker in the OIDC path. After merge: `sdk-v2.8.4` moves to the fixed commit (nothing published under it, no release exists — clean move), sdk publishes, then `simplex-v0.9.8`. Simplex's own repository field is already correct.