### PR TITLE
[evm]: emit an OrderCancelled event from cancelOrder

### DIFF
--- a/.github/workflows/evm.yml
+++ b/.github/workflows/evm.yml
@@ -61,7 +61,12 @@ jobs:
             - name: Install Foundry
               uses: foundry-rs/foundry-toolchain@v1
               with:
-                  version: stable
+                  # Pinned, not `stable`. Foundry v1.8.0 (2026-08-27) probes `anvil_nodeInfo` to
+                  # determine an endpoint's network family; Alchemy answers that with HTTP 400, so
+                  # `vm.createFork` fails and every fork test in this workflow dies in `setUp`.
+                  # v1.7.1 is the last version this suite ran green on. Revert to `stable` once
+                  # upstream stops probing, or once the fork URL is a provider that answers it.
+                  version: v1.7.1
 
             - name: Run Forge build
               run: |
@@ -103,7 +108,12 @@ jobs:
             - name: Install Foundry
               uses: foundry-rs/foundry-toolchain@v1
               with:
-                  version: stable
+                  # Pinned, not `stable`. Foundry v1.8.0 (2026-08-27) probes `anvil_nodeInfo` to
+                  # determine an endpoint's network family; Alchemy answers that with HTTP 400, so
+                  # `vm.createFork` fails and every fork test in this workflow dies in `setUp`.
+                  # v1.7.1 is the last version this suite ran green on. Revert to `stable` once
+                  # upstream stops probing, or once the fork URL is a provider that answers it.
+                  version: v1.7.1
 
             - name: Install Rust toolchain
               uses: dtolnay/rust-toolchain@stable

