### PR TITLE
[indexer]: Haircut pool-priced phantom bids by 30bps before aggregation

### DIFF
--- a/sdk/packages/sdk/docs/ai/ChangeLog.md
+++ b/sdk/packages/sdk/docs/ai/ChangeLog.md
@@ -12,6 +12,16 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-08-24 — Pool-priced phantom bids are haircut 30bps before aggregation
+
+A phantom bid that declares Uniswap V4 positions is quoting off those pools, and a pool price is what a trade gets before the pool takes its fee — so the amount such a bid names is richer than what the solver clears once the sourcing swap goes through. `aggregatePhantomBids` now nets 30bps out of every leg amount on a bid whose declaration carries positions, before the quote reaches the zero-check, the weighted median, or the bidder rows. Non-declaring bids are untouched: wallet inventory has already paid its cost of goods.
+
+The haircut runs off the declaration rather than the positions that survive the on-chain ownership check, so a quote is priced on the same basis the solver priced it on — including on a chain with no V4 contracts configured, where declared positions contribute no weight. A leg whose amount the haircut rounds to zero falls into the existing declined-leg path.
+
+`UNISWAP_QUOTE_HAIRCUT_BPS` and `applyUniswapQuoteHaircut` are exported from both `@/protocols/intents` and the `intents-helpers` sub-path, so the indexer and simplex read the same number instead of restating it.
+
+Files: `src/protocols/intents/phantom-aggregation.ts`, `src/protocols/intents/index.ts`, `src/intents-helpers.ts`, `src/tests/phantomAggregation.test.ts`.
+
 ## 2026-08-21 — HTTP provider no longer caches responses, so a failed phantom poll read is retried
 
 `IntentsCoprocessor.http()` built its `HttpProvider` with polkadot-js defaults, which cache every request that names a block hash by storing the request promise itself — rejected promises included — under a 30s TTL refreshed on every hit. `pollPhantomOrders` retries the block it failed on with identical parameters each tick, so after one reset connection (`fetch failed` / `ECONNRESET`) every later tick got the same rejection back from the cache in a few milliseconds — the same `state_getRuntimeVersion(parentHash)` hash in every log line — and the node never saw another request. With the 15s poll interval inside the 30s TTL the entries never expired, so a filler stayed wedged until restart, placing no phantom bids. The provider is now constructed with cache capacity 0, which sends every request to the node. The cache bought nothing for this api: the poll reads each block once, and `api.at(hash)` reuses registries at the api layer regardless.

--- a/sdk/packages/sdk/docs/ai/Decisions.md
+++ b/sdk/packages/sdk/docs/ai/Decisions.md
@@ -4,6 +4,21 @@ AI-maintained record of non-obvious choices made in `sdk/packages/sdk`: what was
 
 Entry format: heading with the decision, then alternatives considered and the reasoning. Newest first.
 
+## 2026-08-24 — The 30bps pool haircut keys off the declaration, and lands on price only
+
+Chosen: in `aggregatePhantomBids`, haircut a bid's quoted leg amounts by 30bps when its paymasterAndData declaration names Uniswap V4 positions.
+
+Alternatives considered:
+
+- **Keying off the positions that pass the ownership check** (the `positions` array, not `declaration.uniswapV4Positions`). Rejected: those are filtered by owner and skipped entirely when the chain has no `positionManager`/`stateView` configured, so the same bid would be priced two different ways depending on indexer config. The declaration is what the solver signed, and it is what says "this quote came off a pool".
+- **Haircutting the weight instead of the price.** Rejected: the weight is deliverable inventory, read on-chain, and it is also what the liquidity sweep reports — discounting it would make a provider's reported inventory and the depth attributed to it disagree, which the sweep exists to prevent. The fee is a cost of the trade, not a reduction in the size held.
+- **Applying it after the median, to the leg's published price.** Rejected: the median is liquidity-weighted across bids, so haircutting the aggregate would also discount wallet-funded quotes that never pay a pool fee, and it would change which quote wins the median only by accident. The haircut belongs on the individual quote, before it competes.
+- **Making the rate configurable per chain or pool.** Deferred: the positions these bids declare sit in 30bps-tier pools, and a knob invites the number to drift out of sync between the indexer and simplex. A single exported constant is easy to widen into a lookup if a different tier ever shows up.
+
+Why 30bps at all: without it, a pool-priced bid reads richer than a wallet-funded one on a fee it has not yet paid, so it wins the median and the published price is one nobody can actually execute at.
+
+A consequence worth knowing: a leg amount small enough that the haircut rounds it to zero now takes the "solver declined this leg" path. That is the correct reading — a quote that rounds away is not a price — and it only bites at dust amounts.
+
 ## 2026-08-21 — The coprocessor's HTTP provider runs with its response cache off
 
 Chosen: `new HttpProvider(httpUrl, {}, 0)` — capacity 0 disables polkadot-js's per-provider LRU outright, so every `send` reaches the node.

