### PR TITLE
[evm, sdk, simplex]: Give solver bids a signed expiry

### DIFF
--- a/evm/src/apps/intentsv2/SolverAccount.sol
+++ b/evm/src/apps/intentsv2/SolverAccount.sol
@@ -40,9 +40,35 @@ contract SolverAccount is Account, ERC7821, IERC1271 {
 
     /**
      * @notice Expected signature length for intent solver selection
-     * @dev abi.encodePacked(commitment, solverSignature, sessionSignature) = 32 + 65 + 65 = 162 bytes
+     * @dev abi.encodePacked(commitment, validUntil, solverSignature, sessionSignature)
+     *      = 32 + 6 + 65 + 65 = 168 bytes
      */
-    uint256 private constant INTENT_SELECT_SIGNATURE_LENGTH = 162;
+    uint256 private constant INTENT_SELECT_SIGNATURE_LENGTH = 168;
+
+    /**
+     * @notice EIP-712 type hash for the expiry the solver signs alongside the operation
+     * @dev The bid's `validUntil` cannot live in an unsigned part of the operation: the
+     *      EntryPoint's `userOpHash` does not cover `op.signature`, so an expiry carried
+     *      there and nowhere else could simply be rewritten by whoever replays the bid.
+     *      Binding it into the digest the solver signs is what makes it tamper-evident.
+     */
+    bytes32 private constant BID_VALIDITY_TYPEHASH = keccak256("BidValidity(bytes32 userOpHash,uint48 validUntil)");
+
+    /**
+     * @notice EIP-712 domain type hash
+     */
+    bytes32 private constant EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+
+    /**
+     * @notice Hashed EIP-712 domain name for the bid-validity digest
+     */
+    bytes32 private constant BID_DOMAIN_NAME = keccak256("SolverAccount");
+
+    /**
+     * @notice Hashed EIP-712 domain version for the bid-validity digest
+     */
+    bytes32 private constant BID_DOMAIN_VERSION = keccak256("1");
 
     /**
      * @notice Cached select function selector
@@ -86,12 +112,20 @@ contract SolverAccount is Account, ERC7821, IERC1271 {
      *    signature from a bid and submit the op on this path. Without a select()
      *    staged during validation the fill reverts, but the bid's nonce would be
      *    consumed and the solver griefed of the gas fees.
-     * 2. Intent solver selection (162 bytes): abi.encodePacked(commitment,
-     *    solverSignature, sessionSignature). The solver signs the plain userOpHash,
-     *    and the userOp's nonce key must equal the lower 192 bits of
+     * 2. Intent solver selection (168 bytes): abi.encodePacked(commitment, validUntil,
+     *    solverSignature, sessionSignature). The solver signs an EIP-712 BidValidity
+     *    digest over (userOpHash, validUntil) rather than the plain userOpHash, and the
+     *    userOp's nonce key must equal the lower 192 bits of
      *    keccak256(abi.encodePacked(commitment, sessionKey)) — binding the operation
      *    to the order and the session key it was bid against, so neither can be
      *    swapped after signing.
+     *
+     *    `validUntil` is returned to the EntryPoint as a validity range, so a bid stops
+     *    being executable once it lapses. Without it a signed bid was valid forever: the
+     *    order's `deadline` is chosen by the placer with no upper bound, and neither
+     *    retracting the bid on Hyperbridge nor letting it go unselected invalidates
+     *    anything on this chain — leaving the placer holding a free, unexpiring option
+     *    to make the solver fill at a stale price.
      *
      * @param op The packed user operation containing calldata, signature, and other fields
      * @param userOpHash The hash of the user operation (with EntryPoint and chain ID)
@@ -111,13 +145,20 @@ contract SolverAccount is Account, ERC7821, IERC1271 {
             return super.validateUserOp(op, userOpHash, missingAccountFunds);
         }
 
-        // Expected format: abi.encodePacked(commitment, solverSignature, sessionSignature)
-        // commitment: 32 bytes, solverSignature: 65 bytes, sessionSignature: 65 bytes
-        if (op.signature.length < INTENT_SELECT_SIGNATURE_LENGTH) return ERC4337Utils.SIG_VALIDATION_FAILED;
+        // Expected format: abi.encodePacked(commitment, validUntil, solverSignature, sessionSignature)
+        // commitment: 32 bytes, validUntil: 6 bytes, solverSignature: 65 bytes, sessionSignature: 65 bytes.
+        // Exact-length (not >=): the layout is fixed, so trailing bytes can only be malleability.
+        if (op.signature.length != INTENT_SELECT_SIGNATURE_LENGTH) return ERC4337Utils.SIG_VALIDATION_FAILED;
 
         bytes32 commitment = bytes32(op.signature[0:32]);
-        bytes calldata solverSignature = op.signature[32:97];
-        bytes calldata sessionSignature = op.signature[97:162];
+        uint48 validUntil = uint48(bytes6(op.signature[32:38]));
+        bytes calldata solverSignature = op.signature[38:103];
+        bytes calldata sessionSignature = op.signature[103:168];
+
+        // A zero validUntil is not "no opinion", it is unbounded: ERC4337Utils.parseValidationData
+        // expands 0 to BLOCK_RANGE_MASK. Refusing it here is what stops the old never-expiring
+        // behaviour from being reachable simply by signing an empty expiry.
+        if (validUntil == 0) return ERC4337Utils.SIG_VALIDATION_FAILED;
 
         // Call IntentGatewayV2.select to recover the sessionKey. This also stages the
         // transient-storage selection that fillOrder enforces at execution.
@@ -131,12 +172,39 @@ contract SolverAccount is Account, ERC7821, IERC1271 {
         address sessionKey = abi.decode(returnData, (address));
         uint192 userOpNonce = uint192(uint256(keccak256(abi.encodePacked(commitment, sessionKey))));
         if (uint192(op.nonce >> 64) != userOpNonce) return ERC4337Utils.SIG_VALIDATION_FAILED;
-        if (!_rawSignatureValidation(userOpHash, solverSignature)) return ERC4337Utils.SIG_VALIDATION_FAILED;
+        if (!_rawSignatureValidation(_bidValidityDigest(userOpHash, validUntil), solverSignature)) {
+            return ERC4337Utils.SIG_VALIDATION_FAILED;
+        }
 
         // Pay for gas if needed
         _payPrefund(missingAccountFunds);
 
-        return ERC4337Utils.SIG_VALIDATION_SUCCESS;
+        // validAfter = 0 keeps the BLOCK_RANGE_FLAG clear, so this packs as a TIMESTAMP range —
+        // the only range the canonical EntryPoint interprets.
+        return ERC4337Utils.packValidationData(address(0), 0, validUntil);
+    }
+
+    /**
+     * @notice EIP-712 digest binding an operation hash to the expiry the solver agreed to
+     * @dev The domain's `verifyingContract` is `address(this)`, which under EIP-7702 is the
+     *      solver's own EOA — so a bid signed for one solver account cannot be replayed against
+     *      another. The digest is recomputed here rather than trusting a value passed in calldata
+     *      because only the solver's signature over it makes the expiry unforgeable.
+     *
+     *      Note there is deliberately no upper bound on `validUntil` in this contract: ERC-7562
+     *      forbids the TIMESTAMP opcode during validation, so the account cannot compare the
+     *      expiry against the current time. Capping the tenor is the signer's job — see
+     *      `maxBidTenorSec` on the filler side.
+     * @param userOpHash The EntryPoint-supplied hash of the operation
+     * @param validUntil Unix timestamp after which the bid is no longer valid
+     * @return The EIP-712 digest the solver is expected to have signed
+     */
+    function _bidValidityDigest(bytes32 userOpHash, uint48 validUntil) internal view returns (bytes32) {
+        bytes32 domainSeparator = keccak256(
+            abi.encode(EIP712_DOMAIN_TYPEHASH, BID_DOMAIN_NAME, BID_DOMAIN_VERSION, block.chainid, address(this))
+        );
+        bytes32 structHash = keccak256(abi.encode(BID_VALIDITY_TYPEHASH, userOpHash, validUntil));
+        return keccak256(abi.encodePacked(hex"1901", domainSeparator, structHash));
     }
 
     /**

--- a/evm/tests/foundry/account/SolverAccountTest.sol
+++ b/evm/tests/foundry/account/SolverAccountTest.sol
@@ -25,6 +25,9 @@ contract SolverAccountTest is Test {
     SolverAccount public solverAccount;
     IntentGatewayV2 public intentGateway;
 
+    /// @dev 2030-01-01; far enough out that no test trips over it.
+    uint48 internal constant VALID_UNTIL = 1893456000;
+
     address public entryPoint = address(ERC4337Utils.ENTRYPOINT_V08); // ERC-4337 v0.8 EntryPoint
     address public solver;
     uint256 public solverPrivateKey;
@@ -117,7 +120,7 @@ contract SolverAccountTest is Test {
         uint256 result = solverAccount.validateUserOp(op, userOpHash, 0);
 
         // With EIP-7702 simulation, the signature should be valid
-        assertEq(result, ERC4337Utils.SIG_VALIDATION_SUCCESS);
+        assertEq(result, _expectedValid(VALID_UNTIL));
     }
 
     function test_ValidateUserOp_StandardECDSA_InvalidSigner_Fails() public {
@@ -192,7 +195,7 @@ contract SolverAccountTest is Test {
         vm.prank(entryPoint);
         uint256 result = solverAccount.validateUserOp(op, userOpHash, 0);
 
-        assertEq(result, ERC4337Utils.SIG_VALIDATION_SUCCESS);
+        assertEq(result, _expectedValid(VALID_UNTIL));
     }
 
     /// @dev The fillOrder selector on a target other than the IntentGateway is harmless.
@@ -211,7 +214,7 @@ contract SolverAccountTest is Test {
         vm.prank(entryPoint);
         uint256 result = solverAccount.validateUserOp(op, userOpHash, 0);
 
-        assertEq(result, ERC4337Utils.SIG_VALIDATION_SUCCESS);
+        assertEq(result, _expectedValid(VALID_UNTIL));
     }
 
     // ============================================
@@ -228,7 +231,7 @@ contract SolverAccountTest is Test {
         // by the nonce key.
         bytes memory solverSignature = _signUserOpHash(userOpHash);
 
-        bytes memory signature = abi.encodePacked(testCommitment, solverSignature, sessionSignature);
+        bytes memory signature = _bidSig(testCommitment, VALID_UNTIL, solverSignature, sessionSignature);
 
         PackedUserOperation memory op = PackedUserOperation({
             sender: address(solverAccount),
@@ -250,7 +253,7 @@ contract SolverAccountTest is Test {
         vm.prank(entryPoint);
         uint256 result = solverAccount.validateUserOp(op, userOpHash, 0);
 
-        assertEq(result, ERC4337Utils.SIG_VALIDATION_SUCCESS);
+        assertEq(result, _expectedValid(VALID_UNTIL));
     }
 
     /// @dev fillOrder calldata is the normal payload for a selected bid — it must only
@@ -260,7 +263,7 @@ contract SolverAccountTest is Test {
 
         bytes memory sessionSignature = _createSessionKeySignature(testCommitment, address(solverAccount));
         bytes memory solverSignature = _signUserOpHash(userOpHash);
-        bytes memory signature = abi.encodePacked(testCommitment, solverSignature, sessionSignature);
+        bytes memory signature = _bidSig(testCommitment, VALID_UNTIL, solverSignature, sessionSignature);
 
         Execution[] memory calls = new Execution[](1);
         calls[0] = Execution({
@@ -289,7 +292,7 @@ contract SolverAccountTest is Test {
         vm.prank(entryPoint);
         uint256 result = solverAccount.validateUserOp(op, userOpHash, 0);
 
-        assertEq(result, ERC4337Utils.SIG_VALIDATION_SUCCESS);
+        assertEq(result, _expectedValid(VALID_UNTIL));
     }
 
     function test_ValidateUserOp_IntentSelection_PlainUserOpHash_WrongNonceKey_Fails() public {
@@ -300,7 +303,7 @@ contract SolverAccountTest is Test {
         // Valid solver signature over the plain userOpHash...
         bytes memory solverSignature = _signUserOpHash(userOpHash);
 
-        bytes memory signature = abi.encodePacked(testCommitment, solverSignature, sessionSignature);
+        bytes memory signature = _bidSig(testCommitment, VALID_UNTIL, solverSignature, sessionSignature);
 
         // ...but the userOp's nonce key is not keccak256(commitment ‖ sessionKey):
         // the signed userOp is not bound to the order/session being selected, so
@@ -341,7 +344,7 @@ contract SolverAccountTest is Test {
         bytes memory solverSignature = _createSolverSignature(userOpHash, testCommitment, sessionKey);
 
         // Create combined signature: commitment + solverSignature + sessionSignature
-        bytes memory signature = abi.encodePacked(testCommitment, solverSignature, sessionSignature);
+        bytes memory signature = _bidSig(testCommitment, VALID_UNTIL, solverSignature, sessionSignature);
 
         PackedUserOperation memory op = PackedUserOperation({
             sender: address(solverAccount),
@@ -371,8 +374,8 @@ contract SolverAccountTest is Test {
     function test_ValidateUserOp_IntentSelection_WrongSignatureLength_TooShort() public {
         bytes32 userOpHash = keccak256("test_userop");
 
-        // Create signature that's too short (less than 162 bytes)
-        bytes memory signature = new bytes(161);
+        // Create signature that's too short (less than 168 bytes)
+        bytes memory signature = new bytes(167);
 
         PackedUserOperation memory op = PackedUserOperation({
             sender: address(solverAccount),
@@ -407,7 +410,7 @@ contract SolverAccountTest is Test {
         bytes memory solverSignature = _createSolverSignature(userOpHash, testCommitment, sessionKey);
 
         // Create combined signature
-        bytes memory signature = abi.encodePacked(testCommitment, solverSignature, invalidSessionSignature);
+        bytes memory signature = _bidSig(testCommitment, VALID_UNTIL, solverSignature, invalidSessionSignature);
 
         PackedUserOperation memory op = PackedUserOperation({
             sender: address(solverAccount),
@@ -423,7 +426,9 @@ contract SolverAccountTest is Test {
 
         // Mock IntentGateway.select to fail (return empty or revert)
         SelectOptions memory expectedOptions = SelectOptions({
-            commitment: testCommitment, solver: address(solverAccount), signature: invalidSessionSignature
+            commitment: testCommitment,
+            solver: address(solverAccount),
+            signature: invalidSessionSignature
         });
         bytes memory selectCalldata = abi.encodeWithSelector(intentGateway.select.selector, expectedOptions);
 
@@ -447,7 +452,7 @@ contract SolverAccountTest is Test {
         bytes memory invalidSolverSignature = abi.encodePacked(r, s, v);
 
         // Create combined signature
-        bytes memory signature = abi.encodePacked(testCommitment, invalidSolverSignature, sessionSignature);
+        bytes memory signature = _bidSig(testCommitment, VALID_UNTIL, invalidSolverSignature, sessionSignature);
 
         PackedUserOperation memory op = PackedUserOperation({
             sender: address(solverAccount),
@@ -486,7 +491,7 @@ contract SolverAccountTest is Test {
         bytes memory solverSignature = _signUserOpHash(userOpHash);
 
         // But include WRONG commitment in the signature bytes
-        bytes memory signature = abi.encodePacked(wrongCommitment, solverSignature, sessionSignature);
+        bytes memory signature = _bidSig(wrongCommitment, VALID_UNTIL, solverSignature, sessionSignature);
 
         PackedUserOperation memory op = PackedUserOperation({
             sender: address(solverAccount),
@@ -522,7 +527,7 @@ contract SolverAccountTest is Test {
         bytes memory solverSignature = _signUserOpHash(userOpHash);
 
         // Create combined signature
-        bytes memory signature = abi.encodePacked(testCommitment, solverSignature, sessionSignature);
+        bytes memory signature = _bidSig(testCommitment, VALID_UNTIL, solverSignature, sessionSignature);
 
         PackedUserOperation memory op = PackedUserOperation({
             sender: address(solverAccount),
@@ -559,7 +564,7 @@ contract SolverAccountTest is Test {
         // First operation with commitment1
         bytes memory sessionSignature1 = _createSessionKeySignature(commitment1, address(solverAccount));
         bytes memory solverSignature1 = _signUserOpHash(userOpHash1);
-        bytes memory signature1 = abi.encodePacked(commitment1, solverSignature1, sessionSignature1);
+        bytes memory signature1 = _bidSig(commitment1, VALID_UNTIL, solverSignature1, sessionSignature1);
 
         PackedUserOperation memory op1 = PackedUserOperation({
             sender: address(solverAccount),
@@ -585,7 +590,7 @@ contract SolverAccountTest is Test {
         // Second operation with commitment2
         bytes memory sessionSignature2 = _createSessionKeySignature(commitment2, address(solverAccount));
         bytes memory solverSignature2 = _signUserOpHash(userOpHash2);
-        bytes memory signature2 = abi.encodePacked(commitment2, solverSignature2, sessionSignature2);
+        bytes memory signature2 = _bidSig(commitment2, VALID_UNTIL, solverSignature2, sessionSignature2);
 
         PackedUserOperation memory op2 = PackedUserOperation({
             sender: address(solverAccount),
@@ -630,7 +635,7 @@ contract SolverAccountTest is Test {
         bytes memory solverSignature = _signUserOpHash(userOpHash);
 
         // Create combined signature
-        bytes memory signature = abi.encodePacked(testCommitment, solverSignature, sessionSignature);
+        bytes memory signature = _bidSig(testCommitment, VALID_UNTIL, solverSignature, sessionSignature);
 
         PackedUserOperation memory op = PackedUserOperation({
             sender: address(solverAccount),
@@ -655,6 +660,118 @@ contract SolverAccountTest is Test {
 
         // Should fail because solver signature was for sessionKey but IntentGateway returned sessionKey2
         assertEq(result, ERC4337Utils.SIG_VALIDATION_FAILED);
+    }
+
+    /// @dev A zero expiry is not "no opinion" — ERC4337Utils.parseValidationData expands
+    ///      0 to BLOCK_RANGE_MASK, i.e. valid forever. That is exactly the never-expiring
+    ///      bid this format exists to prevent, so it must be refused outright.
+    function test_ValidateUserOp_IntentSelection_ZeroValidUntil_Reverts() public {
+        bytes32 userOpHash = keccak256("test_userop");
+
+        bytes memory sessionSignature = _createSessionKeySignature(testCommitment, address(solverAccount));
+        bytes memory solverSignature = _signBidValidity(userOpHash, 0);
+        bytes memory signature = _bidSig(testCommitment, 0, solverSignature, sessionSignature);
+
+        PackedUserOperation memory op = _standardOp("", signature);
+        op.nonce = _bidNonce(testCommitment, sessionKey);
+
+        vm.prank(entryPoint);
+        uint256 result = solverAccount.validateUserOp(op, userOpHash, 0);
+
+        assertEq(result, ERC4337Utils.SIG_VALIDATION_FAILED);
+    }
+
+    /// @dev The whole point of putting validUntil inside the signed digest: op.signature is
+    ///      not covered by userOpHash, so anyone replaying a bid could otherwise rewrite the
+    ///      expiry in the blob and revive a dead bid. Signing for one expiry and presenting
+    ///      another must fail.
+    function test_ValidateUserOp_IntentSelection_TamperedValidUntil_Reverts() public {
+        bytes32 userOpHash = keccak256("test_userop");
+
+        bytes memory sessionSignature = _createSessionKeySignature(testCommitment, address(solverAccount));
+        // Signed for VALID_UNTIL, presented with a far later expiry.
+        bytes memory solverSignature = _signBidValidity(userOpHash, VALID_UNTIL);
+        bytes memory signature = _bidSig(testCommitment, VALID_UNTIL + 86400, solverSignature, sessionSignature);
+
+        PackedUserOperation memory op = _standardOp("", signature);
+        op.nonce = _bidNonce(testCommitment, sessionKey);
+
+        vm.prank(entryPoint);
+        uint256 result = solverAccount.validateUserOp(op, userOpHash, 0);
+
+        assertEq(result, ERC4337Utils.SIG_VALIDATION_FAILED);
+    }
+
+    /// @dev The returned validation data must actually carry the expiry, otherwise the
+    ///      EntryPoint has nothing to enforce and the bid is executable forever.
+    function test_ValidateUserOp_IntentSelection_ReturnsExpiry() public {
+        bytes32 userOpHash = keccak256("test_userop");
+        uint48 expiry = uint48(block.timestamp + 300);
+
+        bytes memory sessionSignature = _createSessionKeySignature(testCommitment, address(solverAccount));
+        bytes memory solverSignature = _signBidValidity(userOpHash, expiry);
+        bytes memory signature = _bidSig(testCommitment, expiry, solverSignature, sessionSignature);
+
+        PackedUserOperation memory op = _standardOp("", signature);
+        op.nonce = _bidNonce(testCommitment, sessionKey);
+
+        SelectOptions memory expectedOptions =
+            SelectOptions({commitment: testCommitment, solver: address(solverAccount), signature: sessionSignature});
+        vm.mockCall(
+            address(intentGateway),
+            abi.encodeWithSelector(intentGateway.select.selector, expectedOptions),
+            abi.encode(sessionKey)
+        );
+
+        vm.prank(entryPoint);
+        uint256 result = solverAccount.validateUserOp(op, userOpHash, 0);
+
+        (, uint48 validAfter, uint48 validUntil,) = ERC4337Utils.parseValidationData(result);
+        assertEq(validUntil, expiry);
+        assertEq(validAfter, 0);
+    }
+
+    /// @dev A signature longer than the fixed layout is refused rather than truncated.
+    function test_ValidateUserOp_IntentSelection_OverlongSignature_Reverts() public {
+        bytes32 userOpHash = keccak256("test_userop");
+
+        bytes memory sessionSignature = _createSessionKeySignature(testCommitment, address(solverAccount));
+        bytes memory solverSignature = _signUserOpHash(userOpHash);
+        bytes memory signature =
+            abi.encodePacked(_bidSig(testCommitment, VALID_UNTIL, solverSignature, sessionSignature), bytes1(0x00));
+
+        PackedUserOperation memory op = _standardOp("", signature);
+        op.nonce = _bidNonce(testCommitment, sessionKey);
+
+        vm.prank(entryPoint);
+        uint256 result = solverAccount.validateUserOp(op, userOpHash, 0);
+
+        assertEq(result, ERC4337Utils.SIG_VALIDATION_FAILED);
+    }
+
+    /// @dev Pinned against the same vector asserted in the SDK's
+    ///      packedUserOpTypedData.test.ts — guards TS/Solidity drift in the BidValidity
+    ///      digest. If these disagree, every bid the SDK signs is rejected on-chain.
+    function test_BidValidityDigest_MatchesSdkVector() public {
+        // The SDK vector fixes the account address and chain, so mirror them here.
+        vm.chainId(8453);
+        bytes32 userOpHash = 0x1122334455667788112233445566778811223344556677881122334455667788;
+
+        bytes32 domainSeparator = keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak256("SolverAccount"),
+                keccak256("1"),
+                block.chainid,
+                address(0x5FbDB2315678afecb367f032d93F642f64180aa3)
+            )
+        );
+        bytes32 structHash = keccak256(
+            abi.encode(keccak256("BidValidity(bytes32 userOpHash,uint48 validUntil)"), userOpHash, uint48(1893456000))
+        );
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+
+        assertEq(digest, 0x9e02de364fe8fc317a79ca6770e4fb15fe92546ade132c86ddef6315ff12c314);
     }
 
     /// @dev Pinned against the same vector asserted in the SDK's
@@ -741,11 +858,49 @@ contract SolverAccountTest is Test {
         return abi.encodePacked(r, s, v);
     }
 
-    /// @notice Solver signature over the plain v0.8 userOpHash (the EIP-712 digest of
-    ///         the PackedUserOperation).
-    function _signUserOpHash(bytes32 userOpHash) internal view returns (bytes memory) {
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(solverPrivateKey, userOpHash);
+    /// @notice The EIP-712 BidValidity digest the solver signs. Mirrors
+    ///         SolverAccount._bidValidityDigest; if the two ever disagree every bid is
+    ///         rejected on-chain, so this is deliberately spelled out rather than reused.
+    function _bidDigest(bytes32 userOpHash, uint48 validUntil) internal view returns (bytes32) {
+        bytes32 domainSeparator = keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak256("SolverAccount"),
+                keccak256("1"),
+                block.chainid,
+                address(solverAccount)
+            )
+        );
+        bytes32 structHash = keccak256(
+            abi.encode(keccak256("BidValidity(bytes32 userOpHash,uint48 validUntil)"), userOpHash, validUntil)
+        );
+        return keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+    }
+
+    /// @notice Solver signature over the BidValidity digest, which binds the operation
+    ///         to the expiry the bid is good for.
+    function _signBidValidity(bytes32 userOpHash, uint48 validUntil) internal view returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(solverPrivateKey, _bidDigest(userOpHash, validUntil));
         return abi.encodePacked(r, s, v);
+    }
+
+    /// @notice Solver signature over the BidValidity digest at the default expiry.
+    function _signUserOpHash(bytes32 userOpHash) internal view returns (bytes memory) {
+        return _signBidValidity(userOpHash, VALID_UNTIL);
+    }
+
+    /// @notice Packs the 168-byte selection signature the account expects.
+    function _bidSig(bytes32 commitment, uint48 validUntil, bytes memory solverSig, bytes memory sessionSig)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodePacked(commitment, bytes6(validUntil), solverSig, sessionSig);
+    }
+
+    /// @notice Validation data a well-formed bid must return: success, expiring at validUntil.
+    function _expectedValid(uint48 validUntil) internal pure returns (uint256) {
+        return ERC4337Utils.packValidationData(address(0), 0, validUntil);
     }
 
     /// @notice The 4337 nonce binding a bid to its order and session key:

--- a/sdk/packages/sdk/docs/ai/ChangeLog.md
+++ b/sdk/packages/sdk/docs/ai/ChangeLog.md
@@ -12,6 +12,28 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-08-27 — Solver bids carry a signed expiry
+
+`prepareSubmitBid` now requires a `validUntil` and signs an EIP-712 `BidValidity(bytes32 userOpHash,uint48 validUntil)`
+digest instead of the bare `userOpHash`. The selection signature grew from 97 to 103 bytes
+(`commitment ‖ validUntil ‖ solverSig`), so the completed form `SolverAccount` validates is 168 rather than 162 bytes;
+the 65-byte session signature is still appended by whoever selects the solver, so `Bid.execute` is unchanged.
+
+Previously a signed bid was valid forever. `SolverAccount.validateUserOp` returned `SIG_VALIDATION_SUCCESS`, which
+packs `validUntil = 0`, and `ERC4337Utils.parseValidationData` expands 0 to `BLOCK_RANGE_MASK`. Nothing else bounded
+it: `order.deadline` is chosen by the order placer with no contract-side ceiling, and `retract_bid` on Hyperbridge
+does not touch the destination chain. The placer holds the session key, so they alone chose when to exercise — a free
+option on solver inventory, taken up only once the rate had moved against the solver.
+
+The expiry has to live inside the signed digest because the EntryPoint's `userOpHash` does not cover `op.signature`;
+an expiry carried alongside the signature could simply be rewritten by whoever replays the bid.
+
+Found by the scheduled IntentGateway/Simplex security audit.
+
+Files: `src/protocols/intents/BidManager.ts`, `src/protocols/intents/CryptoUtils.ts`, `src/types/index.ts`,
+`src/tests/packedUserOpTypedData.test.ts`, plus `evm/src/apps/intentsv2/SolverAccount.sol` and
+`evm/tests/foundry/account/SolverAccountTest.sol`.
+
 ## 2026-08-25 — Intent quotes use aggregate indexed pool rates by default
 
 `IntentGateway.quoteIntent` now prices orders from the pair-centric indexer's depth-weighted aggregate `LiquidityPool.buyRate` and `sellRate`. Source and destination chains resolve the configured token deployments, while the quote converts the pool's whole-token rate into raw amounts with configured decimals, applies the source gateway protocol fee, and exposes the selected rate and timestamp in metadata. Reverse sell-rate reciprocals round up so quotes do not overpromise output. Phantom snapshot and Uniswap V4 pricing remain explicit compatibility strategies. Live sequential tests cover exact-input USDC to cNGN and exact-output cNGN to USDC across BSC and Base, including their different token decimal scales. The dead `binance.llamarpc.com` BSC default was replaced with `bsc-rpc.publicnode.com` after it blocked those live checks.

--- a/sdk/packages/sdk/docs/ai/Decisions.md
+++ b/sdk/packages/sdk/docs/ai/Decisions.md
@@ -4,6 +4,41 @@ AI-maintained record of non-obvious choices made in `sdk/packages/sdk`: what was
 
 Entry format: heading with the decision, then alternatives considered and the reasoning. Newest first.
 
+## 2026-08-27 — The bid expiry is a signed EIP-712 field, not a validation-time check
+
+Chosen: the solver signs `BidValidity(bytes32 userOpHash,uint48 validUntil)` and `SolverAccount` returns `validUntil`
+to the EntryPoint as a validity range. The account itself never judges whether the expiry is reasonable.
+
+It cannot. ERC-7562 forbids the `TIMESTAMP` opcode during validation, so the account has no way to compare `validUntil`
+against the current time — capping the tenor is necessarily the signer's job (`bidValiditySeconds` on the filler).
+The account's role is narrower but load-bearing: make the expiry unforgeable, and hand it to the one component that
+*is* allowed to enforce it.
+
+Alternatives rejected:
+
+- *Carry `validUntil` in an unsigned part of the operation.* Cheapest, and wrong: `userOpHash` does not cover
+  `op.signature`, so a replayer would just rewrite the expiry and revive a dead bid. Everything about this fix depends
+  on the expiry being inside the digest.
+- *`keccak256(userOpHash ‖ validUntil)` instead of EIP-712.* Fewer bytes and no domain separator. Rejected because it
+  hands the signer an opaque 32-byte digest. The existing `packedUserOpTypedData` exists specifically so signing
+  infrastructure can see what it is signing, and here that property is worth more than usual: a named `validUntil`
+  field is what lets an MPC/TEE policy engine refuse to sign a bid whose tenor is too long. Since the account cannot
+  check the tenor on-chain, the signer is the only place that check can live — so the payload has to be legible there.
+- *Re-hash the whole `PackedUserOperation` with `validUntil` appended.* Keeps full-operation visibility, but duplicates
+  the EntryPoint's own hashing inside `validateUserOp` — more gas in the validation phase and a second copy of a
+  consensus-critical encoding to keep in sync. Binding to `userOpHash` gets the same coverage transitively.
+- *An on-chain ceiling like `validUntil <= block.timestamp + 1 days`.* Would have made the contract a backstop against
+  a buggy SDK. Not expressible: same ERC-7562 restriction.
+
+The domain's `verifyingContract` is `address(this)` — under EIP-7702 the solver's own EOA — so a bid cannot be
+replayed against a different solver account. Rejecting `validUntil == 0` is part of the fix rather than a nicety:
+zero is how the old unbounded behaviour is spelled, so accepting it would leave the hole open.
+
+Rollout: `SolverAccount` is reached by EIP-7702 delegation, so a new deployment lives at a new address and solvers
+migrate by re-delegating. Old and new can coexist per solver, which is why the contract refuses the 162-byte format
+outright rather than accepting both — a compatibility window would keep the unexpiring path alive for exactly as long
+as it existed.
+
 ## 2026-08-25 — Intent quotes default to directional indexed rates without fallback
 
 Chosen: `quoteIntent` defaults to an `indexed_rates` strategy that selects the depth-weighted aggregate `LiquidityPool.buyRate` for base-to-quote orders and `sellRate` for quote-to-base orders. Source and destination chains resolve the configured token deployments; raw amounts are calculated from the indexer's 18-decimal whole-token pool rate and both tokens' configured decimals. A missing directional rate is an error.

--- a/sdk/packages/sdk/src/protocols/intents/BidManager.ts
+++ b/sdk/packages/sdk/src/protocols/intents/BidManager.ts
@@ -1,4 +1,4 @@
-import { decodeFunctionData, concat } from "viem"
+import { decodeFunctionData, concat, hashTypedData, numberToHex } from "viem"
 import { ABI as IntentGatewayV2ABI } from "@/abis/IntentGatewayV2"
 import { ADDRESS_ZERO, bytes32ToBytes20 } from "@/utils"
 import type {
@@ -73,7 +73,17 @@ export class BidManager {
 			maxPriorityFeePerGas,
 			callData,
 			paymasterAndData = "0x" as HexString,
+			validUntil,
 		} = options
+
+		// SolverAccount rejects a zero validUntil, but failing here gives the caller a
+		// usable error instead of an opaque AA24 from the bundler.
+		if (validUntil <= 0n) {
+			throw new Error(`[BidManager] validUntil must be a positive unix timestamp, got ${validUntil}`)
+		}
+		if (validUntil >= 1n << 48n) {
+			throw new Error(`[BidManager] validUntil must fit in uint48, got ${validUntil}`)
+		}
 
 		const chainId = BigInt(
 			this.ctx.dest.client.chain?.id ?? Number.parseInt(this.ctx.dest.config.stateMachineId.split("-")[1]),
@@ -103,11 +113,20 @@ export class BidManager {
 				`[BidManager] bid nonce key does not bind the order commitment and session key; on-chain validation will fail (order=${order.id})`,
 			)
 		}
+		// The solver signs (userOpHash, validUntil), not the bare userOpHash: the expiry
+		// has to be covered by this signature or a replayer could extend it at will.
+		const userOpHash = hashTypedData(CryptoUtils.packedUserOpTypedData(userOp, entryPointAddress, chainId))
 		const solverSignature = await solverSigner.signTypedData(
-			CryptoUtils.packedUserOpTypedData(userOp, entryPointAddress, chainId),
+			CryptoUtils.bidValidityTypedData(userOpHash, validUntil, solverAccount, chainId),
 		)
 
-		const signature = concat([order.id as HexString, solverSignature as HexString]) as HexString
+		// SolverAccount expects abi.encodePacked(commitment, validUntil, solverSig, sessionSig).
+		// The 65-byte session signature is appended by whoever selects this solver.
+		const signature = concat([
+			order.id as HexString,
+			numberToHex(validUntil, { size: 6 }),
+			solverSignature as HexString,
+		]) as HexString
 
 		return { ...userOp, signature }
 	}

--- a/sdk/packages/sdk/src/protocols/intents/CryptoUtils.ts
+++ b/sdk/packages/sdk/src/protocols/intents/CryptoUtils.ts
@@ -223,6 +223,64 @@ export class CryptoUtils {
 	}
 
 	/**
+	 * Builds the EIP-712 payload a solver signs when bidding: the operation hash
+	 * bound to the expiry the bid is valid until.
+	 *
+	 * `SolverAccount` recomputes this digest in `validateUserOp` and returns
+	 * `validUntil` to the EntryPoint as a validity range. The expiry has to be inside
+	 * the signed digest rather than carried alongside it, because the EntryPoint's
+	 * `userOpHash` does not cover `op.signature` — an expiry living only in the
+	 * signature blob could be rewritten by anyone replaying the bid.
+	 *
+	 * The domain's `verifyingContract` is the solver account itself (under EIP-7702,
+	 * the solver's own EOA), so a bid signed for one account cannot be replayed
+	 * against another.
+	 *
+	 * Signing infrastructure sees a named `validUntil` field, which lets an MPC/TEE
+	 * policy engine refuse to sign a bid whose tenor is longer than the operator
+	 * intends — a check that is impossible against an opaque digest, and impossible
+	 * on-chain because ERC-7562 forbids reading the clock during validation.
+	 *
+	 * @param userOpHash - EntryPoint v0.8 `userOpHash` of the operation being bid.
+	 * @param validUntil - Unix timestamp (seconds) after which the bid is dead.
+	 * @param solverAccount - The solver account the bid executes against.
+	 * @param chainId - Chain ID of the destination network.
+	 * @returns A viem `TypedDataDefinition` for the bid's validity.
+	 */
+	static bidValidityTypedData(userOpHash: HexString, validUntil: bigint, solverAccount: Hex, chainId: bigint) {
+		return {
+			domain: {
+				name: "SolverAccount",
+				version: "1",
+				// See packedUserOpTypedData: runtime number so server-side JSON hashers
+				// emit a canonical v4 numeric chainId.
+				chainId: Number(chainId) as unknown as bigint,
+				verifyingContract: solverAccount,
+			},
+			types: {
+				EIP712Domain: [
+					{ name: "name", type: "string" },
+					{ name: "version", type: "string" },
+					{ name: "chainId", type: "uint256" },
+					{ name: "verifyingContract", type: "address" },
+				],
+				BidValidity: [
+					{ name: "userOpHash", type: "bytes32" },
+					{ name: "validUntil", type: "uint48" },
+				],
+			} as const,
+			primaryType: "BidValidity" as const,
+			message: {
+				userOpHash,
+				// viem types uint48 as a JS number. uint48 maxes out at ~2.8e14, comfortably
+				// inside Number.MAX_SAFE_INTEGER, so the narrowing is exact — and the digest is
+				// identical either way, since viem encodes the value, not its JS type.
+				validUntil: Number(validUntil),
+			},
+		}
+	}
+
+	/**
 	 * Computes the EIP-712 struct hash of a `PackedUserOperation`.
 	 *
 	 * Hashes dynamic fields (`initCode`, `callData`, `paymasterAndData`) before

--- a/sdk/packages/sdk/src/tests/packedUserOpTypedData.test.ts
+++ b/sdk/packages/sdk/src/tests/packedUserOpTypedData.test.ts
@@ -51,3 +51,43 @@ describe("packedUserOpTypedData", () => {
 		)
 	})
 })
+
+describe("bidValidityTypedData", () => {
+	const SOLVER = "0x5fbdb2315678afecb367f032d93f642f64180aa3" as HexString
+	const USER_OP_HASH = "0x1122334455667788112233445566778811223344556677881122334455667788" as HexString
+	const VALID_UNTIL = 1893456000n
+
+	// Pinned against the same vector asserted in SolverAccountTest.sol. If this drifts,
+	// every bid this SDK signs is rejected on-chain — the account recomputes this digest
+	// itself and compares the recovered signer, so a one-byte disagreement in the type
+	// string or field order silently invalidates the whole bid path.
+	it("digest matches the SolverAccount._bidValidityDigest vector", () => {
+		const typed = CryptoUtils.bidValidityTypedData(USER_OP_HASH, VALID_UNTIL, SOLVER, 8453n)
+		expect(hashTypedData(typed)).toBe("0x9e02de364fe8fc317a79ca6770e4fb15fe92546ade132c86ddef6315ff12c314")
+	})
+
+	it("binds the expiry: a different validUntil is a different digest", () => {
+		const a = hashTypedData(CryptoUtils.bidValidityTypedData(USER_OP_HASH, VALID_UNTIL, SOLVER, 8453n))
+		const b = hashTypedData(CryptoUtils.bidValidityTypedData(USER_OP_HASH, VALID_UNTIL + 1n, SOLVER, 8453n))
+		expect(a).not.toBe(b)
+	})
+
+	it("binds the account: the same bid cannot be replayed against another solver", () => {
+		const a = hashTypedData(CryptoUtils.bidValidityTypedData(USER_OP_HASH, VALID_UNTIL, SOLVER, 8453n))
+		const b = hashTypedData(
+			CryptoUtils.bidValidityTypedData(
+				USER_OP_HASH,
+				VALID_UNTIL,
+				"0x000000000000000000000000000000000000beef" as HexString,
+				8453n,
+			),
+		)
+		expect(a).not.toBe(b)
+	})
+
+	it("binds the chain", () => {
+		const a = hashTypedData(CryptoUtils.bidValidityTypedData(USER_OP_HASH, VALID_UNTIL, SOLVER, 8453n))
+		const b = hashTypedData(CryptoUtils.bidValidityTypedData(USER_OP_HASH, VALID_UNTIL, SOLVER, 1n))
+		expect(a).not.toBe(b)
+	})
+})

--- a/sdk/packages/sdk/src/types/index.ts
+++ b/sdk/packages/sdk/src/types/index.ts
@@ -1348,6 +1348,18 @@ export interface SubmitBidOptions {
 	 * Defaults to "0x" (EntryPoint deposit pays gas).
 	 */
 	paymasterAndData?: HexString
+	/**
+	 * Unix timestamp (seconds) after which this bid may no longer be executed.
+	 *
+	 * Returned to the EntryPoint by `SolverAccount` as a validity range, so the bid
+	 * stops being executable once it lapses. This is the only thing bounding how long
+	 * the signature lives: the order's `deadline` is chosen by the placer with no upper
+	 * bound, and retracting the bid on Hyperbridge does not invalidate it on the
+	 * destination chain. Keep it short — it is the window over which the quoted price
+	 * is a firm commitment. Must be non-zero; `SolverAccount` rejects 0 because the
+	 * EntryPoint reads a zero `validUntil` as "never expires".
+	 */
+	validUntil: bigint
 }
 
 export interface EstimateFillOrderParams {

--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -14,7 +14,7 @@ Newest entries first.
 
 ## 2026-08-27 — Bids are stamped with an expiry (`bidValiditySeconds`)
 
-Every bid this filler signs now carries a `validUntil`, defaulting to 300 seconds and configurable as
+Every bid this filler signs now carries a `validUntil`, defaulting to 1800 seconds (30 minutes) and configurable as
 `simplex.bidValiditySeconds`. Both bid paths set it — the real one in `prepareBidUserOp` and the phantom quote in
 `preparePhantomBidUserOp` — through a single `bidValidUntil()` helper.
 

--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -12,6 +12,26 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-08-27 — Bids are stamped with an expiry (`bidValiditySeconds`)
+
+Every bid this filler signs now carries a `validUntil`, defaulting to 300 seconds and configurable as
+`simplex.bidValiditySeconds`. Both bid paths set it — the real one in `prepareBidUserOp` and the phantom quote in
+`preparePhantomBidUserOp` — through a single `bidValidUntil()` helper.
+
+A bid is a firm price the order placer can take up whenever they choose. Nothing bounded that window: `order.deadline`
+is placer-chosen with no ceiling, and `enqueueRetraction` only clears the bid on Hyperbridge, which has no effect on
+the destination chain. So a bid signed at one rate stayed executable indefinitely and was exercised only if the rate
+moved against us — a written option on this filler's inventory, at no premium. Volatile pairs (USDC/CNGN) are the
+worst case, since the naira reprices in steps rather than drifting.
+
+This is the half of the fix that has to live off-chain: `SolverAccount` binds the expiry into the signature but
+cannot judge it, because ERC-7562 forbids reading the clock during ERC-4337 validation.
+
+Found by the scheduled IntentGateway/Simplex security audit.
+
+Files: `src/services/ContractInteractionService.ts`, `src/services/FillerConfigService.ts`, `src/config/filler-toml.ts`,
+`src/core/boot.ts`.
+
 ## 2026-08-26 — Final-review fixes: cause-chain probe classification, batching guards (#1071)
 
 Second review round on the 08-24 fixes; the transport-error fix (F4) did not survive contact with viem, and the new batching/zero-first code had gaps.

--- a/sdk/packages/simplex/docs/ai/Decisions.md
+++ b/sdk/packages/simplex/docs/ai/Decisions.md
@@ -4,6 +4,33 @@ AI-maintained record of non-obvious choices made in `sdk/packages/simplex`: what
 
 Entry format: heading with the decision, then alternatives considered and the reasoning. Newest first.
 
+## 2026-08-27 — Bid tenor is capped in the filler, because the account cannot cap it
+
+Chosen: `bidValiditySeconds` (default 300) is applied here, in `ContractInteractionService.bidValidUntil()`, and
+stamped into every bid. `SolverAccount` enforces that the expiry is *signed*, never that it is *sensible*.
+
+The split is forced, not stylistic. ERC-7562 bans the `TIMESTAMP` opcode during validation, so the account cannot
+compare `validUntil` against now; all it can do is bind the value to the signature and hand it to the EntryPoint.
+Whether 5 minutes or 30 days is appropriate is a pricing question anyway, and pricing lives here.
+
+300 seconds is chosen to comfortably cover the existing quote-to-fill path — cross-chain confirmation waits run to
+roughly 180s on the deepest default policies — while staying far below the window over which a quote on a volatile
+pair stops being one. It is deliberately not tied to `BID_TTL_MS` (the 1-hour Hyperbridge retraction sweep): that TTL
+governs reclaiming a deposit, this governs how long we are short an option, and an hour is far too long for the latter.
+
+Alternatives rejected:
+
+- *Derive it from the order's own deadline.* The deadline is placer-controlled with no ceiling — the very input this
+  is defending against.
+- *Reuse the 1-hour bid TTL.* Conflates deposit housekeeping with price risk, and 1h of free optionality on a naira
+  pair is worth real money.
+- *Per-pair tenors.* Correct in the long run — a stablecoin pair could safely carry a longer expiry than USDC/CNGN —
+  but a single conservative global default fixes the exposure now without adding a config surface to get wrong.
+
+The phantom-quote path gets the same stamp. Phantom bids are quotes rather than executable fills, so the expiry is
+mostly belt-and-braces there — but they are signed with the same key and the same nonce key, so there is no reason to
+leave one signed artefact unbounded.
+
 ## 2026-08-26 — Probe failures classified by cause chain; only zero allowances batch (#1147 review 2)
 
 Chosen: `paymasterSupportsPermit2` decides "unsupported" by walking the error's cause chain for `ContractFunctionRevertedError`/`ContractFunctionZeroDataError`, not by the thrown type. The 08-24 attempt checked `instanceof ContractFunctionExecutionError`, but viem wraps every `readContract` failure — transport errors included — in exactly that type (verified by constructing both failure shapes against the installed viem 2.47.6: a 429 arrives as `ContractFunctionExecutionError(cause: HttpRequestError)`, a revert as `ContractFunctionExecutionError(cause: ContractFunctionRevertedError)`). The thrown type therefore carries zero signal; the cause chain carries all of it. `ContractFunctionZeroDataError` counts as "unsupported" too: it means the address returned no data (no code), which is a deterministic contract-state answer, not a transport blip. Alternative — catching everything but only caching on a message-string match — rejected as brittle across RPC providers.

--- a/sdk/packages/simplex/docs/ai/Decisions.md
+++ b/sdk/packages/simplex/docs/ai/Decisions.md
@@ -6,17 +6,25 @@ Entry format: heading with the decision, then alternatives considered and the re
 
 ## 2026-08-27 — Bid tenor is capped in the filler, because the account cannot cap it
 
-Chosen: `bidValiditySeconds` (default 300) is applied here, in `ContractInteractionService.bidValidUntil()`, and
+Chosen: `bidValiditySeconds` (default 1800) is applied here, in `ContractInteractionService.bidValidUntil()`, and
 stamped into every bid. `SolverAccount` enforces that the expiry is *signed*, never that it is *sensible*.
 
 The split is forced, not stylistic. ERC-7562 bans the `TIMESTAMP` opcode during validation, so the account cannot
 compare `validUntil` against now; all it can do is bind the value to the signature and hand it to the EntryPoint.
 Whether 5 minutes or 30 days is appropriate is a pricing question anyway, and pricing lives here.
 
-300 seconds is chosen to comfortably cover the existing quote-to-fill path — cross-chain confirmation waits run to
-roughly 180s on the deepest default policies — while staying far below the window over which a quote on a volatile
-pair stops being one. It is deliberately not tied to `BID_TTL_MS` (the 1-hour Hyperbridge retraction sweep): that TTL
-governs reclaiming a deposit, this governs how long we are short an option, and an hour is far too long for the latter.
+1800 seconds is set by the selection window, not by the quote's shelf life. A bid is not consumed when it is signed —
+it sits in the coprocessor until the order placer selects a solver, and a bid that lapses before selection is simply
+lost revenue. `BID_TTL_MS` (the 1-hour retraction sweep) is the closest thing to a stated expectation for how long
+that takes, so an expiry has to be a decent fraction of an hour or the filler bids into the void. 30 minutes sits
+inside that window while still halving the worst case, and comfortably clears the quote-to-fill path itself, where
+cross-chain confirmation waits reach roughly 180s on the deepest default policies.
+
+The trade-off is real and worth stating plainly: 30 minutes of free optionality on a volatile pair is not nothing.
+The security property this fix delivers is that the option is now *bounded and priced by us* rather than unbounded and
+chosen by the placer — 1800 is a default, not a ceiling, and USDC/CNGN is exactly the pair to turn it down on. It is
+deliberately still shorter than `BID_TTL_MS`: that TTL governs reclaiming a deposit, this governs how long we are
+short an option, and the two should not be assumed to move together.
 
 Alternatives rejected:
 

--- a/sdk/packages/simplex/src/config/filler-toml.ts
+++ b/sdk/packages/simplex/src/config/filler-toml.ts
@@ -165,6 +165,17 @@ export interface FillerTomlConfig {
 		 * CCTP/USDT0-covered chains"); an empty array declares no accepted sources.
 		 */
 		acceptedSourceChains?: string[]
+		/**
+		 * How long a signed bid stays executable, in seconds. Defaults to 300.
+		 *
+		 * This is how long the quoted price is a firm commitment the placer can take up.
+		 * Nothing else bounds it: the order's `deadline` is chosen by the placer with no
+		 * upper limit, and retracting the bid on Hyperbridge has no effect on the
+		 * destination chain — so before this existed, every bid was executable forever and
+		 * the placer could sit on it until the rate moved in their favour. Set it to the
+		 * longest stale quote you are willing to honour; volatile pairs want less.
+		 */
+		bidValiditySeconds?: number
 	}
 	chains: UserProvidedChainConfig[]
 	rebalancing?: RebalancingConfig

--- a/sdk/packages/simplex/src/config/filler-toml.ts
+++ b/sdk/packages/simplex/src/config/filler-toml.ts
@@ -166,7 +166,7 @@ export interface FillerTomlConfig {
 		 */
 		acceptedSourceChains?: string[]
 		/**
-		 * How long a signed bid stays executable, in seconds. Defaults to 300.
+		 * How long a signed bid stays executable, in seconds. Defaults to 1800 (30 minutes).
 		 *
 		 * This is how long the quoted price is a firm commitment the placer can take up.
 		 * Nothing else bounds it: the order's `deadline` is chosen by the placer with no

--- a/sdk/packages/simplex/src/core/boot.ts
+++ b/sdk/packages/simplex/src/core/boot.ts
@@ -277,6 +277,7 @@ export async function bootFiller(config: FillerTomlConfig, options: BootOptions)
 		entryPointAddress: config.simplex.entryPointAddress,
 		rebalancing: config.rebalancing,
 		targetGasUnits: config.simplex.targetGasUnits,
+		bidValiditySeconds: config.simplex.bidValiditySeconds,
 		blockScanIntervalSeconds: config.simplex.blockScanIntervalSeconds,
 		gasFeeBump: config.simplex.gasFeeBump,
 		overfillProtection: config.simplex.overfillProtection,

--- a/sdk/packages/simplex/src/services/ContractInteractionService.ts
+++ b/sdk/packages/simplex/src/services/ContractInteractionService.ts
@@ -666,6 +666,7 @@ export class ContractInteractionService {
 			maxPriorityFeePerGas: cachedEstimate.maxPriorityFeePerGas,
 			callData,
 			paymasterAndData,
+			validUntil: this.bidValidUntil(),
 		})
 
 		// Encode the UserOp as bytes for submission to Hyperbridge
@@ -682,6 +683,23 @@ export class ContractInteractionService {
 		)
 
 		return { commitment, userOp: encodedUserOp }
+	}
+
+	/**
+	 * Expiry stamped into every bid this filler signs.
+	 *
+	 * A bid is a firm quote the placer can take up whenever they like, and nothing
+	 * else bounds that window — `order.deadline` is placer-chosen with no ceiling, and
+	 * retracting on Hyperbridge leaves the destination-chain signature untouched. An
+	 * unexpiring bid is therefore a free option on this filler's inventory, exercised
+	 * only when the rate has moved against us. This is the cap on that option's tenor.
+	 *
+	 * It has to be enforced here rather than in `SolverAccount`: ERC-7562 forbids the
+	 * TIMESTAMP opcode during validation, so the account can bind the expiry to the
+	 * signature but cannot judge whether it is a sane one.
+	 */
+	private bidValidUntil(): bigint {
+		return BigInt(Math.floor(Date.now() / 1000) + this.configService.getBidValiditySeconds())
 	}
 
 	/**
@@ -744,6 +762,7 @@ export class ContractInteractionService {
 							uniswapV4Positions: uniswapV4PositionIds?.map((id) => BigInt(id)),
 						})
 					: ("0x" as HexString),
+			validUntil: this.bidValidUntil(),
 		})
 
 		return { commitment, userOp: encodeUserOpScale(userOp) }

--- a/sdk/packages/simplex/src/services/FillerConfigService.ts
+++ b/sdk/packages/simplex/src/services/FillerConfigService.ts
@@ -144,7 +144,7 @@ export interface FillerConfig {
 	 */
 	targetGasUnits?: number
 	/**
-	 * Seconds a signed bid stays executable. Defaults to 300.
+	 * Seconds a signed bid stays executable. Defaults to 1800 (30 minutes).
 	 * See `bidValiditySeconds` in filler-toml for why this bound matters.
 	 */
 	bidValiditySeconds?: number
@@ -586,7 +586,7 @@ export class FillerConfigService {
 	}
 
 	/**
-	 * How long a signed bid remains executable, in seconds. Defaults to 300.
+	 * How long a signed bid remains executable, in seconds. Defaults to 1800 (30 minutes).
 	 *
 	 * A bid is a firm price the placer may take up at a moment of their choosing;
 	 * this is the only thing bounding that window, since the order deadline is
@@ -594,7 +594,7 @@ export class FillerConfigService {
 	 * destination chain.
 	 */
 	getBidValiditySeconds(): number {
-		return this.fillerConfig?.bidValiditySeconds ?? 300
+		return this.fillerConfig?.bidValiditySeconds ?? 1800
 	}
 
 	/** Ceiling bps above user-requested output. Default 500 (5%). */

--- a/sdk/packages/simplex/src/services/FillerConfigService.ts
+++ b/sdk/packages/simplex/src/services/FillerConfigService.ts
@@ -144,6 +144,11 @@ export interface FillerConfig {
 	 */
 	targetGasUnits?: number
 	/**
+	 * Seconds a signed bid stays executable. Defaults to 300.
+	 * See `bidValiditySeconds` in filler-toml for why this bound matters.
+	 */
+	bidValiditySeconds?: number
+	/**
 	 * Overfill protection knobs. If omitted, defaults are used
 	 * (maxOverfillBps=500, maxConsecutiveClamps=3).
 	 */
@@ -578,6 +583,18 @@ export class FillerConfigService {
 	 */
 	getTargetGasUnits(): bigint {
 		return BigInt(this.fillerConfig?.targetGasUnits ?? 3_000_000)
+	}
+
+	/**
+	 * How long a signed bid remains executable, in seconds. Defaults to 300.
+	 *
+	 * A bid is a firm price the placer may take up at a moment of their choosing;
+	 * this is the only thing bounding that window, since the order deadline is
+	 * placer-controlled and Hyperbridge-side retraction does not reach the
+	 * destination chain.
+	 */
+	getBidValiditySeconds(): number {
+		return this.fillerConfig?.bidValiditySeconds ?? 300
 	}
 
 	/** Ceiling bps above user-requested output. Default 500 (5%). */


### PR DESCRIPTION
A signed bid was valid forever. SolverAccount.validateUserOp returned SIG_VALIDATION_SUCCESS, which packs validUntil = 0, and ERC4337Utils expands 0 to BLOCK_RANGE_MASK. Nothing else bounded it: order.deadline is chosen by the order placer with no contract-side ceiling, and retract_bid on Hyperbridge does not reach the destination chain. Since the placer holds the session key, they alone decided when to exercise — a free option on solver inventory, taken up only once the rate had moved against the solver.

The selection signature is now 168 bytes
(commitment | validUntil | solverSig | sessionSig) and the solver signs an EIP-712 BidValidity(bytes32 userOpHash,uint48 validUntil) digest. The expiry must be inside the signed digest because userOpHash does not cover op.signature — an expiry carried alongside it could be rewritten by whoever replays the bid. validUntil == 0 is rejected, since zero is how the old unbounded behaviour is spelled.

The account binds the expiry but cannot judge it: ERC-7562 forbids the TIMESTAMP opcode during validation. Capping the tenor is therefore the signer's job, so simplex stamps every bid via bidValiditySeconds (default 300).
