### PR TITLE
[sdk, simplex]: stop the phantom poll replaying a failed read from the HTTP provider cache

### DIFF
--- a/sdk/packages/sdk/docs/ai/ChangeLog.md
+++ b/sdk/packages/sdk/docs/ai/ChangeLog.md
@@ -12,6 +12,14 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-08-21 — HTTP provider no longer caches responses, so a failed phantom poll read is retried
+
+`IntentsCoprocessor.http()` built its `HttpProvider` with polkadot-js defaults, which cache every request that names a block hash by storing the request promise itself — rejected promises included — under a 30s TTL refreshed on every hit. `pollPhantomOrders` retries the block it failed on with identical parameters each tick, so after one reset connection (`fetch failed` / `ECONNRESET`) every later tick got the same rejection back from the cache in a few milliseconds — the same `state_getRuntimeVersion(parentHash)` hash in every log line — and the node never saw another request. With the 15s poll interval inside the 30s TTL the entries never expired, so a filler stayed wedged until restart, placing no phantom bids. The provider is now constructed with cache capacity 0, which sends every request to the node. The cache bought nothing for this api: the poll reads each block once, and `api.at(hash)` reuses registries at the api layer regardless.
+
+`intentsCoprocessorHttpCache.test.ts` pins the dependency's behaviour against a stub node that RSTs one request, and that the provider the coprocessor builds retries it.
+
+Files: `src/chains/intentsCoprocessor.ts`, `src/tests/intentsCoprocessorHttpCache.test.ts`.
+
 ## 2026-08-19 — Fix the refund-POST gas pin #1144 left behind
 
 #1144 split `CANCEL_MESSAGE_GAS = 800_000n` into `SOURCE_GET_RESPONSE_GAS` and `REFUND_POST_GAS`, both 1M, but left `orderCanceller.test.ts` asserting the POST at 800k — main's own CI has failed the concurrent-sdk step since it merged, and every PR cut from it inherited the red check. The pin now matches the shipped constant, with a comment naming the origin so the next reprice updates both.

--- a/sdk/packages/sdk/docs/ai/Decisions.md
+++ b/sdk/packages/sdk/docs/ai/Decisions.md
@@ -4,6 +4,18 @@ AI-maintained record of non-obvious choices made in `sdk/packages/sdk`: what was
 
 Entry format: heading with the decision, then alternatives considered and the reasoning. Newest first.
 
