### PR TITLE
[crates]: republish crypto-utils, the last stale 2512 pin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-utils"
-version = "0.3.0"
+version = "2606.0.0"
 dependencies = [
  "anyhow",
  "parity-scale-codec",
@@ -15452,7 +15452,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-ismp"
-version = "2606.0.0"
+version = "2606.1.0"
 dependencies = [
  "anyhow",
  "crypto-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -250,14 +250,14 @@ ibc-proto = { version = "0.52.0", default-features = false, package = "ibc-proto
 # published crates
 ismp = { version = "2606.1.0", path = "./modules/ismp/core", default-features = false }
 serde-hex-utils = { version = "0.2.0", path = "modules/utils/serde", default-features = false }
-crypto-utils = { version = "0.3.0", path = "modules/utils/crypto", default-features = false }
+crypto-utils = { version = "2606.0.0", path = "modules/utils/crypto", default-features = false }
 bls-utils = { path = "modules/utils/bls-utils", default-features = false }
 grandpa-verifier-primitives = { version = "2606.0.0", path = "./modules/consensus/grandpa/primitives", default-features = false }
 grandpa-verifier = { version = "2606.0.0", path = "./modules/consensus/grandpa/verifier", default-features = false }
 ismp-grandpa = { version = "2606.0.0", path = "./modules/ismp/clients/grandpa", default-features = false }
 ismp-parachain = { version = "2606.0.0", path = "./modules/ismp/clients/parachain/client", default-features = false }
 ismp-parachain-runtime-api = { version = "2606.0.0", path = "./modules/ismp/clients/parachain/runtime-api", default-features = false }
-pallet-ismp = { version = "2606.0.0", path = "modules/pallets/ismp", default-features = false }
+pallet-ismp = { version = "2606.1.0", path = "modules/pallets/ismp", default-features = false }
 pallet-ismp-rpc = { version = "2606.0.0", path = "modules/pallets/ismp/rpc" }
 pallet-ismp-runtime-api = { version = "2606.0.0", path = "modules/pallets/ismp/runtime-api", default-features = false }
 pallet-bandwidth = { path = "modules/pallets/bandwidth", default-features = false }

--- a/modules/pallets/ismp/Cargo.toml
+++ b/modules/pallets/ismp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-ismp"
-version = "2606.0.0"
+version = "2606.1.0"
 edition = "2021"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 license = "Apache-2.0"

--- a/modules/utils/crypto/Cargo.toml
+++ b/modules/utils/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-utils"
-version = "0.3.0"
+version = "2606.0.0"
 edition = "2021"
 authors = ["Polytope Labs <hello@polytope.technology>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Follow-up to #1174, which fixed #1172 but not completely.

## What #1174 missed

#1174 unified the `polkadot-sdk` umbrella, and it did. From a clean project, `pallet-ismp = "2606.0.0"` plus `ismp-grandpa = "2606.0.0"` now resolves a single `polkadot-sdk 2606.0.0`, with `sp-runtime` and `frame-support` collapsed to one version each.

But the reporter's actual symptom is still there. `sp-core` and `sp-io` remain doubled:

```
sp-core   39.0.0  + 43.0.0
sp-io     44.0.0  + 48.0.0
```

That's the `duplicate lang item in sp_io` from #1172, still reproducible after the republish.

## Cause

Same bug, one crate over. Published `crypto-utils 0.3.0` requires `sp-core ^39.0.0` and `sp-io ^44.0.0`. The workspace moved to `43.0.0` and `48.0.0` in #1062, so the artifact on crates.io carries requirements its own source no longer has, under the same version number. `pallet-ismp` depends on it, so it reaches everyone.

Two reasons it survived the last fix:

- **It doesn't depend on the umbrella.** `crypto-utils` depends on the standalone `sp-core` and `sp-io` crates directly, so it never showed up when I looked for crates depending on `polkadot-sdk`.
- **It uses `^`, not `=`.** So rather than failing to resolve — which is loud — it silently duplicates.

I swept all 15 released crates' published requirements against the workspace's current ones. `crypto-utils` is the last stale artifact; everything else is consistent.

## Changes

- `crypto-utils` `0.3.0` → `2606.0.0`
- `pallet-ismp` `2606.0.0` → `2606.1.0`

## Why CalVer, and why not a patch bump

**CalVer** for the same reason `ismp-abi` and `beefy-verifier-primitives` moved there in #1174: the crate is pinned to an SDK line, so its version should say which one. `serde-hex-utils` stays on semver because it has no SDK dependency at all — that's the line between the two schemes, and `crypto-utils` was on the wrong side of it.

I originally scoped this as `0.4.0`. `2606.0.0` is the same fix and satisfies the same hard constraint below, but it also removes the anomaly rather than preserving it.

**Not a patch bump**, and this is the constraint that matters: `pallet-ismp 2512.2.0` and `2606.0.0` *both* require `crypto-utils ^0.3.0`. A `0.3.1` would be picked up by the 2512 line as well, dragging the 2606-era `sp-*` requirements onto it and breaking a line that resolves cleanly today. `2606.0.0` does not match `^0.3.0`, so 2512 is untouched.

**`pallet-ismp` has to be bumped too.** The published `2606.0.0` is immutable and pins `crypto-utils ^0.3.0`, so without a bump the new version never reaches anyone. Nothing downstream needs republishing — `ismp-grandpa`, `ismp-parachain`, `substrate-state-machine`, `pallet-ismp-rpc`, `pallet-ismp-runtime-api` and `pallet-hyper-fungible-token` all require `pallet-ismp ^2606.0.0` and pick up `2606.1.0` on their own.

## Publishing

`crypto-utils` first, then `pallet-ismp`. Both are already in `scripts/release-crates.sh`.

## Verification

- `cargo check` passes for `crypto-utils` and `pallet-ismp`
- lockfile updates cleanly, exactly 2 packages changed, single `sp-core 43.0.0`, `sp-io 48.0.0` and `polkadot-sdk 2606.0.0`
- reproduced the remaining `sp-core`/`sp-io` duplication against the live index, post-#1174

Full workspace build left to CI.
