### PR TITLE
[sdk]: fix the refund-POST gas pin #1144 left behind

### DIFF
--- a/sdk/packages/sdk/docs/ai/ChangeLog.md
+++ b/sdk/packages/sdk/docs/ai/ChangeLog.md
@@ -12,6 +12,12 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-08-19 — Fix the refund-POST gas pin #1144 left behind
+
+#1144 split `CANCEL_MESSAGE_GAS = 800_000n` into `SOURCE_GET_RESPONSE_GAS` and `REFUND_POST_GAS`, both 1M, but left `orderCanceller.test.ts` asserting the POST at 800k — main's own CI has failed the concurrent-sdk step since it merged, and every PR cut from it inherited the red check. The pin now matches the shipped constant, with a comment naming the origin so the next reprice updates both.
+
+Files: `src/tests/orderCanceller.test.ts`.
+
 ## 2026-08-18 — `SigningAccount` shrinks to `signTypedData` alone
 
 `SigningAccount` is the contract a solver's signing backend satisfies to submit bids (`SubmitBidOptions.solverSigner`). It declared `signMessage(messageHash, chainId)`, which nothing in this package ever called: bids are signed as EIP-712 UserOperations in `BidManager.prepareSubmitBid` via `signTypedData`, and `GasEstimator`'s one `signMessage` call is viem's own method on a locally derived account, not this interface. The requirement propagated out to every implementer — including `@hyperbridge/simplex`, whose public `Signer` satisfied this type (it no longer extends it; simplex adapts with `sdkSigningAccount` at the two call sites) — so removing it here is what let that interface shrink to what a solver actually needs.

--- a/sdk/packages/sdk/src/tests/orderCanceller.test.ts
+++ b/sdk/packages/sdk/src/tests/orderCanceller.test.ts
@@ -55,7 +55,7 @@ describe("OrderCanceller recovery", () => {
 		expect(intentUtils.convertGasToFeeToken).toHaveBeenCalledWith(ctx, 1_000_000n, "source", "EVM-1")
 	})
 
-	it("keeps destination cancellation refund POSTs at an 800k gas budget", async () => {
+	it("keeps destination cancellation refund POSTs at a 1M gas budget", async () => {
 		vi.mocked(intentUtils.convertGasToFeeToken).mockResolvedValue(1_000n)
 		const ctx = {
 			source: {
@@ -75,7 +75,9 @@ describe("OrderCanceller recovery", () => {
 
 		await estimateRelayerFee("EVM-1", "EVM-42161")
 
-		expect(intentUtils.convertGasToFeeToken).toHaveBeenCalledWith(ctx, 800_000n, "source", "EVM-1")
+		// REFUND_POST_GAS moved 800k -> 1M alongside the GET repricing in #1144,
+		// which updated the constant but not this pin.
+		expect(intentUtils.convertGasToFeeToken).toHaveBeenCalledWith(ctx, 1_000_000n, "source", "EVM-1")
 	})
 
 	it("normalizes state-machine IDs in cancellation storage keys", () => {


### PR DESCRIPTION
#1144 split `CANCEL_MESSAGE_GAS = 800_000n` into `SOURCE_GET_RESPONSE_GAS` and `REFUND_POST_GAS`, both 1M — and left `orderCanceller.test.ts` asserting the POST at 800k. **Main's CI has failed the `Run SDK test - concurrent` step since it merged**, and every PR cut from current main inherits the red check (#1149, #1150, #1151 are all blocked on it).

One-line fix: the pin now matches the shipped constant, renamed to say 1M, with a comment naming the origin so the next reprice updates both. 9/9 passing locally.