### PR TITLE
[indexer]: run substrate chains on the Polytope subql node build

### DIFF
--- a/sdk/packages/indexer/docker/docker-compose.local.yml
+++ b/sdk/packages/indexer/docker/docker-compose.local.yml
@@ -1,6 +1,6 @@
 services:
     subquery-node-hyperbridge-gargantua-local:
-        image: subquerynetwork/subql-node-substrate:v5.9.1
+        image: polytopelabs/subql-node-substrate:v6.4.7-0
         restart: always
         network_mode: host
         environment:
@@ -37,7 +37,7 @@ services:
             retries: 30
 
     # subquery-node-cere-local:
-    #     image: subquerynetwork/subql-node-substrate:v5.9.1
+    #     image: polytopelabs/subql-node-substrate:v6.4.7-0
     #     restart: always
     #     network_mode: host
     #     environment:

--- a/sdk/packages/indexer/docker/docker-compose.nexus-ci.yml
+++ b/sdk/packages/indexer/docker/docker-compose.nexus-ci.yml
@@ -1,6 +1,6 @@
 services:
     subquery-node-hyperbridge-nexus-ci:
-        image: subquerynetwork/subql-node-substrate:v5.9.1
+        image: polytopelabs/subql-node-substrate:v6.4.7-0
         restart: unless-stopped
         network_mode: host
         environment:

--- a/sdk/packages/indexer/docs/ai/ChangeLog.md
+++ b/sdk/packages/indexer/docs/ai/ChangeLog.md
@@ -38,6 +38,11 @@ That was blocking the new test, and it was also silently keeping the existing `p
 running — that file passes again now.
 
 Files: `src/utils/phantom-decode.ts`, `src/utils/__tests__/phantom-decode.fill.test.ts`, `jest.config.ts`.
+## 2026-08-26 — Substrate chains run on the Polytope build of the SubQuery node (#1163)
+
+The stock `subquerynetwork/subql-node-substrate` image could not survive an RPC interruption: after a websocket drop it gave the endpoint five reconnect attempts and then exited, and any request that failed while the socket was down (a block fetch or a mapping handler read) took the process down immediately; both providers also cached rejected request promises, so retries replayed the stale error. Over http it never retried a 429 from the rate-limited hosted RPC. The substrate image is now `polytopelabs/subql-node-substrate:v6.4.7-0`, built from the `polytope-labs/subql` fork with those behaviours changed (no response caching, requests wait for the reconnect, unbounded reconnect with capped backoff, http retries honouring Retry-After with a client-wide pause). The EVM image is unchanged.
+
+Files: `scripts/generate-compose.ts`, `docker/docker-compose.local.yml`, `docker/docker-compose.nexus-ci.yml`.
 
 ## 2026-08-19 — Pool rates renormalize by the leg's own standard amount
 

--- a/sdk/packages/indexer/docs/ai/Decisions.md
+++ b/sdk/packages/indexer/docs/ai/Decisions.md
@@ -26,6 +26,15 @@ The jest `transformIgnorePatterns` addition names the ESM-only packages explicit
 `node_modules`. The broad form is slower and pulls unrelated packages through ts-jest; the explicit list fails
 loudly (an unparsed `export`) if the SDK's dependency graph grows another ESM-only package, which is the right
 failure mode — silence here is what let the tests stop running unnoticed.
+## 2026-08-26 — Substrate node resilience is fixed in a forked node image, not in the indexer
+
+Chosen: the substrate SubQuery node image comes from the `polytope-labs/subql` fork (`polytopelabs/subql-node-substrate`), where the websocket provider is wrapped so requests wait out a disconnect, response caching is disabled, reconnects are unbounded, and the http provider retries rate limits with a client-wide pause. The indexer package only changes the image reference.
+
+Alternative rejected — make the indexer tolerate it: retry handler RPC reads, lower `--workers`, rely on `restart: unless-stopped`. The exits come from inside the node (block fetcher and dispatcher), which handler code cannot reach, and a restart is not a reconnect: it drops the unfinalized cache and, under `--multi-chain`, forces a rewind. The rate limit on the hosted http RPC is per client, so per-call retries in handlers cannot coordinate with the node's own fetch traffic; only the provider can pause all of them.
+
+Alternative rejected — upstream the changes first and wait. Worth doing, but the deployment needs the behaviour now; the fork mirrors how `polytopelabs/subql-node-ethereum` is already produced from `polytope-labs/subql-ethereum`.
+
+Accepted: this moves substrate from the deployed node 5.9.1 to 6.4.7 (node-core 19.x), matching `polytope-labs/subql`'s main after it was synced to upstream. The fork PR is built on that main, so it carries only these behavioural changes as a single commit, not the version history.
 
 ## 2026-08-19 — The standard-amount check bounds plausibility instead of pinning one unit
 

--- a/sdk/packages/indexer/scripts/generate-compose.ts
+++ b/sdk/packages/indexer/scripts/generate-compose.ts
@@ -7,7 +7,7 @@ import Handlebars from "handlebars"
 import { getEnv, getValidChains } from "../src/configs"
 
 const EVM_IMAGE = "subquerynetwork/subql-node-ethereum:v6.5.0"
-const SUBSTRATE_IMAGE = "subquerynetwork/subql-node-substrate:v5.9.1"
+const SUBSTRATE_IMAGE = "polytopelabs/subql-node-substrate:v6.4.7-0"
 
 // Setup paths
 const root = process.cwd()


### PR DESCRIPTION
Substrate chains run on `polytopelabs/subql-node-substrate:v5.10.1-0` (from the `polytope-labs/subql` fork) instead of the upstream image, which exits on an RPC disconnect and caches failed requests. Image reference and docs only.

Depends on the fork image being published first (polytope-labs/subql#1).
