### PR TITLE
[simplex]: size fills against the balance the wallet actually keeps

### DIFF
--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -12,6 +12,24 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-08-19 — Two more ways a fill could be sized past what the wallet can pay
+
+Both found while tracing the paymaster shortfall below, both with the same failure signature — a credit or a balance that the sizing believed in and the chain did not.
+
+**Uniswap V4 credited liquidity it was not going to remove.** `removeCallParameters` re-derives the decrease as `liquidityPercentage.multiply(position.liquidity).quotient`, which truncates, while the planner priced the fill from the untruncated liquidity it asked for. The gap is always in the reverting direction and scales with the withdrawal: at the old 1e6 denominator, a slice of ~0.0159% of a position shed 0.63% of it, roughly $93 of phantom credit on a $14.8k draw. A new `liquidityRemoval` helper resolves the percentage and the liquidity it actually encodes together, at a 1e18 denominator, and the planner now credits and consumes that figure and hands the same `Percent` to the SDK. It also returns null for a slice too thin to register rather than letting the SDK's ZERO_LIQUIDITY invariant throw.
+
+**The escrow-release dispatch fee was unaccounted for.** `HyperApp.dispatchWithFeeToken` pulls `dispatchFee` from the solver's wallet in the destination host's fee token — USDC on Base, the same token most fills pay out. `buildApprovalAndFillCalldata` already added it to the approval; nothing subtracted it from the balance. It is priced by `estimateGasFillPost`, which depends on the funding calls the leg loop produces and so cannot run before it, so `evaluateOrder` now checks affordability straight after the estimate: for a cross-chain order it requires the fee token's post-fill residue to cover the dispatch fee plus the paymaster reserve, and skips otherwise. Shrinking the fill is not an option — cross-chain orders cannot be partially filled.
+
+Files: `src/funding/uniswapV4/UniswapV4FundingPlanner.ts`, `src/strategies/fx.ts`, `src/tests/funding/uniswapV4Removal.test.ts`, `docs/ai/{ChangeLog,Decisions,Flow}.md`.
+
+## 2026-08-19 — Fill sizing reserves the paymaster's gas pull
+
+A partial fill on Base reverted with `ERC20: transfer amount exceeds balance` after being short by 28,993 units — $0.029 on a $14,808.699383 fill. The fill was sized as wallet balance plus the Uniswap V4 credit and bid to the last unit, but the paymaster charges gas in the same USDC and pulls it via `transferFrom` during `validatePaymasterUserOp`, before the batch runs. The bid amount was bit-exact `balance + credited`, and the revert delta was bit-exact the prefund.
+
+The only reserve the sizing loop knew about came from `FundingVenue.walletReserveForToken`, which is the vault's `minBalance`. `UniswapV4FundingPlanner` returns `0n` there by design (LP positions have no wallet float), and a filler configured with no venue at all never enters that loop, so both setups sized fills with zero headroom. A new `paymasterReserveForToken` in the paymaster module now contributes a reserve for the chain's USDC and USDT whenever a paymaster is configured, scaled by each token's own decimals, and the leg loop seeds `reserve` with it.
+
+Files: `src/services/paymaster/index.ts`, `src/strategies/fx.ts`, `src/tests/services/paymaster-reserve.test.ts`, `docs/ai/{ChangeLog,Decisions,Flow}.md`.
+
 ## 2026-08-19 — Cross-lane orders skip cleanly instead of erroring "Shared cache is not initialized"
 
 An operator running only Base saw `ERROR: [intent-filler]: Shared cache is not initialized` whenever an order destined to a chain their filler does not run scrolled past. The solver-selection cache is only ever populated for configured, non-watch-only chains (boot's `solverSelectionChains`), so any other destination fell through `handleNewOrder`'s cache check and was dropped with an error that reads like the filler is broken. The behavior (drop) was correct — there is no client, bundler or float for an unconfigured destination — the diagnosis was not, and it dates to #287.

--- a/sdk/packages/simplex/docs/ai/Decisions.md
+++ b/sdk/packages/simplex/docs/ai/Decisions.md
@@ -4,6 +4,46 @@ AI-maintained record of non-obvious choices made in `sdk/packages/simplex`: what
 
 Entry format: heading with the decision, then alternatives considered and the reasoning. Newest first.
 
+## 2026-08-19 — The V4 planner credits the liquidity the calldata encodes, rather than rounding the percentage up
+
+Chosen: `liquidityRemoval(totalLiquidity, desiredLiquidity)` returns the `Percent` and the liquidity the SDK will derive from it, applying the SDK's own truncation, and the planner prices the withdrawal from that liquidity. The denominator went from 1e6 to 1e18 at the same time.
+
+Alternatives considered: (a) rounding the percentage up so the removal covers what was asked; (b) raising the denominator alone and leaving the credit computed from the requested liquidity.
+
+Why (a) loses: rounding up removes more liquidity than the planner reserved against `remainingLiquidity`, so concurrent plans over one position would over-commit it, and at 100% it cannot round up at all — the case that has to stay exact. Truncating and telling the truth about it is strictly safer than removing more than intended. (b) shrinks the error without removing it, and the error is unbounded in the wrong direction: the credit stays an estimate the chain is not obliged to honour, which is exactly what makes it revert. Fixing the arithmetic and fixing the honesty are separate; only the second one closes the failure mode.
+
+What this does NOT close: `credited` is still the amount the position yields at the *plan-time* `sqrtPriceX96`. Normally the planner's slippage buffer absorbs drift — it targets `remaining × (1 + slippageBps)` and `finalOutputAmount` is capped at `targetOutput`, so the overshoot stays in the wallet as headroom. A drained position (`cappedLiq === availLiq`) has no overshoot and therefore no headroom, which is the exact shape of the fill that failed. Anyone able to move the pool price between bid and execution, by less than the min-amounts tolerance so the withdrawal still succeeds, can make it yield less than was credited and revert the fill. It is griefing rather than theft — `amount0Min`/`amount1Min` prevent a genuinely bad payout, so the cost is a wasted revert that still bills the paymaster. The fix would be to credit `burnAmountsWithSlippage` (the minimum the calldata will accept) instead of the expected amounts, at the price of a systematic under-fill of one slippage tolerance on every drained withdrawal; that trade-off was left to the operator rather than taken here.
+
+The zero guard belongs on the product, not the percentage. Both floors collapse independently: for a 3,441,646,880,004-unit position a single unit of liquidity gives a percentage of 290,558/1e18, which is non-zero, and a decrease of zero — which is what the SDK's ZERO_LIQUIDITY invariant throws on. Guarding the percentage looks equivalent and is not.
+
+Both are applied because they solve different halves. The 1e18 denominator keeps the withdrawal from silently under-delivering against the target (the caller would otherwise plan a second position it did not need); the truthful credit keeps the fill from being sized against tokens the pool will not pay.
+
+## 2026-08-19 — The dispatch fee is a gate after the estimate, not a reserve in the leg loop
+
+Chosen: `evaluateOrder` checks the fee token's post-fill residue against `dispatchFee + paymasterReserve` immediately after `estimateGasFillPost`, and skips the order when it falls short.
+
+Alternatives considered: (a) reserving the dispatch fee in the leg loop alongside the paymaster reserve; (b) moving `estimateGasFillPost` above the leg loop so the figure is available there; (c) reserving a flat configured amount of the fee token.
+
+Why not (a): the figure does not exist yet. `estimateGasFillPost` bumps `callGasLimit` by the funding prepends the leg loop produces and caches the result, so it cannot be priced before the loop that depends on it. (b) is the same problem stated as an ordering change — calling it early caches an estimate with no funding gas bump, and the later call returns that wrong cached value. (c) guesses at a number the estimator already knows exactly.
+
+A gate rather than a resize because a cross-chain order cannot be partially filled (`partialEligibleCheap` requires `sourceChain === destChain`): the fill is all-or-nothing, so an unaffordable one is not ours to take. Same-chain orders dispatch nothing and are unaffected — `dispatchFee` is 0 and `buildApprovalAndFillCalldata` likewise only adds the fee token requirement when the chains differ.
+
+The residue is read through `getAndCacheBalance`, which post-loop returns each output token's balance net of what the fill draws from it, and reads fresh for a fee token no leg paid out. The paymaster reserve is added to the requirement so the dispatch cannot be paid out of the gas headroom.
+
+## 2026-08-19 — Both paymaster tokens carry the wallet reserve, rather than predicting which one is charged
+
+Chosen: `paymasterReserveForToken` (exported from `src/services/paymaster`, called by `FXFiller`'s leg loop) reserves on the leg's output token whenever it is the chain's USDC or USDT and a paymaster is configured — without working out which of the two this UserOp will actually be charged in.
+
+Alternatives considered: (a) replicating the selection ladder (Circle USDC, then Simplex USDC, then Simplex USDT, each gated on a >= 1 token balance) so only the winning token is reserved; (b) resolving the paymaster token once per order before the leg loop and threading it down; (c) returning a non-zero reserve from `UniswapV4FundingPlanner.walletReserveForToken`.
+
+Why (a) loses: it is circular. `buildPaymasterAndData` picks the token at submit time from live balances, and the sizing being computed here is one of the inputs to that pick — a fill that draws USDC under one token makes `selectToken` fall through to USDT, so the prediction invalidates itself. It also duplicates the ladder outside the paymaster module, where a third token would silently not be covered. (b) is sound and would avoid the double-reserve, but it buys little: most chains configure one stablecoin, so the over-reservation is usually nothing and at worst a few dollars of held-back float, against a failure mode that reverts a five-figure fill. (c) was the original instinct and is the wrong layer twice over — `walletReserveForToken` is called for every output token, including exotics the paymaster never charges in, and the venue cannot resolve decimals for a token outside its own pools. Decisively, the UniswapV4 venue is only constructed when `vault.uniswapV4.positions` is non-empty, and the reserve loop only iterates `fundingVenues`: a filler with neither a vault nor V4 positions never runs that loop at all and has the identical bug, so a fix living in the venue would cover some configurations and silently miss others.
+
+Where it lives is a separate question from where it is called. The call has to be unconditional in the leg loop, but the knowledge — which tokens are eligible, at what decimals — belongs beside `selectToken` in the paymaster module that already owns token selection. So `FXFiller` holds one call and no USDC/USDT/decimals detail, and adding a third paymaster token is a change in one file next to the selection ladder it has to stay consistent with.
+
+Sizing: `PAYMASTER_RESERVE_TOKENS = 2n`, scaled per token by `getUsdcDecimals` / `getUsdtDecimals`. The observed prefund was under three cents and most of it came back in postOp, so this is deliberately headroom — for gas spikes, and for other UserOps in flight against the same balance between evaluation and execution. Note the reserve is a no-op for any fill the wallet comfortably covers; it only binds when the fill is balance-limited, which is exactly the partial-fill case that broke.
+
+Not covered: `dispatchWithFeeToken` pulls `relayerFee` in the fee token from this same wallet. It was `0` on the order that failed (same-chain, no dispatch), but on a cross-chain fill it is dollars, not cents, and the reserve does not currently account for it.
+
 ## 2026-08-19 — Review round: shared bench state, Retry-After, and a warn on bench
 
 Chosen, from PR review findings (Wizdave97): (a) bench state is a static map keyed by endpoint URL, not per-instance — the scanner and the confirmation poller construct separate QuorumPublicClients over the same URLs, so instance-local benches halved the relief and evaporated on `setRpcUrls` rebuilds; `clearAllSuspensions()` exists for tests. (b) The bench duration honours the provider's `Retry-After` (clamped to [1s, 5min]) — a per-second limiter should not cost five minutes of degraded quorum. (c) Benching warns through the caller's LoggerContext, naming the endpoint, the duration, and the new effective bar — the bar silently dropping from 2-of-2 to 1-of-1 was otherwise invisible unless a QuorumError happened to be thrown. (d) The all-benched fallback names itself in QuorumError messages instead of reporting `skipped: 0` as if nothing were wrong.

--- a/sdk/packages/simplex/docs/ai/Flow.md
+++ b/sdk/packages/simplex/docs/ai/Flow.md
@@ -2,6 +2,38 @@
 
 AI-maintained map of how code paths in `sdk/packages/simplex` actually execute, so that when something breaks you can tell whether the fault is upstream or downstream of where the symptom appears. Only flows that have been read and verified are documented; coverage grows as areas of the package are touched.
 
+## Filling: how a fill amount is sized, and who else spends the same balance
+
+Verified against the reverted Base fill `0x31de53fe...` (UserOp `0xe090acd1...`), traced end to end.
+
+### Sizing, per leg
+
+`FXFiller.evaluateOrder` walks `order.inputs` and sizes each leg independently (`src/strategies/fx.ts`):
+
+1. `targetOutput` = the smaller of what the curve will pay (`policyMaxOutput`) and what the exposure cap allows (`desiredOutput`).
+2. `reserve` = the paymaster reserve for this token (`paymasterReserveForToken`, from `src/services/paymaster`) plus every funding venue's `walletReserveForToken`. Only the vault returns a non-zero venue reserve, its configured `minBalance`; `UniswapV4FundingPlanner` returns `0n`. The paymaster half is seeded outside the venue loop deliberately — the loop is empty when no vault and no V4 positions are configured, and that filler still sizes partial fills.
+3. `usableWallet` = balance − reserve. `walletContribution` = `min(targetOutput, usableWallet)`.
+4. Any shortfall is requested from each funding venue in turn via `planWithdrawalForToken`, which returns ERC-7821 calls and the amount it expects them to credit. The calls accumulate in `fundingCalls`. For V4 that credit is priced from `liquidityRemoval`, the liquidity the encoded DECREASE_LIQUIDITY actually carries — not the liquidity the planner asked for, which the SDK truncates.
+5. `finalOutputAmount` = `min(walletContribution + credited, targetOutput)`.
+
+After the loop, `estimateGasFillPost` prices the fill. A cross-chain order then has to clear one more affordability check: `fillOrder` dispatches the escrow-release message and `HyperApp.dispatchWithFeeToken` pulls `dispatchFee` from the same wallet in the destination host's fee token (USDC on Base — often the token just paid out). The fee is only known here, after the funding calls it depends on exist, and a cross-chain order cannot be partially filled, so the order is skipped when the residue will not cover the fee plus the paymaster reserve.
+
+Whenever `finalOutputAmount < output.amount` the fill is an under-fill and has to clear `partialEligible()` — same chain, no output calldata, no prior partial — or the order is skipped.
+
+The outputs and the funding calls are cached against the order id (`setFillerOutputs`, `setFundingPrepends`). `ContractInteractionService.prepareBidUserOp` reads them back verbatim and signs them into the bid; nothing re-reads the balance between sizing and execution, and the bid is committed, so an amount that was affordable at evaluation must still be affordable when the UserOp lands.
+
+### The batch, in execution order
+
+`callData` is an ERC-7821 batch: the funding calls first (for V4, `PositionManager.multicall(modifyLiquidities)` encoding DECREASE_LIQUIDITY + TAKE_PAIR), then `approve` for the fill amount, then `IntentGateway.fillOrder`, which does the `transferFrom` that moves the output token to the user.
+
+What matters is what happens *before* any of that. The EntryPoint runs paymaster validation first, and `SimplexPaymaster` prefunds by pulling the EntryPoint's worst-case gas cost out of the solver's wallet with `transferFrom`, in whichever stablecoin `selectToken` picked — refunding the unused part in `_postOp`, long after the batch has already run or reverted. So the balance the batch sees is always lower than the balance the sizing saw, by the prefund.
+
+That is what `paymasterReserveForToken` exists to absorb. Without it, a balance-limited fill — `walletContribution == usableWallet == balance` — is sized to the last unit and reverts by exactly the prefund: 28,993 units of USDC against a 14,808,699,383 fill, where 14,377,624,370 (wallet) + 431,075,013 (V4 credit) reproduces the bid amount exactly.
+
+### Which token the paymaster charges
+
+Decided at submit time, not at sizing time, by `buildPaymasterAndData` (`src/services/paymaster/index.ts`): the Circle paymaster if configured and USDC balance >= 1 USDC, else the Simplex paymaster over the first of `[USDC, USDT]` with a balance >= 1 token (`selectToken`), else no paymaster. Because the sizing decision feeds the balances that decide this, the reserve covers both eligible tokens instead of predicting one.
+
 ## Signing: from construction to each signature
 
 ### Where the signer comes from

--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/simplex",
-	"version": "0.10.0",
+	"version": "0.10.1",
 	"license": "Apache-2.0",
 	"description": "Automated intent filler for the Hyperbridge IntentGateway \u2014 run it as a binary or embed it as a library",
 	"main": "dist/index.js",

--- a/sdk/packages/simplex/src/funding/uniswapV4/UniswapV4FundingPlanner.ts
+++ b/sdk/packages/simplex/src/funding/uniswapV4/UniswapV4FundingPlanner.ts
@@ -25,6 +25,46 @@ import { encodeFunctionData } from "viem"
 const DEFAULT_SLIPPAGE_BPS = 50
 
 /**
+ * Denominator of the liquidity percentage handed to `removeCallParameters`.
+ *
+ * The SDK re-derives the liquidity to decrease as
+ * `liquidityPercentage.multiply(position.liquidity).quotient`, which truncates.
+ * A coarse denominator therefore removes measurably less than asked for — at
+ * 1e6, taking a 0.0158% slice of a position loses up to 0.63% of it.
+ */
+const LIQUIDITY_PERCENT_PRECISION = 10n ** 18n
+
+/**
+ * Resolves a desired liquidity decrease into the percentage the SDK is given and
+ * the liquidity it will actually encode, applying the SDK's own truncation.
+ *
+ * Callers must credit the fill from the returned `liquidity`, never from what
+ * they asked for: the two differ, always downwards, and a credit computed from
+ * the larger figure overstates the tokens the pool will pay out — which reverts
+ * the fill that was sized against it.
+ */
+export function liquidityRemoval(
+	totalLiquidity: bigint,
+	desiredLiquidity: bigint,
+): { percentage: Percent; liquidity: bigint } | null {
+	if (totalLiquidity <= 0n || desiredLiquidity <= 0n) return null
+
+	const capped = desiredLiquidity > totalLiquidity ? totalLiquidity : desiredLiquidity
+	const pct = (capped * LIQUIDITY_PERCENT_PRECISION) / totalLiquidity
+	const liquidity = (pct * totalLiquidity) / LIQUIDITY_PERCENT_PRECISION
+	// Both floors can collapse to nothing independently, so the guard belongs on
+	// the product the SDK actually decreases — a non-zero percentage can still
+	// derive a zero decrease and trip its ZERO_LIQUIDITY invariant. There is no
+	// fill to plan from a slice that thin either way.
+	if (liquidity === 0n) return null
+
+	return {
+		percentage: new Percent(pct.toString(), LIQUIDITY_PERCENT_PRECISION.toString()),
+		liquidity,
+	}
+}
+
+/**
  * Funding venue that sources output tokens by removing liquidity from
  * Uniswap V4 concentrated-liquidity positions (ERC-721 NFTs).
  *
@@ -331,8 +371,15 @@ export class UniswapV4FundingPlanner implements FundingVenue {
 
 				const cappedLiq = neededLiq > availLiq ? availLiq : neededLiq
 
+				// Resolve the percentage the calldata will carry *before* pricing the
+				// withdrawal, and price it from the liquidity that percentage actually
+				// decreases. Pricing `cappedLiq` instead over-credits by the SDK's
+				// truncation, and the fill sized against that credit reverts.
+				const removal = liquidityRemoval(pos.liquidity, cappedLiq)
+				if (!removal) continue
+
 				// Build SDK Position to compute expected amounts
-				const sdkPosition = state.buildSdkPosition(pos.tokenId, cappedLiq)
+				const sdkPosition = state.buildSdkPosition(pos.tokenId, removal.liquidity)
 				if (!sdkPosition) continue
 
 				// The SDK Position computes amounts for the given liquidity
@@ -348,6 +395,7 @@ export class UniswapV4FundingPlanner implements FundingVenue {
 						neededLiq: neededLiq.toString(),
 						availLiq: availLiq.toString(),
 						cappedLiq: cappedLiq.toString(),
+						removedLiq: removal.liquidity.toString(),
 						amount0: amount0.toString(),
 						amount1: amount1.toString(),
 						credit: credit.toString(),
@@ -361,18 +409,18 @@ export class UniswapV4FundingPlanner implements FundingVenue {
 
 				// Use V4PositionManager.removeCallParameters to generate the calldata
 				// This encodes DECREASE_LIQUIDITY + TAKE_PAIR actions internally
-				const call = this.buildRemoveLiquidityCall(state, pos, cappedLiq, deadlineTimestamp)
+				const call = this.buildRemoveLiquidityCall(state, pos, removal.percentage, deadlineTimestamp)
 				if (!call) continue
 
 				allCalls.push(call)
 				totalCredited += credit
 				remaining -= credit
-				state.consume(pos.tokenId, cappedLiq)
+				state.consume(pos.tokenId, removal.liquidity)
 
 				this.logger.debug(
 					{
 						tokenId: pos.tokenId.toString(),
-						liquidity: cappedLiq.toString(),
+						liquidity: removal.liquidity.toString(),
 						tokenOut: tokenNeed,
 						credited: credit.toString(),
 					},
@@ -461,33 +509,21 @@ export class UniswapV4FundingPlanner implements FundingVenue {
 	 * The SDK internally encodes:
 	 *   1. DECREASE_LIQUIDITY action (position tokenId, liquidity delta, min amounts)
 	 *   2. TAKE_PAIR action (currency0, currency1, recipient)
+	 *
+	 * The liquidity delta is absolute in the encoded calldata, so it is fixed at
+	 * plan time and does not drift with the position's on-chain liquidity.
 	 */
 	private buildRemoveLiquidityCall(
 		state: UniswapV4LiquidityState,
 		pos: HydratedV4Position,
-		liquidity: bigint,
+		liquidityPercentage: Percent,
 		deadlineTimestamp?: bigint,
 	): ERC7821Call | null {
-		// Build an SDK Position representing what we want to remove
-		const sdkPosition = state.buildSdkPosition(pos.tokenId, liquidity)
-		if (!sdkPosition) return null
-
-		// Compute the percentage of total position liquidity being removed
-		// The SDK expects a Percent representing what fraction of the position to exit
-		const totalLiq = pos.liquidity
-		if (totalLiq === 0n) return null
-
-		// Calculate percentage with high precision
-		// liquidityPercentage = liquidity / totalLiquidity
-		const pctNumerator = liquidity * 1_000_000n
-		const pctDenominator = totalLiq
-		const pctValue = pctNumerator / pctDenominator
-
-		const liquidityPercentage = new Percent(pctValue.toString(), "1000000")
-
-		// Build a full-liquidity Position for the SDK (it computes the removal
-		// proportionally based on liquidityPercentage)
-		const fullPosition = state.buildSdkPosition(pos.tokenId, totalLiq)
+		// The SDK takes the whole position plus the fraction to exit, and derives
+		// the liquidity to decrease itself. `liquidityPercentage` must be the one
+		// `liquidityRemoval` produced, so the encoded decrease matches the amounts
+		// the caller credited.
+		const fullPosition = state.buildSdkPosition(pos.tokenId, pos.liquidity)
 		if (!fullPosition) return null
 
 		const deadline = deadlineTimestamp ? Number(deadlineTimestamp) : Math.floor(Date.now() / 1000) + 30 * 60

--- a/sdk/packages/simplex/src/services/paymaster/index.ts
+++ b/sdk/packages/simplex/src/services/paymaster/index.ts
@@ -97,6 +97,55 @@ export async function buildPaymasterAndData(options: PaymasterOptions): Promise<
 	}
 }
 
+// ── Wallet reserve ───────────────────────────────────────────────────
+
+/**
+ * Whole tokens of a paymaster-eligible stablecoin a fill must leave in the
+ * wallet. The paymaster's pull is the EntryPoint's worst-case gas cost — cents
+ * on an L2, most of it refunded in postOp — so this is mostly headroom for gas
+ * spikes and for other UserOps in flight against the same balance.
+ */
+export const PAYMASTER_RESERVE_TOKENS = 2n
+
+/**
+ * Wallet balance of `tokenLower` that a fill on `chain` must not spend, because
+ * the paymaster charges gas in this token and pulls it from the same wallet
+ * during validatePaymasterUserOp — before the UserOp's callData runs. A fill
+ * sized to the whole balance is therefore always short by that pull.
+ *
+ * Every eligible token carries the reserve, not just the one that ends up
+ * charged: {@link buildPaymasterAndData} chooses between them at submit time
+ * from live balances, and the fill sizing that consults this is one of the
+ * inputs to that choice, so there is no winner to predict here.
+ *
+ * Returns 0 for a chain with no paymaster and for any token it cannot charge in.
+ */
+export function paymasterReserveForToken(
+	chain: string,
+	tokenLower: string,
+	configService: FillerConfigService,
+): bigint {
+	if (!hasPaymaster(chain, configService)) return 0n
+
+	const candidates: [HexString, () => number][] = [
+		[configService.getUsdcAsset(chain), () => configService.getUsdcDecimals(chain)],
+		[configService.getUsdtAsset(chain), () => configService.getUsdtDecimals(chain)],
+	]
+
+	for (const [address, decimals] of candidates) {
+		if (!isConfiguredAsset(address)) continue
+		if (address.toLowerCase() !== tokenLower) continue
+		return PAYMASTER_RESERVE_TOKENS * 10n ** BigInt(decimals())
+	}
+
+	return 0n
+}
+
+/** Unconfigured assets come back from the config service as "0x" or the zero address. */
+function isConfiguredAsset(address: HexString | undefined): address is HexString {
+	return !!address && address !== "0x" && address.toLowerCase() !== "0x0000000000000000000000000000000000000000"
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────
 
 /**

--- a/sdk/packages/simplex/src/strategies/fx.ts
+++ b/sdk/packages/simplex/src/strategies/fx.ts
@@ -21,6 +21,7 @@ import { Decimal } from "decimal.js"
 import { ERC20_ABI } from "@/config/abis/ERC20"
 import type { FundingVenue } from "@/funding/types"
 import type { Signer } from "@/services/wallet"
+import { paymasterReserveForToken } from "@/services/paymaster"
 
 /**
  * A trading pair the engine serves. `token0` and `token1` are registry symbols
@@ -685,14 +686,13 @@ export class FXFiller implements FillerStrategy {
 					)
 				}
 
-				// Spend the free wallet balance first, down to the configured minBalance
-				// reserve — kept liquid for the gas/paymaster pull during
-				// validatePaymasterUserOp — then source any remaining shortfall from the
-				// funding venues (the vault).
+				// Spend the free wallet balance first, down to the reserve — the paymaster's
+				// gas pull during validatePaymasterUserOp plus the vault's configured
+				// minBalance — then source any remaining shortfall from the funding venues.
 				const tokenAddress = bytes32ToBytes20(output.token).toLowerCase()
 				const balance = await this.getAndCacheBalance(tokenAddress, walletAddress, destClient, balanceCache)
 
-				let reserve = 0n
+				let reserve = paymasterReserveForToken(destChain, tokenAddress, this.configService)
 				for (const venue of this.fundingVenues) {
 					reserve += venue.walletReserveForToken(destChain, tokenAddress)
 				}
@@ -970,8 +970,39 @@ export class FXFiller implements FillerStrategy {
 			// left in place but dormant (always recorded as a clean, unclamped outcome).
 			this.recordOrderOutcome(false, order.id)
 
-			const { totalCostInSourceFeeToken, relayerFeeInSourceFeeToken } =
+			const { totalCostInSourceFeeToken, relayerFeeInSourceFeeToken, dispatchFee } =
 				await this.contractService.estimateGasFillPost(order)
+
+			// `fillOrder` dispatches the escrow-release message back to the source
+			// chain, and HyperApp.dispatchWithFeeToken pulls `dispatchFee` from this
+			// same wallet in the destination host's fee token — which on most chains
+			// is the USDC the fill is already paying out. The leg loop above committed
+			// the balance to outputs without knowing this figure (it is only priced
+			// here, after the funding calls it depends on exist), so the affordability
+			// check has to happen now. A cross-chain order cannot be partially filled,
+			// so shrinking the fill is not on the table: either the residue covers the
+			// dispatch or the order is not ours to take.
+			if (sourceChain !== destChain && dispatchFee > 0n) {
+				const feeToken = await this.contractService.getFeeTokenWithDecimals(destChain)
+				const feeTokenLower = feeToken.address.toLowerCase()
+				// Post-loop, `balanceCache` holds each output token's balance net of
+				// what the fill draws from it; a fee token no leg paid out is read fresh.
+				const residual = await this.getAndCacheBalance(feeTokenLower, walletAddress, destClient, balanceCache)
+				const required = dispatchFee + paymasterReserveForToken(destChain, feeTokenLower, this.configService)
+				if (residual < required) {
+					this.logger.info(
+						{
+							orderId: order.id,
+							feeToken: feeTokenLower,
+							residual: formatUnits(residual, feeToken.decimals),
+							dispatchFee: formatUnits(dispatchFee, feeToken.decimals),
+							required: formatUnits(required, feeToken.decimals),
+						},
+						"Skipping order: fill leaves too little of the fee token to dispatch the escrow release",
+					)
+					return 0
+				}
+			}
 
 			// GATE 1 — execution cost (independent). order.fees exist solely to pay
 			// for execution: the fill gas plus, for cross-chain orders, the relayer

--- a/sdk/packages/simplex/src/tests/funding/uniswapV4Removal.test.ts
+++ b/sdk/packages/simplex/src/tests/funding/uniswapV4Removal.test.ts
@@ -1,0 +1,154 @@
+import { liquidityRemoval } from "@/funding/uniswapV4/UniswapV4FundingPlanner"
+import { Percent, Token } from "@uniswap/sdk-core"
+import { Pool as V4Pool, Position as V4Position, V4PositionManager } from "@uniswap/v4-sdk"
+import { decodeAbiParameters, decodeFunctionData, parseAbi } from "viem"
+import { describe, it, expect } from "vitest"
+
+// `removeCallParameters` re-derives the liquidity to decrease as
+// `liquidityPercentage.multiply(position.liquidity).quotient`, which truncates.
+// The planner credits a fill from what it expects the pool to pay out, so the
+// figure it prices must be the liquidity the calldata actually carries — never
+// the larger one it asked for, which reverts the fill sized against it.
+
+// The position drained by the reverted Base fill, tokenId 2226801.
+const POSITION_LIQUIDITY = 3_441_646_880_004n
+
+// A 1e6 denominator loses up to 1/floor(desired * 1e6 / total) of the withdrawal
+// — worst when that division lands just under a whole number. This slice is
+// ~0.0159% of the position, where the old code shed 0.63%.
+const WORST_CASE_SLICE = (POSITION_LIQUIDITY * 158_999n) / 1_000_000_000n
+
+describe("liquidityRemoval", () => {
+	it("removes the whole position exactly when asked for all of it", () => {
+		const removal = liquidityRemoval(POSITION_LIQUIDITY, POSITION_LIQUIDITY)
+		expect(removal?.liquidity).toBe(POSITION_LIQUIDITY)
+		expect(removal?.percentage.equalTo(1)).toBe(true)
+	})
+
+	it("never encodes more liquidity than asked for", () => {
+		for (const desired of [2n, 7n, 1_000n, 543_210_987n, POSITION_LIQUIDITY / 3n, POSITION_LIQUIDITY - 1n]) {
+			const removal = liquidityRemoval(POSITION_LIQUIDITY, desired)
+			expect(removal).not.toBeNull()
+			expect(removal!.liquidity).toBeLessThanOrEqual(desired)
+		}
+	})
+
+	it("loses at most one unit of liquidity to truncation, even on the worst slice", () => {
+		const removal = liquidityRemoval(POSITION_LIQUIDITY, WORST_CASE_SLICE)
+		expect(WORST_CASE_SLICE - removal!.liquidity).toBeLessThanOrEqual(1n)
+	})
+
+	it("beats the 1e6 denominator it replaced", () => {
+		// What the old code encoded: floor(desired * 1e6 / total) / 1e6 * total.
+		const coarsePct = (WORST_CASE_SLICE * 1_000_000n) / POSITION_LIQUIDITY
+		const coarse = (coarsePct * POSITION_LIQUIDITY) / 1_000_000n
+		const removal = liquidityRemoval(POSITION_LIQUIDITY, WORST_CASE_SLICE)
+
+		expect(coarse).toBeLessThan(removal!.liquidity)
+		// The old shortfall is a real fraction of the withdrawal, not a rounding unit:
+		// on a $14.8k draw that is roughly $93 of credit the pool never pays out.
+		expect(Number(WORST_CASE_SLICE - coarse) / Number(WORST_CASE_SLICE)).toBeGreaterThan(0.006)
+	})
+
+	it("caps a request for more than the position holds", () => {
+		const removal = liquidityRemoval(POSITION_LIQUIDITY, POSITION_LIQUIDITY * 2n)
+		expect(removal?.liquidity).toBe(POSITION_LIQUIDITY)
+	})
+
+	it("returns null rather than encoding a zero decrease", () => {
+		// The SDK's ZERO_LIQUIDITY invariant throws on a zero partial position, so a
+		// slice too thin to register must not reach it. Note the percentage alone is
+		// not the test: for this position a single unit of liquidity yields a
+		// non-zero percentage whose product with the total still floors to nothing.
+		expect(liquidityRemoval(POSITION_LIQUIDITY, 0n)).toBeNull()
+		expect(liquidityRemoval(0n, 100n)).toBeNull()
+		expect(liquidityRemoval(10n ** 30n, 1n)).toBeNull()
+		expect(liquidityRemoval(POSITION_LIQUIDITY, 1n)).toBeNull()
+		// One unit up, it survives — the boundary is real, not a blanket rejection.
+		expect(liquidityRemoval(POSITION_LIQUIDITY, 2n)?.liquidity).toBe(1n)
+	})
+})
+
+// `liquidityRemoval` reproduces the SDK's own truncation so the planner can
+// credit a fill from the liquidity the calldata will actually carry. That is a
+// contract with `removeCallParameters`, not an implementation detail: if a
+// v4-sdk upgrade changes how it derives the decrease, the credit silently goes
+// back to overstating and fills revert. So assert it against the real encoder.
+describe("liquidityRemoval matches what removeCallParameters encodes", () => {
+	const TOKEN0 = new Token(8453, "0x46c85152bfe9f96829aa94755d9f915f9b10ef5f", 18)
+	const TOKEN1 = new Token(8453, "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913", 6)
+
+	/** Runs the real SDK encoder and pulls the liquidity out of DECREASE_LIQUIDITY. */
+	function encodedLiquidity(totalLiquidity: bigint, percentage: Percent): bigint {
+		const pool = new V4Pool(
+			TOKEN0,
+			TOKEN1,
+			3000,
+			60,
+			"0x0000000000000000000000000000000000000000",
+			"79228162514264337593543950336",
+			totalLiquidity.toString(),
+			0,
+		)
+		const position = new V4Position({
+			pool,
+			tickLower: -600,
+			tickUpper: 600,
+			liquidity: totalLiquidity.toString(),
+		})
+		const { calldata } = V4PositionManager.removeCallParameters(position, {
+			slippageTolerance: new Percent(50, 10_000),
+			deadline: "1900000000",
+			hookData: "0x",
+			tokenId: "2226801",
+			liquidityPercentage: percentage,
+			burnToken: false,
+		})
+
+		const { args } = decodeFunctionData({
+			abi: parseAbi(["function modifyLiquidities(bytes unlockData, uint256 deadline)"]),
+			data: calldata as `0x${string}`,
+		})
+		const [, params] = decodeAbiParameters(
+			[{ type: "bytes" }, { type: "bytes[]" }],
+			args[0] as `0x${string}`,
+		)
+		// DECREASE_LIQUIDITY params: (tokenId, liquidity, amount0Min, amount1Min, hookData)
+		const [, liquidity] = decodeAbiParameters(
+			[{ type: "uint256" }, { type: "uint256" }, { type: "uint128" }, { type: "uint128" }, { type: "bytes" }],
+			(params as readonly `0x${string}`[])[0],
+		)
+		return liquidity as bigint
+	}
+
+	it("encodes exactly the liquidity the planner credited", () => {
+		for (const desired of [
+			POSITION_LIQUIDITY,
+			POSITION_LIQUIDITY - 1n,
+			POSITION_LIQUIDITY / 2n,
+			POSITION_LIQUIDITY / 3n,
+			WORST_CASE_SLICE,
+			1_000_000n,
+			2n,
+		]) {
+			const removal = liquidityRemoval(POSITION_LIQUIDITY, desired)
+			expect(removal, `no removal for ${desired}`).not.toBeNull()
+			expect(encodedLiquidity(POSITION_LIQUIDITY, removal!.percentage)).toBe(removal!.liquidity)
+		}
+	})
+
+	it("never hands the SDK a percentage it will reject", () => {
+		// Every non-null result must encode without tripping ZERO_LIQUIDITY.
+		for (let desired = 1n; desired <= 40n; desired++) {
+			const removal = liquidityRemoval(POSITION_LIQUIDITY, desired)
+			if (!removal) continue
+			expect(removal.liquidity).toBeGreaterThan(0n)
+			expect(encodedLiquidity(POSITION_LIQUIDITY, removal.percentage)).toBe(removal.liquidity)
+		}
+	})
+
+	it("still encodes the whole position when the fill drains it", () => {
+		const removal = liquidityRemoval(POSITION_LIQUIDITY, POSITION_LIQUIDITY)
+		expect(encodedLiquidity(POSITION_LIQUIDITY, removal!.percentage)).toBe(POSITION_LIQUIDITY)
+	})
+})

