### PR TITLE
[simplex]: skip cross-lane orders cleanly instead of erroring

### DIFF
--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -12,6 +12,14 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-08-19 — Cross-lane orders skip cleanly instead of erroring "Shared cache is not initialized"
+
+An operator running only Base saw `ERROR: [intent-filler]: Shared cache is not initialized` whenever an order destined to a chain their filler does not run scrolled past. The solver-selection cache is only ever populated for configured, non-watch-only chains (boot's `solverSelectionChains`), so any other destination fell through `handleNewOrder`'s cache check and was dropped with an error that reads like the filler is broken. The behavior (drop) was correct — there is no client, bundler or float for an unconfigured destination — the diagnosis was not, and it dates to #287.
+
+`handleNewOrder` now checks the destination first: not a configured chain, or configured but watch-only → debug-level skip, cache untouched. The "Shared cache is not initialized" error survives for what it actually means now — a configured, filling destination with a genuinely absent entry, which is an initialization bug. Pinned by `order-destination.test.ts`: unconfigured / non-EVM / watch-only destinations never touch the cache, a filling destination proceeds to the allowlist, and the configured-but-uncached case still errors.
+
+Files: `src/core/filler.ts`, `src/tests/core/order-destination.test.ts` (new).
+
 ## 2026-08-18 — Signer return contracts spelled out
 
 The docs showed `Promise<HexString>` twice and `Promise<Signature>` once without saying that the three mean different things: `signTypedData` returns a bare 65-byte `r ‖ s ‖ v` signature (`v` 27/28, the `eth_signTypedData_v4` form), `signAuthorization` returns split components with `yParity` strictly 0/1, and `signTransaction` returns the whole signed transaction as typed-envelope RLP — not a signature at all. An implementer had to reverse-engineer that from the adapters. The contracts now live in the `Signer` and `Signature` docblocks (what an IDE shows), a "Return exactly" table on both doc pages, and the sdk's `SigningAccount.signTypedData` docblock.

--- a/sdk/packages/simplex/src/core/filler.ts
+++ b/sdk/packages/simplex/src/core/filler.ts
@@ -14,6 +14,7 @@ import {
 	type TokenInfo,
 	type PhantomBid,
 } from "@hyperbridge/sdk"
+import { parseChainKey } from "@/config/interpolated-curve"
 import { INTENT_GATEWAY_V2_ABI } from "@/config/abis/IntentGatewayV2"
 import type { Address } from "viem"
 import pQueue from "p-queue"
@@ -601,7 +602,33 @@ export class IntentFiller {
 		this.globalQueue.add(async () => {
 			this.logger.info({ orderId: order.id }, "New order detected")
 			try {
-				// Early check: if solver selection is active, ensure hyperbridge is configured
+				// Orders destined to chains this filler cannot fill on are expected
+				// mainnet traffic, not faults — other fillers cover other lanes. They
+				// used to fall through to the cache check below and be dropped with a
+				// misleading "Shared cache is not initialized" ERROR, since the cache
+				// is only ever populated for configured, non-watch-only chains.
+				const destinationChainId = parseChainKey(order.destination)
+				if (
+					destinationChainId === null ||
+					!this.configService.getConfiguredChainIds().includes(destinationChainId)
+				) {
+					this.logger.debug(
+						{ orderId: order.id, destination: order.destination },
+						"Order destination is not a configured chain, skipping",
+					)
+					return
+				}
+				if (this.isChainWatchOnly(destinationChainId)) {
+					this.logger.debug(
+						{ orderId: order.id, destination: order.destination },
+						"Order destination is watch-only, skipping",
+					)
+					return
+				}
+
+				// Early check: if solver selection is active, ensure hyperbridge is configured.
+				// With the destination confirmed configured and filling above, a missing
+				// entry now really is an initialization bug.
 				const solverSelectionActive = this.contractService.getCache().getSolverSelection(order.destination)
 				if (solverSelectionActive == null) {
 					this.logger.error({ orderId: order.id }, "Shared cache is not initialized")

--- a/sdk/packages/simplex/src/tests/core/order-destination.test.ts
+++ b/sdk/packages/simplex/src/tests/core/order-destination.test.ts
@@ -42,9 +42,7 @@ function build(watchOnly: Record<number, boolean> = {}) {
 }
 
 async function detect(filler: IntentFiller, destination: string) {
-	// biome-ignore lint/suspicious/noExplicitAny: driving the private intake path
 	;(filler as any).handleNewOrder({ id: "0xorder", user: "0xUSER", source: "EVM-1", destination }, "0xtx")
-	// biome-ignore lint/suspicious/noExplicitAny: draining the intake queue
 	await (filler as any).globalQueue.onIdle()
 }
 

--- a/sdk/packages/simplex/src/tests/core/order-destination.test.ts
+++ b/sdk/packages/simplex/src/tests/core/order-destination.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest"
+import type { HexString } from "@hyperbridge/sdk"
+import { IntentFiller } from "@/core/filler"
+import { MemoryDataStore } from "@/data/memory"
+import { stubOrderScanner } from "../helpers/stub-scanner"
+
+/**
+ * An order's destination decides where the fill would execute. A destination
+ * this filler has no configuration for — or watches without filling — is
+ * expected mainnet traffic (other fillers cover other lanes), and used to fall
+ * through to the solver-selection cache check, which dropped the order with a
+ * misleading "Shared cache is not initialized" ERROR: the cache is only ever
+ * populated for configured, non-watch-only chains, so the error fired for
+ * healthy fillers on every cross-lane order.
+ */
+
+const OUR_ADDRESS = "0xAAAA00000000000000000000000000000000AAAA" as HexString
+
+function build(watchOnly: Record<number, boolean> = {}) {
+	const getSolverSelection = vi.fn((chain: string) => (chain === "EVM-1" ? false : null))
+	const isUserAllowed = vi.fn(() => false) // ends the happy path right after the guards
+
+	const filler = new IntentFiller(
+		[{ chainId: 1 } as never],
+		[],
+		{ maxConcurrentOrders: 1, watchOnly } as never,
+		{
+			loggers: undefined,
+			getHyperbridgeWsUrl: () => undefined,
+			getSubstratePrivateKey: () => undefined,
+			getConfiguredChainIds: () => [1, 2],
+			isUserAllowed,
+		} as never,
+		{} as never,
+		{ getCache: () => ({ getSolverSelection }) } as never,
+		{ address: OUR_ADDRESS } as never,
+		{ orders: stubOrderScanner([1]) },
+		undefined,
+		new MemoryDataStore().bids,
+	)
+	return { filler, getSolverSelection, isUserAllowed }
+}
+
+async function detect(filler: IntentFiller, destination: string) {
+	// biome-ignore lint/suspicious/noExplicitAny: driving the private intake path
+	;(filler as any).handleNewOrder({ id: "0xorder", user: "0xUSER", source: "EVM-1", destination }, "0xtx")
+	// biome-ignore lint/suspicious/noExplicitAny: draining the intake queue
+	await (filler as any).globalQueue.onIdle()
+}
+
+describe("order destination gating", () => {
+	it("skips an order destined to an unconfigured chain without touching the cache", async () => {
+		const { filler, getSolverSelection } = build()
+		await detect(filler, "EVM-999999")
+		expect(getSolverSelection).not.toHaveBeenCalled()
+	})
+
+	it("skips a destination that is not a chain key at all", async () => {
+		const { filler, getSolverSelection } = build()
+		await detect(filler, "KUSAMA-4009")
+		expect(getSolverSelection).not.toHaveBeenCalled()
+	})
+
+	it("skips an order destined to a watch-only chain", async () => {
+		const { filler, getSolverSelection } = build({ 2: true })
+		await detect(filler, "EVM-2")
+		expect(getSolverSelection).not.toHaveBeenCalled()
+	})
+
+	it("a configured, filling destination proceeds through the cache to the allowlist", async () => {
+		const { filler, getSolverSelection, isUserAllowed } = build()
+		await detect(filler, "EVM-1")
+		expect(getSolverSelection).toHaveBeenCalledWith("EVM-1")
+		expect(isUserAllowed).toHaveBeenCalled()
+	})
+
+	// The error is reserved for what it actually means now: a destination this
+	// filler is configured to fill on whose cache entry is genuinely absent.
+	it("still errors on a configured destination with no cache entry", async () => {
+		const { filler, getSolverSelection, isUserAllowed } = build()
+		await detect(filler, "EVM-2") // configured (id 2), not watch-only, cache returns null
+		expect(getSolverSelection).toHaveBeenCalledWith("EVM-2")
+		expect(isUserAllowed).not.toHaveBeenCalled()
+	})
+})


### PR DESCRIPTION
An operator running only Base sees `ERROR: [intent-filler]: Shared cache is not initialized` whenever an order destined to a chain their filler does not run scrolls past — alarming, and wrong about what happened.

## Root cause

The solver-selection cache is only ever populated for **configured, non-watch-only** chains (boot's `solverSelectionChains`). `handleNewOrder` checked the cache before checking whether the destination is a chain this filler runs at all, so every cross-lane order fell into the cache-miss path and was dropped with an error suggesting the filler is broken. The *drop* was correct — there is no client, bundler or float for an unconfigured destination — the *diagnosis* was not. Dates to #287; surfaced by an operator log during the quorum work.

## Fix

`handleNewOrder` checks the destination first: not a configured chain, or configured but watch-only → **debug-level skip**, cache untouched. `Shared cache is not initialized` survives for what it actually means now: a configured, filling destination with a genuinely absent entry — an initialization bug worth erroring about.

## Tests

`order-destination.test.ts` pins all five paths: unconfigured, non-EVM, and watch-only destinations never touch the cache; a filling destination proceeds through the cache to the allowlist; a configured-but-uncached destination still errors.