### PR TITLE
[simplex] Simplex fx strategy pricing

### DIFF
--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -12,6 +12,62 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-08-20 — Fills pay the curve amount again, not the user's requested amount
+
+`FXFiller` had stopped overfilling entirely: every fill paid out exactly
+`order.output.assets[i].amount`. `targetOutput` was `min(policyMaxOutput, desiredOutput)`, and
+`desiredOutput` is `output.amount` whenever the leg is not exposure-capped. Combined with the
+acceptance gate just below it (`if (policyMaxOutput < desiredOutput) return 0` — skip when the
+curve pays less than asked), the two form a pincer: any order that survives to a fill has
+`policyMaxOutput >= desiredOutput`, so `targetOutput` was always `desiredOutput`. Not an edge
+case — 100% of non-balance-limited fills paid the requested amount and nothing more, whatever the
+configured exchange rate said. Observed on Base fill `0x60b299e8...`: 25.469 ycNGN redeemed to
+1,380 cNGN and exactly 1,380 cNGN forwarded, no surplus transfer and no `DustCollected`.
+
+Introduced by #1123, which added `capFraction`/`desiredOutput` for the `maxOrderSize` exposure cap
+and then reused `desiredOutput` as the general fill target — conflating "the slice the cap allows"
+with "the amount to pay". Before #1123 the target was `policyMaxOutput` outright. No test asserts
+the payout against the curve, so it landed silently.
+
+`targetOutput` is now `policyMaxOutput` in every case — see the entry below, which took the cap
+branch back out after this landed.
+
+Files: src/strategies/fx.ts.
+
+## 2026-08-20 — The curve amount is the payout unconditionally, and `maxOrderSize` is optional
+
+Two changes to the same sizing decision.
+
+**`targetOutput = policyMaxOutput`, capped or not.** The fix above still let the exposure cap clamp
+the payout down to the user's pro-rata ask on a capped leg. It no longer does. `maxOrderSize` still
+binds where it always did — `computeLegPolicyOutput` rations `token0ForLeg` against the pair's
+remaining budget before the rate is applied, so a capped leg's curve amount is already the capped
+slice's worth. What changes is the escrow side: paying above the pro-rata ask draws down more input
+than the cap fraction nominally allots. That is more of the user's token for the same outlay, and
+the outlay itself is still capped.
+
+`capLimited` had to follow. It was `desiredOutput < output.amount` — true whenever a cap was active
+at all — and it forces the partial-fill eligibility gate. With the payout no longer clamped to
+`desiredOutput`, a curve running far enough above the order's rate can cover the whole ask out of a
+capped slice; that is a full fill and gating it as a partial would reject cross-chain and calldata
+orders the filler can actually serve. The condition is now `capFraction.lt(1) && policyMaxOutput <
+output.amount` — the cap is active *and* it actually shortens the fill.
+
+**`maxOrderSize` is now optional.** `TradingPair.maxOrderSize` is `Decimal | undefined`; absent
+means uncapped, and the pair fills every order at its full notional. `validatePairConfigs` no
+longer requires it (a malformed value is still rejected), `tradingPairFrom` maps an absent TOML
+value to `undefined` instead of the placeholder `new Decimal(0)`, and `sizeOrder` budgets an
+uncapped pair against the order's own total so the per-pair ration still stops sibling legs
+double-spending the same token0 without ever binding below the order. `FXFiller`'s constructor
+check accepts absence and keeps exempting reference-only pairs, which never fill and whose callers
+still pass a placeholder `0`.
+
+Test updated: `validatePairConfigs > requires a positive maxOrderSize` asserted the removed throw;
+it is now `accepts an omitted maxOrderSize, and rejects a malformed one`.
+
+Files: src/strategies/fx.ts, src/config/pairs.ts, src/core/boot.ts, src/simplex.ts,
+src/tests/pairs.test.ts.
+
 ## 2026-08-19 — A phantom probe is no longer rationed by the pair's exposure cap
 
 `quotePhantomFill` fed the pair's per-order exposure budget into `computeLegPolicyOutput`, which

--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -12,6 +12,26 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-08-20 — Regression test: fills pay the curve amount
+
+The payout fix below restored `targetOutput = policyMaxOutput`, but nothing asserted the payout —
+the original regression landed silently precisely because no test pinned `calculateProfitability`'s
+cached outputs (the figure `prepareBidUserOp` signs into the bid) against the curve.
+`fx.curve-payout.test.ts` drives `calculateProfitability` with mocked chain access and pins the
+three sizing outcomes: an uncapped leg pays the curve amount, not the user's requested amount; a
+capped leg pays the capped slice's worth at the curve, not the user's pro-rata ask; and a
+balance-limited leg pays what the wallet covers — a full fill when that still clears the ask.
+Verified to fail on the pre-fix clamp: reintroducing `min(policyMaxOutput, desiredOutput)` fails
+all three cases with exactly the clamped amounts.
+
+The file is added to `test:filler`, the script CI actually runs — a payout test the CI never
+executes would repeat the original failure mode. (`pnpm test` runs the full suite, but CI does not;
+`pairs.test.ts`, which exercises the profit gates, is in no CI script at all and currently fails 12
+of its cases on main — 9 predating #1154 and 3 from #1154 unrationing phantom probes without
+updating the cap expectations. Repairing that suite and wiring it into CI is a separate task.)
+
+Files: src/tests/strategies/fx.curve-payout.test.ts (new), package.json, docs/ai/ChangeLog.md.
+
 ## 2026-08-20 — A per-order cap can be removed, from the UI and over the API
 
 The previous entry made `maxOrderSize` optional in config but left it one-way at runtime: an

--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -12,6 +12,34 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-08-20 — A per-order cap can be removed, from the UI and over the API
+
+The previous entry made `maxOrderSize` optional in config but left it one-way at runtime: an
+operator could add a cap to an uncapped market, and could not take one off without editing the TOML
+by hand. Both halves of that are now closed.
+
+`AdminStrategy` gains `clearMaxOrderSize?: () => void` alongside `setMaxOrderSize`, implemented in
+`adminStrategyFor` by setting the live `TradingPair.maxOrderSize` to `undefined` — the engine reads
+the cap per order, so removal binds on the next evaluation exactly as a resize does.
+
+`DELETE /api/strategies/:index/max-order-size` exposes it, on its own route rather than as a null on
+the existing `PUT /api/strategies/:index`. `DELETE /api/strategies/:index` already means "remove the
+market"; a cap removal one typo away from a market removal is not worth one fewer endpoint. The
+handler is idempotent and refuses reference-only markets, matching the PUT.
+
+`Simplex.clearMaxOrderSize(index)` is the library equivalent, shaped after the existing
+`clearCurve`.
+
+In the operator dashboard, the cap field is now blankable: emptying it turns the button into
+"Remove cap" and issues the DELETE, while any other edit still PUTs. The button enables on any
+change from the persisted value, including set-to-blank, which the old `!maxOrderSize.trim()` guard
+disabled. The setup wizard's cap fields accept blank too and omit the key entirely rather than
+emitting `""`, which config validation would reject as a malformed decimal rather than read as "no
+cap".
+
+Files: src/core/boot.ts, src/services/server/UiServer.ts, src/simplex.ts,
+ui/src/operator/Operator.tsx, ui/src/wizard/state.ts, ui/src/wizard/steps/Strategies.tsx.
+
 ## 2026-08-20 — Fills pay the curve amount again, not the user's requested amount
 
 `FXFiller` had stopped overfilling entirely: every fill paid out exactly

--- a/sdk/packages/simplex/docs/ai/Decisions.md
+++ b/sdk/packages/simplex/docs/ai/Decisions.md
@@ -4,6 +4,37 @@ AI-maintained record of non-obvious choices made in `sdk/packages/simplex`: what
 
 Entry format: heading with the decision, then alternatives considered and the reasoning. Newest first.
 