--- a/sdk/packages/sdk/docs/ai/Flow.md
+++ b/sdk/packages/sdk/docs/ai/Flow.md
@@ -27,3 +27,16 @@ Each tick, skipped if the previous one is still running:
 Step 4 is what made the provider cache dangerous: with caching on, re-reading a block whose `state_getRuntimeVersion` had rejected was answered by the cached rejection rather than a fresh request (fixed 2026-08-21). In `@hyperbridge/simplex` one `HyperbridgeScanner` owns this poll and fans `onError` out to every subscribing filler, so a single failed tick logs once from the scanner and once per filler.
 
 The cadence is `intervalMs` when given, otherwise `phantomPollIntervalMs()`: 6s on Gargantua, 15s elsewhere, decided by the runtime's `specName` read over the same HTTP api, falling back to 15s if that read fails.
+
+## How a phantom order's bids become one price per leg
+
+`aggregatePhantomBids` (`src/protocols/intents/phantom-aggregation.ts`) is the whole path, run by the indexer (`handlePhantomOrderPrices.handler.ts`) and by simplex's phantom E2E test against the same code.
+
+1. Resolve the destination chain's RPC, EVM chain id, and `SolverAccount`. Any of the three missing means no snapshot at all — an unverified quote must never reach the price — and `fetchBidsForOrder` then pulls the bid set from the Hyperbridge node.
+2. Per bid: SCALE-decode the UserOperation, pull the inner `fillOrder` out of its ERC-7821 batch (`extractFill`), and reject it unless the order in that calldata commits to the order being priced. The solver's signature is checked over the EntryPoint userOpHash (`isVerifiedSolverBid`), and a solver already counted for this order is skipped, so one bid copied under N fillers still counts once.
+3. Decode the paymasterAndData declaration — accepted source chains and declared V4 position tokenIds — which the userOpHash covers, so it is as authentic as the quote.
+4. **Price adjustment**: if the declaration names positions, every leg amount is multiplied by `(10_000 - UNISWAP_QUOTE_HAIRCUT_BPS) / 10_000`. This happens before the `solverAmount !== 0n` filter, so a quote the haircut rounds away is read as a declined leg.
+5. Weight each quoted leg by the solver's deliverable inventory in *that leg's* output token on the destination chain: ERC-20 balance + redeemable vault shares (`getBalance`) plus the withdrawable side of any declared position the solver actually owns on-chain (`readPosition`, filtered by owner). Then sweep the solver's whole inventory into `lpBalances` once per bid.
+6. Per leg: drop every zero-weight quote — from the median, from `bidCount`, and from `bidders` alike — and drop the leg entirely if none is left. Otherwise `weightedMedian` picks the price, and `lowestPrice`/`highestPrice` are set to that same median rather than the raw bid extremes.
+
+A malformed bid is skipped and the rest are priced; a `PhantomRpcError` aborts the whole run instead, because a partial bid set publishes a confident price built from whichever bids happened to be readable.