--- a/sdk/packages/simplex/src/tests/services/paymaster-reserve.test.ts
+++ b/sdk/packages/simplex/src/tests/services/paymaster-reserve.test.ts
@@ -1,0 +1,74 @@
+import { paymasterReserveForToken, PAYMASTER_RESERVE_TOKENS } from "@/services/paymaster"
+import type { FillerConfigService } from "@/services/FillerConfigService"
+import type { HexString } from "@hyperbridge/sdk"
+import { describe, it, expect } from "vitest"
+
+// The reserve exists because the paymaster charges gas in USDC or USDT and
+// pulls it from the solver's wallet during validatePaymasterUserOp, before the
+// UserOp's callData runs. A partial fill sized to the whole balance is short by
+// exactly that pull — the failure this guards against reverted a $14,808.699383
+// fill on Base for 2.9 cents.
+
+const CHAIN = "EVM-8453"
+const USDC = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913" as HexString
+const USDT = "0xfde4c96c8593536e31f229ea8f37b2ada2699bb2" as HexString
+const EXOTIC = "0x2222222222222222222222222222222222222222" as HexString
+const ZERO = "0x0000000000000000000000000000000000000000" as HexString
+
+interface ChainAssets {
+	usdc?: HexString
+	usdcDecimals?: number
+	usdt?: HexString
+	usdtDecimals?: number
+	paymaster?: boolean
+}
+
+function configFor(assets: ChainAssets): FillerConfigService {
+	return {
+		getUsdcAsset: () => assets.usdc ?? ZERO,
+		getUsdtAsset: () => assets.usdt ?? ZERO,
+		getUsdcDecimals: () => assets.usdcDecimals ?? 6,
+		getUsdtDecimals: () => assets.usdtDecimals ?? 6,
+		getCirclePaymasterAddress: () =>
+			assets.paymaster === false ? undefined : ("0x0578cfb241215b77442a541325d6a4e6dfe700ec" as HexString),
+		getSimplexPaymasterAddress: () => undefined,
+	} as unknown as FillerConfigService
+}
+
+const reserve = (assets: ChainAssets, token: HexString): bigint =>
+	paymasterReserveForToken(CHAIN, token.toLowerCase(), configFor(assets))
+
+describe("paymasterReserveForToken", () => {
+	it("reserves whole tokens of USDC at the chain's decimals", () => {
+		expect(reserve({ usdc: USDC, usdcDecimals: 6 }, USDC)).toBe(PAYMASTER_RESERVE_TOKENS * 1_000_000n)
+	})
+
+	it("reserves USDT at its own decimals, not USDC's", () => {
+		// USDT is 18 decimals on BSC and 6 on Base — a literal reserve would be
+		// wrong by a factor of 10^12 on one of them.
+		const assets = { usdc: USDC, usdcDecimals: 6, usdt: USDT, usdtDecimals: 18 }
+		expect(reserve(assets, USDT)).toBe(PAYMASTER_RESERVE_TOKENS * 10n ** 18n)
+		expect(reserve(assets, USDC)).toBe(PAYMASTER_RESERVE_TOKENS * 1_000_000n)
+	})
+
+	it("reserves nothing for a token the paymaster cannot charge in", () => {
+		expect(reserve({ usdc: USDC, usdt: USDT }, EXOTIC)).toBe(0n)
+	})
+
+	it("reserves nothing when the chain has no paymaster", () => {
+		expect(reserve({ usdc: USDC, paymaster: false }, USDC)).toBe(0n)
+	})
+
+	it("does not treat an unconfigured stablecoin as a match for the native token", () => {
+		// Unconfigured assets read back as the zero address, and a native-token
+		// leg carries the zero address too. Matching them would reserve a
+		// stablecoin's worth of native balance against a paymaster that never
+		// charges in it.
+		expect(reserve({ usdc: USDC, usdt: undefined }, ZERO)).toBe(0n)
+	})
+
+	it("matches the configured asset case-insensitively", () => {
+		const checksummed = `0x${USDC.slice(2).toUpperCase()}` as HexString
+		expect(reserve({ usdc: checksummed }, USDC)).toBe(PAYMASTER_RESERVE_TOKENS * 1_000_000n)
+	})
+})


