### PR TITLE
[sdk]: recover intent execution from rpc failures

### DIFF
--- a/sdk/packages/sdk/CHANGELOG.md
+++ b/sdk/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @hyperbridge/sdk
 
+## 2.8.9
+
+### Patch Changes
+
+- Intent execution now bounds coprocessor, bundler, simulation, receipt, and deadline RPC calls. Recoverable transport failures emit retry status updates; uncertain UserOperation sends are reconciled before another bid can be submitted.
+
 ## 2.8.8
 
 ### Patch Changes

--- a/sdk/packages/sdk/package.json
+++ b/sdk/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/sdk",
-	"version": "2.8.8",
+	"version": "2.8.9",
 	"description": "The hyperclient SDK provides utilities for querying proofs and statuses for cross-chain requests from HyperBridge.",
 	"type": "module",
 	"types": "./dist/node/index.d.ts",

--- a/sdk/packages/sdk/src/chains/evm.ts
+++ b/sdk/packages/sdk/src/chains/evm.ts
@@ -61,6 +61,10 @@ import {
 	generateRootWithProof,
 } from "@/utils"
 
+// viem aborts the underlying HTTP request when this timeout expires. Intent
+// execution also has a guard at its call sites for custom/injected clients.
+const RPC_TIMEOUT_MS = 15_000
+
 import UniswapV2Factory from "@/abis/uniswapV2Factory"
 import UniswapRouterV2 from "@/abis/uniswapRouterV2"
 
@@ -163,7 +167,7 @@ export class EvmChain implements IChain {
 		this.publicClient = createPublicClient({
 			// @ts-ignore
 			chain: chains[params.chainId],
-			transport: http(params.rpcUrl),
+			transport: http(params.rpcUrl, { timeout: RPC_TIMEOUT_MS, retryCount: 0 }),
 		})
 		this.chainConfigService = new ChainConfigService()
 	}
