### PR TITLE
[docs]: spell out what each Signer method returns

### DIFF
--- a/docs/content/developers/sdk/api/simplex.mdx
+++ b/docs/content/developers/sdk/api/simplex.mdx
@@ -515,6 +515,14 @@ Each operation names what is being authorised rather than handing over a digest,
 provider's policy engine can read it. A backend that only signs digests should not implement this by
 hand — pass its `sign(hash)` to `digestSigner`.
 
+Each method returns something different, and the difference is the part that trips an implementation:
+
+| Method | Return exactly |
+|--------|----------------|
+| `signTypedData` | The 65-byte `r ‖ s ‖ v` signature as 0x-hex (132 characters), `v` **27 or 28** — what `eth_signTypedData_v4` and viem's `signTypedData` produce. On-chain validation recovers against this form |
+| `signAuthorization` | The **split** signature `{ r, s, yParity }`: `r`/`s` as 32-byte 0x-hex, `yParity` strictly **0 or 1** (subtract 27 from a legacy `v` — anything else is rejected, because EIP-7702 would otherwise skip the mis-encoded tuple silently). Split because the authorization is embedded field-by-field in the transaction |
+| `signTransaction` | The **whole signed transaction** — typed-envelope RLP as `eth_sendRawTransaction` takes it (`0x02…` for EIP-1559, `0x04…` for set-code), not a bare signature. From a signed digest, viem's `serializeTransaction(tx, signature)` produces it |
+
 `signTypedData` takes no chain id: EIP-712 carries it in `domain.chainId`, which is what the digest
 covers and what a backend scoping a signing request to a chain reads.
 

--- a/docs/content/developers/sdk/simplex.mdx
+++ b/docs/content/developers/sdk/simplex.mdx
@@ -122,6 +122,15 @@ what the digest covers and what a backend that scopes a signing request to a cha
 A solver needs a signer unless every chain is watch-only, where it signs nothing and a throwaway key
 stands in.
 
