### PR TITLE
[crates]: republish ismp-abi and beefy-verifier-primitives, and keep polkadot-sdk out of ismp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2947,7 +2947,7 @@ dependencies = [
 
 [[package]]
 name = "beefy-verifier-primitives"
-version = "0.1.1"
+version = "2606.0.0"
 dependencies = [
  "derive_more 1.0.0",
  "parity-scale-codec",
@@ -10495,7 +10495,7 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "ismp"
-version = "2606.0.0"
+version = "2606.1.0"
 dependencies = [
  "alloy-primitives 1.5.7",
  "alloy-sol-types 1.5.7",
@@ -10515,7 +10515,7 @@ dependencies = [
 
 [[package]]
 name = "ismp-abi"
-version = "0.1.1"
+version = "2606.0.0"
 dependencies = [
  "alloy-contract",
  "alloy-network",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -248,7 +248,7 @@ ibc-core-host = { version = "0.57.0", default-features = false }
 ibc-proto = { version = "0.52.0", default-features = false, package = "ibc-proto"}
 
 # published crates
-ismp = { version = "2606.0.0", path = "./modules/ismp/core", default-features = false }
+ismp = { version = "2606.1.0", path = "./modules/ismp/core", default-features = false }
 serde-hex-utils = { version = "0.2.0", path = "modules/utils/serde", default-features = false }
 crypto-utils = { version = "0.3.0", path = "modules/utils/crypto", default-features = false }
 bls-utils = { path = "modules/utils/bls-utils", default-features = false }
@@ -268,14 +268,14 @@ substrate-state-machine = { version = "2606.0.0", path = "modules/ismp/state-mac
 
 # local crates
 ismp-testsuite = { path = "./modules/ismp/testsuite" }
-ismp-abi = { version = "0.1.1", path = "./evm/rust", default-features = false }
+ismp-abi = { version = "2606.0.0", path = "./evm/rust", default-features = false }
 simnode-tests = { path = "parachain/simtests" }
 integration-tests = { path = "parachain/integration-tests" }
 hyperclient = { path = "modules/hyperclient", default-features = false }
 subxt-utils = { path = "modules/utils/subxt", default-features = false }
 
 # consensus provers & verifiers
-beefy-verifier-primitives = { version = "0.1.1", path = "./modules/consensus/beefy/primitives", default-features = false }
+beefy-verifier-primitives = { version = "2606.0.0", path = "./modules/consensus/beefy/primitives", default-features = false }
 beefy-prover = { path = "./modules/consensus/beefy/prover" }
 beefy-verifier = { path = "./modules/consensus/beefy/verifier", default-features = false }
 bsc-prover = { path = "./modules/consensus/bsc/prover" }

--- a/evm/rust/Cargo.toml
+++ b/evm/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ismp-abi"
-version = "0.1.1"
+version = "2606.0.0"
 edition = "2021"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 description = "Generated rust types for the ISMP solidity ABI"

--- a/evm/rust/Cargo.toml
+++ b/evm/rust/Cargo.toml
@@ -22,20 +22,33 @@ alloy-provider = { workspace = true, optional = true }
 alloy-network = { workspace = true, optional = true }
 alloy-transport = { workspace = true, optional = true }
 
-beefy-verifier-primitives = { workspace = true, default-features = false }
+beefy-verifier-primitives = { workspace = true, default-features = false, optional = true }
 
 # SCALE codec for the host-params SCALE representation that lives alongside the
 # ABI types so the cross-language conversion impls have a single home.
-codec = { workspace = true }
-scale-info = { workspace = true }
+codec = { workspace = true, optional = true }
+scale-info = { workspace = true, optional = true }
 
 [dependencies.polkadot-sdk]
 workspace = true
 default-features = false
+optional = true
 features = ["sp-consensus-beefy", "sp-mmr-primitives", "frame-support", "sp-runtime"]
 
 [features]
-default = ["std"]
+default = ["std", "substrate"]
+# The polkadot-sdk-typed surface: the SCALE `HostParam` mirrors in `host_params`
+# and the BEEFY conversions in `conversions`. Everything else — the generated
+# `sol!` bindings and `ToU256` — is plain alloy and needs none of it. Kept off by
+# `ismp`, which only uses the generated types, so the protocol crate does not
+# carry the polkadot-sdk umbrella (and its exact version pin) into the dependency
+# tree of every crate that depends on it.
+substrate = [
+    "dep:polkadot-sdk",
+    "dep:beefy-verifier-primitives",
+    "dep:codec",
+    "dep:scale-info",
+]
 std = [
     "dep:alloy-contract",
     "dep:alloy-provider",
@@ -45,10 +58,10 @@ std = [
     "primitive-types/std",
     "alloy-sol-types/std",
     "alloy-primitives/std",
-    "beefy-verifier-primitives/std",
-    "polkadot-sdk/std",
-    "codec/std",
-    "scale-info/std",
+    "beefy-verifier-primitives?/std",
+    "polkadot-sdk?/std",
+    "codec?/std",
+    "scale-info?/std",
 ]
 # Generated bindings for Solidity test-only helper contracts (e.g. BeefyConsensusClientTest).
 # Off by default so production builds don't pull in test-harness ABIs.

--- a/evm/rust/src/conversions.rs
+++ b/evm/rust/src/conversions.rs
@@ -43,6 +43,7 @@ impl ToU256 for usize {
 	}
 }
 
+#[cfg(feature = "substrate")]
 mod beefy {
 	use super::ToU256;
 	use crate::{

--- a/evm/rust/src/lib.rs
+++ b/evm/rust/src/lib.rs
@@ -19,6 +19,12 @@
 //! [`mod@conversions`] compile in both `std` and `no_std`. Only `#[sol(rpc)]` (the
 //! provider-backed contract-call bindings, via `alloy-contract` / `alloy-provider` /
 //! `alloy-network` / `alloy-transport`) is gated on `std`, since those crates are std-only.
+//!
+//! The polkadot-sdk-typed surface — [`mod@host_params`] and the BEEFY conversions in
+//! [`mod@conversions`] — sits behind the `substrate` feature. It is on by default, but
+//! `ismp` turns it off: the protocol crate only needs the generated `sol!` types, and
+//! leaving the umbrella out keeps its exact version pin from propagating to everything
+//! that depends on `ismp`.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -27,8 +33,10 @@ extern crate alloc;
 mod generated;
 
 pub mod conversions;
+#[cfg(feature = "substrate")]
 pub mod host_params;
 
 pub use conversions::*;
 pub use generated::*;
+#[cfg(feature = "substrate")]
 pub use host_params::*;

--- a/modules/consensus/beefy/primitives/Cargo.toml
+++ b/modules/consensus/beefy/primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beefy-verifier-primitives"
-version = "0.1.1"
+version = "2606.0.0"
 edition = "2021"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 description = "Primitive types for the BEEFY consensus client"

--- a/modules/ismp/core/Cargo.toml
+++ b/modules/ismp/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ismp"
-version = "2606.0.0"
+version = "2606.1.0"
 edition = "2021"
 description = "Rust implementation of the interoperable state machine protocol"
 authors = ["Polytope Labs <hello@polytope.technology>"]

--- a/modules/pallets/beefy-consensus-proofs/Cargo.toml
+++ b/modules/pallets/beefy-consensus-proofs/Cargo.toml
@@ -23,7 +23,7 @@ beefy-verifier-primitives = { workspace = true, default-features = false }
 
 # ABI
 alloy-sol-types = { workspace = true, default-features = false }
-ismp-abi = { workspace = true, default-features = false }
+ismp-abi = { workspace = true, default-features = false, features = ["substrate"] }
 
 # misc
 anyhow = { workspace = true, default-features = false }

--- a/modules/pallets/host-executive/Cargo.toml
+++ b/modules/pallets/host-executive/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 # polytope labs
 ismp = { workspace = true }
 pallet-ismp = { workspace = true }
-ismp-abi = { workspace = true }
+ismp-abi = { workspace = true, features = ["substrate"] }
 
 # crates.io
 codec = { workspace = true }

--- a/modules/pallets/testsuite/Cargo.toml
+++ b/modules/pallets/testsuite/Cargo.toml
@@ -67,7 +67,7 @@ beefy-verifier-primitives = { workspace = true }
 subxt-core = { workspace = true, default-features = true }
 futures = { workspace = true }
 tokio = { workspace = true }
-ismp-abi = { workspace = true, features = ["std"] }
+ismp-abi = { workspace = true, features = ["std", "substrate"] }
 
 [dependencies.alloy]
 workspace = true

--- a/scripts/release-crates.sh
+++ b/scripts/release-crates.sh
@@ -3,6 +3,8 @@
 cargo release \
 -p serde-hex-utils \
 -p crypto-utils \
+-p beefy-verifier-primitives \
+-p ismp-abi \
 -p ismp \
 -p pallet-ismp \
 -p pallet-ismp-runtime-api \

--- a/tesseract/consensus/beefy/Cargo.toml
+++ b/tesseract/consensus/beefy/Cargo.toml
@@ -35,7 +35,7 @@ pallet-ismp-rpc = { workspace = true }
 pallet-beefy-consensus-proofs = { workspace = true }
 ismp = { workspace = true }
 ismp-beefy = { workspace = true }
-ismp-abi = { workspace = true }
+ismp-abi = { workspace = true, features = ["substrate"] }
 substrate-state-machine = { workspace = true }
 beefy-verifier-primitives = { workspace = true }
 beefy-prover = { workspace = true }


### PR DESCRIPTION
Fixes #1172.

Two commits. The first is the republish the issue asks for. The second removes the reason it spread so far.

## The bug

`ismp-abi` and `beefy-verifier-primitives` are each published at exactly one version, `0.1.1`, and both pin `polkadot-sdk = "=2512.3.2"`. The workspace moved to `=2606.0.0` in #1062, but neither crate was republished, so the artifacts on crates.io still carry the pre-upgrade pin.

`ismp 2606.0.0` depends on `ismp-abi ^0.1.1`, so every consumer of the 2606 line pulls two SDK umbrellas into one graph:

```console
$ cargo add pallet-ismp@2606.0.0 ismp-grandpa@2606.0.0 && cargo generate-lockfile
$ grep -A1 'name = "polkadot-sdk"' Cargo.lock | grep version
version = "2512.3.2"
version = "2606.0.0"
```

Both requirements are exact, so nothing reconciles them. It also doesn't stop at the facade crate — the components double up too, which is what produces the `duplicate lang item in sp_io` error the reporter hit:

```
sp-core       39.0.0  + 43.0.0
sp-runtime    45.0.0  + 48.0.0
sp-io         44.0.0  + 48.0.0
frame-support 45.1.3  + 48.0.0
```

## Commit 1 — put both crates back on the release line

`scripts/release-crates.sh` drives `cargo release` over 13 crates, and neither of these is in it. Walking the workspace dependency closure from the released set, they're the only two crates reachable from a released crate that aren't released themselves.

The version scheme is what hid it. Every released crate that pins the umbrella is on CalVer; the two that don't pin it (`serde-hex-utils`, `crypto-utils`) are on semver. These two pin `=2606.0.0` but sit on `0.1.1` — the only exceptions — so their version numbers gave no signal that the pin had moved underneath them.

- `beefy-verifier-primitives` `0.1.1` → `2606.0.0`
- `ismp-abi` `0.1.1` → `2606.0.0`
- `ismp` `2606.0.0` → `2606.1.0`
- both added to `scripts/release-crates.sh`

Two things worth a look here.

**`ismp` has to be bumped as well.** Publishing `ismp-abi` on its own fixes nothing, because the already-published `ismp 2606.0.0` is immutable and requires `ismp-abi ^0.1.1`. Bumping `ismp` is what carries the fix to consumers. Nothing downstream needs republishing — `pallet-ismp`, `ismp-grandpa` and the rest require `ismp ^2606.0.0`, so they pick up `2606.1.0` on their own.

**Deliberately not a patch bump.** `ismp-abi 0.1.2` would satisfy the existing `^0.1.1` and fix the 2606 line without touching `ismp`, which is exactly why it's wrong: the 2512 line resolves to a single `polkadot-sdk 2512.3.2` today, and a patch bump would drag the 2606 pin onto it. That moves the breakage rather than fixing it. The CalVer bump is chosen so `^0.1.1` does *not* match.

## Commit 2 — keep the umbrella out of `ismp`

`ismp` sits at the root of the published tree, so an SDK pin on it reaches everything. That's why a stale pin on one small ABI crate turned into a broken FRAME runtime.

It doesn't need the umbrella. It uses `sp-weights` directly, which is fine — `Weight` is in its public API and the crate is small and standalone. The heavy dependencies all arrive through `ismp-abi`, which pulls `frame-support`, `sp-runtime`, `sp-consensus-beefy` and `sp-mmr-primitives` for two modules `ismp` never touches: the SCALE `HostParam` mirrors in `host_params`, and the BEEFY conversions in `conversions`. What `ismp` actually imports is the generated `sol!` bindings and `ToU256`, all plain alloy.

So both modules now sit behind a `substrate` feature, with `polkadot-sdk`, `beefy-verifier-primitives`, `codec` and `scale-info` optional on it. The feature is on by default, so external consumers of `ismp-abi` see no change. `ismp` turns it off.

Four workspace crates use the gated surface while inheriting `default-features = false`, so they opt in explicitly — `pallet-ismp-host-executive`, `pallet-beefy-consensus-proofs`, `pallet-ismp-testsuite` and `tesseract-beefy`. A workspace build would have covered them through feature unification, but `cargo check -p <one>` wouldn't, so the opt-in is written out.

Result: `ismp`'s dependency tree goes from 420 crates to 270, with no `polkadot-sdk`, `frame-support`, `sp-io`, `sp-core` or `sp-runtime` left in it. The 2606 pin now lives only on crates that are genuinely SDK-bound, where consumers already expect it.

## Publishing

Order matters — `beefy-verifier-primitives`, then `ismp-abi`, then `ismp`. `cargo release` takes that from the script ordering. Until they're published, `cargo package` on `ismp-abi`/`ismp` can't resolve the new requirement from the registry, which is expected. `beefy-verifier-primitives` still has to be published even though `ismp` no longer uses it, since cargo requires optional dependencies to resolve at publish time.

## Verification

- `cargo check` passes for: `ismp-abi` with the feature off (both `no_std` and `std`), `ismp-abi` with it on, `ismp` with it off, and the two pallets that opt in
- `cargo tree -p ismp` shows no polkadot-sdk, frame-support, sp-io, sp-core or sp-runtime
- workspace lockfile updates cleanly, still a single `polkadot-sdk 2606.0.0`
- reproduced the dual-SDK resolution on the 2606 line and confirmed the 2512 line is clean, both against the live index

Full workspace build is left to CI.