--- a/docs/content/developers/evm/intent-gateway/cancelling-orders.mdx
+++ b/docs/content/developers/evm/intent-gateway/cancelling-orders.mdx
@@ -86,14 +86,25 @@ struct CancelOptions {
 
 `height` is only meaningful for source-side cross-chain cancels. It must point to a block after the order deadline, ensuring the proof captures a state where no fill could have occurred. The SDK selects this value automatically. For same-chain and destination-side cancels, `height` is ignored.
 
+### The `OrderCancelled` event
+
+```solidity
+// Emitted on whichever chain the cancellation was initiated from.
+event OrderCancelled(bytes32 indexed commitment, address canceller);
+```
+
+`cancelOrder` emits this once, before it routes to any of the three cancellation paths, so it fires the moment a cancellation is initiated whichever route handles it. Every route-specific check reverts, and a revert discards logs, so the event never announces a cancellation that did not happen. It is the only signal keyed to the order that a cross-chain cancel produces on the initiating chain; the host's `GetRequestEvent` and `PostRequestEvent` carry no reference to the order.
+
+`canceller` is `msg.sender`. On the destination route that need not be `order.user`: after the deadline anyone may cancel, so this is the only record of who did.
+
 ### The `EscrowRefunded` event
 
 ```solidity
 // Emitted on the source chain when escrowed tokens are returned to the user.
-event EscrowRefunded(bytes32 indexed commitment);
+event EscrowRefunded(bytes32 indexed commitment, TokenInfo[] tokens);
 ```
 
-For same-chain cancels, `EscrowRefunded` is emitted in the same transaction. For source-side cross-chain cancels, it is emitted once Hyperbridge delivers the destination proof back to the source chain and the refund is processed. For destination-side cancels, it is emitted on the source chain once the refund message from Hyperbridge is received and settled.
+`EscrowRefunded` remains the terminal event — `OrderCancelled` says a cancellation started, this one says the money is back. For same-chain cancels it follows in the same transaction. For source-side cross-chain cancels, it is emitted once Hyperbridge delivers the destination proof back to the source chain and the refund is processed. For destination-side cancels, it is emitted on the source chain once the refund message from Hyperbridge is received and settled.
 
 ## Set up the gateway, indexer, and wallets
 

--- a/docs/content/developers/evm/intent-gateway/overview.mdx
+++ b/docs/content/developers/evm/intent-gateway/overview.mdx
@@ -54,17 +54,19 @@ When the settlement message arrives on the source chain, the ISMP host calls `on
 1. Marks the order as filled (`_filled[commitment] = solver`)
 2. Transfers each escrowed input token to the solver
 3. Releases stored transaction fees (in fee token) to the solver
-4. Emits `EscrowReleased(commitment)`
+4. Emits `EscrowReleased(commitment, tokens)`
 
 ### Cancellation
 
 There are two modes for cross-chain cancellation:
 
+`cancelOrder` emits `OrderCancelled(commitment, canceller)` on the chain the cancellation is initiated from, before it routes to either path below. `EscrowRefunded` remains the terminal event, on the source chain, once the escrow is actually returned.
+
 **Cancel from source chain**: The user calls `cancelOrder()` on the source chain, which dispatches a `DispatchGet` storage read request to query the destination chain's fill status. The `CancelOptions.height` must be greater than `order.deadline` — this ensures the proof is taken from a block after the order has expired. A relayer processes this request on Hyperbridge by providing storage proofs from the destination chain. If the storage slot for `_filled[commitment]` is empty (order unfilled), Hyperbridge dispatches a response back to the source chain. The `onGetResponse` handler verifies the empty proof and calls `withdraw()` to refund the escrowed tokens to the user. If the order was filled, the response contains a non-empty value and the handler reverts with `Filled()`.
 
 ![Cancel from Source Chain](./images/intent-gateway-cancel-source.svg)
 
-**Cancel from destination chain**: Before the deadline, only the order owner can call `cancelOrder()` on the destination chain. After the deadline, anyone can cancel. The function marks the order as cancelled locally (`_filled[commitment] = user`) to prevent future fills, then dispatches a cross-chain `RefundEscrow` message back to the source chain. When the source chain receives this message via `onAccept()`, it calls `withdraw()` to refund the escrowed tokens to the user and emits `EscrowRefunded(commitment)`.
+**Cancel from destination chain**: Before the deadline, only the order owner can call `cancelOrder()` on the destination chain. After the deadline, anyone can cancel. The function marks the order as cancelled locally (`_filled[commitment] = user`) to prevent future fills, then dispatches a cross-chain `RefundEscrow` message back to the source chain. When the source chain receives this message via `onAccept()`, it calls `withdraw()` to refund the escrowed tokens to the user and emits `EscrowRefunded(commitment, tokens)`.
 
 ![Cancel from Destination Chain](./images/intent-gateway-cancel-dest.svg)
 

--- a/evm/src/apps/IntentGatewayV2.sol
+++ b/evm/src/apps/IntentGatewayV2.sol
@@ -467,6 +467,10 @@ contract IntentGatewayV2 is IntrinsicIntents, ExtrinsicIntents, ReentrancyGuardT
      *
      * Reverts if the order has already been filled or if called from the wrong chain.
      *
+     * Emits `OrderCancelled` on whichever chain the cancellation is initiated from. `EscrowRefunded`
+     * remains the terminal event: same transaction for a same-chain cancel, on the source chain
+     * after a Hyperbridge round trip for a cross-chain one.
+     *
      * @param order The order to cancel. Must match the exact order that was placed.
      * @param options Cancel options including proof height and relayer fee for cross-chain cancels.
      */
@@ -481,7 +485,19 @@ contract IntentGatewayV2 is IntrinsicIntents, ExtrinsicIntents, ReentrancyGuardT
         bytes32 orderDest = keccak256(order.destination);
         bool isSameChain = orderSource == orderDest;
 
+        // Emitted here, once, rather than from each of the three routes below. Every check those
+        // routes make — Unauthorized, NotExpired, UnknownOrder — reverts, and a revert discards
+        // logs, so an early emit can never announce a cancellation that did not happen. Emitting
+        // before the branch also keeps `EscrowRefunded` the last log on the same-chain route, where
+        // the refund is processed in this same transaction. Three emit sites cost bytecode this
+        // contract does not have: it sits within ~100 bytes of the EIP-170 limit.
+        emit OrderCancelled({commitment: commitment, canceller: msg.sender});
+
         if (isSameChain) {
+            // Checked here rather than inside `_cancelSameChain`, which used to re-read `host()`,
+            // re-query the host's state machine id and re-hash `order.source` to reach the same
+            // answer this function already has. Same check, one external call fewer.
+            if (currentChain != orderSource) revert WrongChain();
             _cancelSameChain(order, commitment);
         } else if (currentChain == orderSource) {
             _cancelFromSource(order, options, commitment);

--- a/evm/src/apps/intentsv2/ExtrinsicIntents.sol
+++ b/evm/src/apps/intentsv2/ExtrinsicIntents.sol
@@ -181,6 +181,9 @@ abstract contract ExtrinsicIntents is IntentsBase, HyperApp {
      * The GET response is handled by `onGetResponse`, which refunds the escrow if
      * the slot is indeed empty.
      *
+     * `cancelOrder` has already emitted `OrderCancelled`; the matching `EscrowRefunded` follows
+     * on this chain once the GET response returns through Hyperbridge.
+     *
      * @param order The order to cancel.
      * @param options Cancel options including the proof height and relayer fee.
      * @param commitment The keccak256 hash of the ABI-encoded order.
@@ -232,6 +235,11 @@ abstract contract ExtrinsicIntents is IntentsBase, HyperApp {
      * Marks the order as filled (to prevent future fill attempts) and dispatches a
      * RefundEscrow message via Hyperbridge to the source chain to release the escrowed
      * tokens back to the original user.
+     *
+     * `cancelOrder` has already emitted `OrderCancelled` on this chain — the only trace of the
+     * cancellation a solver watching this chain gets, since the host's `PostRequestEvent` carries
+     * no reference to the order. The matching `EscrowRefunded` follows on the source chain once
+     * Hyperbridge delivers the refund message.
      *
      * @param order The order to cancel.
      * @param options Cancel options including the relayer fee.

--- a/evm/src/apps/intentsv2/IntentsBase.sol
+++ b/evm/src/apps/intentsv2/IntentsBase.sol
@@ -284,6 +284,17 @@ abstract contract IntentsBase is EIP712 {
     event EscrowRefunded(bytes32 indexed commitment, TokenInfo[] tokens);
 
     /**
+     * @dev Emitted when an order's cancellation is initiated, on the chain it is initiated from.
+     * For same-chain orders the refund is processed in the same transaction and `EscrowRefunded`
+     * follows; for cross-chain orders `EscrowRefunded` follows on the source chain once the
+     * cancellation has travelled through Hyperbridge.
+     * @param commitment The order commitment hash.
+     * @param canceller The account that initiated the cancellation. The destination-side route is
+     * permissionless after expiry, so this is not necessarily the order's creator.
+     */
+    event OrderCancelled(bytes32 indexed commitment, address canceller);
+
+    /**
      * @dev Emitted when the gateway's configuration parameters are updated via governance.
      * @param previous The previous parameter values.
      * @param current The new parameter values.

--- a/evm/src/apps/intentsv2/IntrinsicIntents.sol
+++ b/evm/src/apps/intentsv2/IntrinsicIntents.sol
@@ -16,7 +16,6 @@ pragma solidity ^0.8.24;
 
 import {IntentsBase} from "./IntentsBase.sol";
 import {TokenInfo, Order, Params, WithdrawalRequest, FillOptions} from "@hyperbridge/core/apps/IntentGatewayV2.sol";
-import {IDispatcher} from "@hyperbridge/core/interfaces/IDispatcher.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
@@ -151,20 +150,19 @@ abstract contract IntrinsicIntents is IntentsBase {
     /**
      * @dev Cancels a same-chain order and refunds the remaining escrowed tokens to the user.
      *
-     * Only the original order creator (order.user) may cancel. Verifies the order
-     * was placed on this chain, collects all remaining escrow balances (which may be
-     * reduced by prior partial fills), and issues a full refund via `_withdraw`.
+     * Only the original order creator (order.user) may cancel. Collects all remaining escrow
+     * balances (which may be reduced by prior partial fills) and issues a full refund via
+     * `_withdraw`. `cancelOrder` is the only caller and has already established that this chain
+     * is the order's source.
+     *
+     * `cancelOrder` has already emitted `OrderCancelled`; the `EscrowRefunded` of this refund
+     * follows it in the same transaction.
      *
      * @param order The order to cancel.
      * @param commitment The keccak256 hash of the ABI-encoded order.
      */
     function _cancelSameChain(Order calldata order, bytes32 commitment) internal {
         if (order.user != bytes32(uint256(uint160(msg.sender)))) revert Unauthorized();
-
-        address hostAddr = host();
-        bytes32 currentChain = keccak256(IDispatcher(hostAddr).host());
-        bytes32 orderSource = keccak256(order.source);
-        if (orderSource != currentChain) revert WrongChain();
 
         uint256 inputsLen = order.inputs.length;
         TokenInfo[] memory remainingTokens = new TokenInfo[](inputsLen);

--- a/evm/tests/foundry/IntentGatewayV2SameChainTest.sol
+++ b/evm/tests/foundry/IntentGatewayV2SameChainTest.sol
@@ -380,6 +380,13 @@ contract IntentGatewayV2SameChainTest is MainnetForkBaseTest {
         vm.startPrank(user);
         CancelOptions memory cancelOpts = CancelOptions({height: uint64(block.number), relayerFee: 0});
 
+        // `OrderCancelled` announces the cancel, `EscrowRefunded` closes it — in that order,
+        // so a consumer applying statuses in log order settles on the refund.
+        vm.expectEmit(true, false, false, true, address(intentGateway));
+        emit IntentsBase.OrderCancelled(keccak256(abi.encode(order)), user);
+        vm.expectEmit(true, false, false, false, address(intentGateway));
+        emit IntentsBase.EscrowRefunded(keccak256(abi.encode(order)), inputs);
+
         intentGateway.cancelOrder(order, cancelOpts);
         vm.stopPrank();
 

--- a/evm/tests/foundry/IntentGatewayV2Test.sol
+++ b/evm/tests/foundry/IntentGatewayV2Test.sol
@@ -2032,6 +2032,10 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
 
         vm.startPrank(user);
         dai.approve(address(intentGateway), type(uint256).max);
+
+        vm.expectEmit(true, false, false, true, address(intentGateway));
+        emit IntentsBase.OrderCancelled(keccak256(abi.encode(order)), user);
+
         intentGateway.cancelOrder(order, cancelOptions);
         vm.stopPrank();
     }
@@ -2342,6 +2346,10 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
 
         vm.startPrank(user);
         dai.approve(address(intentGateway), type(uint256).max);
+
+        vm.expectEmit(true, false, false, true, address(intentGateway));
+        emit IntentsBase.OrderCancelled(commitment, user);
+
         intentGateway.cancelOrder(order, cancelOptions);
         vm.stopPrank();
 
@@ -2428,6 +2436,57 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         vm.stopPrank();
     }
 
+    function testCancelOrderFromSourceChainDispatchesGetRequest() public {
+        uint256 inputAmount = 1000 * 1e6;
+
+        TokenInfo[] memory inputs = new TokenInfo[](1);
+        inputs[0] = TokenInfo({token: bytes32(uint256(uint160(address(usdc)))), amount: inputAmount});
+
+        TokenInfo[] memory outputAssets = new TokenInfo[](1);
+        outputAssets[0] = TokenInfo({token: bytes32(uint256(uint160(address(dai)))), amount: 1000 * 1e18});
+
+        PaymentInfo memory output =
+            PaymentInfo({beneficiary: bytes32(uint256(uint160(user))), assets: outputAssets, call: ""});
+
+        // Cross-chain order placed here; this chain is the source.
+        Order memory order = Order({
+            user: bytes32(uint256(uint160(user))),
+            source: host.host(),
+            destination: bytes("DEST_CHAIN"),
+            deadline: block.number + 100,
+            nonce: 0,
+            fees: 0,
+            session: address(0),
+            predispatch: DispatchInfo({assets: new TokenInfo[](0), call: ""}),
+            inputs: inputs,
+            output: output
+        });
+
+        vm.startPrank(user);
+        usdc.approve(address(intentGateway), inputAmount);
+        intentGateway.placeOrder(order, bytes32(0));
+        vm.stopPrank();
+
+        vm.roll(block.number + 101);
+
+        bytes32 commitment = keccak256(abi.encode(order));
+        CancelOptions memory cancelOptions = CancelOptions({relayerFee: 1 ether, height: uint64(order.deadline + 1)});
+
+        // The GET dispatch is the only other trace this route leaves, and it carries no
+        // reference to the order — `OrderCancelled` is what keys the cancel to a commitment.
+        vm.expectCall(
+            address(host), abi.encodeWithSignature("dispatch((bytes,uint64,bytes[],uint64,uint256,bytes,address))")
+        );
+        vm.expectEmit(true, false, false, true, address(intentGateway));
+        emit IntentsBase.OrderCancelled(commitment, user);
+
+        vm.prank(user);
+        intentGateway.cancelOrder{value: 0.1 ether}(order, cancelOptions);
+
+        // Escrow is untouched until the GET response comes back through `onGetResponse`.
+        assertEq(intentGateway._orders(commitment, address(usdc)), inputAmount, "Escrow should still be held");
+    }
+
     function testCancelOrderFromWrongChainFails() public {
         uint256 inputAmount = 1000 * 1e6;
 
@@ -2460,6 +2519,41 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         vm.expectRevert(IntentsBase.WrongChain.selector);
         intentGateway.cancelOrder(order, cancelOptions);
         vm.stopPrank();
+    }
+
+    function testCancelSameChainOrderBelongingToAnotherChainFails() public {
+        uint256 inputAmount = 1000 * 1e6;
+
+        TokenInfo[] memory inputs = new TokenInfo[](1);
+        inputs[0] = TokenInfo({token: bytes32(uint256(uint160(address(usdc)))), amount: inputAmount});
+
+        TokenInfo[] memory outputAssets = new TokenInfo[](1);
+        outputAssets[0] = TokenInfo({token: bytes32(uint256(uint160(address(dai)))), amount: 1000 * 1e18});
+
+        PaymentInfo memory output =
+            PaymentInfo({beneficiary: bytes32(uint256(uint160(user))), assets: outputAssets, call: ""});
+
+        // Same-chain order (source == destination), but for a chain that is not this one. The
+        // same-chain route is selected on `source == destination` alone, so without this check a
+        // foreign order would reach `_cancelSameChain` and be refunded against escrow held here.
+        Order memory order = Order({
+            user: bytes32(uint256(uint160(user))),
+            source: bytes("SOURCE_CHAIN"),
+            destination: bytes("SOURCE_CHAIN"),
+            deadline: block.number + 100,
+            nonce: 0,
+            fees: 0,
+            session: address(0),
+            predispatch: DispatchInfo({assets: new TokenInfo[](0), call: ""}),
+            inputs: inputs,
+            output: output
+        });
+
+        CancelOptions memory cancelOptions = CancelOptions({relayerFee: 0, height: 0});
+
+        vm.prank(user);
+        vm.expectRevert(IntentsBase.WrongChain.selector);
+        intentGateway.cancelOrder(order, cancelOptions);
     }
 
     function testRefundEscrowOnSourceChainAfterDestinationCancellation() public {
@@ -2598,6 +2692,11 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         // Anyone (filler) can cancel after expiry
         vm.startPrank(filler);
         dai.approve(address(intentGateway), type(uint256).max);
+
+        // `canceller` is msg.sender, which on this route need not be the order's creator.
+        vm.expectEmit(true, false, false, true, address(intentGateway));
+        emit IntentsBase.OrderCancelled(commitment, filler);
+
         intentGateway.cancelOrder(order, cancelOptions);
         vm.stopPrank();
 

--- a/sdk/packages/core/contracts/apps/IntentGatewayV2.sol
+++ b/sdk/packages/core/contracts/apps/IntentGatewayV2.sol
@@ -227,6 +227,13 @@ interface IIntentGatewayV2 {
     /// @notice Thrown when an action is attempted on an unknown order.
     error UnknownOrder();
 
+    /// @notice Thrown when the cross-chain peer is unknown.
+    error UnknownInstance();
+
+    /// @notice Thrown when a solver attempts to partially fill an order that carries output
+    ///         calldata. Such orders must be filled completely in a single fill.
+    error PartialFillNotAllowed();
+
     // ============================================
     // Events
     // ============================================
@@ -266,23 +273,48 @@ interface IIntentGatewayV2 {
     );
 
     /**
-     * @notice Emitted when an order is filled.
+     * @notice Emitted when an order is fully filled.
      * @param commitment The unique identifier of the order
      * @param filler The address of the entity that filled the order
+     * @param outputs The output token amounts provided by the filler
+     * @param inputs The escrowed input tokens released to the filler
      */
-    event OrderFilled(bytes32 indexed commitment, address filler);
+    event OrderFilled(bytes32 indexed commitment, address filler, TokenInfo[] outputs, TokenInfo[] inputs);
 
     /**
-     * @notice Emitted when an escrow is released.
+     * @notice Emitted when an order is partially filled. Only same-chain orders
+     *         support incremental fills.
      * @param commitment The unique identifier of the order
+     * @param filler The address of the entity that provided this partial fill
+     * @param outputs The output token amounts provided in this fill
+     * @param inputs The proportional escrowed input tokens released to the filler
      */
-    event EscrowReleased(bytes32 indexed commitment);
+    event PartialFill(bytes32 indexed commitment, address filler, TokenInfo[] outputs, TokenInfo[] inputs);
 
     /**
-     * @notice Emitted when an escrow is refunded.
+     * @notice Emitted when an order's cancellation is initiated, on the chain it is
+     *         initiated from. `EscrowRefunded` remains the terminal event: it follows in
+     *         the same transaction for a same-chain cancel, and on the source chain once
+     *         the cancellation has travelled through Hyperbridge for a cross-chain one.
      * @param commitment The unique identifier of the order
+     * @param canceller The account that initiated the cancellation. The destination-side
+     *        route is permissionless after expiry, so this is not necessarily the creator.
      */
-    event EscrowRefunded(bytes32 indexed commitment);
+    event OrderCancelled(bytes32 indexed commitment, address canceller);
+
+    /**
+     * @notice Emitted when an escrow is released to the filler.
+     * @param commitment The unique identifier of the order
+     * @param tokens The tokens and amounts released
+     */
+    event EscrowReleased(bytes32 indexed commitment, TokenInfo[] tokens);
+
+    /**
+     * @notice Emitted when an escrow is refunded to the original user.
+     * @param commitment The unique identifier of the order
+     * @param tokens The tokens and amounts refunded
+     */
+    event EscrowRefunded(bytes32 indexed commitment, TokenInfo[] tokens);
 
     /**
      * @notice Emitted when parameters are updated.
@@ -292,11 +324,11 @@ interface IIntentGatewayV2 {
     event ParamsUpdated(Params previous, Params current);
 
     /**
-     * @notice Emitted when a new deployment is added.
-     * @param stateMachineId The state machine identifier
-     * @param gateway The gateway identifier
+     * @notice Emitted when a gateway instance is registered for a remote state machine.
+     * @param chain The state machine identifier for the new deployment
+     * @param gateway The address of the deployed gateway on that chain
      */
-    event NewDeploymentAdded(bytes stateMachineId, address gateway);
+    event DeploymentAdded(string chain, address gateway);
 
     /**
      * @notice Emitted when dust is collected.
@@ -312,6 +344,13 @@ interface IIntentGatewayV2 {
      * @param beneficiary The beneficiary of the funds
      */
     event DustSwept(address token, uint256 amount, address beneficiary);
+
+    /**
+     * @notice Emitted when a destination-specific protocol fee override is set via governance.
+     * @param chain The destination state machine identifier
+     * @param feeBps The protocol fee in basis points for orders targeting this destination
+     */
+    event DestinationProtocolFeeUpdated(string chain, uint256 feeBps);
 
     // ============================================
     // Constants

--- a/sdk/packages/core/docs/ai/ChangeLog.md
+++ b/sdk/packages/core/docs/ai/ChangeLog.md
@@ -1,0 +1,36 @@
+# ChangeLog
+
+AI-maintained log of code changes in `sdk/packages/core`. Every AI-assisted change appends an entry here: date, what changed, and the files touched. This is not the release changelog — `sdk/packages/core/CHANGELOG.md` is the published release log and is managed separately.
+
+Entry format:
+
+```
+## YYYY-MM-DD — short title (issue/PR if any)
+What changed and why, in a few sentences.
+Files: list of files touched.
+```
+
+Newest entries first.
+
+## 2026-08-27 — `IIntentGatewayV2` brought back in sync with the gateway (#1160)
+
+`IIntentGatewayV2` had drifted from the deployed `IntentGatewayV2`. Every declaration in the
+interface is now identical to the one in `evm/src/apps/intentsv2/IntentsBase.sol`, verified by
+diffing the two declaration sets:
+
+- `OrderFilled`, `EscrowReleased` and `EscrowRefunded` were still the pre-`tokens` signatures. All
+  three take a `TokenInfo[]` the interface did not declare.
+- `NewDeploymentAdded(bytes stateMachineId, address gateway)` does not exist. The gateway emits
+  `DeploymentAdded(string chain, address gateway)` — wrong name and wrong parameter type, so a
+  consumer filtering on it would have matched nothing.
+- `PartialFill`, `DestinationProtocolFeeUpdated`, and the `UnknownInstance` and
+  `PartialFillNotAllowed` errors were absent.
+- `OrderCancelled(bytes32 indexed commitment, address canceller)` was added, the event this issue
+  introduces on the gateway.
+
+Nothing else in the repo compiles against these declarations — `SolverAccount.sol` imports the
+interface only for `select.selector` and `fillOrder.selector` — so the change is inert here and
+matters to integrators who read the interface as the gateway's published surface.
+
+Files: `contracts/apps/IntentGatewayV2.sol`, `package.json`, `docs/ai/ChangeLog.md`,
+`docs/ai/Decisions.md`, `docs/ai/Flow.md`.

--- a/sdk/packages/core/docs/ai/Decisions.md
+++ b/sdk/packages/core/docs/ai/Decisions.md
@@ -1,0 +1,32 @@
+# Decisions
+
+AI-maintained record of non-obvious choices made in `sdk/packages/core`: what was decided, what the alternatives were, and why. Read this before changing related code so a later change does not silently undo a deliberate trade-off.
+
+Entry format: heading with the decision, then alternatives considered and the reasoning. Newest first.
+
+## 2026-08-27 — `NewDeploymentAdded` was renamed rather than kept for compatibility
+
+Chosen: the interface's `NewDeploymentAdded(bytes stateMachineId, address gateway)` was replaced
+with the gateway's actual `DeploymentAdded(string chain, address gateway)`.
+
+Renaming a declaration in a published interface normally breaks consumers. It does not here,
+because there is nothing to break: no deployed gateway has ever emitted `NewDeploymentAdded`, so
+anyone filtering on that topic has been matching zero logs. Keeping it would preserve a name that
+only ever produces silence, next to the real one.
+
+Alternative rejected — declare both. The interface would then advertise an event the contract
+cannot emit, which is the state that caused this in the first place.
+
+## 2026-08-27 — Declarations here are kept identical to `IntentsBase`, not merely compatible
+
+Chosen: every event and error in `IIntentGatewayV2` matches `evm/src/apps/intentsv2/IntentsBase.sol`
+exactly — same name, same parameter types, same `indexed` flags.
+
+Nothing compiles against these declarations (`SolverAccount.sol` uses the interface only for two
+function selectors), so a mismatch produces no build error anywhere in the repo. That is exactly
+why the drift went unnoticed through several signature changes. The only thing that can catch it
+is the rule that the two lists are equal, which is cheap to check by diffing them.
+
+Alternative rejected — declare only the subset integrators are expected to use. It sounds tidier,
+but it makes "missing from the interface" ambiguous: you cannot tell a deliberate omission from
+another four events nobody updated.

--- a/sdk/packages/core/docs/ai/Flow.md
+++ b/sdk/packages/core/docs/ai/Flow.md
@@ -1,0 +1,25 @@
+# Flow
+
+AI-maintained map of how code paths in `sdk/packages/core` actually execute, so that when something breaks you can tell whether the fault is upstream or downstream of where the symptom appears. Only flows that have been read and verified are documented; coverage grows as areas of the package are touched.
+
+## What `IIntentGatewayV2` is, and what actually reads it
+
+`contracts/apps/IntentGatewayV2.sol` is a declaration-only file: structs, errors, events, and
+external function signatures. There is no implementation of `IIntentGatewayV2` in this package —
+the gateway lives at `evm/src/apps/IntentGatewayV2.sol` and inherits its events and errors from
+`evm/src/apps/intentsv2/IntentsBase.sol`.
+
+Two consumers, and they use it very differently:
+
+1. **`evm/src/apps/intentsv2/SolverAccount.sol`** imports it and reads exactly two things:
+   `IIntentGatewayV2.select.selector` and `IIntentGatewayV2.fillOrder.selector`. It resolves via the
+   `@hyperbridge/core/` remapping in `evm/remappings.txt`, which points at
+   `node_modules/@hyperbridge/core/contracts/` — a workspace symlink, so an edit here is picked up
+   by `forge build` in `evm/` with no publish step. Only the two function signatures matter to it.
+2. **Integrators**, who read the file as the gateway's published ABI surface. Everything else in it
+   — the events especially — exists for them alone.
+
+That split is the whole reason the events drift: nothing in the repo compiles against them, so a
+wrong signature is silent locally and only wrong for whoever depends on the package. The
+declaration lists in this file and in `IntentsBase.sol` are kept identical; diffing them is the
+only check that exists.

--- a/sdk/packages/core/package.json
+++ b/sdk/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/core",
-	"version": "2.3.1",
+	"version": "2.3.2",
 	"description": "Hyperbridge Solidity SDK for dispatching & receiving cross-chain messages",
 	"author": "Polytope Labs <hello@polytope.technology>",
 	"license": "Apache-2.0",


### PR DESCRIPTION
Refs #1160 — the contract side only. The consumers the issue also describes (indexer, SDK, simplex) follow separately, once the gateway upgrade is live and the event is actually being emitted on chain.

Carries an unrelated CI fix as its own commit; see the last section.

`cancelOrder` emitted nothing. The only event in the whole cancellation lifecycle was `EscrowRefunded`, which fires when the refund lands on the source chain — the same transaction for a same-chain cancel, a Hyperbridge round trip later for a cross-chain one. A cross-chain order cancelled from the destination was therefore indistinguishable from an open one for the whole trip, and forever if its refund message got stuck.

## The event

`IntentsBase` gains:

```solidity
event OrderCancelled(bytes32 indexed commitment, address canceller);
```

emitted **once**, from `cancelOrder`, before it routes to any of the three cancellation paths. Every route-specific check (`Unauthorized`, `NotExpired`, `UnknownOrder`, `WrongChain`) reverts, and a revert discards logs, so an early emit can never announce a cancellation that did not happen. Emitting before the branch also keeps `EscrowRefunded` the last log on the same-chain route, where the refund is processed in the same transaction.

`canceller` is `msg.sender`. On the destination route that need not be the order's creator: cancelling is permissionless after expiry, so this is the only record of who did it.

`EscrowRefunded` remains the terminal event, and the completion paths (`onGetResponse`, `onAccept` with `RefundEscrow`) are untouched. Additive ABI change on a contract that upgrades through cross-chain governance, so this is an implementation upgrade with no redeploy.

## The gateway is at the EIP-170 ceiling

Worth knowing independently of this PR. On main:

| Contract | Runtime size | Margin |
|---|---|---|
| `IntentGatewayV2` | 24,502 | 74 |
| `IntentGatewayV2Upgraded` (test fixture) | 24,541 | 35 |

35 bytes is the real budget, because `forge build --sizes` in CI covers test contracts and that fixture is an `IntentGatewayV2` subclass. One emit costs 36; three cost 150. The first version of this PR emitted from all three routes and failed CI at −76.

So the emit was consolidated to one site, and the bytes were bought back where they were being wasted: `_cancelSameChain` was re-reading `host()`, re-querying the host's state machine id and re-hashing `order.source` to reach a `WrongChain` answer that `cancelOrder` — its only caller — had already computed. That check moved up into `cancelOrder`. Net result, with the event added:

| Contract | Runtime size | Margin | vs main |
|---|---|---|---|
| `IntentGatewayV2` | 24,451 | 125 | **−51** |
| `IntentGatewayV2Upgraded` | 24,490 | 86 | −51 |

It also drops an external call from every same-chain cancel.

Two things to flag on that change:

- The relocated check had **no test coverage**. It does now (`testCancelSameChainOrderBelongingToAnotherChainFails`), and I verified it fails when the check is removed rather than passing vacuously — without it a same-chain order belonging to another chain reaches `_cancelSameChain` and reverts `UnknownOrder` instead.
- Behavioural nuance: a caller who is both unauthorized *and* on the wrong chain now gets `WrongChain` where it previously got `Unauthorized`. Both revert; the precedence was never a documented guarantee.

## Interface drift

`IIntentGatewayV2` in `@hyperbridge/core` had drifted from the deployed gateway; every declaration now matches `IntentsBase` exactly (verified by diffing the two declaration sets). Beyond adding `OrderCancelled`:

- `OrderFilled`, `EscrowReleased` and `EscrowRefunded` were still the pre-`tokens` signatures.
- `NewDeploymentAdded(bytes stateMachineId, address gateway)` does not exist — the gateway emits `DeploymentAdded(string chain, address gateway)`, so anyone filtering on that topic was matching zero logs.
- `PartialFill`, `DestinationProtocolFeeUpdated`, `UnknownInstance` and `PartialFillNotAllowed` were absent.

Nothing in the repo compiles against these declarations (`SolverAccount.sol` uses the interface only for two function selectors), which is exactly why the drift went unnoticed.

## Docs

`cancelling-orders.mdx` and `overview.mdx`. Both also documented `EscrowRefunded` and `EscrowReleased` without their `tokens` field.

## Tests

`vm.expectEmit` on each route. Same-chain pins both events *and their order*; the destination route pins the canceller as the relayer, not the user, on the post-expiry path. Two tests added for paths that had no coverage at all: the source-side cross-chain cancel, and the same-chain `WrongChain` check.

`forge build --sizes` passes. `forge test --match-path "tests/foundry/IntentGatewayV2*.sol"`: 120 passed, 0 failed. Full CI suite: 369 passed, 0 failed, 20 skipped.

## Second commit: pinning foundry (unrelated)

`evm.yml` asked for `version: stable`, which is a channel, not a pin. Foundry v1.8.0 was published at 12:30 today and `stable` took it immediately:

| Run | forge | Result |
|---|---|---|
| main `84730100a`, 10:00 | 1.7.1 | ✅ |
| anything after 12:30 | 1.8.0 | ❌ |

1.8.0 probes `anvil_nodeInfo` to determine an endpoint's network family; Alchemy answers with HTTP 400, so `vm.createFork` cannot instantiate and every fork test dies in `setUp` — 13 suites with nothing in common. Both jobs in `evm.yml` are pinned to v1.7.1, the last version this suite ran green on. The `nightly` workflows are left alone; they are on a moving version deliberately and are passing.

This unblocks every EVM pull request, not just this one. It is a workaround with a shelf life — the in-file comment names both exits (upstream stops probing, or `MAINNET_FORK_URL` moves to a provider that answers it) so v1.7.1 does not quietly become permanent. Kept as a separate commit so it can be cherry-picked or reverted on its own.

## Releases

`core` 2.3.2. `@hyperbridge/sdk` and `@hyperbridge/simplex` are untouched.