+## 2026-08-21 — The coprocessor's HTTP provider runs with its response cache off
+
+Chosen: `new HttpProvider(httpUrl, {}, 0)` — capacity 0 disables polkadot-js's per-provider LRU outright, so every `send` reaches the node.
+
+Alternatives considered:
+
+- A shorter TTL, or a poll interval longer than the TTL. The TTL slides — each hit refreshes it — so any poll faster than the TTL keeps a cached rejection alive indefinitely, and a slower poll would heal after one TTL only by coupling the cadence to a cache constant; the poll was made faster on purpose (#1138).
+- A provider wrapper, or an upstream fix, that drops an entry when its promise rejects. Correct, but more code holding state this api has no use for, and an upstream fix still needs the workaround until it ships: polkadot-js master has the same `send` as 16.5.6.
+- Keeping the cache and retrying inside the poll tick. A retry hits the same cache key and gets the same rejection; only a different request shape would get past it.
+
+Why: the HTTP api exists for one-shot reads whose whole value is that nothing persists between calls (see the `http()` and `pollPhantomOrders` doc comments). A promise cache is exactly such persistence, and its only effect on this api was the failure mode: the poll reads each block once, so there are no repeat hits to serve, and `api.at(hash)` already reuses decoded registries at the api layer. Disabling it removes the hazard without adding a mechanism.
+
 ## 2026-08-18 — `SigningAccount` describes only what the SDK calls
 
 (Amended the same day: `signRawHash` was removed in a follow-up commit; see the closing paragraph.)

--- a/sdk/packages/sdk/docs/ai/Flow.md
+++ b/sdk/packages/sdk/docs/ai/Flow.md
@@ -12,3 +12,18 @@ AI-maintained map of how code paths in `sdk/packages/sdk` actually execute, so t
 4. The returned signature is prefixed with the order id (`concat([order.id, solverSignature])`) — that concatenation, not the bare signature, is what goes on the UserOperation.
 
 `signTypedData` is the interface's only member: `signMessage`, `signRawHash`, and `signTypedData`'s chain-id argument were all removed on 2026-08-18 as uncalled. `GasEstimator`'s `signMessage` call is viem's method on a locally derived account, unrelated to `SigningAccount`.
+
+## How the phantom order poll reads Hyperbridge
+
+`IntentsCoprocessor.pollPhantomOrders` (`src/chains/intentsCoprocessor.ts`) drives every read over the HTTP api from `http()`, never the websocket. `http()` derives the endpoint from the websocket provider's own endpoint (`deriveHttpUrl`) and builds an `ApiPromise` on an `HttpProvider` with its response cache disabled (capacity 0); the connect is `isReadyOrError` raced against `HTTP_CONNECT_TIMEOUT_MS`, and a failed connect is not cached.
+
+Each tick, skipped if the previous one is still running:
+
+1. `chain_getHeader()` for the head. No block hash, so polkadot-js never caches it — always a live request.
+2. On the first successful head read the cursor is set to `head - 1 - lookbackBlocks`; if `head <= cursor` the tick ends.
+3. For each block from `cursor + 1` to `min(head, cursor + maxBlocksPerPoll)`, `getPhantomOrdersInBlock` calls `chain_getBlockHash(n)`, then `api.at(hash)`, then `system.events` at that block. `api.at` resolves a registry through `getBlockRegistry`: reused by `lastBlockHash` or by runtime version where it can, otherwise `chain_getHeader(hash)` followed by `state_getRuntimeVersion(parentHash)` — which is why a failure there logs the parent's hash, not the scanned block's.
+4. The cursor advances per block, only once that block's events were read. A failure leaves it in place and fires `onError`; the next tick re-reads the same block with the same parameters.
+
+Step 4 is what made the provider cache dangerous: with caching on, re-reading a block whose `state_getRuntimeVersion` had rejected was answered by the cached rejection rather than a fresh request (fixed 2026-08-21). In `@hyperbridge/simplex` one `HyperbridgeScanner` owns this poll and fans `onError` out to every subscribing filler, so a single failed tick logs once from the scanner and once per filler.
+
+The cadence is `intervalMs` when given, otherwise `phantomPollIntervalMs()`: 6s on Gargantua, 15s elsewhere, decided by the runtime's `specName` read over the same HTTP api, falling back to 15s if that read fails.

--- a/sdk/packages/sdk/src/chains/intentsCoprocessor.ts
+++ b/sdk/packages/sdk/src/chains/intentsCoprocessor.ts
@@ -343,7 +343,15 @@ export class IntentsCoprocessor {
 		if (!this.httpApi) {
 			const httpUrl = deriveHttpUrl(this.wsEndpoint())
 			const api = new ApiPromise({
-				provider: new HttpProvider(httpUrl),
+				// Response cache off (third argument, capacity 0). polkadot-js caches every request that
+				// names a block hash — `chain_getHeader(hash)`, `state_getRuntimeVersion(hash)`, storage
+				// reads at a hash — by storing the request promise itself, a rejected one included, for a
+				// 30s TTL that every hit refreshes. The phantom poll retries the block it failed on with
+				// identical parameters every tick, so one reset connection became the same rejection
+				// replayed from memory on every tick, faster than the TTL could lapse, and the node never
+				// saw a second request. The cache bought nothing here anyway: the poll reads each block
+				// once, and `api.at(hash)` reuses registries at the api layer regardless.
+				provider: new HttpProvider(httpUrl, {}, 0),
 				typesBundle: HYPERBRIDGE_TYPES_BUNDLE,
 				// A second connection to the node the ws api already reported on; its init warnings
 				// would just be duplicates.

--- a/sdk/packages/sdk/src/tests/intentsCoprocessorHttpCache.test.ts
+++ b/sdk/packages/sdk/src/tests/intentsCoprocessorHttpCache.test.ts
@@ -1,0 +1,113 @@
+import http from "node:http"
+import type { AddressInfo } from "node:net"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { HttpProvider, type ApiPromise } from "@polkadot/api"
+import { IntentsCoprocessor } from "@/chains/intentsCoprocessor"
+
+/**
+ * polkadot-js's `HttpProvider` caches every request that names a block hash, and what it caches is
+ * the request promise itself — a rejected one included — under a TTL that every hit refreshes. The
+ * phantom order poll retries the block it failed on with identical parameters on every tick, so a
+ * single reset connection turned into the same rejection replayed from memory for as long as the
+ * process lived; the node never saw a second request. The coprocessor builds its HTTP provider with
+ * that cache off. These pin both halves: the hazard in the dependency, so the workaround rests on a
+ * check rather than a memory, and the provider the coprocessor actually builds being free of it.
+ */
+
+const BLOCK_HASH = `0x${"de".repeat(32)}`
+const RUNTIME_VERSION = { specName: "nexus", specVersion: 1 }
+
+vi.mock("@polkadot/api", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@polkadot/api")>()
+
+	/** Stands in for ApiPromise: ready without a handshake, keeping the provider it was built on. */
+	class FakeApiPromise {
+		provider: unknown
+		isReadyOrError = Promise.resolve(this)
+		disconnect = async () => {}
+		constructor(options: { provider: unknown }) {
+			this.provider = options.provider
+		}
+	}
+
+	return { ...actual, ApiPromise: FakeApiPromise }
+})
+
+/**
+ * A node that resets the connection on the first `resets` requests and answers every one after —
+ * the failure seen in the field was a TCP RST mid-request, which fetch reports as a bare
+ * "fetch failed".
+ */
+function stubNode(resets: number) {
+	let resetsLeft = resets
+	let answered = 0
+	const server = http.createServer((req, res) => {
+		let body = ""
+		req.on("data", (chunk: Buffer) => {
+			body += chunk
+		})
+		req.on("end", () => {
+			const { id } = JSON.parse(body) as { id: number }
+			if (resetsLeft > 0) {
+				resetsLeft -= 1
+				req.socket.resetAndDestroy()
+				return
+			}
+			answered += 1
+			res.setHeader("content-type", "application/json")
+			res.end(JSON.stringify({ jsonrpc: "2.0", id, result: RUNTIME_VERSION }))
+		})
+	})
+
+	return {
+		/** Requests that reached the node and were answered. */
+		answered: () => answered,
+		listen: () =>
+			new Promise<number>((resolve) =>
+				server.listen(0, "127.0.0.1", () => resolve((server.address() as AddressInfo).port)),
+			),
+		close: () =>
+			new Promise<void>((resolve, reject) => {
+				server.closeAllConnections()
+				server.close((err) => (err ? reject(err) : resolve()))
+			}),
+	}
+}
+
+describe("coprocessor HTTP provider cache", () => {
+	let node: ReturnType<typeof stubNode>
+	let port: number
+
+	beforeEach(async () => {
+		node = stubNode(1)
+		port = await node.listen()
+	})
+
+	afterEach(() => node.close())
+
+	// The dependency's own behaviour. If this starts failing, polkadot-js no longer caches
+	// rejections, and the capacity override in `IntentsCoprocessor.http` can be reconsidered.
+	it("polkadot-js HttpProvider replays a cached rejection instead of retrying", async () => {
+		const provider = new HttpProvider(`http://127.0.0.1:${port}`)
+
+		await expect(provider.send("state_getRuntimeVersion", [BLOCK_HASH], true)).rejects.toThrow("fetch failed")
+		await expect(provider.send("state_getRuntimeVersion", [BLOCK_HASH], true)).rejects.toThrow("fetch failed")
+
+		expect(node.answered()).toBe(0)
+		expect(provider.stats.total.cached).toBe(1)
+	})
+
+	it("the coprocessor's HTTP api retries a read that failed rather than replaying the failure", async () => {
+		// The HTTP endpoint is derived from the websocket's; that endpoint is all the coprocessor
+		// reads from the ws api to build it.
+		const wsApi = { _rpcCore: { provider: { endpoint: `ws://127.0.0.1:${port}` } } } as unknown as ApiPromise
+		const coprocessor = IntentsCoprocessor.fromApi(wsApi)
+
+		const { provider } = (await coprocessor.queryApi()) as unknown as { provider: HttpProvider }
+
+		await expect(provider.send("state_getRuntimeVersion", [BLOCK_HASH], true)).rejects.toThrow("fetch failed")
+		await expect(provider.send("state_getRuntimeVersion", [BLOCK_HASH], true)).resolves.toEqual(RUNTIME_VERSION)
+
+		expect(node.answered()).toBe(1)
+	})
+})


### PR DESCRIPTION
## What

Build the coprocessor's `HttpProvider` with its response cache disabled — `new HttpProvider(httpUrl, {}, 0)` in `IntentsCoprocessor.http()` — plus a regression test and `docs/ai` entries.

## Why

A filler got stuck logging this every 15s, with the **same block hash and the same stack trace on every tick**:

```
WARN: [hyperbridge-scanner]: Phantom order poll failed, will retry   "fetch failed" / "read ECONNRESET"
WARN: [intent-filler]: Phantom order poll failed, will retry          (same error, fanned out to the subscriber)
RPC-CORE: getRuntimeVersion(at?: BlockHash): RuntimeVersion:: fetch failed
Failed HTTP Request: {"method":"state_getRuntimeVersion","params":["0xde679fb8…"]}
```

The endpoint was healthy: the head read (`chain_getHeader()`, uncached because it names no block hash) succeeded on every tick.

Root cause: polkadot-js's `HttpProvider` caches every request that carries a block hash (`chain_getHeader(hash)`, `state_getRuntimeVersion(hash)`, storage reads at a hash) by storing the request *promise* in an LRU — a rejected promise included — with a 30s TTL that `get()` refreshes on every hit. `pollPhantomOrders` advances its cursor only past blocks it fully read, so after one genuine `ECONNRESET` on `state_getRuntimeVersion(parentHash)` it re-read the same block with identical parameters every tick, got the cached rejection back in ~3ms, and never sent that request again. With the 15s poll interval inside the 30s sliding TTL the entry never expired: phantom bidding from that filler was dead until restart. polkadot-js `master` has the same `send()` as 16.5.6, so a bump does not fix it.

Reproduced against a local node that RSTs exactly one request, polled every 1.5s with a 4s TTL and two cacheable calls per tick (the production shape):

```
tick 0 @0s:   FAIL fetch failed | cause=ECONNRESET | 25ms | cached hits=0  | server served getRuntimeVersion=0
tick 1 @1.5s: FAIL fetch failed | cause=ECONNRESET | 3ms  | cached hits=2  | server served getRuntimeVersion=0
…
tick 8 @12s:  FAIL fetch failed | cause=ECONNRESET | 3ms  | cached hits=16 | server served getRuntimeVersion=0
--- cacheCapacity=0
tick 0: FAIL fetch failed | cause=ECONNRESET
tick 1: OK   server served getRuntimeVersion=1
```

## Fix

Capacity 0 short-circuits the cache in `HttpProvider.send`, so every request reaches the node. The cache bought this api nothing: the poll reads each block exactly once, and `api.at(hash)` reuses decoded registries at the api layer regardless. The only other consumer of the HTTP api is simplex's `BalanceProvider`, which loses a 30s cache on `.at(hash)` reads.

Alternatives (recorded in `docs/ai/Decisions.md`): a shorter TTL or slower poll does not help because the TTL slides; a wrapper that evicts on rejection is more state for an api whose point is to hold none; a retry inside the tick hits the same cache key.

## Tests

- `src/tests/intentsCoprocessorHttpCache.test.ts`, against a stub node that RSTs one request:
  1. pins the dependency's behaviour — a default `HttpProvider` replays the cached rejection and the stub sees zero requests. If this ever fails, upstream stopped caching rejections and the override can be reconsidered.
  2. the provider the coprocessor actually builds (derived from the ws endpoint, via `queryApi()`) retries and succeeds.
- `pollPhantomOrders`, `intentsCoprocessorHttpFallback`, `submitPhantomBids` suites pass unchanged.

Operational note: a filler already in this state needs a restart to drop the poisoned entry; this change prevents it from recurring.
