### PR TITLE
[sdk, simplex]: sdk 2.8.7, simplex 0.11.2

### DIFF
--- a/sdk/packages/sdk/package.json
+++ b/sdk/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/sdk",
-	"version": "2.8.6",
+	"version": "2.8.7",
 	"description": "The hyperclient SDK provides utilities for querying proofs and statuses for cross-chain requests from HyperBridge.",
 	"type": "module",
 	"types": "./dist/node/index.d.ts",

--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/simplex",
-	"version": "0.11.1",
+	"version": "0.11.2",
 	"license": "Apache-2.0",
 	"description": "Automated intent filler for the Hyperbridge IntentGateway \u2014 run it as a binary or embed it as a library",
 	"main": "dist/index.js",


### PR DESCRIPTION
Patch bumps to publish the phantom-poll fix in #1158:

- `@hyperbridge/sdk` 2.8.6 → **2.8.7**
- `@hyperbridge/simplex` 0.11.1 → **0.11.2**

Both, not just simplex: the fix is in `packages/sdk` (`IntentsCoprocessor.http()`), and simplex's `workspace:*` dependency is rewritten to the sdk's concrete version when `pnpm pack` runs. A simplex-only bump would ship 0.11.2 against the sdk 2.8.6 already on npm — without the fix — and `publish-simplex.yml`'s "Refuse an unpublished @hyperbridge/sdk" guard would reject it anyway once `packages/sdk` differs from the `sdk-v2.8.6` tree.

Version fields only, matching the previous standalone bump (`[sdk]: 2.8.6`). The lockfile does not encode workspace package versions (`pnpm install --frozen-lockfile` passes unchanged).

## Release order

1. Merge #1158.
2. Merge this PR.
3. Tag the sdk on a commit that contains both, and let `publish-sdk.yml` finish (2.8.7 on npm):
   ```
   git tag sdk-v2.8.7 <commit> && git push origin sdk-v2.8.7
   ```
4. Then tag simplex on the same commit — the guard compares `packages/sdk` against `sdk-v2.8.7`, so it must be the same tree:
   ```
   git tag simplex-v0.11.2 <commit> && git push origin simplex-v0.11.2
   ```

If this merges before #1158, nothing publishes on its own — the tags are the trigger — but the tags must then go on a commit that includes #1158, or 0.11.2 ships without the fix.
