### PR TITLE
Fix indexer healthcheck: unresolvable host + non-liveness endpoint

### DIFF
--- a/sdk/packages/indexer/scripts/templates/partials/docker-service.hbs
+++ b/sdk/packages/indexer/scripts/templates/partials/docker-service.hbs
@@ -13,7 +13,21 @@ subquery-{{chainName}}:
   command:
     {{> docker-command}}
   healthcheck:
-    test: ['CMD', 'curl', '-f', 'http://subquery-node-{{chainName}}:3000/ready']
-    interval: 3s
-    timeout: 5s
+    # /health reflects liveness after startup (unlike /ready, which latches true
+    # once ready) and stays green during initial sync / catch-up. It returns 500
+    # once the node stops advancing its target height (>60s) or stops processing
+    # blocks (>--timeout). The check runs inside the container, so target localhost.
+    test: ['CMD', 'curl', '-f', 'http://localhost:3000/health']
+    interval: 30s
+    timeout: 10s
     retries: 10
+    start_period: 120s
+{{#unless unfinalizedBlocks}}
+  # Finalized-only chains resume cleanly from the persisted height on restart, so
+  # they may opt into autoheal (the host must run an autoheal watcher for the
+  # label to take effect). Chains with --unfinalized-blocks are intentionally
+  # excluded: restarting them drops the unfinalized cache and forces a multichain
+  # rewind while --disable-multichain-rewind-lock is set.
+  labels:
+    autoheal: "true"
+{{/unless}}


### PR DESCRIPTION
# Fix indexer healthcheck: unresolvable host + non-liveness endpoint

## Summary
The generated per-chain compose services have a healthcheck that has **never
passed on any chain**, and even once reachable would not detect the failure mode
we actually hit in production (a silently stalled indexer). This fixes the probe
and lets finalized-only chains opt into auto-restart.

Single file changed: `sdk/packages/indexer/scripts/templates/partials/docker-service.hbs`
(the Handlebars partial every `docker/<env>/<chain>.yml` is generated from).

## The bug
```yaml
test: ['CMD', 'curl', '-f', 'http://subquery-node-{{chainName}}:3000/ready']
interval: 3s
```
Two independent problems:

1. **Hostname never resolves.** The service is named `subquery-{{chainName}}`
   (line 1 of this same partial), but the probe curls
   `subquery-node-{{chainName}}`. That host does not exist on the compose
   network, so every check fails with `curl: (6) Could not resolve host`. Result:
   **every subquery container reports `unhealthy` permanently** — one fleet had a
   failing streak of 35,000+ checks since boot. Because the signal is stuck-red
   for everyone, it's useless for alerting and can't drive any restart tooling.

2. **`/ready` is the wrong endpoint.** `/ready` latches `true` once the node
   finishes starting and never flips back. During a real ~6h production stall
   (the node's RPC WebSocket dropped and the substrate indexer never
   reconnected — `apiConnected:false`, target height frozen) **`/ready` kept
   returning 200 the entire time.** A corrected hostname alone would still not
   have caught it.

## The fix
Probe `/health` on `localhost` (the check runs *inside* the container), with
timings suited to a liveness probe:
```yaml
test: ['CMD', 'curl', '-f', 'http://localhost:3000/health']
interval: 30s
timeout: 10s
retries: 10
start_period: 120s
```
`/health` (node-core `HealthService`) returns HTTP 500 when either:
- the **target height** hasn't advanced for `10 x max(6s, blockTime)` = **60s**
  (this is the stalled-RPC case above), or
- **no block has been processed** for `max(900s, --timeout)` = **30 min** with our
  `--timeout=1800`.

Both use wall-clock time. Crucially, `/health` **stays green during initial sync
and catch-up**: the node is still processing blocks and the RPC target is still
advancing, so neither threshold trips (verified on the live fleet — all 12
mainnet chains returned 200 across repeated sampling while actively catching up).
`retries: 10 x interval: 30s` gives a ~5-minute debounce so a brief RPC blip
doesn't cause a spurious restart; `start_period: 120s` covers boot/connect.

## Auto-restart, gated to restart-safe chains
Docker does not restart unhealthy containers on its own — the host must run an
autoheal watcher (e.g. `willfarrell/autoheal`, which acts on the `autoheal=true`
label). This PR adds that label **only** to chains where restarting is safe:

```hbs
{{#unless unfinalizedBlocks}}
  labels:
    autoheal: "true"
{{/unless}}
```

`unfinalizedBlocks` is already computed in `generate-compose.ts` and drives
`--unfinalized-blocks`. Chains that track unfinalized blocks
(`--unfinalized-blocks`, e.g. base/ethereum/arbitrum/optimism/gnosis/soneium)
are **excluded**: restarting them drops the unfinalized-block cache and forces a
~1000-block multichain rewind while `--disable-multichain-rewind-lock` is set,
which previously produced a cross-chain data hole. Finalized-only chains
(`--unfinalized-blocks=false`: hyperbridge-nexus, bsc, polygon, cere, argon,
polkadot-hub) resume cleanly from the persisted height and get the label.

If you'd prefer a healthcheck-only change, drop the `{{#unless}}` block — the
first hunk stands alone.

## Testing
- Rendered the partial through Handlebars 4.7 for both an `unfinalizedBlocks:true`
  chain (base) and a `false` chain (hyperbridge-nexus); both parse as valid YAML.
  The true chain gets the fixed healthcheck and **no** label; the false chain
  gets the healthcheck **plus** `autoheal: "true"`.
- Confirmed on the running fleet that `/health` returns 200 during active
  catch-up and 500 during a stalled/frozen-target state, and that `/ready`
  stayed 200 through the stall.

## Rollout notes (not code)
- The fix flows into the next `indexer-*` release: CI regenerates a fresh
  `docker/` dir, so the new healthcheck lands in the shipped ymls. `deploy.sh`
  recreates containers (`compose down` + `up`), which applies the new healthcheck
  and labels.
- `generate-compose.ts` **skips files that already exist**, so regenerating in a
  dirty working tree won't overwrite old ymls — regenerate into a clean `docker/`.
- For auto-restart to take effect, run an autoheal watcher on the host. Until the
  `--disable-multichain-rewind-lock` situation is resolved, do **not** point
  autoheal at all containers (label-scoped mode only), or the unfinalized chains
  will rewind on restart.