+Each method returns something different, and the difference is the part that trips an implementation:
+
+| Method | Return exactly |
+|--------|----------------|
+| `signTypedData` | The 65-byte `r ‖ s ‖ v` signature as 0x-hex (132 characters), `v` **27 or 28** — what `eth_signTypedData_v4` and viem's `signTypedData` produce. On-chain validation recovers against this form |
+| `signAuthorization` | The **split** signature `{ r, s, yParity }`: `r`/`s` as 32-byte 0x-hex, `yParity` strictly **0 or 1** (subtract 27 from a legacy `v` — anything else is rejected, because EIP-7702 would otherwise skip the mis-encoded tuple silently). Split because the authorization is embedded field-by-field in the transaction |
+| `signTransaction` | The **whole signed transaction** — typed-envelope RLP as `eth_sendRawTransaction` takes it (`0x02…` for EIP-1559, `0x04…` for set-code), not a bare signature. From a signed digest, viem's `serializeTransaction(tx, signature)` produces it |
+
+
 ### Out of the box
 
 ```ts lineNumbers

--- a/sdk/packages/sdk/src/types/index.ts
+++ b/sdk/packages/sdk/src/types/index.ts
@@ -1315,6 +1315,9 @@ export interface SigningAccount {
 	 *
 	 * No chain id parameter: EIP-712 carries it in `domain.chainId`, which is what
 	 * the digest covers and what a backend scoping the request to a chain reads.
+	 *
+	 * Returns the 65-byte `r ‖ s ‖ v` signature as 0x-hex, `v` 27 or 28 — the
+	 * `eth_signTypedData_v4` form. Bid validation recovers against exactly this.
 	 */
 	signTypedData: (typedData: unknown) => Promise<HexString>
 }

--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -12,6 +12,12 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-08-18 — Signer return contracts spelled out
+
+The docs showed `Promise<HexString>` twice and `Promise<Signature>` once without saying that the three mean different things: `signTypedData` returns a bare 65-byte `r ‖ s ‖ v` signature (`v` 27/28, the `eth_signTypedData_v4` form), `signAuthorization` returns split components with `yParity` strictly 0/1, and `signTransaction` returns the whole signed transaction as typed-envelope RLP — not a signature at all. An implementer had to reverse-engineer that from the adapters. The contracts now live in the `Signer` and `Signature` docblocks (what an IDE shows), a "Return exactly" table on both doc pages, and the sdk's `SigningAccount.signTypedData` docblock.
+
+Files: `src/services/wallet/types.ts`, `sdk/packages/sdk/src/types/index.ts`, `docs/content/developers/sdk/{simplex,api/simplex}.mdx`.
+
 ## 2026-08-18 — Audit fixes: yParity guards, the signerless one-way door, and honest tests
 
 A six-dimension adversarial audit of the signer branch confirmed 21 distinct issues; this change fixes all of them except the two deliberate semver calls (patch releases carrying breaking surface changes — restated in the PR and left to the maintainer).

--- a/sdk/packages/simplex/src/services/wallet/types.ts
+++ b/sdk/packages/simplex/src/services/wallet/types.ts
@@ -67,7 +67,12 @@ export type SignerConfig =
 			type: SignerType.Turnkey
 	  } & TurnkeySignerConfig)
 
-/** A secp256k1 signature in split form, which is how EIP-7702 and raw digests consume it. */
+/**
+ * A secp256k1 signature in split form, which is how EIP-7702 and raw digests
+ * consume it: `r` and `s` as 32-byte 0x-hex, and `yParity` strictly 0 or 1.
+ * A backend that hands back the legacy `v` (27/28) should subtract 27 — the
+ * delegation path rejects anything else rather than letting viem mis-encode it.
+ */
 export interface Signature {
 	r: HexString
 	s: HexString
@@ -146,19 +151,33 @@ export interface Signer {
 	readonly address: HexString
 	/** Names the backend in logs — `"privateKey"`, `"turnkey"`, or whatever names yours. */
 	readonly mode: string
-	/** EIP-712. Signs every bid UserOperation and every paymaster permit. */
+	/**
+	 * EIP-712. Signs every bid UserOperation and every paymaster permit.
+	 *
+	 * Returns the 65-byte `r ‖ s ‖ v` signature as 0x-hex (132 characters), with
+	 * `v` 27 or 28 — exactly what `eth_signTypedData_v4` and viem's
+	 * `signTypedData` produce. On-chain validation recovers against this form.
+	 */
 	signTypedData(typedData: TypedDataPayload): Promise<HexString>
 	/**
 	 * Signs an EIP-7702 authorization tuple — the delegation that makes this
 	 * account a solver. Backends with a structured encoding for it (Turnkey) use
 	 * that; others sign `keccak256(0x05 ‖ rlp([chainId, contractAddress, nonce]))`.
+	 *
+	 * Returns the SPLIT signature — see {@link Signature}: `yParity` must be 0 or
+	 * 1, not the legacy `v`. This is the one method that does not return hex,
+	 * because the authorization is embedded field-by-field in the transaction.
 	 */
 	signAuthorization(auth: AuthorizationRequest): Promise<Signature>
 	/**
-	 * Signs and serialises a transaction, returning the RLP-encoded, signed bytes
-	 * ready to broadcast. Backends that take transactions (MPCVault's vault API,
-	 * Turnkey's transaction payloads) keep the transaction legible to their policy
-	 * engine; others serialise it and sign the digest.
+	 * Signs and serialises a transaction. Backends that take transactions
+	 * (MPCVault's vault API, Turnkey's transaction payloads) keep the transaction
+	 * legible to their policy engine; others serialise it and sign the digest.
+	 *
+	 * Returns the WHOLE SIGNED TRANSACTION — typed-envelope RLP as
+	 * `eth_sendRawTransaction` takes it (`0x02…` for EIP-1559, `0x04…` for
+	 * set-code), not a bare signature. viem's `serializeTransaction(tx, signature)`
+	 * produces it from a signed digest.
 	 */
 	signTransaction(tx: SignerTransaction): Promise<HexString>
 }


### PR DESCRIPTION
The `Signer` interface docs showed `Promise<HexString>` twice and `Promise<Signature>` once without saying the three mean different things — a bare 65-byte signature, split components, and whole signed transaction bytes. An implementer had to reverse-engineer the return contracts from the bundled adapters.

Now stated in three places an implementer actually looks:

- **`types.ts` docblocks** (IDE hover): each method says exactly what to return, and `Signature` documents the 0/1 `yParity` requirement and the subtract-27 rule.
- **A "Return exactly" table** in the library guide's Signing section and the API reference.
- **The sdk's `SigningAccount.signTypedData`** docblock (the `eth_signTypedData_v4` form, `v` 27/28).

Docs and docblocks only — no behavior change. The docblock halves ride the next patch releases; the mdx pages deploy from main.