--- a/sdk/packages/sdk/src/intents-helpers.ts
+++ b/sdk/packages/sdk/src/intents-helpers.ts
@@ -6,6 +6,7 @@ export { default as IntentGatewayV2 } from "@/abis/IntentGatewayV2"
 export { poolSlug, sortPoolSymbols } from "@/protocols/intents/liquidity-pool"
 export {
 	aggregatePhantomBids,
+	applyUniswapQuoteHaircut,
 	decodeAcceptedSourceChains,
 	decodePhantomBidDeclaration,
 	encodeAcceptedSourceChains,
@@ -20,6 +21,7 @@ export {
 	weightedMedian,
 	zipFillLegs,
 	ENTRY_POINT_V08_ADDRESS,
+	UNISWAP_QUOTE_HAIRCUT_BPS,
 	FILL_ORDER_ABI,
 	type AggregationLogger,
 	type BidNonceKeyFn,

--- a/sdk/packages/sdk/src/protocols/intents/index.ts
+++ b/sdk/packages/sdk/src/protocols/intents/index.ts
@@ -37,6 +37,8 @@ export {
 	decodeAcceptedSourceChains,
 	encodePhantomBidDeclaration,
 	decodePhantomBidDeclaration,
+	applyUniswapQuoteHaircut,
+	UNISWAP_QUOTE_HAIRCUT_BPS,
 	type PhantomBidDeclaration,
 } from "./phantom-aggregation"
 export {

--- a/sdk/packages/sdk/src/protocols/intents/phantom-aggregation.ts
+++ b/sdk/packages/sdk/src/protocols/intents/phantom-aggregation.ts
@@ -372,6 +372,22 @@ export interface AggregationLogger {
 	warn: (payload: unknown, message: string) => void
 }
 
+/**
+ * Haircut applied to a quote that is priced off a Uniswap V4 pool, in basis points.
+ *
+ * A bid that declares V4 positions is quoting off those pools, and a pool price is what a trade
+ * gets BEFORE the pool takes its fee — so the amount such a bid names is more than the solver
+ * would actually be left holding once the swap that sources it clears. 30bps is the fee tier the
+ * pools these positions sit in charge, so netting it out here is what makes a pool-priced quote
+ * comparable to a wallet-funded one, whose inventory has already paid its cost of goods.
+ */
+export const UNISWAP_QUOTE_HAIRCUT_BPS = 30n
+
+/** Applies {@link UNISWAP_QUOTE_HAIRCUT_BPS} to a quoted output amount, rounding down. */
+export function applyUniswapQuoteHaircut(amount: bigint): bigint {
+	return (amount * (10_000n - UNISWAP_QUOTE_HAIRCUT_BPS)) / 10_000n
+}
+
 // Liquidity-weighted median of solver quotes. Each quote's influence is proportional to `weight` —
 // the solver's total balance for the output token across native + vault venues — so a solver that
 // can actually deliver size moves the price more than one quoting on thin liquidity. Returns the
@@ -1049,7 +1065,21 @@ async function runAggregation(
 			// A zero amount is how a solver declines a leg it does not price, so it is not a quote.
 			// Weights are fetched concurrently: the memo caches promises, so identical output tokens
 			// across legs still collapse to a single RPC round trip.
-			const quotedLegs = [...fillData.legs.entries()].filter(([, leg]) => leg.solverAmount !== 0n)
+			//
+			// A bid that names V4 positions is priced off those pools, so its quote is haircut by
+			// the pool fee before anything downstream reads it — the median, the bidder rows, and
+			// the zero-check right here, which then treats a quote the haircut rounds away exactly
+			// as it treats a declined one. The declaration drives this rather than the positions
+			// that survive the ownership check below, so the quote is haircut on the same basis
+			// the solver priced it on, whether or not this chain has V4 contracts configured.
+			const poolPriced = declaration.uniswapV4Positions.length > 0
+			const quotedLegs = [...fillData.legs.entries()]
+				.map(([legIndex, leg]): [number, FillLeg] =>
+					poolPriced
+						? [legIndex, { ...leg, solverAmount: applyUniswapQuoteHaircut(leg.solverAmount) }]
+						: [legIndex, leg],
+				)
+				.filter(([, leg]) => leg.solverAmount !== 0n)
 
 			// Liquidity a solver parked in a Uniswap V4 position is real capacity but holds no ERC-20
 			// balance, so without this it reads as zero and the leg is dropped. The bid only NAMES

--- a/sdk/packages/sdk/src/tests/phantomAggregation.test.ts
+++ b/sdk/packages/sdk/src/tests/phantomAggregation.test.ts
@@ -10,6 +10,7 @@ import {
 	setAggregationFetch,
 	splitBidSignature,
 	weightedMedian,
+	applyUniswapQuoteHaircut,
 	encodeAcceptedSourceChains,
 	encodePhantomBidDeclaration,
 	AGGREGATION_ATTEMPTS,
@@ -725,6 +726,49 @@ describe("aggregatePhantomBids bid verification", () => {
 			// Weighted purely by the position: the balance read returns zero for every token.
 			expect(result!.legs).toHaveLength(1)
 			expect(result!.legs[0].bidders[0].weight).toBeGreaterThan(0n)
+		})
+
+		// A pool price is what a trade gets before the pool takes its fee, so a bid quoting off one
+		// names more than it clears. The snapshot prices it net of that fee rather than letting a
+		// pool-priced quote outbid a wallet-funded one on 30bps it never had.
+		it("haircuts a pool-priced quote by 30bps before it reaches the median", async () => {
+			const userOp = await signedBidUserOp({
+				signingKey: SOLVER_KEY,
+				paymasterAndData: encodePhantomBidDeclaration({ uniswapV4Positions: [TOKEN_ID] }),
+			})
+			setAggregationFetch(v4Rpc([userOp], solverAddress))
+
+			const result = await aggregateWithV4(solverAddress)
+
+			expect(result!.legs[0].medianPrice).toBe((SOLVER_AMOUNT * 9_970n) / 10_000n)
+			expect(result!.legs[0].medianPrice).toBe(applyUniswapQuoteHaircut(SOLVER_AMOUNT))
+			// The haircut is on the price only: the position still backs the leg at full size.
+			expect(result!.legs[0].bidders[0].weight).toBe(
+				result!.lpBalances.find((lp) => lp.tokenAddress.toLowerCase() === USDT)!.balance,
+			)
+		})
+
+		// Only a pool-priced bid pays it — a solver quoting off wallet inventory has already paid
+		// its cost of goods, and a source-chain-only declaration says nothing about a pool.
+		it("leaves a bid that declares no position unhaircut", async () => {
+			const userOp = await signedBidUserOp({
+				signingKey: SOLVER_KEY,
+				paymasterAndData: encodeAcceptedSourceChains([CHAIN]),
+			})
+			setAggregationFetch(mockRpc([userOp], delegatedTo(SOLVER_ACCOUNT)))
+
+			const result = await aggregatePhantomBids({
+				nodeUrl: NODE_URL,
+				evmRpcUrls: { [CHAIN]: "http://base.test" },
+				chain: CHAIN,
+				gatewayAddress: GATEWAY,
+				commitment: COMMITMENT,
+				yieldVaults: { [CHAIN]: { [USDT]: [] } },
+				solverAccount: SOLVER_ACCOUNT,
+				uniswapV4: { [CHAIN]: { positionManager: POSITION_MANAGER, stateView: STATE_VIEW } },
+			})
+
+			expect(result!.legs[0].medianPrice).toBe(SOLVER_AMOUNT)
 		})
 
 		// The sweep is where a provider's inventory is reported, so a position missing from it makes


### PR DESCRIPTION
A phantom bid that declares Uniswap V4 positions is quoting off those pools, and a pool price is what a trade gets before the pool takes its fee — so the amount such a bid names is richer than what the solver clears once the sourcing swap goes through. Left as-is it outbids a wallet-funded quote on 30bps it never paid, wins the liquidity-weighted median, and publishes a price nobody can execute at.

aggregatePhantomBids now nets 30bps out of every leg amount on a bid whose declaration carries positions, before the quote reaches the zero-check, the median, or the bidder rows. Bids that declare no position are untouched: that inventory has already paid its cost of goods.

The haircut keys off the declaration rather than the positions that survive the on-chain ownership check, so a quote is priced on the basis the solver priced it on — including on a chain with no V4 contracts configured, where declared positions contribute no weight either way. It lands on price only, never on weight: weight is deliverable inventory and is what the liquidity sweep reports, so discounting it would make a provider's reported inventory disagree with the depth attributed to it. A leg amount small enough that the haircut rounds it to zero takes the existing declined-leg path.

UNISWAP_QUOTE_HAIRCUT_BPS and applyUniswapQuoteHaircut are exported from both @/protocols/intents and the intents-helpers sub-path, so the indexer — which runs this same function — reads the number instead of restating it.