### PR TITLE
[sdk]: quote intents using indexed buy and sell rates

### DIFF
--- a/docs/content/developers/evm/intent-gateway/placing-orders.mdx
+++ b/docs/content/developers/evm/intent-gateway/placing-orders.mdx
@@ -189,7 +189,7 @@ const walletClient = createWalletClient({ account, transport: http(SOURCE_RPC_UR
 
 ### Quote the swap and create the order
 
-`quoteIntent()` reads Phantom price snapshots through the indexer attached in setup. For an exact-input order, `amountIn` is the amount you send and `amountOut` is the quoted output you require from the solver.
+`quoteIntent()` reads the latest aggregate pool buy or sell rate through the indexer attached in setup. For an exact-input order, `amountIn` is the amount you send and `amountOut` is the quoted output you require from the solver.
 
 ```typescript title="create-order.ts" lineNumbers
 import { type Order } from "@hyperbridge/sdk"

--- a/docs/content/developers/sdk/api/intent-gateway.mdx
+++ b/docs/content/developers/sdk/api/intent-gateway.mdx
@@ -175,9 +175,9 @@ while (true) {
 
 ### quoteIntent(params)
 
-Quotes an intent from the latest directional Phantom order price snapshot by default. Pass token addresses directly—no token metadata is required. No `strategy` option is needed for Phantom quotes. Pass `strategy: "uniswap_v4"` only when explicitly requesting a Uniswap quote, which prices against the configured Base (`EVM-8453`) pool rather than the gateway destination chain.
+Quotes an intent from the latest aggregate pool buy or sell rate published by the indexer. The pool rate is depth-weighted from fresh chain samples. Pass token addresses directly—the SDK resolves their configured symbols and decimals. No `strategy` option is needed for indexed-rate quotes.
 
-Phantom-backed quotes require an attached Hyperbridge indexer client. There is no automatic Uniswap fallback.
+Indexed-rate quotes require an attached Hyperbridge indexer client. There is no automatic fallback to another price source.
 
 Use `amountIn` and `amountOut` when constructing the `inputs` and `output.assets` for an IntentGateway V2 order.
 
@@ -195,12 +195,14 @@ const quote = await gateway.quoteIntent({
 });
 
 console.log(quote.amountIn, quote.amountOut);
-if (quote.strategy === "phantom_snapshot") {
-  console.log(quote.quoteMetadata.medianPrice);
+if (quote.strategy === "indexed_rates") {
+  console.log(quote.quoteMetadata.rateSide, quote.quoteMetadata.rate);
 }
 ```
 
-The Phantom feed currently supports USDC → cNGN, cNGN → USDC, USDT → cNGN, and cNGN → USDT. Regardless of the order's source or destination chain, snapshots exist only for the canonical Base USDC/cNGN market: the SDK resolves USDC and USDT to Base USDC, and cNGN to Base cNGN, before querying the exact direction.
+The order's source and destination chains select the configured token deployments. The SDK uses the pool's indexed buy rate when the order buys the quote token with the base token, and the indexed sell rate for the reverse direction. If that direction has no indexed rate, the quote fails clearly instead of using a different market.
+
+The previous Phantom snapshot source remains available with `strategy: "phantom_snapshot"`. Pass `strategy: "uniswap_v4"` only when explicitly requesting a Uniswap quote.
 
 For non-Phantom pairs whose pools are not configured by the SDK, pass an explicit Uniswap V4 PoolKey:
 
@@ -225,11 +227,11 @@ const quote = await gateway.quoteIntent({
 
 When passing an explicit PoolKey for cross-chain Uniswap quotes, also pass `currencyIn` inside the `poolKey` override — the Base-side address of the input currency. It defaults to `tokenIn`, which only works when that address is part of the Base pool, and must equal `currency0` or `currency1`.
 
-The result includes `amountIn`, `amountOut`, and strategy-specific quote metadata. Phantom metadata contains the snapshot commitment, block number/time, directional token addresses, `standardAmount`, median/low/high prices, contributing bid count, and source-chain protocol fee. Uniswap metadata contains the V4 PoolKey, quoter, quote chain, and protocol fee.
+The result includes `amountIn`, `amountOut`, and strategy-specific quote metadata. Indexed-rate metadata contains the source and destination chains, base and quote symbols, the buy or sell rate used, its update time, and the source-chain protocol fee.
 
 `amountIn` and `amountOut` already account for the IntentGateway protocol fee that the gateway deducts from order inputs. Exact-input quotes price the swap against the post-fee input, so `amountOut` is the snapshot-priced output; exact-output quotes return the gross `amountIn` required to produce the requested `amountOut`. Use the returned amounts directly as the order's `inputs` and `output.assets`—no further fee or slippage adjustment is required.
 
-For an exact-input Phantom quote, the SDK deducts the gateway fee and computes `floor(netInput × medianPrice / standardAmount)`. For an exact-output quote, it computes `ceil(amountOut × standardAmount / medianPrice)` and grosses that input up for the gateway fee. A missing indexer, missing snapshot, or invalid snapshot throws an explicit error; the SDK does not silently switch price sources.
+For exact-input quotes, the SDK deducts the gateway fee before applying the directional rate. For exact-output quotes, it calculates the required net input from that rate and then grosses the input up for the gateway fee. Token decimals are read from SDK chain configuration. A missing indexer, missing directional rate, or invalid rate throws an explicit error.
 
 ### queryAvailableLiquidity(params)
 
@@ -278,9 +280,9 @@ method returns `undefined` only when the destination has no indexed pool sample.
 
 ### queryBuyAndSellRates(params)
 
-Returns chain-specific buy and sell rates for a token pair. Callers provide
-token symbols and numeric chain IDs; token addresses and canonical symbol casing
-are resolved internally from the SDK configuration.
+Returns the indexer's aggregate buy and sell rates for a token pool. Callers
+provide token symbols and numeric chain IDs; token addresses and canonical
+symbol casing are resolved internally from the SDK configuration.
 
 ```typescript lineNumbers
 const rates = await gateway.queryBuyAndSellRates({
@@ -298,10 +300,10 @@ if (rates) {
 ```
 
 Both rates use the less valuable token as the quote currency. For USDC/cNGN,
-both values are therefore cNGN per one USDC. The requested input-to-output rate
-is read on the destination chain and the reverse rate is read on the source
-chain; both are then oriented into the same units. Either rate and its matching
-timestamp can be `null` when that chain and direction have not been priced.
+both values are therefore cNGN per one USDC. Nexus depth-weights fresh per-chain
+samples into the pool's `buyRate` and `sellRate`; the SDK orients those fields
+into the same units. Either rate and its matching timestamp can be `null` when
+that pool direction has not been priced.
 
 Symbol matching is case-insensitive, so `"cNGN"`, `"cngn"`, and `"CNGN"` all
 resolve to the canonical `"cNGN"` pool symbol.

--- a/sdk/packages/sdk/CHANGELOG.md
+++ b/sdk/packages/sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @hyperbridge/sdk
 
+## 2.8.8
+
+### Patch Changes
+
+- `IntentGateway.quoteIntent()` now uses the indexer's depth-weighted aggregate pool buy and sell rates by default, including configured token decimals and the source gateway protocol fee. Reverse sell rates round conservatively so quotes do not overpromise output. Legacy Phantom snapshot and Uniswap V4 quotes remain available as explicit strategies.
+- Replaced the non-resolving default BSC RPC with the publicnode endpoint.
+
 ## 2.8.5
 
 ### Patch Changes

--- a/sdk/packages/sdk/docs/ai/ChangeLog.md
+++ b/sdk/packages/sdk/docs/ai/ChangeLog.md
@@ -12,6 +12,12 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-08-25 — Intent quotes use aggregate indexed pool rates by default
+
+`IntentGateway.quoteIntent` now prices orders from the pair-centric indexer's depth-weighted aggregate `LiquidityPool.buyRate` and `sellRate`. Source and destination chains resolve the configured token deployments, while the quote converts the pool's whole-token rate into raw amounts with configured decimals, applies the source gateway protocol fee, and exposes the selected rate and timestamp in metadata. Reverse sell-rate reciprocals round up so quotes do not overpromise output. Phantom snapshot and Uniswap V4 pricing remain explicit compatibility strategies. Live sequential tests cover exact-input USDC to cNGN and exact-output cNGN to USDC across BSC and Base, including their different token decimal scales. The dead `binance.llamarpc.com` BSC default was replaced with `bsc-rpc.publicnode.com` after it blocked those live checks.
+
+Files: `src/configs/chain.ts`, `src/protocols/intents/IntentGateway.ts`, `src/protocols/intents/LiquidityEngine.ts`, `src/protocols/intents/index.ts`, `src/protocols/intents/quote/index.ts`, `src/protocols/intents/quote/indexedRates.ts`, `src/protocols/intents/quote/types.ts`, `src/tests/sequential/intentGateway.test.ts`, `package.json`, `CHANGELOG.md`, `docs/ai/ChangeLog.md`, `docs/ai/Decisions.md`, `../../../docs/content/developers/sdk/api/intent-gateway.mdx`, `../../../docs/content/developers/evm/intent-gateway/placing-orders.mdx`.
+
 ## 2026-08-24 — Pool-priced phantom bids are haircut 30bps before aggregation
 
 A phantom bid that declares Uniswap V4 positions is quoting off those pools, and a pool price is what a trade gets before the pool takes its fee — so the amount such a bid names is richer than what the solver clears once the sourcing swap goes through. `aggregatePhantomBids` now nets 30bps out of every leg amount on a bid whose declaration carries positions, before the quote reaches the zero-check, the weighted median, or the bidder rows. Non-declaring bids are untouched: wallet inventory has already paid its cost of goods.

--- a/sdk/packages/sdk/docs/ai/Decisions.md
+++ b/sdk/packages/sdk/docs/ai/Decisions.md
@@ -4,6 +4,21 @@ AI-maintained record of non-obvious choices made in `sdk/packages/sdk`: what was
 
 Entry format: heading with the decision, then alternatives considered and the reasoning. Newest first.
 
+## 2026-08-25 — Intent quotes default to directional indexed rates without fallback
+
+Chosen: `quoteIntent` defaults to an `indexed_rates` strategy that selects the depth-weighted aggregate `LiquidityPool.buyRate` for base-to-quote orders and `sellRate` for quote-to-base orders. Source and destination chains resolve the configured token deployments; raw amounts are calculated from the indexer's 18-decimal whole-token pool rate and both tokens' configured decimals. A missing directional rate is an error.
+
+Alternatives considered:
+
+- **Keep defaulting to the legacy directional Phantom snapshot.** Rejected: those snapshots resolve through a canonical Base market and do not use the pair-centric pool rate, so quotes can disagree with the indexer's current market.
+- **Quote directly from one source/destination pair of `PoolChainLiquidity` rows.** Rejected: those rows are inputs to the indexer's pool price. `LiquidityPool.buyRate` and `sellRate` are the maintained depth-weighted merge of fresh chain samples and are the intended market-level quote.
+- **Silently fall back to Phantom or Uniswap when a rate is absent.** Rejected: an order would be priced from a different market than the caller requested, hiding stale or incomplete indexer coverage and producing another unfillable quote.
+- **Remove the old strategies immediately.** Rejected for compatibility: callers that explicitly select them can continue doing so, while all calls without a strategy use the corrected path.
+
+The result uses a new `indexed_rates` discriminant and includes the selected rate side, value, timestamp, pair symbols, chains, and protocol fee. This makes the price used to construct the order inspectable without exposing indexer internals.
+
+The public sell rate is the reciprocal of the indexer's base-per-quote direction. That reciprocal rounds up at 18 decimals: rounding down would let a quote-token-to-base-token order request slightly more base output than the indexed direction supports. Buy rates are already indexer-floored outputs and remain unchanged.
+
 ## 2026-08-24 — The 30bps pool haircut keys off the declaration, and lands on price only
 
 Chosen: in `aggregatePhantomBids`, haircut a bid's quoted leg amounts by 30bps when its paymasterAndData declaration names Uniswap V4 positions.

--- a/sdk/packages/sdk/package.json
+++ b/sdk/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/sdk",
-	"version": "2.8.7",
+	"version": "2.8.8",
 	"description": "The hyperclient SDK provides utilities for querying proofs and statuses for cross-chain requests from HyperBridge.",
 	"type": "module",
 	"types": "./dist/node/index.d.ts",

--- a/sdk/packages/sdk/src/configs/chain.ts
+++ b/sdk/packages/sdk/src/configs/chain.ts
@@ -477,7 +477,7 @@ export const chainConfigs: Record<number, ChainConfigData> = {
 			// "Usdt0Oft": Not available on BSC
 		},
 		rpcEnvKey: "BSC_MAINNET",
-		defaultRpcUrl: "https://binance.llamarpc.com",
+		defaultRpcUrl: "https://bsc-rpc.publicnode.com",
 		consensusStateId: "BSC0",
 		coingeckoId: "binance-smart-chain",
 		erc4626Vaults: [

--- a/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
+++ b/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
@@ -49,6 +49,7 @@ import {
 	type IntentQuoteStrategyHandler,
 	type QuoteIntentParams,
 	type QuoteIntentResult,
+	IndexedRateIntentQuoteStrategy,
 	PhantomSnapshotIntentQuoteStrategy,
 	UniswapV4IntentQuoteStrategy,
 	UnsupportedIntentQuotePairError,
@@ -71,8 +72,8 @@ const CROSS_CHAIN_ORDER_FEE_GAS_PRICE_BUMP_PERCENT = 10n
  *
  * `IntentGateway` orchestrates the complete lifecycle of an intent-based
  * cross-chain swap:
- * - **Quoting** — prices the order's input/output amounts via Phantom order
- *   snapshots by default, with Uniswap V4 available as an explicit strategy.
+ * - **Quoting** — prices the order's input/output amounts from aggregate
+ *   indexed pool rates by default, with legacy quote strategies available explicitly.
  * - **Order placement** — encodes and yields `placeOrder` calldata; caller
  *   signs and submits the transaction.
  * - **Order execution** — polls the Hyperbridge coprocessor for solver bids,
@@ -166,6 +167,10 @@ export class IntentGateway {
 		this.gasEstimator = gasEstimator
 		this._crypto = crypto
 		this.quoteStrategies = {
+			indexed_rates: new IndexedRateIntentQuoteStrategy(
+				dest.configService,
+				() => this.requireIndexer().queryClient,
+			),
 			phantom_snapshot: new PhantomSnapshotIntentQuoteStrategy(
 				dest.configService,
 				() => this.requireIndexer().queryClient,
@@ -228,26 +233,26 @@ export class IntentGateway {
 	/**
 	 * Quotes an intent between this gateway's source and destination chains.
 	 *
-	 * Uses the latest directional Phantom order price snapshot from the attached
-	 * indexer by default. Pass `strategy: "uniswap_v4"` only when explicitly
-	 * requesting a Uniswap quote. Provide exactly one of `amountIn` or `amountOut`.
+	 * Uses the indexer's latest aggregate directional pool rate by default. Pass
+	 * `strategy: "phantom_snapshot"` or `strategy: "uniswap_v4"` only when
+	 * explicitly requesting a legacy quote source. Provide exactly one of
+	 * `amountIn` or `amountOut`.
 	 *
-	 * Both built-in strategies resolve their canonical market on Base,
-	 * regardless of this gateway's destination chain. Returned
+	 * The gateway's source and destination chains resolve the configured order
+	 * tokens; the indexer supplies the depth-weighted pool rate. Returned
 	 * `amountIn`/`amountOut` already account for the gateway's protocol fee
-	 * (`quoteMetadata.protocolFeeBps`), which the gateway deducts from order
-	 * inputs; use the returned amounts directly when placing the order.
+	 * (`quoteMetadata.protocolFeeBps`), which the gateway deducts from order inputs.
 	 *
 	 * @param params - Token pair, amount, and optional strategy/pool overrides.
 	 * @returns The quoted amounts plus strategy-specific metadata.
 	 * @throws {UnsupportedIntentQuoteStrategyError} For unknown strategies.
 	 * @throws {UnsupportedIntentQuotePairError} When the selected strategy does not support the pair.
-	 * @throws {PhantomSnapshotUnavailableError} When an eligible cNGN pair has no snapshot.
+	 * @throws {IndexedRateUnavailableError} When the requested direction has no indexed rate.
 	 */
 	async quoteIntent(params: QuoteIntentParams): Promise<QuoteIntentResult> {
 		const source = { stateMachineId: this.source.config.stateMachineId, client: this.source.client }
 		const destination = { stateMachineId: this.dest.config.stateMachineId, client: this.dest.client }
-		const strategy = params.strategy ?? "phantom_snapshot"
+		const strategy = params.strategy ?? "indexed_rates"
 		const handler = this.quoteStrategies[strategy]
 		if (!handler) throw new UnsupportedIntentQuoteStrategyError(strategy)
 
@@ -293,9 +298,9 @@ export class IntentGateway {
 	}
 
 	/**
-	 * Returns chain-specific buy and sell rates in less-valued quote-token units
-	 * without requiring token addresses. Symbols are matched case-insensitively;
-	 * chain IDs are numeric IDs for chains configured in the SDK.
+	 * Returns aggregate indexed pool buy and sell rates in less-valued quote-token
+	 * units without requiring token addresses. Symbols are matched
+	 * case-insensitively; chain IDs resolve configured token deployments.
 	 */
 	async queryBuyAndSellRates(params: QueryBuyAndSellRatesParams): Promise<BuyAndSellRates | undefined> {
 		const { queryClient } = this.requireIndexer()

--- a/sdk/packages/sdk/src/protocols/intents/LiquidityEngine.ts
+++ b/sdk/packages/sdk/src/protocols/intents/LiquidityEngine.ts
@@ -11,8 +11,6 @@ const SELL = "SELL"
 const BUY = "BUY"
 const USD_STABLE_SYMBOLS = new Set<ConfiguredAssetSymbol>(["USDC", "USDT"])
 
-type PoolDirection = typeof SELL | typeof BUY
-
 interface AvailableLiquidityResponse {
 	poolChainLiquidities: {
 		nodes: PoolChainLiquidityNode[]
@@ -37,16 +35,17 @@ interface PoolRouteNode {
 }
 
 interface BuyAndSellRatesResponse {
-	direct: RateConnection
-	reverse: RateConnection
+	liquidityPools: {
+		nodes: LiquidityPoolRateNode[]
+	}
 }
 
-interface RateConnection {
-	nodes: ChainRateNode[]
-}
-
-interface ChainRateNode {
-	rate: string
+interface LiquidityPoolRateNode {
+	id: string
+	token0Symbol: string
+	token1Symbol: string
+	sellRate: string | null
+	buyRate: string | null
 	lastUpdatedAt: string
 }
 
@@ -119,12 +118,12 @@ export class LiquidityEngine {
 	}
 
 	/**
-	 * Returns chain-specific buy and sell rates in less-valued quote-token units
-	 * per one base token.
+	 * Returns the indexed pool's aggregate buy and sell rates in less-valued
+	 * quote-token units per one base token.
 	 *
-	 * The requested direction is read on the destination chain; its reverse is
-	 * read on the source chain. This mirrors where each direction's output token
-	 * must be delivered for a cross-chain trade.
+	 * The indexer depth-weights fresh per-chain samples into the pool rates. The
+	 * source and destination chains remain part of the result because they define
+	 * the cross-chain route whose configured token symbols were resolved.
 	 */
 	async getBuyAndSellRates(params: {
 		sourceChain: Chains
@@ -133,22 +132,21 @@ export class LiquidityEngine {
 		tokenOutSymbol: ConfiguredAssetSymbol
 	}): Promise<BuyAndSellRates | undefined> {
 		const pool = resolveLiquidityPool(params.tokenInSymbol, params.tokenOutSymbol)
-		const directDirection: PoolDirection =
-			params.tokenInSymbol.toLowerCase() === pool.token0Symbol.toLowerCase() ? SELL : BUY
-		const reverseDirection: PoolDirection = directDirection === SELL ? BUY : SELL
 		const response = await this.queryClient.request<BuyAndSellRatesResponse>(BUY_AND_SELL_RATES, {
 			poolId: pool.poolId,
-			directChain: params.destinationChain,
-			directDirection,
-			reverseChain: params.sourceChain,
-			reverseDirection,
 		})
-		if (!response?.direct?.nodes || !response?.reverse?.nodes) {
-			throw new InvalidLiquidityIndexerResponseError("rate connections are missing")
+		if (!response?.liquidityPools?.nodes) {
+			throw new InvalidLiquidityIndexerResponseError("liquidity pool connection is missing")
 		}
+		const indexedPool = response.liquidityPools.nodes[0]
+		if (!indexedPool) return undefined
+		validateIndexedPool(indexedPool, pool)
 
-		const direct = readIndexedRate(response.direct.nodes[0], "direct rate")
-		const reverse = readIndexedRate(response.reverse.nodes[0], "reverse rate")
+		const sell = readIndexedRate(indexedPool.sellRate, indexedPool.lastUpdatedAt, "pool sell rate")
+		const buy = readIndexedRate(indexedPool.buyRate, indexedPool.lastUpdatedAt, "pool buy rate")
+		const inputIsToken0 = params.tokenInSymbol.toLowerCase() === pool.token0Symbol.toLowerCase()
+		const direct = inputIsToken0 ? sell : buy
+		const reverse = inputIsToken0 ? buy : sell
 		if (!direct && !reverse) return undefined
 
 		const quoteTokenSymbol = resolveQuoteTokenSymbol(
@@ -158,20 +156,20 @@ export class LiquidityEngine {
 			reverse?.scaledRate,
 		)
 		const quoteIsTokenOut = quoteTokenSymbol === params.tokenOutSymbol
-		const buy = quoteIsTokenOut ? direct : reverse
-		const sell = quoteIsTokenOut ? reverse : direct
+		const orientedBuy = quoteIsTokenOut ? direct : reverse
+		const orientedSell = quoteIsTokenOut ? reverse : direct
 
 		return {
 			baseTokenSymbol: quoteIsTokenOut ? params.tokenInSymbol : params.tokenOutSymbol,
 			quoteTokenSymbol,
 			sourceChain: params.sourceChain,
 			destinationChain: params.destinationChain,
-			buyRate: buy ? formatUnits(buy.scaledRate, INDEXER_FIXED_POINT_DECIMALS) : null,
-			sellRate: sell
-				? formatUnits(reciprocalRate(sell.scaledRate, "sell rate"), INDEXER_FIXED_POINT_DECIMALS)
+			buyRate: orientedBuy ? formatUnits(orientedBuy.scaledRate, INDEXER_FIXED_POINT_DECIMALS) : null,
+			sellRate: orientedSell
+				? formatUnits(reciprocalRate(orientedSell.scaledRate, "sell rate"), INDEXER_FIXED_POINT_DECIMALS)
 				: null,
-			buyRateUpdatedAt: buy?.updatedAt ?? null,
-			sellRateUpdatedAt: sell?.updatedAt ?? null,
+			buyRateUpdatedAt: orientedBuy?.updatedAt ?? null,
+			sellRateUpdatedAt: orientedSell?.updatedAt ?? null,
 		}
 	}
 }
@@ -220,18 +218,31 @@ function readIndexerDate(value: string, label: string): Date {
 	return date
 }
 
-function readIndexedRate(node: ChainRateNode | undefined, label: string): IndexedRate | undefined {
-	if (!node) return undefined
+function readIndexedRate(value: string | null, lastUpdatedAt: string, label: string): IndexedRate | undefined {
+	if (value === null) return undefined
 	try {
-		const scaledRate = BigInt(node.rate)
+		const scaledRate = BigInt(value)
 		if (scaledRate <= 0n) throw new Error()
 		return {
 			scaledRate,
-			updatedAt: readIndexerDate(node.lastUpdatedAt, `${label} lastUpdatedAt`),
+			updatedAt: readIndexerDate(lastUpdatedAt, `${label} lastUpdatedAt`),
 		}
 	} catch (error) {
 		if (error instanceof InvalidLiquidityIndexerResponseError) throw error
 		throw new InvalidLiquidityIndexerResponseError(`${label} is not a positive integer`)
+	}
+}
+
+function validateIndexedPool(
+	indexedPool: LiquidityPoolRateNode,
+	expected: { poolId: string; token0Symbol: string; token1Symbol: string },
+): void {
+	if (
+		indexedPool.id.toLowerCase() !== expected.poolId.toLowerCase() ||
+		indexedPool.token0Symbol.toLowerCase() !== expected.token0Symbol.toLowerCase() ||
+		indexedPool.token1Symbol.toLowerCase() !== expected.token1Symbol.toLowerCase()
+	) {
+		throw new InvalidLiquidityIndexerResponseError(`pool identity does not match ${expected.poolId}`)
 	}
 }
 
@@ -252,7 +263,11 @@ function resolveQuoteTokenSymbol(
 }
 
 function reciprocalRate(rate: bigint, label: string): bigint {
-	const reciprocal = (POOL_RATE_SCALE * POOL_RATE_SCALE) / rate
+	const numerator = POOL_RATE_SCALE * POOL_RATE_SCALE
+	// A sell rate is quote token required per base token. Round the reciprocal
+	// up so reverse quotes never promise more base token than the indexed
+	// base-per-quote direction can deliver.
+	const reciprocal = (numerator + rate - 1n) / rate
 	if (reciprocal <= 0n) throw new InvalidLiquidityIndexerResponseError(`${label} reciprocal underflowed`)
 	return reciprocal
 }

--- a/sdk/packages/sdk/src/protocols/intents/index.ts
+++ b/sdk/packages/sdk/src/protocols/intents/index.ts
@@ -7,12 +7,17 @@ export {
 export { poolSlug, sortPoolSymbols } from "./liquidity-pool"
 export { OrderStatusChecker } from "./OrderStatusChecker"
 export {
+	InvalidIndexedRateError,
 	InvalidPhantomSnapshotError,
+	IndexedRateUnavailableError,
 	PhantomSnapshotUnavailableError,
 	UnsupportedIntentQuotePairError,
 	UnsupportedIntentQuoteStrategyError,
 } from "./quote"
 export type {
+	IndexedRateIntentQuoteMetadata,
+	IndexedRateQuoteIntentResult,
+	IndexedRateSide,
 	IntentQuoteStrategy,
 	IntentQuoteTradeType,
 	QuoteIntentParams,

--- a/sdk/packages/sdk/src/protocols/intents/quote/index.ts
+++ b/sdk/packages/sdk/src/protocols/intents/quote/index.ts
@@ -1,7 +1,13 @@
 export { UniswapV4IntentQuoteStrategy } from "./uniswapV4"
 export { PhantomSnapshotIntentQuoteStrategy, PHANTOM_INTENT_QUOTE_CHAIN } from "./phantomSnapshot"
+export { IndexedRateIntentQuoteStrategy } from "./indexedRates"
 export {
+	InvalidIndexedRateError,
 	InvalidPhantomSnapshotError,
+	IndexedRateUnavailableError,
+	type IndexedRateIntentQuoteMetadata,
+	type IndexedRateQuoteIntentResult,
+	type IndexedRateSide,
 	PhantomSnapshotUnavailableError,
 	type IntentQuoteChainContext,
 	type IntentQuoteStrategy,

--- a/sdk/packages/sdk/src/protocols/intents/quote/indexedRates.ts
+++ b/sdk/packages/sdk/src/protocols/intents/quote/indexedRates.ts
@@ -1,0 +1,199 @@
+import type { ChainConfigService } from "@/configs/ChainConfigService"
+import { type ConfiguredAssetSymbol, getConfigByStateMachineId } from "@/configs/chain"
+import {
+	LiquidityEngine,
+	UnsupportedLiquidityAssetError,
+	UnsupportedLiquidityChainError,
+} from "@/protocols/intents/LiquidityEngine"
+import type { BuyAndSellRates, HexString, IndexerQueryClient } from "@/types"
+import { parseUnits } from "viem"
+import { deductProtocolFee, divCeil, grossUpForProtocolFee, readProtocolFeeBps, validateQuoteParams } from "./shared"
+import {
+	type IndexedRateQuoteIntentResult,
+	type IndexedRateSide,
+	IndexedRateUnavailableError,
+	type IntentQuoteChainContext,
+	type IntentQuoteStrategyHandler,
+	InvalidIndexedRateError,
+	type QuoteIntentParams,
+} from "./types"
+
+const INDEXED_RATE_DECIMALS = 18
+const INDEXED_RATE_SCALE = 10n ** BigInt(INDEXED_RATE_DECIMALS)
+
+interface ResolvedQuoteAsset {
+	symbol: ConfiguredAssetSymbol
+	address: HexString
+	decimals: number
+}
+
+interface SelectedIndexedRate {
+	side: IndexedRateSide
+	rate: string
+	scaledRate: bigint
+	updatedAt: Date
+}
+
+/** Quotes raw token amounts from the indexer's aggregate directional pool rates. */
+export class IndexedRateIntentQuoteStrategy implements IntentQuoteStrategyHandler {
+	constructor(
+		private readonly chainConfigService: ChainConfigService,
+		private readonly getQueryClient: () => IndexerQueryClient,
+	) {}
+
+	async quote(
+		params: QuoteIntentParams,
+		source: IntentQuoteChainContext,
+		destination: IntentQuoteChainContext,
+	): Promise<IndexedRateQuoteIntentResult> {
+		validateQuoteParams(params)
+		const sourceConfig = getConfigByStateMachineId(source.stateMachineId)
+		const destinationConfig = getConfigByStateMachineId(destination.stateMachineId)
+		if (!sourceConfig) throw new UnsupportedLiquidityChainError(source.stateMachineId)
+		if (!destinationConfig) throw new UnsupportedLiquidityChainError(destination.stateMachineId)
+
+		const tokenIn = this.resolveAsset(sourceConfig.stateMachineId, params.tokenIn)
+		const tokenOut = this.resolveAsset(destinationConfig.stateMachineId, params.tokenOut)
+		const [protocolFeeBps, rates] = await Promise.all([
+			readProtocolFeeBps(this.chainConfigService, source),
+			new LiquidityEngine(this.getQueryClient()).getBuyAndSellRates({
+				sourceChain: sourceConfig.stateMachineId,
+				destinationChain: destinationConfig.stateMachineId,
+				tokenInSymbol: tokenIn.symbol,
+				tokenOutSymbol: tokenOut.symbol,
+			}),
+		])
+		if (!rates) {
+			throw new IndexedRateUnavailableError({
+				source: sourceConfig.stateMachineId,
+				destination: destinationConfig.stateMachineId,
+				tokenIn: tokenIn.symbol,
+				tokenOut: tokenOut.symbol,
+			})
+		}
+
+		const selectedRate = selectIndexedRate(rates, tokenIn.symbol, tokenOut.symbol)
+		return quoteWithIndexedRate(params, tokenIn, tokenOut, selectedRate, rates, protocolFeeBps)
+	}
+
+	private resolveAsset(chain: string, address: HexString): ResolvedQuoteAsset {
+		const asset = this.chainConfigService.getAssetMetadataByAddress(chain, address)
+		if (!asset) throw new UnsupportedLiquidityAssetError(chain, address)
+		const { decimals } = asset
+		if (decimals === undefined || !Number.isSafeInteger(decimals) || decimals < 0) {
+			throw new InvalidIndexedRateError(`decimals are not configured for ${asset.symbol} on ${chain}`)
+		}
+		return { ...asset, decimals }
+	}
+}
+
+function selectIndexedRate(
+	rates: BuyAndSellRates,
+	tokenInSymbol: ConfiguredAssetSymbol,
+	tokenOutSymbol: ConfiguredAssetSymbol,
+): SelectedIndexedRate {
+	if (tokenInSymbol === rates.baseTokenSymbol && tokenOutSymbol === rates.quoteTokenSymbol) {
+		return readIndexedRate(
+			"buy",
+			rates.buyRate,
+			rates.buyRateUpdatedAt,
+			rates,
+			tokenInSymbol,
+			tokenOutSymbol,
+		)
+	}
+	if (tokenInSymbol === rates.quoteTokenSymbol && tokenOutSymbol === rates.baseTokenSymbol) {
+		return readIndexedRate(
+			"sell",
+			rates.sellRate,
+			rates.sellRateUpdatedAt,
+			rates,
+			tokenInSymbol,
+			tokenOutSymbol,
+		)
+	}
+	throw new InvalidIndexedRateError(
+		`indexed pair ${rates.baseTokenSymbol}/${rates.quoteTokenSymbol} does not match ${tokenInSymbol}/${tokenOutSymbol}`,
+	)
+}
+
+function readIndexedRate(
+	side: IndexedRateSide,
+	rate: string | null,
+	updatedAt: Date | null,
+	rates: BuyAndSellRates,
+	tokenInSymbol: ConfiguredAssetSymbol,
+	tokenOutSymbol: ConfiguredAssetSymbol,
+): SelectedIndexedRate {
+	if (!rate || !updatedAt) {
+		throw new IndexedRateUnavailableError({
+			source: rates.sourceChain,
+			destination: rates.destinationChain,
+			tokenIn: tokenInSymbol,
+			tokenOut: tokenOutSymbol,
+			side,
+		})
+	}
+	try {
+		const scaledRate = parseUnits(rate, INDEXED_RATE_DECIMALS)
+		if (scaledRate <= 0n || Number.isNaN(updatedAt.getTime())) throw new Error()
+		return { side, rate, scaledRate, updatedAt }
+	} catch {
+		throw new InvalidIndexedRateError(`${side} rate or timestamp is invalid`)
+	}
+}
+
+function quoteWithIndexedRate(
+	params: QuoteIntentParams,
+	tokenIn: ResolvedQuoteAsset,
+	tokenOut: ResolvedQuoteAsset,
+	selectedRate: SelectedIndexedRate,
+	rates: BuyAndSellRates,
+	protocolFeeBps: bigint,
+): IndexedRateQuoteIntentResult {
+	const inputUnit = 10n ** BigInt(tokenIn.decimals)
+	const outputUnit = 10n ** BigInt(tokenOut.decimals)
+	if (params.amountIn !== undefined) {
+		const netAmountIn = deductProtocolFee(params.amountIn, protocolFeeBps)
+		const amountOut =
+			selectedRate.side === "buy"
+				? (netAmountIn * selectedRate.scaledRate * outputUnit) / (inputUnit * INDEXED_RATE_SCALE)
+				: (netAmountIn * outputUnit * INDEXED_RATE_SCALE) / (inputUnit * selectedRate.scaledRate)
+		if (amountOut <= 0n) throw new InvalidIndexedRateError("quote rounds down to zero output")
+		return buildResult("EXACT_INPUT", params.amountIn, amountOut, selectedRate, rates, protocolFeeBps)
+	}
+
+	if (params.amountOut === undefined) throw new Error("Quote amount is missing after validation")
+	const netAmountIn =
+		selectedRate.side === "buy"
+			? divCeil(params.amountOut * inputUnit * INDEXED_RATE_SCALE, selectedRate.scaledRate * outputUnit)
+			: divCeil(params.amountOut * inputUnit * selectedRate.scaledRate, outputUnit * INDEXED_RATE_SCALE)
+	const amountIn = grossUpForProtocolFee(netAmountIn, protocolFeeBps)
+	return buildResult("EXACT_OUTPUT", amountIn, params.amountOut, selectedRate, rates, protocolFeeBps)
+}
+
+function buildResult(
+	tradeType: IndexedRateQuoteIntentResult["tradeType"],
+	amountIn: bigint,
+	amountOut: bigint,
+	selectedRate: SelectedIndexedRate,
+	rates: BuyAndSellRates,
+	protocolFeeBps: bigint,
+): IndexedRateQuoteIntentResult {
+	return {
+		strategy: "indexed_rates",
+		tradeType,
+		amountIn,
+		amountOut,
+		quoteMetadata: {
+			sourceChain: rates.sourceChain,
+			destinationChain: rates.destinationChain,
+			baseTokenSymbol: rates.baseTokenSymbol,
+			quoteTokenSymbol: rates.quoteTokenSymbol,
+			rateSide: selectedRate.side,
+			rate: selectedRate.rate,
+			rateUpdatedAt: selectedRate.updatedAt,
+			protocolFeeBps,
+		},
+	}
+}

--- a/sdk/packages/sdk/src/protocols/intents/quote/types.ts
+++ b/sdk/packages/sdk/src/protocols/intents/quote/types.ts
@@ -1,8 +1,10 @@
-import type { PublicClient } from "viem"
+import type { Chains, ConfiguredAssetSymbol } from "@/configs/chain"
 import type { HexString } from "@/types"
+import type { PublicClient } from "viem"
 
-export type IntentQuoteStrategy = "uniswap_v4" | "phantom_snapshot"
+export type IntentQuoteStrategy = "indexed_rates" | "uniswap_v4" | "phantom_snapshot"
 export type IntentQuoteTradeType = "EXACT_INPUT" | "EXACT_OUTPUT"
+export type IndexedRateSide = "buy" | "sell"
 
 /**
  * Full Uniswap V4 PoolKey. V4 pools cannot be discovered from a token pair alone.
@@ -33,10 +35,10 @@ export interface UniswapV4IntentQuoteOptions {
  * Parameters for `IntentGateway.quoteIntent`. The source and destination
  * chains come from the gateway instance itself.
  *
- * Quotes default to `phantom_snapshot`. Pass `strategy: "uniswap_v4"` only to
- * explicitly request a Uniswap quote. `tokenIn` and `tokenOut` are token
- * addresses; the SDK resolves configured token metadata internally. Provide
- * exactly one of `amountIn` or `amountOut`.
+ * Quotes default to the aggregate pool's `indexed_rates`. Legacy Phantom
+ * snapshots and Uniswap V4 remain available as explicit strategies. `tokenIn`
+ * and `tokenOut` are token addresses; the SDK resolves configured token
+ * metadata and decimals internally. Provide exactly one amount.
  */
 export interface QuoteIntentParams {
 	strategy?: IntentQuoteStrategy
@@ -87,6 +89,20 @@ export interface PhantomSnapshotIntentQuoteMetadata {
 	protocolFeeBps: bigint
 }
 
+export interface IndexedRateIntentQuoteMetadata {
+	sourceChain: Chains
+	destinationChain: Chains
+	baseTokenSymbol: ConfiguredAssetSymbol
+	quoteTokenSymbol: ConfiguredAssetSymbol
+	/** Directional pool rate used for this order. */
+	rateSide: IndexedRateSide
+	/** Quote-token units per one base token. */
+	rate: string
+	rateUpdatedAt: Date
+	/** Source gateway protocol fee already reflected in the returned quote amounts. */
+	protocolFeeBps: bigint
+}
+
 /**
  * Quote data partners need before constructing an IntentGateway V2 order.
  *
@@ -110,7 +126,18 @@ export interface PhantomSnapshotQuoteIntentResult {
 	quoteMetadata: PhantomSnapshotIntentQuoteMetadata
 }
 
-export type QuoteIntentResult = UniswapV4QuoteIntentResult | PhantomSnapshotQuoteIntentResult
+export interface IndexedRateQuoteIntentResult {
+	strategy: "indexed_rates"
+	tradeType: IntentQuoteTradeType
+	amountIn: bigint
+	amountOut: bigint
+	quoteMetadata: IndexedRateIntentQuoteMetadata
+}
+
+export type QuoteIntentResult =
+	| IndexedRateQuoteIntentResult
+	| UniswapV4QuoteIntentResult
+	| PhantomSnapshotQuoteIntentResult
 
 export interface IntentQuoteStrategyHandler {
 	quote(
@@ -153,5 +180,30 @@ export class InvalidPhantomSnapshotError extends Error {
 	constructor(commitment: HexString, reason: string) {
 		super(`Invalid Phantom order price snapshot ${commitment}: ${reason}`)
 		this.name = "InvalidPhantomSnapshotError"
+	}
+}
+
+export class IndexedRateUnavailableError extends Error {
+	constructor(params: {
+		source?: string
+		destination?: string
+		tokenIn?: string
+		tokenOut?: string
+		side?: IndexedRateSide
+	}) {
+		const route =
+			params.source && params.destination && params.tokenIn && params.tokenOut
+				? ` for ${params.tokenIn} -> ${params.tokenOut} on ${params.source} -> ${params.destination}`
+				: ""
+		const side = params.side ? ` ${params.side}` : ""
+		super(`No indexed${side} rate available${route}`)
+		this.name = "IndexedRateUnavailableError"
+	}
+}
+
+export class InvalidIndexedRateError extends Error {
+	constructor(reason: string) {
+		super(`Invalid indexed intent rate: ${reason}`)
+		this.name = "InvalidIndexedRateError"
 	}
 }

--- a/sdk/packages/sdk/src/queries.ts
+++ b/sdk/packages/sdk/src/queries.ts
@@ -310,40 +310,17 @@ query AvailableLiquidity(
 }`
 
 export const BUY_AND_SELL_RATES = `
-query BuyAndSellRates(
-  $poolId: String!
-  $directChain: String!
-  $directDirection: String!
-  $reverseChain: String!
-  $reverseDirection: String!
-) {
-  direct: poolChainLiquidities(
-    filter: {
-      and: [
-        { poolId: { equalToInsensitive: $poolId } }
-        { chain: { equalTo: $directChain } }
-        { direction: { equalTo: $directDirection } }
-      ]
-    }
+query GetLiquidityPoolRate($poolId: String!) {
+  liquidityPools(
     first: 1
+    filter: { id: { equalToInsensitive: $poolId } }
   ) {
     nodes {
-      rate
-      lastUpdatedAt
-    }
-  }
-  reverse: poolChainLiquidities(
-    filter: {
-      and: [
-        { poolId: { equalToInsensitive: $poolId } }
-        { chain: { equalTo: $reverseChain } }
-        { direction: { equalTo: $reverseDirection } }
-      ]
-    }
-    first: 1
-  ) {
-    nodes {
-      rate
+      id
+      token0Symbol
+      token1Symbol
+      sellRate
+      buyRate
       lastUpdatedAt
     }
   }

--- a/sdk/packages/sdk/src/tests/sequential/intentGateway.test.ts
+++ b/sdk/packages/sdk/src/tests/sequential/intentGateway.test.ts
@@ -1,7 +1,7 @@
 import "log-timestamp"
 
 import { strict as assert } from "node:assert"
-import { decodeFunctionData, parseUnits, type PublicClient } from "viem"
+import { decodeFunctionData, formatUnits, parseUnits, type PublicClient } from "viem"
 import { ABI as IntentGatewayV2ABI } from "@/abis/IntentGatewayV2"
 import type { AvailableLiquidity, BuyAndSellRates, HexString, Order, TokenInfo } from "@/types"
 import { EvmChain } from "@/chain"
@@ -14,7 +14,7 @@ import {
 	grossUpForProtocolFee,
 	UNISWAP_INTENT_QUOTE_CHAIN,
 } from "@/protocols/intents/quote/uniswapV4"
-import { PhantomSnapshotIntentQuoteStrategy } from "@/protocols/intents/quote"
+import { divCeil } from "@/protocols/intents/quote/shared"
 import { ChainConfigService } from "@/configs/ChainConfigService"
 import { bytes20ToBytes32 } from "@/utils"
 import { UniswapQuoteEngine, type UniswapQuoteAdapter, type UniswapQuoteToken } from "@/utils/uniswapQuote"
@@ -188,55 +188,91 @@ describe("Intent quote helper", () => {
 		assert(rates.sellRateUpdatedAt && !Number.isNaN(rates.sellRateUpdatedAt.getTime()))
 	}, 120_000)
 
-	it("quotes USDT through the Base USDC Phantom snapshot", async () => {
+	it("quotes exact-input BSC USDC to Base cNGN from indexed rates", async () => {
 		const configService = new ChainConfigService()
-		console.log("USDT -> cNGN intent quote through Base USDC snapshot")
-
-		const baseChain = makeEvmChain(CHAINS.base, configService)
-		const cNgnAddress = configService.getCNgnAsset(BASE_CHAIN)
-		assert(cNgnAddress)
-		const queryClient = createQueryClient({ url: "https://nexus.indexer.polytope.technology/" })
-		const intentGateway = (await IntentGateway.create(baseChain, baseChain)).withQueryClient(queryClient)
+		const cNgnAddress = configService.getCNgnAsset(CHAINS.base.id)
+		const cNgnDecimals = configService.getCNgnDecimals(CHAINS.base.id)
+		assert(cNgnAddress, "Expected cNGN to be configured on Base")
+		assert(cNgnDecimals !== undefined, "Expected cNGN decimals to be configured on Base")
+		const intentGateway = await createLiveIntentGateway(CHAINS.bsc, CHAINS.base, configService)
+		const usdcDecimals = configService.getUsdcDecimals(CHAINS.bsc.id)
+		const amountIn = parseUnits("100", usdcDecimals)
 
 		const quote = await intentGateway.quoteIntent({
-			tokenIn: configService.getUsdtAsset(BASE_CHAIN),
+			tokenIn: configService.getUsdcAsset(CHAINS.bsc.id),
 			tokenOut: cNgnAddress,
-			amountIn: 1_000_000n,
+			amountIn,
 		})
 
-		console.log("amountIn:", quote.amountIn.toString())
-		console.log("amountOut:", quote.amountOut.toString())
-		console.log("protocolFeeBps:", quote.quoteMetadata.protocolFeeBps.toString())
-		assert.equal(quote.strategy, "phantom_snapshot")
-		if (quote.strategy !== "phantom_snapshot") throw new Error("Expected Phantom snapshot quote")
-		console.log("snapshot commitment:", quote.quoteMetadata.commitment)
-		console.log("snapshot block:", quote.quoteMetadata.blockNumber.toString())
-
+		logIntentQuote("BSC USDC → Base cNGN exact input", quote)
+		assert.equal(quote.strategy, "indexed_rates")
+		if (quote.strategy !== "indexed_rates") throw new Error("Expected indexed rate quote")
+		const scaledRate = parseUnits(quote.quoteMetadata.rate, 18)
+		const netAmountIn = deductProtocolFee(amountIn, quote.quoteMetadata.protocolFeeBps)
+		const expectedAmountOut =
+			(netAmountIn * scaledRate * 10n ** BigInt(cNgnDecimals)) /
+			(10n ** BigInt(usdcDecimals) * 10n ** 18n)
 		assert.equal(quote.tradeType, "EXACT_INPUT")
-		assert.equal(quote.amountIn, 1_000_000n)
-		assert(quote.amountOut > 0n)
-		assert.equal(quote.quoteMetadata.quoteChain, BASE_CHAIN)
-		assert(quote.quoteMetadata.medianPrice > 0n)
-		assert(quote.quoteMetadata.bidCount > 0)
+		assert.equal(quote.amountIn, amountIn)
+		assert.equal(quote.amountOut, expectedAmountOut)
+		assert(netAmountIn < amountIn, "Expected the on-chain protocol fee to reduce the priced input")
+		assert(quote.amountOut > parseUnits("100000", cNgnDecimals))
+		assert.equal(quote.quoteMetadata.sourceChain, CHAINS.bsc.id)
+		assert.equal(quote.quoteMetadata.destinationChain, CHAINS.base.id)
+		assert.equal(quote.quoteMetadata.rateSide, "buy")
+		assert(scaledRate > 1_000n * 10n ** 18n)
+		assert(!Number.isNaN(quote.quoteMetadata.rateUpdatedAt.getTime()))
+		console.log("Fee-adjusted buy quote:", {
+			amountIn: `${formatUnits(quote.amountIn, usdcDecimals)} USDC`,
+			amountOut: `${formatUnits(quote.amountOut, cNgnDecimals)} cNGN`,
+		})
+	}, 120_000)
 
-		const bscUsdtQuote = await new PhantomSnapshotIntentQuoteStrategy(configService, () => queryClient).quote(
-			{
-				tokenIn: configService.getUsdtAsset(CHAINS.bsc.id),
-				tokenOut: cNgnAddress,
-				amountIn: 1_000_000n,
-			},
-			{
-				stateMachineId: CHAINS.bsc.id,
-				client: {
-					readContract: async () => [0n, 0n, 0n, 0n, 5n],
-				} as unknown as PublicClient,
-			},
-			{ stateMachineId: BASE_CHAIN, client: baseChain.client },
+	it("quotes exact-output Base cNGN to BSC USDC from indexed rates", async () => {
+		const configService = new ChainConfigService()
+		const cNgnAddress = configService.getCNgnAsset(CHAINS.base.id)
+		const cNgnDecimals = configService.getCNgnDecimals(CHAINS.base.id)
+		assert(cNgnAddress, "Expected cNGN to be configured on Base")
+		assert(cNgnDecimals !== undefined, "Expected cNGN decimals to be configured on Base")
+		const intentGateway = await createLiveIntentGateway(CHAINS.base, CHAINS.bsc, configService)
+		const usdcDecimals = configService.getUsdcDecimals(CHAINS.bsc.id)
+		const amountOut = parseUnits("100", usdcDecimals)
+
+		const quote = await intentGateway.quoteIntent({
+			tokenIn: cNgnAddress,
+			tokenOut: configService.getUsdcAsset(CHAINS.bsc.id),
+			amountOut,
+		})
+
+		logIntentQuote("Base cNGN → BSC USDC exact output", quote)
+		assert.equal(quote.strategy, "indexed_rates")
+		if (quote.strategy !== "indexed_rates") throw new Error("Expected indexed rate quote")
+		const scaledRate = parseUnits(quote.quoteMetadata.rate, 18)
+		const requiredNetAmountIn = divCeil(
+			amountOut * 10n ** BigInt(cNgnDecimals) * scaledRate,
+			10n ** BigInt(usdcDecimals) * 10n ** 18n,
 		)
-		assert.equal(bscUsdtQuote.strategy, "phantom_snapshot")
-		if (bscUsdtQuote.strategy !== "phantom_snapshot") throw new Error("Expected Phantom snapshot quote")
-		assert.equal(bscUsdtQuote.quoteMetadata.tokenA, configService.getUsdcAsset(BASE_CHAIN))
-		assert.equal(bscUsdtQuote.quoteMetadata.tokenB.toLowerCase(), cNgnAddress.toLowerCase())
+		const expectedAmountIn = grossUpForProtocolFee(
+			requiredNetAmountIn,
+			quote.quoteMetadata.protocolFeeBps,
+		)
+		assert.equal(quote.tradeType, "EXACT_OUTPUT")
+		assert.equal(quote.amountOut, amountOut)
+		assert.equal(quote.amountIn, expectedAmountIn)
+		assert(
+			deductProtocolFee(quote.amountIn, quote.quoteMetadata.protocolFeeBps) >= requiredNetAmountIn,
+			"Expected the gross input to cover the required net input after the on-chain protocol fee",
+		)
+		assert(quote.amountIn > parseUnits("100000", cNgnDecimals))
+		assert.equal(quote.quoteMetadata.sourceChain, CHAINS.base.id)
+		assert.equal(quote.quoteMetadata.destinationChain, CHAINS.bsc.id)
+		assert.equal(quote.quoteMetadata.rateSide, "sell")
+		assert(scaledRate > 1_000n * 10n ** 18n)
+		assert(!Number.isNaN(quote.quoteMetadata.rateUpdatedAt.getTime()))
+		console.log("Fee-adjusted sell quote:", {
+			amountIn: `${formatUnits(quote.amountIn, cNgnDecimals)} cNGN`,
+			amountOut: `${formatUnits(quote.amountOut, usdcDecimals)} USDC`,
+		})
 	}, 120_000)
 })
 
@@ -456,10 +492,35 @@ function makeEvmChain(chain: ChainDef, configService: ChainConfigService, bundle
 }
 
 async function createLiveBaseIntentGateway(configService: ChainConfigService): Promise<IntentGateway> {
-	const baseChain = makeEvmChain(CHAINS.base, configService)
-	return (await IntentGateway.create(baseChain, baseChain)).withQueryClient(
-		createQueryClient({ url: "https://nexus.indexer.polytope.technology/" }),
+	return createLiveIntentGateway(CHAINS.base, CHAINS.base, configService)
+}
+
+async function createLiveIntentGateway(
+	source: ChainDef,
+	destination: ChainDef,
+	configService: ChainConfigService,
+): Promise<IntentGateway> {
+	const gateway = await IntentGateway.create(
+		makeEvmChain(source, configService),
+		makeEvmChain(destination, configService),
 	)
+	return gateway.withQueryClient(createQueryClient({ url: "https://nexus.indexer.polytope.technology/" }))
+}
+
+function logIntentQuote(label: string, quote: Awaited<ReturnType<IntentGateway["quoteIntent"]>>): void {
+	console.log(`[quoteIntent] ${label}`)
+	console.log({
+		...quote,
+		amountIn: quote.amountIn.toString(),
+		amountOut: quote.amountOut.toString(),
+		quoteMetadata: {
+			...quote.quoteMetadata,
+			protocolFeeBps: quote.quoteMetadata.protocolFeeBps.toString(),
+			...(quote.strategy === "indexed_rates"
+				? { rateUpdatedAt: quote.quoteMetadata.rateUpdatedAt.toISOString() }
+				: {}),
+		},
+	})
 }
 
 function logLiquidity(label: string, liquidity: AvailableLiquidity | undefined): void {

--- a/sdk/packages/sdk/src/types/index.ts
+++ b/sdk/packages/sdk/src/types/index.ts
@@ -1177,9 +1177,9 @@ export interface AvailableLiquidity {
 }
 
 /**
- * Chain-specific buy and sell rates expressed as quote-token units per one
- * base token. The quote token is the less valuable currency when the indexed
- * rates establish an ordering (for example, cNGN in a USDC/cNGN pair).
+ * Aggregate indexed pool buy and sell rates expressed as quote-token units per
+ * one base token. The quote token is the less valuable currency when the rates
+ * establish an ordering (for example, cNGN in a USDC/cNGN pair).
  */
 export interface BuyAndSellRates {
 	baseTokenSymbol: ConfiguredAssetSymbol


### PR DESCRIPTION
## Summary

- Use indexed buy and sell rates when quoting intents
- Apply the on-chain protocol fee to quotes
- Support cross-chain quotes using chain IDs and token symbols