+## 2026-08-20 — Removing a cap is its own endpoint, not a null on the update
+
+Chosen: `DELETE /api/strategies/:index/max-order-size`, with `AdminStrategy.clearMaxOrderSize` and
+`Simplex.clearMaxOrderSize(index)` behind it. `PUT /api/strategies/:index` still requires a positive
+value.
+
+The obvious alternative — accept `maxOrderSize: null` (or `""`) on the PUT — is one fewer endpoint
+and was rejected on blast radius. `DELETE /api/strategies/:index` already removes the *market*. A
+scheme where a cap removal and a market removal differ by a path suffix is bad enough; one where a
+cap removal is a field value that a serialization bug, a form default, or a stray `undefined` can
+produce is worse, because the failure is silent and the fix is a re-add. An explicit verb on an
+explicit resource cannot be reached by accident.
+
+The handler is idempotent: clearing an already-uncapped market returns 200 with the same state
+rather than 404 or 409. The UI decides what to send from the field's contents alone and does not
+track which state the market is in, so a strict version would make the client carry knowledge it has
+no reason to have.
+
+Alternatives rejected:
+
+- *`PATCH` with `maxOrderSize: null`.* See above.
+- *A `capped: boolean` toggle beside the value.* Two controls for one setting, and it forces a
+  decision about what the value field holds while the toggle is off — remembered, cleared, or
+  ignored. A blank field is the same information with nothing to keep in sync.
+- *Reuse `PUT /api/strategies/:index` with an empty body.* Ambiguous with a no-op update, and the
+  handler already rejects unknown/absent fields to catch exactly that class of mistake.
+
+In the UI the field itself is the control: blank means uncapped, the button relabels to "Remove
+cap", and it enables on any divergence from the persisted value rather than on a non-empty value —
+the old guard made blanking unsubmittable, which is precisely the state that now needs submitting.
+
 ## 2026-08-20 — `maxOrderSize` is optional
 
 Chosen: `TradingPair.maxOrderSize` is `Decimal | undefined`. Absent means uncapped.
@@ -32,10 +63,7 @@ check. `FXFiller` takes `TradingPair[]` as a public constructor argument, and ca
 against the old required field still pass `new Decimal(0)` there. A reference pair never fills, so
 its cap is never read either way — rejecting it would break those callers for nothing.
 
-Not done: there is no way to *clear* a cap once set. `Simplex.setMaxOrderSize` and the UI server's
-PATCH endpoint both require a positive value, so an operator can add a cap to an uncapped pair but
-not remove one without editing the TOML. Adding a clear path is new public API surface and was left
-out.
+Since resolved: removal is now reachable at runtime — see "Removing a cap is its own endpoint".
 
 ## 2026-08-20 — The curve amount is the fill, and the exposure cap does not shorten it
 

--- a/sdk/packages/simplex/docs/ai/Decisions.md
+++ b/sdk/packages/simplex/docs/ai/Decisions.md
@@ -4,6 +4,89 @@ AI-maintained record of non-obvious choices made in `sdk/packages/simplex`: what
 
 Entry format: heading with the decision, then alternatives considered and the reasoning. Newest first.
 
+## 2026-08-20 — `maxOrderSize` is optional
+
+Chosen: `TradingPair.maxOrderSize` is `Decimal | undefined`. Absent means uncapped.
+
+The cap was mandatory in `validatePairConfigs` but already optional in the TOML type, so
+`tradingPairFrom` bridged the gap with `new Decimal(pair.maxOrderSize ?? "0")` — a placeholder that
+only worked because reference-only pairs never reach the sizing path. A zero cap and no cap are
+opposites, and encoding "no cap" as the most restrictive possible value is the kind of thing that
+holds until someone routes a new pair type through the same code.
+
+`sizeOrder` is where absence is resolved: an uncapped pair sets `cappedByPair` to the order's own
+per-pair total and `capFraction` to 1. That keeps the per-pair ration in `computeLegPolicyOutput`
+doing its other job — stopping two legs of the same pair from spending the same token0 twice —
+without it ever binding below the order.
+
+Alternatives rejected:
+
+- *Keep it required and let operators write a very large number.* Works, but "uncapped" then has no
+  representation, only an approximation, and the log line reads as a cap that happens not to bind.
+- *Default an absent cap to `Infinity`.* Same behaviour, but `Decimal(Infinity)` propagates into
+  `capFraction` division and into every log that stringifies the cap. `undefined` makes each
+  consumer state what it does when there is no cap.
+
+Kept deliberately: `assertPairValid` still exempts reference-only pairs from the positive-value
+check. `FXFiller` takes `TradingPair[]` as a public constructor argument, and callers written
+against the old required field still pass `new Decimal(0)` there. A reference pair never fills, so
+its cap is never read either way — rejecting it would break those callers for nothing.
+
+Not done: there is no way to *clear* a cap once set. `Simplex.setMaxOrderSize` and the UI server's
+PATCH endpoint both require a positive value, so an operator can add a cap to an uncapped pair but
+not remove one without editing the TOML. Adding a clear path is new public API surface and was left
+out.
+
+## 2026-08-20 — The curve amount is the fill, and the exposure cap does not shorten it
+
+Chosen: `targetOutput = policyMaxOutput`, unconditionally.
+
+Overfilling is a feature of the protocol, not an accident the filler should suppress.
+`IntrinsicIntents.sol` has an explicit `solverAmount > totalRequired` branch that splits the excess
+between the beneficiary and the protocol (`surplusShareBps`); `quotePhantomFill` publishes
+`policyMaxOutput` as our quoted rate, so paying `output.amount` advertises a price we do not
+honour; and `calculateProfitability`'s own doc says we overfill "if the pair pricing makes that
+attractive. This is how we stay competitive."
+
+`desiredOutput` is redundant with the ration `computeLegPolicyOutput` already applies to
+`token0ForLeg`, and it is no longer a ceiling on payout at all — it survives only as the price
+gate's comparand and in the short-fill logs. `maxOrderSize` binds in the token0 dimension, before
+the rate is applied, which is where the exposure actually is: a capped leg never pays out more than
+the capped slice's worth at the curve.
+
+The trade-off, taken knowingly: escrow releases as `fillAmount / totalRequired`, so on a capped leg
+paying above the user's pro-rata ask draws down more input than the cap fraction nominally allots.
+That is more of the user's token for the same outlay — the cap bounds what the filler spends, not
+what it receives — and treating the receive side as the thing to ration was clamping the price the
+operator configured.
+
+`capLimited` had to follow, and is now `capFraction.lt(1) && policyMaxOutput < output.amount`
+rather than `desiredOutput < output.amount`. It gates partial-fill eligibility, and with the payout
+unclamped a curve far enough above the order's rate can cover the whole ask out of a capped slice.
+That is a full fill; gating it as a partial would reject cross-chain and calldata orders the filler
+can serve.
+
+Alternatives rejected:
+
+- *Clamp to `desiredOutput` on capped legs only.* What this replaced. It keeps the escrow draw
+  exactly proportional to the cap, but at the cost of quoting one price and filling another on
+  every capped order — the same defect as the unconditional clamp, just rarer and harder to see.
+- *Keep the clamp and stop publishing `policyMaxOutput` from `quotePhantomFill`.* Makes the quote
+  match the fill, but by degrading the quote to the order's own rate — which is the counterparty's
+  number, not ours. The price feed would stop carrying any information about the operator's curve.
+- *Re-enable `maxOverfillBps` as part of this change.* Deliberately left alone. The clamp at the
+  overfill-ceiling block is still a no-op assignment (`const policyMaxOutput = rawPolicyMaxOutput`)
+  and `recordOrderOutcome` is still always called with `false`, so `maxOverfillBps` and the halt
+  subsystem remain dormant config. Restoring the payout makes that ceiling meaningful again and it
+  should be either re-armed or deleted outright — a separate decision from fixing the payout, and
+  one that changes the filler's loss bound rather than its price.
+
+Left standing, and known stale: `curveSurplusUsd` (the P&L fallback for legs with no opposite
+curve) measures `policyMaxOutput - output.amount` and calls the difference "ours". With the surplus
+now paid out that term is structurally zero on uncapped legs. It is report-only telemetry — it
+never rejects an order or feeds the execute score — so it under-reports rather than mis-fills, and
+re-basing it on the opposite curve was left out of this change.
+
 ## 2026-08-19 — The exposure cap governs fills, never probes
 
 Chosen: `computeLegPolicyOutput` takes `remainingToken0: Decimal | null`, and `quotePhantomFill`

