### PR TITLE
[simplex]: fix stale pairs.test.ts expectations and run it in CI

### DIFF
--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -211,6 +211,35 @@ it is now `accepts an omitted maxOrderSize, and rejects a malformed one`.
 Files: src/strategies/fx.ts, src/config/pairs.ts, src/core/boot.ts, src/simplex.ts,
 src/tests/pairs.test.ts.
 
+## 2026-08-20 — pairs.test.ts catches up with the probe and paymaster changes, and CI now runs it
+
+`src/tests/pairs.test.ts` failed 12 of its 55 tests on main, unnoticed because no CI script ran
+the file. Both failure groups were stale test expectations, not product regressions — each was
+verified against the intent recorded in the 2026-08-19 entries before editing:
+
+- Three phantom-probe tests still expected `quotePhantomFill` to cap its quote at the pair's
+  `maxOrderSize`. The cap no longer rations probes (see "A phantom probe is no longer rationed by
+  the pair's exposure cap", and the Decisions entry "The exposure cap governs fills, never
+  probes") — that change updated `fx.one-sided-lp.test.ts` only and left this file behind. The
+  assertions now expect the full unrationed quotes (e.g. 200,000 ZARP × 100 = 20,000,000 CNGN
+  where the old cap produced 10,000,000), and the test names/comments no longer claim probes are
+  capped.
+- Nine profit-gates tests scored 0 where they expected a positive result (or the partial-fill
+  flag). The leg loop now calls `paymasterReserveForToken` (see "Fill sizing reserves the
+  paymaster's gas pull"), whose `hasPaymaster` check calls
+  `configService.getCirclePaymasterAddress` / `getSimplexPaymasterAddress` — absent on the
+  suite's `cfg` mock, so every evaluation threw `TypeError` into `calculateProfitability`'s catch
+  and returned 0. Root cause pinned with a throwaway probe test against the exact mock shape. The
+  mock now defines both getters as `() => undefined` (no paymaster configured → zero reserve),
+  which restores the suite's exact spread/fee arithmetic.
+
+`test:filler` now includes `src/tests/pairs.test.ts`, so the file runs in CI (the "Run simplex
+test" step of `.github/workflows/test-sdk.yml`). It is pure-unit — no network, no env. Verified:
+55/55 pass via `pnpm vitest run --maxConcurrency=1 src/tests/pairs.test.ts`, biome lint clean on
+the file, and `vitest list` collects all four `test:filler` files after codegen.
+
+Files: `src/tests/pairs.test.ts`, `package.json`, `docs/ai/{ChangeLog,Decisions}.md`.
+
 ## 2026-08-19 — A phantom probe is no longer rationed by the pair's exposure cap
 
 `quotePhantomFill` fed the pair's per-order exposure budget into `computeLegPolicyOutput`, which

--- a/sdk/packages/simplex/docs/ai/Decisions.md
+++ b/sdk/packages/simplex/docs/ai/Decisions.md
@@ -242,6 +242,25 @@ now paid out that term is structurally zero on uncapped legs. It is report-only 
 never rejects an order or feeds the execute score — so it under-reports rather than mis-fills, and
 re-basing it on the opposite curve was left out of this change.
 
+## 2026-08-20 — pairs.test.ts rides in test:filler, not a new unit-test script
+
+Chosen: append `src/tests/pairs.test.ts` to the existing `test:filler` script, which CI's "Run
+simplex test" step already executes on every simplex PR.
+
+Alternatives rejected:
+
+- *A dedicated `test:unit` script plus a new workflow step.* Cleaner taxonomy (the file is
+  pure-unit while most of its neighbours in `test:filler` need RPC secrets), but it adds a script
+  and a CI step to maintain for one ~3s file, and the oversized `--testTimeout` it inherits is
+  harmless for unit tests. `fx.curve-payout.test.ts` set the precedent independently: it is also
+  pure-unit and was wired into `test:filler` the same way.
+- *Leave it unwired.* That is exactly how 12 stale failures sat on main unnoticed.
+
+Known gap, deliberately out of scope here: several other pure-unit files (`book-crossed`,
+`confirmation-policy`, `fx.one-sided-lp`, `fx.price-guard`, `paymaster-reserve`, …) still run in
+no CI script. If they are ever wired up, a `test:unit` aggregate becomes worth its keep — move
+`pairs.test.ts` into it then.
+
 ## 2026-08-19 — The exposure cap governs fills, never probes
 
 Chosen: `computeLegPolicyOutput` takes `remainingToken0: Decimal | null`, and `quotePhantomFill`

--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -40,7 +40,7 @@
 		"build": "bash ./scripts/build.sh",
 		"prepublishOnly": "npm run build",
 		"test": "pnpm run codegen && vitest --watch=false --maxConcurrency=1",
-		"test:filler": "pnpm run codegen && vitest --watch=false --maxConcurrency=1 --testTimeout=1000000 src/tests/strategies/fx.curve-payout.test.ts src/tests/strategies/fx.testnet.test.ts src/tests/quorum-public-client.test.ts",
+		"test:filler": "pnpm run codegen && vitest --watch=false --maxConcurrency=1 --testTimeout=1000000 src/tests/pairs.test.ts src/tests/strategies/fx.curve-payout.test.ts src/tests/strategies/fx.testnet.test.ts src/tests/quorum-public-client.test.ts",
 		"test:basic:testnet": "pnpm run codegen && vitest --watch=false --maxConcurrency=1 --testTimeout=1000000 src/tests/strategies/basic.testnet.test.ts",
 		"test:fx": "pnpm run codegen && vitest --watch=false --maxConcurrency=1 --testTimeout=1000000 src/tests/strategies/fx.mainnet.test.ts",
 		"test:fx-testnet": "pnpm run codegen && vitest --watch=false --maxConcurrency=1 --testTimeout=1000000 src/tests/strategies/fx.testnet.test.ts",

--- a/sdk/packages/simplex/src/tests/pairs.test.ts
+++ b/sdk/packages/simplex/src/tests/pairs.test.ts
@@ -369,7 +369,9 @@ describe("validatePairConfigs", () => {
 })
 
 // ---------------------------------------------------------------------------
-// FX engine leg math with pair-local rates and caps, via quotePhantomFill
+// FX engine leg math with pair-local rates, via quotePhantomFill. A probe is a
+// price quote, not an allocation, so maxOrderSize never rations it — the cap
+// governs real fills only (see the exposure-cap and profit-gates suites).
 // ---------------------------------------------------------------------------
 
 function makeContractService(): any {
@@ -461,9 +463,9 @@ describe("FXFiller pairs engine", () => {
 		expect((await filler.quotePhantomFill(usdtLeg))?.[0].amount).toBe(parseUnits("100000", 18))
 	})
 
-	it("caps each pair at its own maxOrderSize, in token0 units", async () => {
-		// ZARP-quoted pair: pricing and the cap are denominated in ZARP. The
-		// USDC/ZARP pair only anchors ZARP for confirmation sizing.
+	it("prices ZARP-quoted pairs in token0 units; probes are not rationed by maxOrderSize", async () => {
+		// ZARP-quoted pair: pricing is denominated in ZARP. The USDC/ZARP pair
+		// only anchors ZARP for confirmation sizing.
 		const filler = makeFiller([
 			{ token0: "USDC", token1: "ZARP", maxOrderSize: size("100000"), askPricePolicy: flat("18") },
 			{ token0: "ZARP", token1: "CNGN", maxOrderSize: size("100000"), askPricePolicy: flat("100") },
@@ -486,8 +488,10 @@ describe("FXFiller pairs engine", () => {
 			{ token: bytes20ToBytes32(ZARP), amount: parseUnits("200000", 18) },
 			{ token: bytes20ToBytes32(CNGN), amount: 0n },
 		)
-		// 200,000 ZARP → capped at maxOrderSize 100,000 ZARP → 10,000,000 CNGN
-		expect((await filler.quotePhantomFill(large))?.[0].amount).toBe(parseUnits("10000000", 18))
+		// 200,000 ZARP exceeds maxOrderSize 100,000, but a probe commits no
+		// capital, so the cap does not ration it (it only logs a config warning):
+		// 200,000 × 100 = 20,000,000 CNGN.
+		expect((await filler.quotePhantomFill(large))?.[0].amount).toBe(parseUnits("20000000", 18))
 	})
 
 	it("sizes bid legs through the pair's own curve", async () => {
@@ -504,13 +508,14 @@ describe("FXFiller pairs engine", () => {
 		expect(sized?.inputUsd.eq(new Decimal(2000))).toBe(true)
 		expect((await filler.quotePhantomFill(order))?.[0].amount).toBe(parseUnits("2000", 6))
 
-		// 15,000,000 CNGN ÷ 1500 = 10,000 USDC notional → capped at 5000 USDC out.
+		// 15,000,000 CNGN ÷ 1500 = 10,000 USDC notional — over the 5000 cap, but
+		// probes are not rationed by it: the full 10,000 USDC is quoted.
 		const large = makeOrder(
 			"bid-sizing-large",
 			{ token: bytes20ToBytes32(CNGN), amount: parseUnits("15000000", 18) },
 			{ token: bytes20ToBytes32(USDC), amount: 0n },
 		)
-		expect((await filler.quotePhantomFill(large))?.[0].amount).toBe(parseUnits("5000", 6))
+		expect((await filler.quotePhantomFill(large))?.[0].amount).toBe(parseUnits("10000", 6))
 	})
 
 	it("quotes same-token pairs at the below-par ask, across differing decimals", async () => {
@@ -560,8 +565,9 @@ describe("FXFiller pairs engine", () => {
 			),
 			destination: CHAIN2,
 		} as unknown as Order
-		// 20,000 USDC → capped at maxOrderSize 10,000 → 9,950 out.
-		expect((await filler.quotePhantomFill(large))?.[0].amount).toBe(parseUnits("9950", 18))
+		// 20,000 USDC exceeds maxOrderSize 10,000, but probes are not rationed by
+		// the cap: 20,000 × 0.995 = 19,900 out.
+		expect((await filler.quotePhantomFill(large))?.[0].amount).toBe(parseUnits("19900", 18))
 	})
 
 	it("prefers explicitly configured curves over venue pricing", async () => {
@@ -728,6 +734,11 @@ describe("FXFiller profit gates (fees cover execution; spread independently posi
 		getCNgnAsset: () => undefined,
 		getMaxOverfillBps: () => 500n,
 		getMaxConsecutiveClamps: () => 3,
+		// No paymaster on any chain: the leg loop's paymasterReserveForToken
+		// consults these and must reserve nothing here — this suite asserts
+		// exact spread/fee arithmetic with no gas headroom held back.
+		getCirclePaymasterAddress: () => undefined,
+		getSimplexPaymasterAddress: () => undefined,
 	} as any
 	const signer = { address: SOLVER } as any
 


### PR DESCRIPTION
`src/tests/pairs.test.ts` fails 12 of its 55 tests on main, unnoticed because no CI script runs the file. Both groups are stale test expectations, not product regressions:

- **Three phantom-probe tests** still expected `quotePhantomFill` to cap its quote at the pair's `maxOrderSize`. #1154 deliberately stopped rationing probes (a probe is a price quote, not an allocation — clamping corrupted the published rate) but only updated `fx.one-sided-lp.test.ts`, leaving this file behind. The assertions now expect the full unrationed quotes (e.g. 200,000 ZARP × 100 = 20,000,000 CNGN, not the capped 10,000,000), and the test names/comments no longer claim probes are capped.
- **Nine profit-gates tests** scored 0 where they expected a positive result (or the partial-fill flag). The leg loop from #1153 calls `paymasterReserveForToken`, whose `hasPaymaster` check reads `configService.getCirclePaymasterAddress` / `getSimplexPaymasterAddress` — absent on the suite's mock config, so every evaluation threw a `TypeError` into `calculateProfitability`'s catch and returned 0. The mock now defines both getters returning `undefined` (no paymaster configured → zero reserve), preserving the suite's exact spread/fee arithmetic.

`test:filler` now includes `src/tests/pairs.test.ts`, so the test-sdk workflow actually runs it. The file is pure-unit — no env, no network — and adds ~3s to the step.

Verified: 55/55 pass locally via `pnpm vitest run --maxConcurrency=1 src/tests/pairs.test.ts`, biome lint clean, and `vitest list` collects all three `test:filler` files after codegen. `docs/ai/` ChangeLog and Decisions updated per the repo convention.