### PR TITLE
[simplex]: only fill orders with a single input and output leg

### DIFF
--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -12,6 +12,20 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-08-20 — The filler only takes single-leg orders
+
+`EventMonitor.handleOrder` now forwards an order only when it has exactly one input asset and one
+output asset. Anything else is dropped at the door with an `orderSkipped` event carrying the reason
+`Multi-leg order`, so the operator sees it in the activity feed rather than losing it silently.
+
+The check runs before the de-duplication set is touched: a rejected order id is never marked as
+seen, so a later single-leg order sharing that id is still delivered.
+
+Downstream multi-leg handling is untouched — `FXFiller`'s per-leg loops and the leg-splitting in
+`filler.ts` still run for phantom orders, which do not come through this path.
+
+Files: `src/core/event-monitor.ts`, `src/tests/core/chain-lifecycle.test.ts`, `package.json`.
+
 ## 2026-08-20 — Regression test: fills pay the curve amount
 
 The payout fix below restored `targetOutput = policyMaxOutput`, but nothing asserted the payout —

--- a/sdk/packages/simplex/docs/ai/Decisions.md
+++ b/sdk/packages/simplex/docs/ai/Decisions.md
@@ -4,6 +4,26 @@ AI-maintained record of non-obvious choices made in `sdk/packages/simplex`: what
 
 Entry format: heading with the decision, then alternatives considered and the reasoning. Newest first.
 
+## 2026-08-20 — Multi-leg orders are rejected at the monitor, not deeper in the fill path
+
+Chosen: `EventMonitor` filters on leg count, so an order with more than one input or output asset
+never reaches `IntentFiller`.
+
+The monitor is the one place every real order passes through exactly once, and it already owns the
+other two intake filters (filler-address matching on fills, de-duplication). Rejecting there means
+the constraint holds for every strategy without each of them re-checking, and the cost of a
+rejected order stays at one debug log.
+
+Alternatives rejected:
+
+- *Reject in `FXFiller.evaluateOrder`.* It already refuses an order whose input and output counts
+  disagree, but a balanced multi-leg order would still be priced, quoted and possibly bid. The
+  work is wasted, and a second strategy would need its own copy of the rule.
+- *Filter in the scanner.* The scanner is shared between fillers; a filler that wants multi-leg
+  orders could not opt back in. Per-filler intake policy belongs to the per-filler event bus.
+- *Strip extra legs and fill the first one.* Silently changes what the user asked for. An order is
+  filled whole or not at all.
+
 ## 2026-08-20 — Removing a cap is its own endpoint, not a null on the update
 
 Chosen: `DELETE /api/strategies/:index/max-order-size`, with `AdminStrategy.clearMaxOrderSize` and

--- a/sdk/packages/simplex/docs/ai/Flow.md
+++ b/sdk/packages/simplex/docs/ai/Flow.md
@@ -2,6 +2,28 @@
 
 AI-maintained map of how code paths in `sdk/packages/simplex` actually execute, so that when something breaks you can tell whether the fault is upstream or downstream of where the symptom appears. Only flows that have been read and verified are documented; coverage grows as areas of the package are touched.
 
+## Order intake: what reaches the filler at all
+
+`ChainScanner` polls `eth_getLogs`, rebuilds each `OrderPlaced` log into an `Order` via
+`reconstructOrdersFromLogs`, and hands it to every subscriber. `EventMonitor` is the per-filler
+subscriber and applies three filters in order (`src/core/event-monitor.ts`):
+
+1. **Chain.** A shared scanner may carry chains this filler is not configured for, so events are
+   matched on `chainId` against the monitor's own set.
+2. **Leg count.** The order must have exactly one entry in `inputs` and one in `output.assets`.
+   Anything else emits `orderSkipped` with reason `Multi-leg order` and stops here.
+3. **De-duplication.** The order id must not be in the seen set (last 5,000 ids). A scanner
+   resuming from a cursor re-delivers, and the fill path has no idempotency of its own.
+
+Only what survives all three is emitted as `newOrder`, which `IntentFiller` picks up in its
+constructor and passes to `handleNewOrder`. Fills take a separate path: `onFill` narrows on the
+filler address — `filler` is `indexed: false` in the ABI, so it can never be a topic filter — and
+emits `orderFilledOnChain`.
+
+Phantom orders do not come through here. They are polled from Hyperbridge inside `IntentFiller`,
+so the leg-count filter does not apply to them and `quotePhantomLeg` still splits a bundled
+phantom order into positional single-pair legs.
+
 ## Filling: how a fill amount is sized, and who else spends the same balance
 
 Verified against the reverted Base fill `0x31de53fe...` (UserOp `0xe090acd1...`), traced end to end.