--- a/sdk/packages/simplex/docs/ai/Flow.md
+++ b/sdk/packages/simplex/docs/ai/Flow.md
@@ -10,13 +10,15 @@ Verified against the reverted Base fill `0x31de53fe...` (UserOp `0xe090acd1...`)
 
 `FXFiller.evaluateOrder` walks `order.inputs` and sizes each leg independently (`src/strategies/fx.ts`):
 
-1. `targetOutput` = the smaller of what the curve will pay (`policyMaxOutput`) and what the exposure cap allows (`desiredOutput`).
+1. `targetOutput` = what the curve will pay (`policyMaxOutput`), in every case. This is the amount the leg intends to hand over, and it may exceed what the user asked for — `IntrinsicIntents.fillOrder` takes `solverAmount > totalRequired` and splits the excess between the beneficiary and the protocol (`surplusShareBps`), and it is the same figure `quotePhantomFill` publishes as the pair's quoted rate. A pair's `maxOrderSize` is optional and does not shorten this: it binds earlier and in the other unit, where `computeLegPolicyOutput` rations `token0ForLeg` against the pair's remaining budget before the rate is applied. `desiredOutput` — the user's ask scaled by the same cap — is no longer a ceiling on payout; it survives as the price gate's comparand and in the short-fill logs.
 2. `reserve` = the paymaster reserve for this token (`paymasterReserveForToken`, from `src/services/paymaster`) plus every funding venue's `walletReserveForToken`. Only the vault returns a non-zero venue reserve, its configured `minBalance`; `UniswapV4FundingPlanner` returns `0n`. The paymaster half is seeded outside the venue loop deliberately — the loop is empty when no vault and no V4 positions are configured, and that filler still sizes partial fills.
 3. `usableWallet` = balance − reserve. `walletContribution` = `min(targetOutput, usableWallet)`.
 4. Any shortfall is requested from each funding venue in turn via `planWithdrawalForToken`, which returns ERC-7821 calls and the amount it expects them to credit. The calls accumulate in `fundingCalls`. For V4 that credit is priced from `liquidityRemoval`, the liquidity the encoded DECREASE_LIQUIDITY actually carries — not the liquidity the planner asked for, which the SDK truncates.
 5. `finalOutputAmount` = `min(walletContribution + credited, targetOutput)`.
 
 After the loop, `estimateGasFillPost` prices the fill. A cross-chain order then has to clear one more affordability check: `fillOrder` dispatches the escrow-release message and `HyperApp.dispatchWithFeeToken` pulls `dispatchFee` from the same wallet in the destination host's fee token (USDC on Base — often the token just paid out). The fee is only known here, after the funding calls it depends on exist, and a cross-chain order cannot be partially filled, so the order is skipped when the residue will not cover the fee plus the paymaster reserve.
+
+A capped leg is separately gated as a partial fill when the cap actually shortens it — `capFraction.lt(1) && policyMaxOutput < output.amount`. Both halves matter: with the payout unclamped, a curve running far enough above the order's rate covers the whole ask out of a capped slice, which is a full fill.
 
 Whenever `finalOutputAmount < output.amount` the fill is an under-fill and has to clear `partialEligible()` — same chain, no output calldata, no prior partial — or the order is skipped.
 

--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/simplex",
-	"version": "0.10.2",
+	"version": "0.11.0",
 	"license": "Apache-2.0",
 	"description": "Automated intent filler for the Hyperbridge IntentGateway \u2014 run it as a binary or embed it as a library",
 	"main": "dist/index.js",

--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -40,7 +40,7 @@
 		"build": "bash ./scripts/build.sh",
 		"prepublishOnly": "npm run build",
 		"test": "pnpm run codegen && vitest --watch=false --maxConcurrency=1",
-		"test:filler": "pnpm run codegen && vitest --watch=false --maxConcurrency=1 --testTimeout=1000000 src/tests/strategies/fx.testnet.test.ts src/tests/quorum-public-client.test.ts",
+		"test:filler": "pnpm run codegen && vitest --watch=false --maxConcurrency=1 --testTimeout=1000000 src/tests/strategies/fx.curve-payout.test.ts src/tests/strategies/fx.testnet.test.ts src/tests/quorum-public-client.test.ts",
 		"test:basic:testnet": "pnpm run codegen && vitest --watch=false --maxConcurrency=1 --testTimeout=1000000 src/tests/strategies/basic.testnet.test.ts",
 		"test:fx": "pnpm run codegen && vitest --watch=false --maxConcurrency=1 --testTimeout=1000000 src/tests/strategies/fx.mainnet.test.ts",
 		"test:fx-testnet": "pnpm run codegen && vitest --watch=false --maxConcurrency=1 --testTimeout=1000000 src/tests/strategies/fx.testnet.test.ts",