@@ -200,7 +204,7 @@ export class EvmChain implements IChain {
 	 */
 	static async create(rpcUrl: string, bundlerUrl?: string): Promise<EvmChain> {
 		// Use a chainless transport to fetch the chain ID before we know which chain we're on
-		const tempClient = createPublicClient({ transport: http(rpcUrl) })
+		const tempClient = createPublicClient({ transport: http(rpcUrl, { timeout: RPC_TIMEOUT_MS, retryCount: 0 }) })
 		const chainId = await tempClient.getChainId()
 
 		const host = chainConfigs[chainId]?.addresses?.Host

--- a/sdk/packages/sdk/src/protocols/intents/Bid.ts
+++ b/sdk/packages/sdk/src/protocols/intents/Bid.ts
@@ -18,6 +18,7 @@ import type { Hex } from "viem"
 import { CryptoUtils } from "./CryptoUtils"
 import type { IntentGatewayContext } from "./types"
 import { BundlerMethod } from "./types"
+import { RpcTimeoutError, SubmissionOutcomeUnknownError, withRpcTimeout } from "./RpcError"
 
 /** Constructor parameters for {@link BidImpl}. */
 export interface BidParams {
@@ -166,12 +167,14 @@ export class BidImpl implements Bid {
 		const batchedCalldata = this.crypto.encodeERC7821Execute(calls)
 
 		try {
-			await this.ctx.dest.client.call({
-				account: this.solverAddress,
-				to: this.solverAddress,
-				data: batchedCalldata,
-				value: simulationValue,
-			})
+			await withRpcTimeout("Destination bid simulation", () =>
+				this.ctx.dest.client.call({
+					account: this.solverAddress,
+					to: this.solverAddress,
+					data: batchedCalldata,
+					value: simulationValue,
+				}),
+			)
 		} catch (e: unknown) {
 			throw new Error(`Simulation failed: ${e instanceof Error ? e.message : String(e)}`)
 		}
@@ -207,10 +210,33 @@ export class BidImpl implements Bid {
 			normalizeStateMachineId(this.order.destination),
 		)
 
-		const userOpHash = await this.crypto.sendBundler<HexString>(BundlerMethod.ETH_SEND_USER_OPERATION, [
-			CryptoUtils.prepareBundlerCall(signedUserOp),
-			entryPointAddress,
-		])
+		const expectedUserOpHash = CryptoUtils.computeUserOpHash(signedUserOp, entryPointAddress, this.chainId()) as HexString
+		let userOpHash: HexString
+		try {
+			userOpHash = await this.crypto.sendBundler<HexString>(BundlerMethod.ETH_SEND_USER_OPERATION, [
+				CryptoUtils.prepareBundlerCall(signedUserOp),
+				entryPointAddress,
+			])
+		} catch (err) {
+			// A timeout is fundamentally different from a bundler rejection: the
+			// request may have been accepted after the client disconnected. Preserve
+			// the deterministic hash and make the executor reconcile it before it
+			// ever considers another bid.
+			// Only a JSON-RPC error is a proven pre-submission rejection. Network,
+			// HTTP, parsing, and timeout failures can all happen after the bundler
+			// accepted the bytes, so their outcome must be reconciled.
+			const definitelyRejected = err instanceof Error && err.message.startsWith("Bundler error:")
+			if (err instanceof RpcTimeoutError || !definitelyRejected) {
+				throw new SubmissionOutcomeUnknownError(expectedUserOpHash, err, {
+					userOp: signedUserOp,
+					userOpHash: expectedUserOpHash,
+					solverAddress: this.solverAddress,
+					commitment,
+					fillStatus: "pending",
+				})
+			}
+			throw err
+		}
 
 		let txnHash: HexString | undefined
 		let fillStatus: "full" | "partial" | undefined
@@ -231,10 +257,12 @@ export class BidImpl implements Bid {
 			txnHash = receipt.receipt.transactionHash
 
 			try {
-				const chainReceipt = await this.ctx.dest.client.waitForTransactionReceipt({
-					hash: txnHash,
-					confirmations: 1,
-				})
+				const chainReceipt = await withRpcTimeout("Destination transaction confirmation", () =>
+					this.ctx.dest.client.waitForTransactionReceipt({
+						hash: txnHash!,
+						confirmations: 1,
+					}),
+				)
 				const events = parseEventLogs({
 					abi: IntentGatewayV2ABI,
 					logs: chainReceipt.logs,

--- a/sdk/packages/sdk/src/protocols/intents/BidManager.ts
+++ b/sdk/packages/sdk/src/protocols/intents/BidManager.ts
@@ -1,4 +1,4 @@
-import { decodeFunctionData, concat } from "viem"
+import { decodeFunctionData, concat, parseEventLogs } from "viem"
 import { ABI as IntentGatewayV2ABI } from "@/abis/IntentGatewayV2"
 import { ADDRESS_ZERO, bytes32ToBytes20 } from "@/utils"
 import type {
@@ -16,6 +16,8 @@ import type { IntentGatewayContext } from "./types"
 import { CryptoUtils } from "./CryptoUtils"
 import { BidImpl } from "./Bid"
 import Decimal from "decimal.js"
+import { SubmissionOutcomeUnknownError, withRpcTimeout } from "./RpcError"
+import { BundlerMethod } from "./types"
 
 /**
  * Manages the solver bid lifecycle for IntentGatewayV2 orders.
@@ -220,6 +222,10 @@ export class BidManager {
 			try {
 				return await bid.execute()
 			} catch (err) {
+				// A transport failure after send is not evidence that the bundler
+				// rejected this bid. Propagate it to the executor, which reconciles
+				// the known UserOperation hash before another bid can be submitted.
+				if (err instanceof SubmissionOutcomeUnknownError) throw err
 				executionFailures += 1
 				console.warn(
 					`[BidManager] Bid ${idx + 1} from solver=${bid.solverAddress}: execution FAILED: ` +
@@ -233,6 +239,46 @@ export class BidManager {
 				`${simulationFailures} simulation failure(s), ${executionFailures} execution failure(s)`,
 		)
 		throw new Error("No bids passed simulation and execution")
+	}
+
+	/**
+	 * Reconciles a UserOperation whose send request timed out. This intentionally
+	 * returns `undefined` for an absent receipt instead of treating it as a
+	 * rejection: until a previously submitted operation is disproved, submitting
+	 * a second solver bid could double-fill the order.
+	 */
+	async reconcilePendingSubmission(order: Order, result: SelectBidResult): Promise<SelectBidResult | undefined> {
+		const receipt = await this.crypto.sendBundler<{
+			receipt?: { transactionHash?: HexString }
+		} | null>(BundlerMethod.ETH_GET_USER_OPERATION_RECEIPT, [result.userOpHash])
+		const transactionHash = receipt?.receipt?.transactionHash
+		if (!transactionHash) return undefined
+
+		const chainReceipt = await withRpcTimeout("Destination transaction confirmation", () =>
+			this.ctx.dest.client.waitForTransactionReceipt({ hash: transactionHash, confirmations: 1 }),
+		)
+		const events = parseEventLogs({
+			abi: IntentGatewayV2ABI,
+			logs: chainReceipt.logs,
+			eventName: ["OrderFilled", "PartialFill"],
+		})
+		const matched = events.find((event) =>
+			event.args.commitment.toLowerCase() === (order.id as HexString).toLowerCase(),
+		)
+		if (matched?.eventName === "OrderFilled") return { ...result, txnHash: transactionHash, fillStatus: "full" }
+		if (matched?.eventName === "PartialFill") {
+			return {
+				...result,
+				txnHash: transactionHash,
+				fillStatus: "partial",
+				filledAssets: (matched.args.outputs ?? []) as TokenInfo[],
+			}
+		}
+
+		// The transaction may have been replaced/reverted or the receipt may not
+		// expose logs on this provider. Keep reconciling against the chain rather
+		// than declaring the submission absent.
+		return undefined
 	}
 
 	/**

--- a/sdk/packages/sdk/src/protocols/intents/CryptoUtils.ts
+++ b/sdk/packages/sdk/src/protocols/intents/CryptoUtils.ts
@@ -18,6 +18,7 @@ import ERC7821ABI from "@/abis/erc7281"
 import type { IntentGatewayContext } from "./types"
 import { ERC7821_BATCH_MODE } from "./types"
 import type { BundlerMethod } from "./types"
+import { DEFAULT_INTENT_RPC_TIMEOUT_MS, withRpcTimeout } from "./RpcError"
 
 /**
  * EIP-712 type hash for the `SelectSolver` struct.
@@ -381,19 +382,26 @@ export class CryptoUtils {
 			throw new Error("Bundler URL not configured")
 		}
 
-		const response = await fetch(this.ctx.bundlerUrl, {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
-		})
-
-		const result = await response.json()
+		const result = await withRpcTimeout(
+			`Bundler ${method}`,
+			async (signal) => {
+				const response = await fetch(this.ctx.bundlerUrl!, {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+					signal,
+				})
+				if (!response.ok) throw new Error(`Bundler HTTP ${response.status}`)
+				return response.json() as Promise<{ result?: T; error?: { message?: string } }>
+			},
+			DEFAULT_INTENT_RPC_TIMEOUT_MS,
+		)
 
 		if (result.error) {
 			throw new Error(`Bundler error: ${result.error.message || JSON.stringify(result.error)}`)
 		}
 
-		return result.result
+		return result.result as T
 	}
 
 	/**
@@ -416,13 +424,20 @@ export class CryptoUtils {
 			params: r.params,
 		}))
 
-		const response = await fetch(this.ctx.bundlerUrl, {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify(body),
-		})
-
-		const results = (await response.json()) as { id: number; result?: unknown; error?: { message?: string } }[]
+		const results = await withRpcTimeout(
+			"Bundler batch",
+			async (signal) => {
+				const response = await fetch(this.ctx.bundlerUrl!, {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify(body),
+					signal,
+				})
+				if (!response.ok) throw new Error(`Bundler HTTP ${response.status}`)
+				return response.json() as Promise<{ id: number; result?: unknown; error?: { message?: string } }[]>
+			},
+			DEFAULT_INTENT_RPC_TIMEOUT_MS,
+		)
 		results.sort((a, b) => a.id - b.id)
 
 		return results.map((r) => {

--- a/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
+++ b/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
@@ -64,6 +64,7 @@ import {
 	sleep,
 } from "@/utils"
 import { getFeeToken } from "./utils"
+import { SubmissionOutcomeUnknownError } from "./RpcError"
 
 const CROSS_CHAIN_ORDER_FEE_GAS_PRICE_BUMP_PERCENT = 10n
 
@@ -621,6 +622,12 @@ export class IntentGateway {
 		try {
 			return await this.selectAndExecuteBest(order, bids)
 		} catch (err) {
+			if (err instanceof SubmissionOutcomeUnknownError) {
+				console.warn(
+					`[IntentGateway] bundler submission timed out for ${err.userOpHash}; reconciling before selecting another bid`,
+				)
+				return err.pendingResult
+			}
 			console.warn(
 				`[IntentGateway] autoSelect: bid selection failed this round, continuing to poll: ${
 					err instanceof Error ? err.message : String(err)

--- a/sdk/packages/sdk/src/protocols/intents/OrderExecutor.ts
+++ b/sdk/packages/sdk/src/protocols/intents/OrderExecutor.ts
@@ -4,6 +4,7 @@ import { DEFAULT_POLL_INTERVAL, normalizeStateMachineId, sleep } from "@/utils"
 import type { BidManager } from "./BidManager"
 import { CryptoUtils } from "./CryptoUtils"
 import type { IntentGatewayContext } from "./types"
+import { withRpcTimeout } from "./RpcError"
 
 const USED_USEROPS_STORAGE_KEY = (commitment: HexString) => `used-userops:${commitment.toLowerCase()}`
 
@@ -26,6 +27,7 @@ const USED_USEROPS_STORAGE_KEY = (commitment: HexString) => `used-userops:${comm
  * `usedUserOpsStorage` so that the executor can resume safely after a crash.
  */
 export class OrderExecutor {
+	private readonly activeCommitments = new Set<string>()
 	constructor(
 		private readonly ctx: IntentGatewayContext,
 		private readonly bidManager: BidManager,
@@ -43,7 +45,14 @@ export class OrderExecutor {
 		const blockTimeMs = client.chain?.blockTime ?? 2_000
 
 		while (true) {
-			const currentBlock = await client.getBlockNumber()
+			let currentBlock: bigint
+			try {
+				currentBlock = await withRpcTimeout("Deadline block read", () => client.getBlockNumber())
+			} catch {
+				// A dead destination RPC must not make this monitoring loop disappear.
+				await sleep(Math.min(blockTimeMs, 5_000))
+				continue
+			}
 			if (currentBlock >= deadline) break
 
 			const blocksRemaining = Number(deadline - currentBlock)
@@ -116,7 +125,9 @@ export class OrderExecutor {
 			throw new Error("IntentsCoprocessor required for order execution")
 		}
 
-		const fetchedBids = await intentsCoprocessor.getBidsForOrder(commitment)
+		const fetchedBids = await withRpcTimeout("Coprocessor bid query", () =>
+			intentsCoprocessor.getBidsForOrder(commitment),
+		)
 
 		if (solver) {
 			const { address, timeoutMs } = solver
@@ -240,14 +251,22 @@ export class OrderExecutor {
 		const { order, sessionPrivateKey, auctionTimeMs, pollIntervalMs = DEFAULT_POLL_INTERVAL, solver } = options
 
 		const commitment = order.id as HexString
+		const executionKey = commitment.toLowerCase()
+		if (this.activeCommitments.has(executionKey)) {
+			yield { status: "FAILED", commitment, error: "Execution is already active for this order" }
+			return
+		}
+		this.activeCommitments.add(executionKey)
 
 		if (!this.ctx.intentsCoprocessor) {
 			yield { status: "FAILED", error: "IntentsCoprocessor required for order execution" }
+			this.activeCommitments.delete(executionKey)
 			return
 		}
 
 		if (!this.ctx.bundlerUrl) {
 			yield { status: "FAILED", error: "Bundler URL not configured" }
+			this.activeCommitments.delete(executionKey)
 			return
 		}
 
@@ -283,13 +302,14 @@ export class OrderExecutor {
 			// racing each step against the deadline. We cannot use a merge helper
 			// here because those do not forward values passed to `.next()`.
 			let input: SelectBidResult | undefined
+			let unresolvedSubmission = false
 			while (true) {
 				// When we are delivering a fed-back result (the consumer already
 				// executed a bid), process it without racing the deadline so an
 				// already-submitted UserOp is never dropped by a deadline that
 				// elapsed while the consumer was busy in `bid.execute()`. Only
 				// poll steps (no pending result) race against the deadline.
-				const winner =
+				let winner =
 					input !== undefined
 						? { from: "exec" as const, r: await executionStream.next(input) }
 						: await Promise.race([
@@ -297,6 +317,13 @@ export class OrderExecutor {
 								deadlinePromise.then((r) => ({ from: "deadline" as const, r })),
 							])
 				input = undefined
+
+				if (winner.from === "deadline" && unresolvedSubmission) {
+					// A send timeout means the bundler may hold a valid operation. The
+					// deadline may stop new work, but it cannot turn that uncertainty
+					// into permission to submit another bid or report a false expiry.
+					winner = { from: "exec" as const, r: await executionStream.next(undefined) }
+				}
 
 				if (winner.from === "deadline") {
 					if (!winner.r.done && winner.r.value) yield winner.r.value
@@ -307,6 +334,8 @@ export class OrderExecutor {
 				if (done) return
 
 				const fed = yield value
+				if (value.status === "CONFIRMING_FILL") unresolvedSubmission = true
+				if (value.status === "FILLED" || value.status === "PARTIAL_FILL") unresolvedSubmission = false
 				if (value.status === "BIDS_RECEIVED") input = fed
 				if (value.status === "EXPIRED" || value.status === "FILLED") return
 			}
@@ -316,6 +345,7 @@ export class OrderExecutor {
 			console.log(`[OrderExecutor] Tearing down streams for commitment=${commitment}`)
 			await executionStream.return(undefined as never)
 			await deadlineTimeout.return(undefined as never)
+			this.activeCommitments.delete(executionKey)
 		}
 	}
 
@@ -360,6 +390,7 @@ export class OrderExecutor {
 		const isFreshBid = (bid: FillerBid) => !usedUserOps.has(userOpHashKey(bid.userOp))
 
 		const solverLockStartTime = Date.now()
+		let transportAttempts = 0
 		yield { status: "AWAITING_BIDS", commitment, totalFilledAssets, remainingAssets }
 
 		try {
@@ -377,8 +408,15 @@ export class OrderExecutor {
 						const [bid] = this.bidManager.buildBids(order, [fillerBid], sessionPrivateKey)
 						if (bid) yield { status: "NEW_BID", commitment, bid }
 					}
-				} catch {
-					// Ignore fetch errors during auction, will retry next interval
+				} catch (err) {
+					transportAttempts += 1
+					yield {
+						status: "TRANSPORT_RETRYING",
+						commitment,
+						operation: "Coprocessor bid query",
+						attempt: transportAttempts,
+						error: err instanceof Error ? err.message : String(err),
+					}
 				}
 				const remaining = auctionEnd - Date.now()
 				if (remaining > 0) {
@@ -391,7 +429,15 @@ export class OrderExecutor {
 				try {
 					const bids = await this.fetchBids({ commitment, solver, solverLockStartTime })
 					freshBids = bids.filter(isFreshBid)
-				} catch {
+				} catch (err) {
+					transportAttempts += 1
+					yield {
+						status: "TRANSPORT_RETRYING",
+						commitment,
+						operation: "Coprocessor bid query",
+						attempt: transportAttempts,
+						error: err instanceof Error ? err.message : String(err),
+					}
 					await sleep(pollIntervalMs)
 					continue
 				}
@@ -428,8 +474,36 @@ export class OrderExecutor {
 					transactionHash: result.txnHash,
 				}
 
+				let resolvedResult = result
+				if (result.fillStatus === "pending") {
+					let attempt = 0
+					while (resolvedResult.fillStatus === "pending") {
+						attempt += 1
+						yield {
+							status: "CONFIRMING_FILL",
+							commitment,
+							userOpHash: result.userOpHash,
+							error: "Bundler submission timed out; reconciling its outcome",
+						}
+						try {
+							const reconciled = await this.bidManager.reconcilePendingSubmission(order, result)
+							if (reconciled) resolvedResult = reconciled
+							else throw new Error("UserOperation receipt is not available yet")
+						} catch (err) {
+							yield {
+								status: "TRANSPORT_RETRYING",
+								commitment,
+								operation: "UserOperation submission reconciliation",
+								attempt,
+								error: err instanceof Error ? err.message : String(err),
+							}
+							await sleep(pollIntervalMs)
+						}
+					}
+				}
+
 				const fill = this.processFillResult(
-					result,
+					resolvedResult,
 					commitment,
 					targetAssets,
 					totalFilledAssets,

--- a/sdk/packages/sdk/src/protocols/intents/RpcError.ts
+++ b/sdk/packages/sdk/src/protocols/intents/RpcError.ts
@@ -1,0 +1,53 @@
+/** Default upper bound for an intent-execution RPC request. */
+export const DEFAULT_INTENT_RPC_TIMEOUT_MS = 15_000
+
+/** A request did not settle before its execution deadline. */
+export class RpcTimeoutError extends Error {
+	constructor(
+		readonly operation: string,
+		readonly timeoutMs = DEFAULT_INTENT_RPC_TIMEOUT_MS,
+	) {
+		super(`${operation} timed out after ${timeoutMs}ms`)
+		this.name = "RpcTimeoutError"
+	}
+}
+
+/**
+ * Runs an RPC operation with a finite deadline.  Operations that honour AbortSignal
+ * (notably fetch) are cancelled. The timeout also protects injected/custom clients
+ * which do not expose cancellation.
+ */
+export async function withRpcTimeout<T>(
+	operation: string,
+	request: (signal: AbortSignal) => Promise<T>,
+	timeoutMs = DEFAULT_INTENT_RPC_TIMEOUT_MS,
+): Promise<T> {
+	const controller = new AbortController()
+	let timer: ReturnType<typeof setTimeout> | undefined
+	try {
+		return await Promise.race([
+			request(controller.signal),
+			new Promise<T>((_, reject) => {
+				timer = setTimeout(() => {
+					controller.abort()
+					reject(new RpcTimeoutError(operation, timeoutMs))
+				}, timeoutMs)
+			}),
+		])
+	} finally {
+		if (timer) clearTimeout(timer)
+	}
+}
+
+/** A send timed out after bytes may have reached the bundler. Never retry it as a new bid. */
+export class SubmissionOutcomeUnknownError extends Error {
+	constructor(
+		readonly userOpHash: `0x${string}`,
+		readonly cause: unknown,
+		readonly pendingResult: SelectBidResult,
+	) {
+		super(`UserOperation submission outcome is unknown for ${userOpHash}`)
+		this.name = "SubmissionOutcomeUnknownError"
+	}
+}
+import type { SelectBidResult } from "@/types"

--- a/sdk/packages/sdk/src/protocols/intents/index.ts
+++ b/sdk/packages/sdk/src/protocols/intents/index.ts
@@ -37,6 +37,7 @@ export {
 	orderCommitment,
 } from "./utils"
 export { CryptoUtils, SELECT_SOLVER_TYPEHASH, PACKED_USEROP_TYPEHASH, DOMAIN_TYPEHASH } from "./CryptoUtils"
+export { RpcTimeoutError, SubmissionOutcomeUnknownError, DEFAULT_INTENT_RPC_TIMEOUT_MS } from "./RpcError"
 export {
 	encodeAcceptedSourceChains,
 	decodeAcceptedSourceChains,

--- a/sdk/packages/sdk/src/tests/rpcTimeout.test.ts
+++ b/sdk/packages/sdk/src/tests/rpcTimeout.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest"
+import { RpcTimeoutError, withRpcTimeout } from "@/protocols/intents/RpcError"
+
+describe("intent RPC deadlines", () => {
+	it("aborts a request that does not settle before its deadline", async () => {
+		let signal: AbortSignal | undefined
+		const pending = withRpcTimeout(
+			"test RPC",
+			(requestSignal) => {
+				signal = requestSignal
+				return new Promise<never>(() => undefined)
+			},
+			5,
+		)
+
+		await expect(pending).rejects.toBeInstanceOf(RpcTimeoutError)
+		expect(signal?.aborted).toBe(true)
+	})
+})

--- a/sdk/packages/sdk/src/types/index.ts
+++ b/sdk/packages/sdk/src/types/index.ts
@@ -1555,6 +1555,8 @@ export const IntentOrderStatus = Object.freeze({
 	NEW_BID: "NEW_BID",
 	BIDS_RECEIVED: "BIDS_RECEIVED",
 	BID_SELECTED: "BID_SELECTED",
+	TRANSPORT_RETRYING: "TRANSPORT_RETRYING",
+	CONFIRMING_FILL: "CONFIRMING_FILL",
 	FILLED: "FILLED",
 	PARTIAL_FILL: "PARTIAL_FILL",
 	EXPIRED: "EXPIRED",
@@ -1593,6 +1595,14 @@ export type IntentOrderStatusUpdate =
 	| { status: "AWAITING_BIDS"; commitment: HexString; totalFilledAssets: TokenInfo[]; remainingAssets: TokenInfo[] }
 	| { status: "NEW_BID"; commitment: HexString; bid: Bid }
 	| { status: "BIDS_RECEIVED"; commitment: HexString; bidCount: number; bids: Bid[] }
+	| {
+			status: "TRANSPORT_RETRYING"
+			commitment: HexString
+			operation: string
+			attempt: number
+			error: string
+	  }
+	| { status: "CONFIRMING_FILL"; commitment: HexString; userOpHash: HexString; error?: string }
 	| {
 			status: "BID_SELECTED"
 			commitment: HexString
@@ -1642,7 +1652,7 @@ export interface SelectBidResult {
 	solverAddress: HexString
 	commitment: HexString
 	txnHash?: HexString
-	fillStatus?: "full" | "partial"
+	fillStatus?: "full" | "partial" | "pending"
 	/** Assets filled in this user operation (best-effort, based on on-chain PartialFill logs) */
 	filledAssets?: TokenInfo[]
 }


### PR DESCRIPTION
Add bounded RPC timeouts and recovery handling to SDK intent execution. Timed-out UserOperation submissions are reconciled before another bid is selected, and retry/confirmation status events improve observability