--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/simplex",
-	"version": "0.11.0",
+	"version": "0.11.1",
 	"license": "Apache-2.0",
 	"description": "Automated intent filler for the Hyperbridge IntentGateway \u2014 run it as a binary or embed it as a library",
 	"main": "dist/index.js",

--- a/sdk/packages/simplex/src/core/event-monitor.ts
+++ b/sdk/packages/simplex/src/core/event-monitor.ts
@@ -27,10 +27,13 @@ const SEEN_LIMIT = 5_000
  * `rebalanceExecuted` on it, `ActivityRecorder` attaches to it, and `Simplex`
  * re-exposes it as the public event surface.
  *
- * Two things must stay on this side of the boundary:
+ * Three things must stay on this side of the boundary:
  *  - the `OrderFilled` filler-address filter. `filler` is `indexed: false` on
  *    both `OrderFilled` and `PartialFill`, so it can never be a topic filter;
  *    every consumer receives every fill and narrows it locally.
+ *  - the single-leg filter. Only orders with exactly one input and one output
+ *    asset reach the filler; a multi-leg order is skipped at the door rather
+ *    than split into legs downstream.
  *  - de-duplication. Exactly-once used to be emergent — a private monotonic
  *    cursor made a repeat impossible. A shared feed can replay from a cursor
  *    after a reconnect, so the seen-set below is what preserves the property
