### PR TITLE
[node]: fix remote-crashable RPC panic in as_utf8_string::deserialize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9387,7 +9387,7 @@ dependencies = [
 
 [[package]]
 name = "hyperbridge"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "clap",
  "futures",

--- a/modules/utils/serde/src/lib.rs
+++ b/modules/utils/serde/src/lib.rs
@@ -116,6 +116,10 @@ pub mod as_utf8_string {
 	}
 
 	/// Deserialize a string into utf8 bytes
+	///
+	/// The string must be exactly 4 bytes long (bytes, not chars — a 4-char string of
+	/// multi-byte codepoints is rejected). Anything else is a deserialization error; this
+	/// runs on untrusted RPC input, so it must never panic.
 	pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
 	where
 		D: serde::Deserializer<'de>,
@@ -123,8 +127,11 @@ pub mod as_utf8_string {
 	{
 		let s = <String>::deserialize(deserializer)?;
 
-		let mut bytes = [0u8; 4];
-		bytes.copy_from_slice(s.as_bytes());
+		// `s.len()` is the utf-8 byte length, which is what the `[u8; 4]` needs to match.
+		let bytes: [u8; 4] = s
+			.as_bytes()
+			.try_into()
+			.map_err(|_| serde::de::Error::invalid_length(s.len(), &"a 4-byte utf-8 string"))?;
 		Ok(bytes.into())
 	}
 }
@@ -381,7 +388,7 @@ pub mod seq_of_u8_str_or_hex {
 
 #[cfg(test)]
 mod test {
-	use super::{as_string, seq_of_u8_str_or_hex};
+	use super::{as_string, as_utf8_string, seq_of_u8_str_or_hex};
 	use ismp::router::{GetRequest, GetResponse, PostRequest, StorageValue};
 	use primitive_types::{H256, H512};
 	use serde::Deserialize;
@@ -517,5 +524,78 @@ mod test {
 		let deserialized: StateMachineId = serde_json::from_str(&serialized).unwrap();
 
 		assert_eq!(state_machine_updated, deserialized);
+	}
+
+	// `as_utf8_string` deserializes into a fixed `[u8; 4]`. It used to `copy_from_slice`
+	// straight from the input, which panics on any length mismatch — and it runs on
+	// untrusted RPC input (`consensus_state_id`), so the panic aborted the node's `rpc`
+	// worker thread and took the process down. Wrong lengths must be serde errors.
+	#[test]
+	fn as_utf8_string_rejects_non_four_byte_input() {
+		#[derive(Deserialize, Debug, PartialEq, Eq)]
+		struct TestData {
+			#[serde(with = "as_utf8_string")]
+			id: [u8; 4],
+		}
+
+		for s in [
+			"",          // 0 bytes
+			"AB",        // 2 bytes
+			"ABC",       // 3 bytes
+			"ABCDE",     // 5 bytes
+			"CERE0",     // 5 bytes — the value that crashed the production node
+			"ABC\u{e9}", // 4 chars, 5 bytes: length is counted in bytes, not chars
+		] {
+			let json = serde_json::json!({ "id": s }).to_string();
+			assert!(
+				serde_json::from_str::<TestData>(&json).is_err(),
+				"expected a deserialization error for {s:?}"
+			);
+		}
+
+		// Exactly 4 bytes still round-trips, whether ascii or multi-byte utf-8.
+		assert_eq!(serde_json::from_str::<TestData>(r#"{"id":"ETH0"}"#).unwrap().id, *b"ETH0");
+		assert_eq!(
+			serde_json::from_str::<TestData>(&serde_json::json!({ "id": "h\u{e9}y" }).to_string())
+				.unwrap()
+				.id,
+			[b'h', 0xc3, 0xa9, b'y'],
+		);
+	}
+
+	// End-to-end regression for the RPC payload that crashed the node: a `StateMachineId`
+	// (the argument to `ismp_queryChallengePeriod` / `ismp_queryStateMachineLatestHeight`)
+	// carrying an over-long `consensus_state_id`.
+	#[test]
+	fn state_machine_id_rejects_non_four_byte_consensus_state_id() {
+		use ismp::consensus::StateMachineId;
+
+		let err = serde_json::from_str::<StateMachineId>(
+			r#"{"state_id":"EVM-11155111","consensus_state_id":"CERE0"}"#,
+		)
+		.unwrap_err();
+		// The caller gets a useful message back rather than a dropped connection.
+		assert!(
+			err.to_string().contains("invalid length 5") &&
+				err.to_string().contains("a 4-byte utf-8 string"),
+			"unhelpful error: {err}"
+		);
+
+		assert!(serde_json::from_str::<StateMachineId>(
+			r#"{"state_id":"EVM-11155111","consensus_state_id":"AB"}"#
+		)
+		.is_err());
+
+		// The well-formed request still works.
+		assert_eq!(
+			serde_json::from_str::<StateMachineId>(
+				r#"{"state_id":"EVM-11155111","consensus_state_id":"ETH0"}"#
+			)
+			.unwrap(),
+			StateMachineId {
+				state_id: ismp::host::StateMachine::Evm(11155111),
+				consensus_state_id: *b"ETH0"
+			}
+		);
 	}
 }

--- a/parachain/node/Cargo.toml
+++ b/parachain/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperbridge"
-version = "1.9.3"
+version = "1.9.4"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 description = "The Hyperbridge coprocessor node"
 repository = "https://github.com/polytope-labs/hyperbridge"


### PR DESCRIPTION
Closes #1169

## Problem

`as_utf8_string::deserialize` copied a deserialized string straight into a fixed `[u8; 4]` via `copy_from_slice`, which panics whenever the source length isn't exactly 4:

```rust
let mut bytes = [0u8; 4];
bytes.copy_from_slice(s.as_bytes()); // panics if s.as_bytes().len() != 4
```

That helper deserializes the 4-byte `ConsensusStateId` fields on ISMP RPC types, so a single request to `ismp_queryChallengePeriod` or `ismp_queryStateMachineLatestHeight` carrying a `consensus_state_id` whose UTF-8 length wasn't 4 panicked the node's `rpc` worker thread and aborted the process — dropping every WS/HTTP client, downstream indexers and relayers included. No auth and no unsafe RPC methods required.

Hit in production on the Nexus RPC node (`1.9.3-c28fc0eb42c`, 2026-08-26):

```
Thread 'rpc' panicked at 'copy_from_slice: source slice length (5) does not match destination slice length (4)', modules/utils/serde/src/lib.rs:127
```

## Fix

Validate the length and return a serde error:

```rust
let bytes: [u8; 4] = s
    .as_bytes()
    .try_into()
    .map_err(|_| serde::de::Error::invalid_length(s.len(), &"a 4-byte utf-8 string"))?;
```

`invalid_length` rather than a bare `custom` string, so the caller gets `invalid length 5, expected a 4-byte utf-8 string` back over JSON-RPC instead of a dropped connection — and nothing from the request is echoed into the node's logs.

## Tests

Two regression tests, both confirmed to genuinely catch the bug — reverting the fix and re-running reproduces the exact production message:

```
copy_from_slice: source slice length (5) does not match destination slice length (4)
```

- `as_utf8_string_rejects_non_four_byte_input` — 0/2/3/5-byte inputs including `"CERE0"`, plus `"ABCé"` (4 chars, 5 bytes) to pin that the check is byte-length and not char-count. Positive cases confirm `"ETH0"` and a 4-byte multi-byte string still round-trip.
- `state_machine_id_rejects_non_four_byte_consensus_state_id` — the actual `StateMachineId` payload shape the two RPC methods take, asserting the error message is useful rather than merely non-panicking.

## Audit of the sibling helpers

The issue asked for a sweep of the other fixed-size conversions. No second instance of the pattern — everything else is already fallible:

| Helper | Why it's safe |
|---|---|
| `as_hex::deserialize` / `deserialize_option` | `T: TryFrom<Vec<u8>>` — the `[u8; N]` / `Node` impls return `Err` on length mismatch |
| `seq_of_hex` | `Vec<Vec<u8>>`, no fixed array; `hex::decode` checked |
| `as_string` | `FromStr`, checked |
| `seq_of_str`, `seq_of_u8_str_or_hex` | `TryFrom`, checked |
| `hex_bytes` (intents-coprocessor RPC) — the only other custom serde helper in the repo | `hex::decode` → `Vec<u8>`, checked |

Worth noting the *other* field of the same struct, `state_id`, goes through `StateMachine::from_str`, which was hardened against the identical panic previously. `StateMachineId` is now guarded on both fields.

## Verification

7/7 tests pass, `no_std` build clean, `pallet-ismp-rpc` and `ismp` still compile, zero new clippy warnings in the changed regions.

Node patch-bumped to `1.9.4`.