### PR DESCRIPTION
A partial fill on Base reverted with `ERC20: transfer amount exceeds balance`, short by 28,993 units — $0.029 on a $14,808.699383 fill (`0x31de53fe881c481e22a69af70e4561f1fdd5c87eb21a2486586fb3db6e2a4fdb`). The fill was sized as wallet balance plus the Uniswap V4 credit and bid to the last unit, but the paymaster charges gas in that same USDC and pulls it during `validatePaymasterUserOp`, before the batch runs. The bid was bit-exact `balance + credited`; the revert delta was bit-exact the prefund.

Tracing it turned up two more places where the sizing trusted a number the chain was not going to honour.

**Paymaster reserve.** The only reserve the leg loop knew about came from `FundingVenue.walletReserveForToken`, i.e. the vault's `minBalance`. The V4 planner returns `0n` there by design, and a filler with no funding venue never enters that loop at all, so both configurations sized fills with zero headroom. `paymasterReserveForToken` now contributes a reserve for the chain's USDC and USDT when a paymaster is configured, scaled by each token's own decimals. It covers both eligible tokens rather than predicting which gets charged, because `buildPaymasterAndData` decides that at submit time from the balances this sizing feeds.

**V4 credited liquidity it was not going to remove.** `removeCallParameters` re-derives the decrease as `liquidityPercentage.multiply(position.liquidity).quotient`, which truncates, while the planner priced the fill from the untruncated liquidity it asked for — always in the reverting direction. At the old 1e6 denominator a ~0.0159% slice of a position shed 0.63% of it. `liquidityRemoval` now resolves the percentage and the liquidity it actually encodes together at 1e18, and the planner credits and consumes that figure. A test runs the real SDK encoder and asserts the two agree, so a v4-sdk upgrade that changes the derivation fails loudly.

**The escrow-release dispatch fee.** `HyperApp.dispatchWithFeeToken` pulls `dispatchFee` from the same wallet in the destination host's fee token — USDC on Base, the token most fills pay out. The approval already accounted for it; nothing subtracted it from the balance. It is only priced by `estimateGasFillPost`, which depends on the funding calls the leg loop produces, so affordability is checked straight after the estimate and a cross-chain order is skipped when the residue will not cover the fee plus the paymaster reserve. Cross-chain orders cannot be partially filled, so shrinking the fill is not an option.