@@ -94,6 +97,15 @@ export class EventMonitor extends EventEmitter {
 	}
 
 	private handleOrder(order: Order, transactionHash: string): void {
+		if (order.inputs.length !== 1 || order.output.assets.length !== 1) {
+			this.logger.debug(
+				{ orderId: order.id, inputs: order.inputs.length, outputs: order.output.assets.length },
+				"Multi-leg order, ignoring",
+			)
+			this.emit("orderSkipped", { orderId: order.id, reason: "Multi-leg order" })
+			return
+		}
+
 		const id = order.id
 		if (id) {
 			// At-least-once delivery: a shared feed that resumes from a cursor can

--- a/sdk/packages/simplex/src/tests/core/chain-lifecycle.test.ts
+++ b/sdk/packages/simplex/src/tests/core/chain-lifecycle.test.ts
@@ -28,6 +28,16 @@ function configService(chainId = 1, rpcUrls = RPC_A) {
 	return new FillerConfigService([{ chainId, rpcUrls, bundlerUrl: "https://bundler.example" }])
 }
 
+/** An order with one input and one output leg — the only shape the monitor forwards. */
+function singleLegOrder(id: string, inputs = 1, outputs = 1) {
+	const asset = { token: "0xtoken", amount: 1n }
+	return {
+		id,
+		inputs: Array.from({ length: inputs }, () => asset),
+		output: { beneficiary: "0xbene", assets: Array.from({ length: outputs }, () => asset), call: "0x" },
+	}
+}
+
 describe("FillerConfigService chain set", () => {
 	it("derives the configured chain set from the registered chains", () => {
 		const service = configService()
@@ -179,8 +189,8 @@ describe("EventMonitor chain lifecycle", () => {
 		const seen: string[] = []
 		monitor.on("newOrder", ({ order }) => seen.push(order.id))
 
-		handlers()!.onOrder({ order: { id: "0xmine" }, transactionHash: "0x1", chainId: 1 } as never)
-		handlers()!.onOrder({ order: { id: "0xother" }, transactionHash: "0x2", chainId: 8453 } as never)
+		handlers()!.onOrder({ order: singleLegOrder("0xmine"), transactionHash: "0x1", chainId: 1 } as never)
+		handlers()!.onOrder({ order: singleLegOrder("0xother"), transactionHash: "0x2", chainId: 8453 } as never)
 
 		expect(seen).toEqual(["0xmine"])
 	})
@@ -194,11 +204,46 @@ describe("EventMonitor chain lifecycle", () => {
 
 		// At-least-once: a scanner resuming from a cursor re-delivers, and the fill
 		// path has no idempotency of its own.
-		const event = { order: { id: "0xorder" }, transactionHash: "0xtx", chainId: 1 }
+		const event = { order: singleLegOrder("0xorder"), transactionHash: "0xtx", chainId: 1 }
 		handlers()!.onOrder(event as never)
 		handlers()!.onOrder(event as never)
 
 		expect(seen).toEqual(["0xorder"])
+	})
+
+	it("forwards only single-leg orders", async () => {
+		const { monitor, handlers } = monitorFor([1])
+		await monitor.startListening()
+
+		const seen: string[] = []
+		const skipped: Array<{ orderId?: string; reason?: string }> = []
+		monitor.on("newOrder", ({ order }) => seen.push(order.id))
+		monitor.on("orderSkipped", (event) => skipped.push(event))
+
+		const deliver = (order: unknown) =>
+			handlers()!.onOrder({ order, transactionHash: "0xtx", chainId: 1 } as never)
+
+		deliver(singleLegOrder("0xsingle"))
+		deliver(singleLegOrder("0xtwo-in", 2, 1))
+		deliver(singleLegOrder("0xtwo-out", 1, 2))
+		deliver(singleLegOrder("0xno-legs", 0, 0))
+
+		expect(seen).toEqual(["0xsingle"])
+		expect(skipped.map((event) => event.orderId)).toEqual(["0xtwo-in", "0xtwo-out", "0xno-legs"])
+		expect(skipped.every((event) => event.reason === "Multi-leg order")).toBe(true)
+	})
+
+	it("does not let a rejected multi-leg order occupy the de-duplication set", async () => {
+		const { monitor, handlers } = monitorFor([1])
+		await monitor.startListening()
+
+		const seen: string[] = []
+		monitor.on("newOrder", ({ order }) => seen.push(order.id))
+
+		handlers()!.onOrder({ order: singleLegOrder("0xid", 2, 2), transactionHash: "0xtx", chainId: 1 } as never)
+		handlers()!.onOrder({ order: singleLegOrder("0xid"), transactionHash: "0xtx", chainId: 1 } as never)
+
+		expect(seen).toEqual(["0xid"])
 	})
 
 	it("only re-emits fills credited to this filler", async () => {
@@ -223,7 +268,7 @@ describe("EventMonitor chain lifecycle", () => {
 
 		const seen: string[] = []
 		monitor.on("newOrder", ({ order }) => seen.push(order.id))
-		handlers()!.onOrder({ order: { id: "0xnew" }, transactionHash: "0x1", chainId: 8453 } as never)
+		handlers()!.onOrder({ order: singleLegOrder("0xnew"), transactionHash: "0x1", chainId: 8453 } as never)
 
 		expect(seen).toEqual(["0xnew"])
 	})
@@ -246,7 +291,7 @@ describe("EventMonitor chain lifecycle", () => {
 
 		const seen: string[] = []
 		monitor.on("newOrder", ({ order }) => seen.push(order.id))
-		handlers()!.onOrder({ order: { id: "0xgone" }, transactionHash: "0x1", chainId: 8453 } as never)
+		handlers()!.onOrder({ order: singleLegOrder("0xgone"), transactionHash: "0x1", chainId: 8453 } as never)
 
 		expect(seen).toEqual([])
 	})


### PR DESCRIPTION
`EventMonitor` now forwards an order only when it has exactly one input asset and one output asset. Anything else is dropped at intake with an `orderSkipped` event carrying the reason `Multi-leg order`, so it shows up in the activity feed rather than being silently discarded.

The check runs before the de-duplication set is touched, so a rejected order id is never marked as seen.

Phantom orders are unaffected — they are polled inside `IntentFiller` and do not pass through the monitor, so `quotePhantomLeg` still splits bundled legs as before.