--- a/sdk/packages/simplex/src/config/pairs.ts
+++ b/sdk/packages/simplex/src/config/pairs.ts
@@ -15,7 +15,7 @@ import {
  * [[pairs]]
  * token0 = "USDC"        # quote side — any symbol in the asset registry
  * token1 = "CNGN"        # base side — any symbol in the asset registry
- * maxOrderSize = "5000"  # per-order cap, in token0 units
+ * maxOrderSize = "5000"  # optional per-order cap, in token0 units; omit for uncapped
  * bidPriceCurve = [ { amount = "1000", price = "1580" } ]
  * askPriceCurve = [ { amount = "1000", price = "1550" } ]
  * ```
@@ -251,9 +251,8 @@ export function validatePairConfigs(
 			}
 		}
 
-		if (pair.maxOrderSize === undefined && !pair.referenceOnly) {
-			throw new Error(`pairs.${label}: 'maxOrderSize' is required (per-order cap in ${token0} units)`)
-		}
+		// Optional: omitting it leaves the pair uncapped, filling every order at its
+		// full notional. Present and malformed is still an error.
 		if (pair.maxOrderSize !== undefined) {
 			let maxOrderSize: Decimal
 			try {

--- a/sdk/packages/simplex/src/core/boot.ts
+++ b/sdk/packages/simplex/src/core/boot.ts
@@ -141,8 +141,9 @@ export function tradingPairFrom(pair: PairConfig): TradingPair {
 	return {
 		token0: pair.token0,
 		token1: pair.token1,
-		// Reference-only pairs never fill, so the cap is never consulted.
-		maxOrderSize: new Decimal(pair.maxOrderSize ?? "0"),
+		// Optional: absent means uncapped. Reference-only pairs never fill, so the
+		// cap is never consulted for them either way.
+		maxOrderSize: pair.maxOrderSize === undefined ? undefined : new Decimal(pair.maxOrderSize),
 		referenceOnly: pair.referenceOnly === true,
 		bidPricePolicy: pair.bidPriceCurve?.length ? new FillerPricePolicy({ points: pair.bidPriceCurve }) : undefined,
 		askPricePolicy: pair.askPriceCurve?.length ? new FillerPricePolicy({ points: pair.askPriceCurve }) : undefined,
@@ -176,11 +177,12 @@ export function adminStrategyFor(
 		referenceOnly: pair.referenceOnly === true,
 	}
 	// A reference pair's cap is never consulted (it never fills), so leave it
-	// absent rather than surfacing the placeholder "0" as editable.
+	// absent rather than surfacing an editable field that does nothing. An
+	// uncapped pair reports no current value but can still be given one.
 	if (pair.referenceOnly !== true) {
-		adminStrategy.maxOrderSize = pair.maxOrderSize.toString()
+		adminStrategy.maxOrderSize = pair.maxOrderSize?.toString()
 		adminStrategy.setMaxOrderSize = (value) => {
-			const previous = pair.maxOrderSize.toString()
+			const previous = pair.maxOrderSize?.toString() ?? "uncapped"
 			pair.maxOrderSize = new Decimal(value)
 			adminStrategy.maxOrderSize = value
 			logger.warn(

--- a/sdk/packages/simplex/src/core/boot.ts
+++ b/sdk/packages/simplex/src/core/boot.ts
@@ -153,7 +153,8 @@ export function tradingPairFrom(pair: PairConfig): TradingPair {
 /**
  * Editable view of one trading pair for the UI server, or null for
  * venue-priced (curve-less) pairs — they have nothing to edit. The
- * enableSide/disableSide/setMaxOrderSize closures mutate the live TradingPair:
+ * enableSide/disableSide/setMaxOrderSize/clearMaxOrderSize closures mutate the
+ * live TradingPair:
  * the engine reads curve presence and the cap per order, so assignment opens or
  * closes a direction and resizes the market from the next evaluation.
  */
@@ -188,6 +189,15 @@ export function adminStrategyFor(
 			logger.warn(
 				{ pair: `${pair.token0}/${pair.token1}`, previous, next: value },
 				"Per-order cap resized by operator",
+			)
+		}
+		adminStrategy.clearMaxOrderSize = () => {
+			const previous = pair.maxOrderSize?.toString() ?? "uncapped"
+			pair.maxOrderSize = undefined
+			adminStrategy.maxOrderSize = undefined
+			logger.warn(
+				{ pair: `${pair.token0}/${pair.token1}`, previous },
+				"Per-order cap removed by operator — market is now uncapped",
 			)
 		}
 	}

--- a/sdk/packages/simplex/src/services/server/UiServer.ts
+++ b/sdk/packages/simplex/src/services/server/UiServer.ts
@@ -57,7 +57,10 @@ export interface AdminStrategy {
 	token1: string
 	bid?: FillerPricePolicy
 	ask?: FillerPricePolicy
-	/** Per-order cap in token0 units, as configured. Kept in step with `setMaxOrderSize`. */
+	/**
+	 * Per-order cap in token0 units, as configured; absent when the market is
+	 * uncapped. Kept in step with `setMaxOrderSize` and `clearMaxOrderSize`.
+	 */
 	maxOrderSize?: string
 	/**
 	 * Applies a new per-order cap to the live TradingPair — the engine reads it
@@ -65,6 +68,12 @@ export interface AdminStrategy {
 	 * ran at boot (the edit is then persisted for the next start).
 	 */
 	setMaxOrderSize?: (value: string) => void
+	/**
+	 * Removes the per-order cap from the live TradingPair, leaving the market
+	 * uncapped — it then fills every order at its full notional. Same
+	 * availability as `setMaxOrderSize`.
+	 */
+	clearMaxOrderSize?: () => void
 	/** Same-asset cross-chain market: ask-only, prices strictly below par. */
 	sameToken?: boolean
 	/** Price feed only — the pair never fills; curves stay editable, sides are never opened. */
@@ -399,6 +408,13 @@ export class UiServer {
 			if (method === "DELETE") return this.handleMarketRemove(res, Number(strategyMatch[1]))
 			if (method === "PUT") return this.handleMarketUpdate(req, res, Number(strategyMatch[1]))
 			return sendJson(res, 405, { error: "Method not allowed" })
+		}
+
+		const capMatch = path.match(/^\/api\/strategies\/(\d+)\/max-order-size$/)
+		if (capMatch) {
+			if (this.mode !== "operator") return sendJson(res, 409, { error: "Filler is not running" })
+			if (method !== "DELETE") return sendJson(res, 405, { error: "Method not allowed" })
+			return this.handleMaxOrderSizeClear(res, Number(capMatch[1]))
 		}
 
 		const curvesMatch = path.match(/^\/api\/strategies\/(\d+)\/curves$/)
@@ -912,6 +928,45 @@ export class UiServer {
 		this.logger.warn(
 			{ strategy: index, pair: `${strategy.token0}/${strategy.token1}`, maxOrderSize: value, applied },
 			"Max order size updated by operator",
+		)
+		return sendJson(res, 200, {
+			...serializeStrategy(strategy),
+			applied,
+			restartNeeded: !applied,
+			persisted,
+		})
+	}
+
+	/**
+	 * DELETE /api/strategies/:index/max-order-size — removes a market's per-order
+	 * cap, leaving it uncapped. Its own route rather than a null on the PUT:
+	 * DELETE /api/strategies/:index already means "remove the market", and a cap
+	 * removal that a typo could turn into a market removal is not a trade worth
+	 * making for one fewer endpoint.
+	 *
+	 * Idempotent — clearing an already-uncapped market succeeds and reports the
+	 * same state, so the UI does not have to know which it is.
+	 */
+	private async handleMaxOrderSizeClear(res: ServerResponse, index: number): Promise<void> {
+		const op = this.operator!
+		const strategy = op.strategies.find((s) => s.index === index)
+		if (!strategy) return sendJson(res, 404, { error: `No strategy with index ${index}` })
+		if (strategy.referenceOnly) {
+			return sendJson(res, 409, {
+				error: "Reference-only markets never fill orders — their order cap is never consulted",
+			})
+		}
+
+		const previous = strategy.maxOrderSize
+		strategy.clearMaxOrderSize?.()
+		strategy.maxOrderSize = undefined
+		const pair = op.config.pairs?.[strategy.pairIndex]
+		if (pair) pair.maxOrderSize = undefined
+		const persisted = this.persistConfig()
+		const applied = Boolean(strategy.clearMaxOrderSize)
+		this.logger.warn(
+			{ strategy: index, pair: `${strategy.token0}/${strategy.token1}`, previous, applied },
+			"Max order size removed by operator — market is now uncapped",
 		)
 		return sendJson(res, 200, {
 			...serializeStrategy(strategy),

--- a/sdk/packages/simplex/src/simplex.ts
+++ b/sdk/packages/simplex/src/simplex.ts
@@ -328,6 +328,17 @@ export class PairController {
 		await this.persist()
 	}
 
+	/**
+	 * Removes the per-order cap, leaving the pair uncapped — it then fills every
+	 * order at its full notional. Binds on the next order.
+	 */
+	async clearMaxOrderSize(index: number): Promise<void> {
+		const pair = this.livePair(index)
+		pair.maxOrderSize = undefined
+		this.pairs[index].maxOrderSize = undefined
+		await this.persist()
+	}
+
 	private livePair(index: number) {
 		const pair = this.runtime.tradingPairs?.[index]
 		if (!pair) throw new Error(`Unknown pair ${index}`)

--- a/sdk/packages/simplex/src/simplex.ts
+++ b/sdk/packages/simplex/src/simplex.ts
@@ -208,7 +208,7 @@ export class PairController {
 				index,
 				token0: pair.token0,
 				token1: pair.token1,
-				maxOrderSize: pair.referenceOnly ? undefined : tradingPair?.maxOrderSize.toString(),
+				maxOrderSize: pair.referenceOnly ? undefined : tradingPair?.maxOrderSize?.toString(),
 				bid,
 				ask,
 				sameToken: normalizeSymbol(pair.token0) === normalizeSymbol(pair.token1),

--- a/sdk/packages/simplex/src/strategies/fx.ts
+++ b/sdk/packages/simplex/src/strategies/fx.ts
@@ -37,16 +37,21 @@ import { paymasterReserveForToken } from "@/services/paymaster"
  * cross-chain market: ask-only, with the ask price at or below par — the gap
  * to 1 is the filler's spread, realized in-kind on every fill.
  *
- * `maxOrderSize` caps the pair's exposure per order, denominated in token0 —
- * the curve amount axis shares that unit, so trade pricing never consults an
- * external feed. Confirmation sizing alone converts token0 notionals to USD,
- * derived from the declared curves (USD stables at $1, curve mids as FX edges).
+ * `maxOrderSize` optionally caps the pair's exposure per order, denominated in
+ * token0 — the curve amount axis shares that unit, so trade pricing never
+ * consults an external feed. Omit it and the pair is uncapped: every leg is
+ * priced and filled at its full notional. Confirmation sizing alone converts
+ * token0 notionals to USD, derived from the declared curves (USD stables at $1,
+ * curve mids as FX edges).
  */
 export interface TradingPair {
 	token0: string
 	token1: string
-	/** Maximum token0 notional this pair fills per order. Ignored for reference-only pairs. */
-	maxOrderSize: Decimal
+	/**
+	 * Maximum token0 notional this pair fills per order. Omit for an uncapped
+	 * pair. Ignored for reference-only pairs, which never fill.
+	 */
+	maxOrderSize?: Decimal
 	bidPricePolicy?: FillerPricePolicy
 	askPricePolicy?: FillerPricePolicy
 	/**
@@ -252,9 +257,16 @@ export class FXFiller implements FillerStrategy {
 			)
 		}
 		seenPairs.add(label)
-		if (!pair.referenceOnly && (!pair.maxOrderSize.isFinite() || pair.maxOrderSize.lte(0))) {
+		// Absent is legal — an uncapped pair. Present and nonsensical is not, except
+		// on a reference-only pair, which never fills and whose cap is never read;
+		// callers predating the optional field still pass a placeholder 0 there.
+		if (
+			!pair.referenceOnly &&
+			pair.maxOrderSize !== undefined &&
+			(!pair.maxOrderSize.isFinite() || pair.maxOrderSize.lte(0))
+		) {
 			throw new Error(
-				`FXFiller pair ${pair.token0}/${pair.token1}: maxOrderSize must be a positive token0 amount`,
+				`FXFiller pair ${pair.token0}/${pair.token1}: maxOrderSize must be a positive token0 amount when set`,
 			)
 		}
 		if (pair.referenceOnly) {
@@ -467,13 +479,13 @@ export class FXFiller implements FillerStrategy {
 
 	/**
 	 * Evaluates whether an order is profitable to fill under the per-pair
-	 * `maxOrderSize` caps and the filler's current token balances.
+	 * `maxOrderSize` caps (where set) and the filler's current token balances.
 	 *
 	 * High-level flow:
 	 * - Resolve each (input, output) leg to a configured pair and direction.
 	 * - Estimate each pair's total token0 notional in the order and cap it at
-	 *   the pair's `maxOrderSize`; pair curves are evaluated at that capped
-	 *   notional.
+	 *   the pair's `maxOrderSize` when one is set; pair curves are evaluated at
+	 *   that (possibly uncapped) notional.
 	 * - Walk the legs, allocating from each pair's capped token0 budget and
 	 *   pricing outputs at the pair's rate.
 	 * - Further cap each leg by the filler's current token balance plus
@@ -516,8 +528,8 @@ export class FXFiller implements FillerStrategy {
 
 			const venueUsdPrice = this.venuePriceMemo()
 
-			// Per-pair token0 notionals, capped at each pair's maxOrderSize. The
-			// capped notional is both the curve evaluation point and the budget
+			// Per-pair token0 notionals, capped at each pair's maxOrderSize where one
+			// is set. That notional is both the curve evaluation point and the budget
 			// legs of that pair draw from.
 			const sized = await this.sizeOrder(order, legs, venueUsdPrice)
 			if (!sized) {
@@ -603,7 +615,10 @@ export class FXFiller implements FillerStrategy {
 				const token0Decimals = leg.inputIsToken0 ? inputDecimals : outputDecimals
 				const token1Decimals = leg.inputIsToken0 ? outputDecimals : inputDecimals
 
-				const cappedNotional = cappedByPair.get(leg.pair) ?? leg.pair.maxOrderSize
+				// `sizeOrder` populates an entry for every pair these legs resolve to, so
+				// the fallback is defensive only — the leg's own notional, never a cap
+				// that may not exist.
+				const cappedNotional = cappedByPair.get(leg.pair) ?? legNotionals[i]
 				const rates = await this.resolveLegRates(order.id, leg, cappedNotional, venueUsdPrice)
 				if (!rates) return 0
 				legRatesByIndex.set(i, rates)
@@ -659,7 +674,6 @@ export class FXFiller implements FillerStrategy {
 				const desiredOutput = capFraction.gte(1)
 					? output.amount
 					: BigInt(new Decimal(output.amount.toString()).mul(capFraction).floor().toFixed(0))
-				const capLimited = desiredOutput < output.amount
 
 				// Overfill detection is warn-only: the clamp is DISABLED, so the filler
 				// fills the full computed amount even when it exceeds
@@ -698,11 +712,28 @@ export class FXFiller implements FillerStrategy {
 				}
 				const usableWallet = balance > reserve ? balance - reserve : 0n
 
-				// Source only what we intend to provide. `policyMaxOutput` is what our
-				// curve would pay for the whole input; under an exposure cap we fill
-				// `desiredOutput`, and withdrawing the larger figure from a vault would
-				// strand the difference in the wallet for no fill.
-				const targetOutput = policyMaxOutput < desiredOutput ? policyMaxOutput : desiredOutput
+				// What we intend to provide — and the figure the funding venues are asked
+				// to source, so a vault withdrawal never strands tokens in the wallet.
+				//
+				// Always the curve amount, capped or not. The curve IS the price, and
+				// paying it out even when it exceeds what the user asked for is the
+				// point: IntrinsicIntents.sol has an explicit `solverAmount >
+				// totalRequired` branch that splits the excess between the beneficiary
+				// and the protocol (`surplusShareBps`), and `quotePhantomFill` publishes
+				// this same figure as our quoted rate — paying less would advertise a
+				// price we do not honour.
+				//
+				// `maxOrderSize` still bounds this: `computeLegPolicyOutput` rationed
+				// `token0ForLeg` against the pair's remaining budget before the rate was
+				// applied, so a capped leg's curve amount is already the capped slice's
+				// worth. `desiredOutput` — the user's ask scaled by the same cap — is a
+				// second expression of that ration in output-token units, kept for the
+				// price gate and the short-fill logs, but no longer a ceiling on payout.
+				// The trade-off: on a capped leg, escrow releases as
+				// `fillAmount / totalRequired`, so paying above the pro-rata ask draws
+				// down more input than the cap fraction nominally allots — more of the
+				// user's token for the same outlay, and never more outlay than the cap.
+				const targetOutput = policyMaxOutput
 
 				const walletContribution = targetOutput < usableWallet ? targetOutput : usableWallet
 
@@ -768,7 +799,7 @@ export class FXFiller implements FillerStrategy {
 							inputAmount: input.amount.toString(),
 							legNotional: legNotionals[i].toString(),
 							pricedNotional: token0Used.toString(),
-							maxOrderSize: leg.pair.maxOrderSize.toString(),
+							maxOrderSize: leg.pair.maxOrderSize?.toString() ?? "uncapped",
 							policyOutput: policyMaxOutput.toString(),
 							desiredOutput: desiredOutput.toString(),
 							userRequested: output.amount.toString(),
@@ -779,14 +810,19 @@ export class FXFiller implements FillerStrategy {
 					return 0
 				}
 
-				if (capLimited) {
+				// The cap only shortens the fill if the curve amount it allows actually
+				// falls below the ask. Since the payout is `policyMaxOutput` rather than
+				// the pro-rata `desiredOutput`, a curve running far enough above the
+				// order's rate can cover the whole ask out of a capped slice — that is a
+				// full fill and must not be gated as a partial one.
+				if (capFraction.lt(1) && policyMaxOutput < output.amount) {
 					if (!(await partialEligible())) {
 						this.logger.info(
 							{
 								orderId: order.id,
 								pair: `${leg.pair.token0}/${leg.pair.token1}`,
 								token: output.token,
-								maxOrderSize: leg.pair.maxOrderSize.toString(),
+								maxOrderSize: leg.pair.maxOrderSize?.toString() ?? "uncapped",
 								desiredOutput: desiredOutput.toString(),
 								userRequested: output.amount.toString(),
 								crossChain: sourceChain !== destChain,
@@ -1232,8 +1268,9 @@ export class FXFiller implements FillerStrategy {
 	 *
 	 * The estimate uses the leg's own price source at minimum size (curve at 0,
 	 * or the venue quote) to convert token1-input legs into token0 terms. Each
-	 * pair's total is capped at its `maxOrderSize` — that capped notional is
-	 * the point pair curves are evaluated at and the budget its legs draw from.
+	 * pair's total is capped at its `maxOrderSize` when it has one — that
+	 * notional is the point pair curves are evaluated at and the budget its legs
+	 * draw from. A pair with no cap budgets against the order's own total.
 	 *
 	 * Returns null when a leg cannot be estimated (no usable rate).
 	 */
@@ -1244,7 +1281,7 @@ export class FXFiller implements FillerStrategy {
 	): Promise<{
 		legNotionals: Decimal[]
 		cappedByPair: Map<TradingPair, Decimal>
-		/** min(1, maxOrderSize / uncapped notional) per pair — the exposure cap as a ratio. */
+		/** min(1, maxOrderSize / uncapped notional) per pair — the exposure cap as a ratio; 1 when uncapped. */
 		capFractionByPair: Map<TradingPair, Decimal>
 		totalNotional: Decimal
 	} | null> {
@@ -1279,7 +1316,11 @@ export class FXFiller implements FillerStrategy {
 		// legNotionals (per-pair token0) or getOrderUsdValue (USD).
 		let totalNotional = new Decimal(0)
 		for (const [pair, total] of totals) {
-			cappedByPair.set(pair, Decimal.min(total, pair.maxOrderSize))
+			// An uncapped pair budgets its legs against the order's own notional: the
+			// per-pair ration in `computeLegPolicyOutput` still keeps sibling legs from
+			// double-spending the same token0, it just never binds below the order.
+			const cap = pair.maxOrderSize
+			cappedByPair.set(pair, cap === undefined ? total : Decimal.min(total, cap))
 			// The one place the cap test is exact. Both sides are token0 notionals
 			// derived from `referenceRate`, so the comparison is single-basis —
 			// unlike `token0Used` vs `legNotionals[i]` downstream, where the former
@@ -1287,7 +1328,7 @@ export class FXFiller implements FillerStrategy {
 			// so a sloped curve makes them differ with the cap nowhere near binding.
 			capFractionByPair.set(
 				pair,
-				total.gt(pair.maxOrderSize) && total.gt(0) ? pair.maxOrderSize.div(total) : new Decimal(1),
+				cap !== undefined && total.gt(cap) && total.gt(0) ? cap.div(total) : new Decimal(1),
 			)
 			totalNotional = totalNotional.plus(total)
 		}
@@ -1656,7 +1697,7 @@ export class FXFiller implements FillerStrategy {
 
 			// A probe advertising more than the pair will actually fill is a config problem the
 			// operator has to see: the price is honest, but no order that size can clear it.
-			if (legNotional.gt(leg.pair.maxOrderSize)) {
+			if (leg.pair.maxOrderSize !== undefined && legNotional.gt(leg.pair.maxOrderSize)) {
 				this.logger.warn(
 					{
 						orderId: order.id,

--- a/sdk/packages/simplex/src/tests/pairs.test.ts
+++ b/sdk/packages/simplex/src/tests/pairs.test.ts
@@ -345,10 +345,11 @@ describe("validatePairConfigs", () => {
 		).toThrow(/must be positive/)
 	})
 
-	it("requires a positive maxOrderSize", () => {
-		expect(() => validatePairConfigs([{ token0: "USDC", token1: "CNGN", askPriceCurve: CURVE } as any])).toThrow(
-			/maxOrderSize' is required/,
-		)
+	it("accepts an omitted maxOrderSize, and rejects a malformed one", () => {
+		// Omitted means uncapped — the pair fills every order at its full notional.
+		expect(() =>
+			validatePairConfigs([{ token0: "USDC", token1: "CNGN", askPriceCurve: CURVE } as any]),
+		).not.toThrow()
 		expect(() =>
 			validatePairConfigs([{ token0: "USDC", token1: "CNGN", maxOrderSize: "0", askPriceCurve: CURVE }]),
 		).toThrow(/positive/)

--- a/sdk/packages/simplex/src/tests/strategies/fx.curve-payout.test.ts
+++ b/sdk/packages/simplex/src/tests/strategies/fx.curve-payout.test.ts
@@ -1,0 +1,204 @@
+import { FXFiller, type TradingPair } from "@/strategies/fx"
+import { FillerPricePolicy } from "@/config/interpolated-curve"
+import { AssetRegistry } from "@/config/asset-registry"
+import { bytes20ToBytes32, type HexString, type Order, type TokenInfo } from "@hyperbridge/sdk"
+import { describe, it, expect } from "vitest"
+import { Decimal } from "decimal.js"
+import { parseUnits } from "viem"
+
+// Pins the fill amount `calculateProfitability` caches — the figure
+// `prepareBidUserOp` signs into the bid verbatim — against the configured curve.
+//
+// Regression context: #1123 introduced `desiredOutput` for the `maxOrderSize`
+// cap and took `targetOutput = min(policyMaxOutput, desiredOutput)`. The price
+// gate right below guarantees `policyMaxOutput >= desiredOutput` for any leg
+// that survives to a fill, so every fill silently paid the user's requested
+// amount instead of the curve amount — and no test caught it, because nothing
+// asserted the payout. These tests drive the evaluation with mocked chain
+// access and assert the cached outputs for the three sizing outcomes: uncapped
+// (pay the curve), capped (pay the capped slice's worth at the curve), and
+// balance-limited (pay what the wallet covers).
+
+const CHAIN = "EVM-97"
+const STABLE = "0x1111111111111111111111111111111111111111" as HexString
+const EXOTIC = "0x2222222222222222222222222222222222222222" as HexString
+const SOLVER = "0x3333333333333333333333333333333333333333" as HexString
+
+// Flat ask: the filler sells EXOTIC at 1500 per token0, at every size.
+const FLAT_ASK = new FillerPricePolicy({ points: [{ amount: "0", price: "1500" }] })
+
+// 100 token0 in; the order asks for 149,000 EXOTIC (rate 1490, below the
+// curve's 1500) so the curve amount of 150,000 strictly exceeds the ask.
+const INPUT_AMOUNT = parseUnits("100", 18)
+const REQUESTED_OUTPUT = parseUnits("149000", 18)
+const CURVE_OUTPUT = parseUnits("150000", 18)
+
+const configService = {
+	getUsdcAsset: () => STABLE,
+	getUsdtAsset: () => "0x0000000000000000000000000000000000000000" as HexString,
+	getDaiAsset: () => "0x0000000000000000000000000000000000000000" as HexString,
+	getCNgnAsset: () => undefined,
+	getMaxOverfillBps: () => 500n,
+	getMaxConsecutiveClamps: () => 3,
+	// No paymaster configured → paymasterReserveForToken contributes nothing.
+	getCirclePaymasterAddress: () => undefined,
+	getSimplexPaymasterAddress: () => undefined,
+} as any
+
+/**
+ * Contract service covering everything `calculateProfitability` touches, with
+ * gas priced at zero so the payout under test is the only moving part. Exposes
+ * the filler-output and partial-fill caches for assertions.
+ */
+function makeEvalContractService(): any {
+	const classifications = new Map<string, unknown>()
+	const outputs = new Map<string, TokenInfo[]>()
+	const partials = new Map<string, boolean>()
+	return {
+		getTokenDecimals: async () => 18,
+		getFeeTokenWithDecimals: async () => ({ address: STABLE, decimals: 18 }),
+		estimateGasFillPost: async () => ({
+			totalCostInSourceFeeToken: 0n,
+			relayerFeeInSourceFeeToken: 0n,
+			dispatchFee: 0n,
+		}),
+		// No prior partial fills on-chain: an under-fill stays eligible.
+		partialFillsFor: async () => [0n],
+		cacheService: {
+			getPairClassifications: (id: string) => classifications.get(id),
+			setPairClassifications: (id: string, pairs: unknown) => classifications.set(id, pairs),
+			getFillerOutputs: (id: string) => outputs.get(id),
+			setFillerOutputs: (id: string, value: TokenInfo[]) => outputs.set(id, value),
+			clearPartialFill: (id: string) => partials.delete(id),
+			setPartialFill: (id: string, value: boolean) => partials.set(id, value),
+			getPartialFill: (id: string) => partials.get(id),
+			setFundingPrepends: () => {},
+			clearFundingPrepends: () => {},
+		},
+		outputs,
+		partials,
+	}
+}
+
+/** Public client stub: balances by lowercase token address, everything else static. */
+function makeClientManager(balances: Record<string, bigint>): any {
+	const client = {
+		chain: { blockTime: 2000 },
+		getBlock: async () => ({ number: 100n, timestamp: 1_000_000n }),
+		getBalance: async () => 0n,
+		readContract: async ({ address }: { address: string }) => balances[address.toLowerCase()] ?? 0n,
+	}
+	return { getPublicClient: () => client }
+}
+
+function makeFiller(options: {
+	contractService: any
+	balances: Record<string, bigint>
+	maxOrderSize?: number
+}): FXFiller {
+	const registry = new AssetRegistry(configService, { EXOTIC: { [CHAIN]: EXOTIC } })
+	const pairs: TradingPair[] = [
+		{
+			token0: "USDC",
+			token1: "EXOTIC",
+			...(options.maxOrderSize !== undefined ? { maxOrderSize: new Decimal(options.maxOrderSize) } : {}),
+			askPricePolicy: FLAT_ASK,
+		},
+	]
+	const signer = { address: SOLVER } as any
+	return new FXFiller(
+		signer,
+		configService,
+		makeClientManager(options.balances),
+		options.contractService,
+		pairs,
+		registry,
+	)
+}
+
+/** Same-chain USDC→EXOTIC order (partial-fill eligible: no calldata, not cross-chain). */
+function makeOrder(id: string): Order {
+	const inputs: TokenInfo[] = [{ token: bytes20ToBytes32(STABLE), amount: INPUT_AMOUNT }]
+	const outputs: TokenInfo[] = [{ token: bytes20ToBytes32(EXOTIC), amount: REQUESTED_OUTPUT }]
+	return {
+		id,
+		user: bytes20ToBytes32(SOLVER),
+		source: CHAIN,
+		destination: CHAIN,
+		deadline: 0n,
+		nonce: 0n,
+		// Covers the (zero) execution cost with room to spare, so GATE 1 passes
+		// and the evaluation reaches its cached-outputs answer.
+		fees: parseUnits("1", 18),
+		session: "0x0000000000000000000000000000000000000000" as HexString,
+		predispatch: { assets: [], call: "0x" as HexString },
+		inputs,
+		output: { beneficiary: bytes20ToBytes32(SOLVER), assets: outputs, call: "0x" as HexString },
+	} as unknown as Order
+}
+
+describe("FXFiller curve payout", () => {
+	it("pays the curve amount, not the user's requested amount", async () => {
+		const contractService = makeEvalContractService()
+		const filler = makeFiller({
+			contractService,
+			balances: { [EXOTIC.toLowerCase()]: parseUnits("1000000", 18) },
+			maxOrderSize: 5000,
+		})
+
+		const profit = await filler.calculateProfitability(makeOrder("payout-full"))
+
+		const cached = contractService.outputs.get("payout-full")
+		expect(cached).toHaveLength(1)
+		expect(cached![0].token).toBe(bytes20ToBytes32(EXOTIC))
+		// 100 token0 at the flat ask of 1500 — the curve amount. The #1123
+		// regression paid REQUESTED_OUTPUT (149,000) here instead.
+		expect(cached![0].amount).toBe(CURVE_OUTPUT)
+		expect(cached![0].amount).not.toBe(REQUESTED_OUTPUT)
+		// Paying above the ask is a full fill (the gateway splits the excess),
+		// and the fee surplus makes it score.
+		expect(contractService.partials.get("payout-full")).toBe(false)
+		expect(profit).toBeGreaterThan(0)
+	})
+
+	it("pays a capped leg the capped slice's worth at the curve, not the pro-rata ask", async () => {
+		const contractService = makeEvalContractService()
+		// Cap 40 of the 100 token0 notional: capFraction 0.4. The ration is
+		// applied in token0 BEFORE the rate, so the payout is 40 × 1500 = 60,000 —
+		// not the pro-rata ask of 149,000 × 0.4 = 59,600 (the pre-#1155 clamp),
+		// and not the full ask.
+		const filler = makeFiller({
+			contractService,
+			balances: { [EXOTIC.toLowerCase()]: parseUnits("1000000", 18) },
+			maxOrderSize: 40,
+		})
+
+		await filler.calculateProfitability(makeOrder("payout-capped"))
+
+		const cached = contractService.outputs.get("payout-capped")
+		expect(cached).toHaveLength(1)
+		expect(cached![0].amount).toBe(parseUnits("60000", 18))
+		// The capped slice's worth is below the full ask, so this is an under-fill.
+		expect(contractService.partials.get("payout-capped")).toBe(true)
+	})
+
+	it("pays what the wallet covers when balance-limited, still a full fill above the ask", async () => {
+		const contractService = makeEvalContractService()
+		// Wallet holds 149,500 — between the ask (149,000) and the curve amount
+		// (150,000). The payout is capped by the balance, but it still clears the
+		// ask, so the fill is full, not partial.
+		const filler = makeFiller({
+			contractService,
+			balances: { [EXOTIC.toLowerCase()]: parseUnits("149500", 18) },
+			maxOrderSize: 5000,
+		})
+
+		const profit = await filler.calculateProfitability(makeOrder("payout-balance"))
+
+		const cached = contractService.outputs.get("payout-balance")
+		expect(cached).toHaveLength(1)
+		expect(cached![0].amount).toBe(parseUnits("149500", 18))
+		expect(contractService.partials.get("payout-balance")).toBe(false)
+		expect(profit).toBeGreaterThan(0)
+	})
+})

--- a/sdk/packages/simplex/ui/src/operator/Operator.tsx
+++ b/sdk/packages/simplex/ui/src/operator/Operator.tsx
@@ -317,19 +317,31 @@ function StrategyCurves(props: {
 		}
 	}
 
+	// An empty field means "no cap": the market fills every order at its full
+	// notional. Clearing is its own endpoint rather than a PUT of "", so the
+	// server never has to guess whether a blank body meant remove or mistake.
+	const capValue = maxOrderSize.trim()
+	const capCleared = capValue === ""
+	const capChanged = capValue !== (strategy.maxOrderSize ?? "")
+
 	const applyMaxOrderSize = async () => {
 		setMessage(undefined)
 		setError(undefined)
 		try {
-			const res = await api.put<{ persisted: boolean; restartNeeded: boolean }>(`/api/strategies/${strategy.index}`, {
-				maxOrderSize: maxOrderSize.trim(),
-			})
+			const res = capCleared
+				? await api.del<{ persisted: boolean; restartNeeded: boolean }>(
+						`/api/strategies/${strategy.index}/max-order-size`,
+					)
+				: await api.put<{ persisted: boolean; restartNeeded: boolean }>(`/api/strategies/${strategy.index}`, {
+						maxOrderSize: capValue,
+					})
+			const what = capCleared ? "Cap removed — market is uncapped" : "Cap applied"
 			setMessage(
 				res.restartNeeded
-					? "Saved to config — restart the filler to apply the new cap"
+					? `Saved to config — restart the filler to apply${capCleared ? " the removal" : " the new cap"}`
 					: res.persisted
-						? "Cap applied & saved to config"
-						: "Cap applied in memory — config file could not be written",
+						? `${what} & saved to config`
+						: `${what} in memory — config file could not be written`,
 			)
 			onApplied()
 		} catch (err) {
@@ -391,18 +403,20 @@ function StrategyCurves(props: {
 				<div className="row" style={{ alignItems: "flex-end" }}>
 					<label className="field" style={{ maxWidth: "11rem", margin: 0 }}>
 						<span>Max order size ({token0})</span>
-						<input type="text" value={maxOrderSize} onChange={(e) => setMaxOrderSize(e.target.value)} />
+						<input
+							type="text"
+							value={maxOrderSize}
+							placeholder="uncapped"
+							onChange={(e) => setMaxOrderSize(e.target.value)}
+						/>
 					</label>
-					<button
-						type="button"
-						disabled={!maxOrderSize.trim() || maxOrderSize.trim() === strategy.maxOrderSize}
-						onClick={applyMaxOrderSize}
-					>
-						Save cap
+					<button type="button" disabled={!capChanged} onClick={applyMaxOrderSize}>
+						{capCleared ? "Remove cap" : "Save cap"}
 					</button>
 					<span className="hint">
-						Per-order cap on the {token0} notional — orders needing more than the cap allows are skipped. A
-						new cap binds from the next order.
+						Per-order cap on the {token0} notional — orders needing more than the cap allows are skipped.
+						Leave it empty to remove the cap and fill every order at its full notional. Either change binds
+						from the next order.
 					</span>
 				</div>
 			)}

--- a/sdk/packages/simplex/ui/src/wizard/state.ts
+++ b/sdk/packages/simplex/ui/src/wizard/state.ts
@@ -260,7 +260,10 @@ export function assembleConfig(state: WizardState, defaults: SetupDefaults): Fil
 		return {
 			token0: draft.token0,
 			token1: draft.token1,
-			maxOrderSize: draft.maxOrderSize.trim(),
+			// Omitted entirely when blank: the cap is optional, and an empty string
+			// would fail config validation as a malformed decimal rather than read
+			// as "no cap".
+			...(draft.maxOrderSize.trim() ? { maxOrderSize: draft.maxOrderSize.trim() } : {}),
 			...(withBid ? { bidPriceCurve: toPricePoints(draft.bid) } : {}),
 			...(withAsk ? { askPriceCurve: toPricePoints(draft.ask) } : {}),
 		}

--- a/sdk/packages/simplex/ui/src/wizard/steps/Strategies.tsx
+++ b/sdk/packages/simplex/ui/src/wizard/steps/Strategies.tsx
@@ -365,10 +365,11 @@ export function StepStrategies({ state, setState, defaults }: StepProps) {
 						{pair.enabled && (
 							<div style={{ marginLeft: "1.4rem" }}>
 								<label className="field" style={{ maxWidth: "16rem" }}>
-									<span>Max {pair.token0} per order (larger orders partially fill)</span>
+									<span>Max {pair.token0} per order (blank = uncapped)</span>
 									<input
 										type="text"
 										value={pair.maxOrderSize}
+										placeholder="uncapped"
 										onChange={(e) => patchPair(index, { maxOrderSize: e.target.value })}
 									/>
 								</label>
@@ -542,8 +543,13 @@ function MarketRow(props: {
 					}}
 				/>
 				<label className="field" style={{ margin: 0, maxWidth: "12rem" }}>
-					<span>Max {pair.token0 || "token0"} per order</span>
-					<input type="text" value={pair.maxOrderSize} onChange={(e) => onPatch({ maxOrderSize: e.target.value })} />
+					<span>Max {pair.token0 || "token0"} per order (blank = uncapped)</span>
+					<input
+						type="text"
+						value={pair.maxOrderSize}
+						placeholder="uncapped"
+						onChange={(e) => onPatch({ maxOrderSize: e.target.value })}
+					/>
 				</label>
 				<button type="button" onClick={onRemove}>
 					✕


### PR DESCRIPTION
## The bug

`FXFiller` had stopped overfilling entirely. Every fill paid out exactly `order.output.assets[i].amount` — the amount the user asked for — regardless of what the configured price curve said it was worth.

Observed on Base fill [`0x60b299e8…`](https://basescan.org/tx/0x60b299e81fc861220aa8ad66e9947decc029948ee441921b3a342b36809f7cfa): the solver redeemed 25.469 ycNGN into 1,380 cNGN and forwarded exactly 1,380 cNGN against 0.9995 USDC of escrow. No surplus transfer, no `DustCollected`.

Two lines formed a pincer in `calculateProfitability`:

```ts
const targetOutput = policyMaxOutput < desiredOutput ? policyMaxOutput : desiredOutput
// ...47 lines later...
if (policyMaxOutput < desiredOutput) return 0   // skip when the curve pays less than asked
```

`desiredOutput` is `output.amount` on any leg the exposure cap doesn't bind. The gate below guarantees `policyMaxOutput >= desiredOutput` for anything that survives to a fill, so `targetOutput` was *always* `desiredOutput`. Not an edge case — every non-balance-limited fill, on every pair.

Four things in the tree still assumed the opposite:

1. `calculateProfitability`'s own doc: *"we may intentionally overfill relative to the user's requested outputs … This is how we stay competitive."*
2. The overfill-clamp block, which announces *"the clamp is DISABLED, so the filler fills the full computed amount even when it exceeds (1 + maxOverfillBps) × user-requested"* — unreachable, since `targetOutput` re-clamped at 0 bps, tighter than the safety ceiling it claims to have removed.
3. `quotePhantomFill`, which publishes `policyMaxOutput` to the indexer as our quoted rate. Advertised and delivered prices diverged by the full spread.
4. `IntrinsicIntents.sol:84-92`, which has an explicit `solverAmount > totalRequired` branch splitting the excess between the beneficiary and the protocol (`surplusShareBps`). That path never fired.

**Root cause:** #1123 added `capFraction`/`desiredOutput` for the `maxOrderSize` cap, then reused `desiredOutput` as the general fill target — conflating "the slice the cap allows" with "the amount to pay". Before #1123 the target was `policyMaxOutput` outright. No test asserts payout against the curve, so it landed silently.

## Changes

**`targetOutput = policyMaxOutput`, unconditionally.** The curve is the price. `maxOrderSize` still binds, but where the exposure actually is: `computeLegPolicyOutput` rations `token0ForLeg` against the pair's remaining budget *before* the rate is applied, so a capped leg's curve amount is already the capped slice's worth. `desiredOutput` survives only as the price gate's comparand and in the short-fill logs.

`capLimited` had to follow. It was `desiredOutput < output.amount` — true whenever any cap was active — and it forces the partial-fill eligibility gate. With the payout unclamped, a curve running far enough above the order's rate covers the whole ask out of a capped slice; that's a full fill, and gating it as a partial would reject cross-chain and calldata orders the filler can serve. Now `capFraction.lt(1) && policyMaxOutput < output.amount`.

**`maxOrderSize` is optional.** `TradingPair.maxOrderSize` is `Decimal | undefined`; absent means uncapped. `validatePairConfigs` no longer requires it (malformed values still rejected), `tradingPairFrom` maps absence to `undefined` instead of the placeholder `new Decimal(0)`, and `sizeOrder` budgets an uncapped pair against the order's own total — so the per-pair ration still stops sibling legs double-spending the same token0 without ever binding below the order. The constructor check keeps exempting reference-only pairs, whose callers still pass a placeholder `0`.

**A cap can now be removed.** `AdminStrategy.clearMaxOrderSize`, `Simplex.clearMaxOrderSize(index)`, and `DELETE /api/strategies/:index/max-order-size` — its own route rather than a null on the PUT, because `DELETE /api/strategies/:index` already means "remove the market" and a cap removal one field value away from a market removal isn't worth one fewer endpoint. Idempotent; refuses reference-only markets to match the PUT. In the dashboard, emptying the cap field relabels the button to "Remove cap" and issues the DELETE. The setup wizard's cap fields accept blank and omit the key rather than emitting `""`, which config validation rejects as a malformed decimal rather than reading as "no cap".

## Trade-off, taken knowingly

On a **capped** leg, escrow releases as `fillAmount / totalRequired`, so paying above the user's pro-rata ask draws down more input than the cap fraction nominally allots. That's more of the user's token for the same outlay — the cap bounds what the filler *spends*, not what it *receives* — and rationing the receive side was clamping the price the operator configured. Recorded in `docs/ai/Decisions.md`.

## Versioning

0.10.2 → **0.11.0**, minor rather than the usual per-PR patch: `TradingPair.maxOrderSize` widened to `Decimal | undefined` (breaks TS consumers reading it without a guard), new public surface, and solvers on this version start paying out surplus where they previously didn't.

