### PR TITLE
[indexer, sdk]: Decode phantom bids of either fillOrder shape

### DIFF
--- a/sdk/packages/indexer/docs/ai/ChangeLog.md
+++ b/sdk/packages/indexer/docs/ai/ChangeLog.md
@@ -12,6 +12,33 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-08-28 — Decode phantom bids of either `fillOrder` shape
+
+`extractFillDataVm2` built one ethers `Interface` from `FILL_ORDER_ABI`. When `FillOptions` gained `validUntil`
+that ABI moved to the v2 shape, and since ethers validates the selector before decoding, every v1-shaped bid
+started throwing. The throw was swallowed by a `continue`, the function returned null, and `aggregatePhantomBids`
+drops a null bid with no log line — so the loss was silent.
+
+That is not a future risk: `@hyperbridge/sdk` is a `workspace:*` dependency, so the indexer picked up the v2 ABI
+immediately, while every mainnet gateway still runs the pre-`validUntil` implementation. `getFillOptionsVersion`
+therefore returns 1 and simplex encodes v1 bids, all of which were being discarded — no bidder rows, no median,
+no pool-rate snapshot from any of them.
+
+Now tries both shapes, mirroring the SDK's `decodeFillOrder`. The selectors differ (`0x5cfb1ea5` vs
+`0xa5470064`), so neither can mis-decode the other's payload. The v1 ABI is imported from the SDK rather than
+re-declared here, so the two cannot drift apart again.
+
+Verified by running the real function against both shapes: before the change v1 returned null and v2 decoded;
+after, both decode, and a wrong target or non-`fillOrder` calldata still returns null.
+
+Also adds `transformIgnorePatterns` to the jest config. The SDK's CJS bundles `require()` ESM-only packages
+(`p-queue` -> `eventemitter3`/`p-timeout`, `lodash-es`), which jest cannot parse untransformed, so *any* test
+importing `@hyperbridge/sdk` or its `intents-helpers` sub-path failed to load at all against a freshly built SDK.
+That was blocking the new test, and it was also silently keeping the existing `phantom-decode.test.ts` from
+running — that file passes again now.
+
+Files: `src/utils/phantom-decode.ts`, `src/utils/__tests__/phantom-decode.fill.test.ts`, `jest.config.ts`.
+
 ## 2026-08-19 — Pool rates renormalize by the leg's own standard amount
 
 `resolvePoolLeg` used to require `standardAmount === 10 ** inputDecimals` exactly, and `updateLiquidityPools` derived a chain sample as `medianPrice * scale`, which silently assumes that same one-unit probe. Both now work for whatever standard amount the phantom order carries: the rate is `medianPrice * scale * 10 ** inDecimals / standardAmount`, exact for any probe size, whole-token or not, and it collapses to the old expression when the probe is one unit. Verified against production: the four live one-unit rates (Base cNGN/USDC both directions, BSC cNGN/USDT both directions) reproduce byte-for-byte, and a 1000x probe with a 1000x quote yields the identical rate.

--- a/sdk/packages/indexer/docs/ai/Decisions.md
+++ b/sdk/packages/indexer/docs/ai/Decisions.md
@@ -4,6 +4,29 @@ AI-maintained record of non-obvious choices made in `sdk/packages/indexer`: what
 
 Entry format: heading with the decision, then alternatives considered and the reasoning. Newest first.
 
+## 2026-08-28 — The VM2 decoder tries both `fillOrder` shapes, and the new test avoids the SDK root import
+
+Alternatives to trying both shapes:
+
+- **Track the gateway's version and pick one.** That is what `getFillOptionsVersion` does for *encoding*, where
+  you must choose. Decoding has no such constraint: the selectors differ, so attempting both is unambiguous and
+  needs no chain state, no RPC read, and no cache — all of which the SubQuery sandbox makes awkward.
+- **Decode by selector lookup.** Equivalent in effect, more code, and it would duplicate the selector constants
+  that the ABIs already encode.
+
+Trying v2 then v1 mirrors `decodeFillOrder` exactly, which is the point: the two implementations of this decode
+diverged once already, and keeping them structurally identical is what makes the next divergence visible.
+
+The regression test lives in its own file, `phantom-decode.fill.test.ts`, importing only the `intents-helpers`
+sub-path. The sibling `phantom-decode.test.ts` also imports `@hyperbridge/sdk` root for `CryptoUtils`, which is
+not available on the sub-path. Splitting keeps the new test on exactly the entry point the indexer uses at
+runtime, so it exercises the same module graph the sandbox loads.
+
+The jest `transformIgnorePatterns` addition names the ESM-only packages explicitly rather than transforming all of
+`node_modules`. The broad form is slower and pulls unrelated packages through ts-jest; the explicit list fails
+loudly (an unparsed `export`) if the SDK's dependency graph grows another ESM-only package, which is the right
+failure mode — silence here is what let the tests stop running unnoticed.
+
 ## 2026-08-19 — The standard-amount check bounds plausibility instead of pinning one unit
 
 Chosen: `resolvePoolLeg` accepts any standard amount within a plausibility window around one whole input token, and `updateLiquidityPools` renormalizes the rate by the leg's own standard amount. The pallet is then free to raise the probe size to buy quote precision without the indexer rescaling every published rate by that factor.

--- a/sdk/packages/indexer/docs/ai/Flow.md
+++ b/sdk/packages/indexer/docs/ai/Flow.md
@@ -47,3 +47,23 @@ Verified 2026-08-19 against live mainnet data.
 5. Chain rows (`PoolChainLiquidity`, one per pool/chain/direction) are merged into the pool's single `sellRate`/`buyRate` by `weightedRate` — a depth-weighted **mean**, which unlike the median in step 3 does produce values no filler quoted. Samples older than `MAX_SAMPLE_AGE_BLOCKS` are excluded unless every sample is stale.
 
 Precision note: a leg's quoted output integer *is* the price, to whatever resolution the output token's decimals allow. cNGN into 6-decimal USDC quotes ~715 base units, so the grid is 1/715 = 0.14% and the filler's floor rounding costs up to one full step. Chains whose output token has 18 decimals carry full precision on the same leg — which is why EVM-56 publishes `716845878136200` where Base publishes a bare `715`. The fix is a larger `standardAmount`, which step 4 now supports; see Decisions.md for why the filler's flooring must stay.
+
+## Phantom bid calldata decoding (`extractFillDataVm2`)
+
+Verified by executing the function against both shapes; the selector check is what makes the two-interface
+attempt necessary.
+
+1. `handlePhantomOrderPrices.handler.ts` injects `extractFillDataVm2` into `aggregatePhantomBids` as
+   `extractFill`. The SDK's own `extractFillData` is not used here: it decodes with viem, whose byte handling
+   throws inside SubQuery's VM2 sandbox.
+2. A bid's `callData` is the solver account's ERC-7821 `execute(mode, executionData)` batch. The batch is decoded,
+   and each call whose `target` is the gateway is a `fillOrder` candidate.
+3. `decodeFillOrderEither` tries the v2 interface (`FILL_ORDER_ABI`, with `validUntil`, selector `0xa5470064`)
+   and then the v1 one (`FILL_ORDER_V1_ABI`, selector `0x5cfb1ea5`). ethers validates the selector before
+   decoding, so exactly one can match and there is no payload that could be mis-decoded as the other shape.
+   Which one a bid carries depends on the gateway it targets — solvers encode for the deployment they bid
+   against, and gateways predating `validUntil` take v1.
+4. A call matching neither shape is skipped, and if no call in the batch decodes the function returns null.
+5. **Null is dropped silently upstream** — `aggregatePhantomBids` does `if (!fillData) continue` with no log. A
+   decoding regression therefore shows up as missing pool rates rather than as an error, which is why the shapes
+   are covered by tests rather than left to runtime observation.

--- a/sdk/packages/indexer/jest.config.ts
+++ b/sdk/packages/indexer/jest.config.ts
@@ -15,5 +15,9 @@ export default {
 		"^@/(.*)$": "<rootDir>/src/$1",
 	},
 	moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+	// The SDK's CJS bundles `require()` ESM-only packages (p-queue -> eventemitter3, lodash-es),
+	// which jest cannot parse unless they are transformed. Without this, any test importing
+	// `@hyperbridge/sdk` or its `intents-helpers` sub-path fails to load at all.
+	transformIgnorePatterns: ["node_modules/\\.pnpm/(?!(p-queue|p-timeout|eventemitter3|lodash-es)@)"],
 	testTimeout: 30000,
 }

--- a/sdk/packages/indexer/src/utils/__tests__/phantom-decode.fill.test.ts
+++ b/sdk/packages/indexer/src/utils/__tests__/phantom-decode.fill.test.ts
@@ -1,0 +1,85 @@
+import { encodeFunctionData } from "viem"
+import {
+	encodeERC7821ExecuteBatch,
+	FILL_ORDER_ABI,
+	FILL_ORDER_V1_ABI,
+	type HexString,
+} from "@hyperbridge/sdk/intents-helpers"
+import { extractFillDataVm2 } from "@/utils/phantom-decode"
+
+// A solver encodes its fill with viem (simplex), against whichever gateway it targets, and the
+// indexer decodes it with ethers. `FillOptions.validUntil` gave `fillOrder` two shapes with
+// different selectors (0x5cfb1ea5 -> 0xa5470064), so a decoder that knows only one silently
+// rejects every bid of the other — and `aggregatePhantomBids` drops an undecodable bid with no
+// log line. Both shapes are live: gateways predating `validUntil` take v1, upgraded ones v2.
+//
+// This file deliberately imports only the `intents-helpers` sub-path, the same VM2-safe entry the
+// indexer uses at runtime. The sibling `phantom-decode.test.ts` pulls the full `@hyperbridge/sdk`
+// bundle, which jest cannot transform once the SDK's dist is freshly built (its CJS output
+// requires ESM-only `lodash-es`, and there is no `transformIgnorePatterns` override).
+describe("extractFillDataVm2", () => {
+	const GATEWAY = "0x1111111111111111111111111111111111111111" as HexString
+	const OUTPUT_TOKEN = `0x${"55".repeat(32)}` as HexString
+	const SOLVER_AMOUNT = 12_345n
+
+	const order = {
+		user: `0x${"11".repeat(32)}`,
+		source: "0x",
+		destination: "0x",
+		deadline: 0n,
+		nonce: 0n,
+		fees: 0n,
+		session: `0x${"22".repeat(20)}`,
+		predispatch: { assets: [], call: "0x" },
+		inputs: [{ token: `0x${"33".repeat(32)}`, amount: 1n }],
+		output: {
+			beneficiary: `0x${"44".repeat(32)}`,
+			assets: [{ token: OUTPUT_TOKEN, amount: 2n }],
+			call: "0x",
+		},
+	}
+	const outputs = [{ token: OUTPUT_TOKEN, amount: SOLVER_AMOUNT }]
+
+	/** A bid as it arrives: the fillOrder call wrapped in the solver account's ERC-7821 batch. */
+	function bid(abi: unknown, args: unknown[]): HexString {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const fillCalldata = (encodeFunctionData as any)({ abi, functionName: "fillOrder", args }) as HexString
+		return encodeERC7821ExecuteBatch([{ target: GATEWAY, value: 0n, data: fillCalldata }])
+	}
+
+	it("decodes a bid encoded for an upgraded gateway (v2, with validUntil)", () => {
+		const calldata = bid(FILL_ORDER_ABI, [order, { relayerFee: 0n, nativeDispatchFee: 0n, validUntil: 99n, outputs }])
+
+		const result = extractFillDataVm2(calldata, GATEWAY)
+
+		expect(result).not.toBeNull()
+		expect(result!.legs).toHaveLength(1)
+		expect(result!.legs[0].outputToken.toLowerCase()).toBe(OUTPUT_TOKEN.toLowerCase())
+		expect(result!.legs[0].solverAmount).toBe(SOLVER_AMOUNT)
+	})
+
+	// The regression: every mainnet gateway still predates `validUntil`, so this is the shape
+	// actually on the wire today. Decoding only v2 dropped all of it.
+	it("decodes a bid encoded for a gateway that predates validUntil (v1)", () => {
+		const calldata = bid(FILL_ORDER_V1_ABI, [order, { relayerFee: 0n, nativeDispatchFee: 0n, outputs }])
+
+		const result = extractFillDataVm2(calldata, GATEWAY)
+
+		expect(result).not.toBeNull()
+		expect(result!.legs).toHaveLength(1)
+		expect(result!.legs[0].outputToken.toLowerCase()).toBe(OUTPUT_TOKEN.toLowerCase())
+		expect(result!.legs[0].solverAmount).toBe(SOLVER_AMOUNT)
+	})
+
+	it("returns null when the batch targets a different contract", () => {
+		const calldata = bid(FILL_ORDER_ABI, [order, { relayerFee: 0n, nativeDispatchFee: 0n, validUntil: 0n, outputs }])
+
+		expect(extractFillDataVm2(calldata, "0x2222222222222222222222222222222222222222")).toBeNull()
+	})
+
+	it("returns null for calldata that is neither fillOrder shape", () => {
+		const calldata = encodeERC7821ExecuteBatch([{ target: GATEWAY, value: 0n, data: "0xdeadbeef" }])
+
+		expect(extractFillDataVm2(calldata, GATEWAY)).toBeNull()
+	})
+})

--- a/sdk/packages/indexer/src/utils/phantom-decode.ts
+++ b/sdk/packages/indexer/src/utils/phantom-decode.ts
@@ -3,6 +3,7 @@ import { ethers } from "ethers"
 import {
 	zipFillLegs,
 	FILL_ORDER_ABI,
+	FILL_ORDER_V1_ABI,
 	type BidNonceKeyFn,
 	type FillData,
 	type HexString,
@@ -19,9 +20,33 @@ import {
 // (isBytesLike), so it works in the sandbox. These are injected into aggregatePhantomBids so the SDK
 // itself stays on the plain viem helpers (used by simplex/tests in Node, where viem is fine).
 const executeIface = new Interface(["function execute(bytes32 mode, bytes executionData)"])
+// Both `fillOrder` shapes, because a bid carries whichever one its target gateway speaks.
+// `FillOptions.validUntil` changed the selector (0x5cfb1ea5 -> 0xa5470064), so a solver bidding
+// against a gateway that predates it sends the v1 shape. ethers validates the selector before
+// decoding, so a single interface silently rejects every bid of the other shape — and
+// `extractFillDataVm2`'s caller drops those bids without logging. This mirrors the SDK's
+// `decodeFillOrder`, which tries v2 then falls back to v1; the two must stay in step.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const fillIface = new Interface(FILL_ORDER_ABI as any)
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const legacyFillIface = new Interface(FILL_ORDER_V1_ABI as any)
 const CALL_TUPLE = ["tuple(address target, uint256 value, bytes data)[]"]
+
+/**
+ * Decodes a `fillOrder` call of either shape, or returns null if it is neither.
+ *
+ * The selectors differ, so there is no payload one interface could mis-decode as the other.
+ */
+function decodeFillOrderEither(data: string): ReadonlyArray<unknown> | null {
+	for (const iface of [fillIface, legacyFillIface]) {
+		try {
+			return iface.decodeFunctionData("fillOrder", data)
+		} catch {
+			// Wrong shape for this interface; try the other.
+		}
+	}
+	return null
+}
 
 /** Drop-in for the SDK's extractFillData that decodes with ethers (VM2-safe). */
 export function extractFillDataVm2(callData: HexString, gatewayAddress: string): FillData | null {
@@ -33,12 +58,8 @@ export function extractFillDataVm2(callData: HexString, gatewayAddress: string):
 		const normalized = gatewayAddress.toLowerCase()
 		for (const call of calls) {
 			if (call.target.toLowerCase() !== normalized) continue
-			let decoded
-			try {
-				decoded = fillIface.decodeFunctionData("fillOrder", call.data)
-			} catch {
-				continue
-			}
+			const decoded = decodeFillOrderEither(call.data)
+			if (!decoded) continue
 			const order = decoded[0] as Record<string, unknown>
 			const options = decoded[1] as Record<string, unknown>
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/sdk/packages/sdk/docs/ai/ChangeLog.md
+++ b/sdk/packages/sdk/docs/ai/ChangeLog.md
@@ -12,6 +12,21 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-08-28 — Export `FILL_ORDER_V1_ABI` for consumers that cannot use `decodeFillOrder`
+
+`decodeFillOrder` handles both `fillOrder` shapes, but it is viem-based and viem's byte handling throws inside
+SubQuery's VM2 sandbox, so the indexer reimplements the decode with ethers. It was building its interface from
+`FILL_ORDER_ABI` alone and therefore rejected every v1-shaped bid — which is every bid on mainnet today, since no
+gateway has been upgraded past `validUntil` yet.
+
+The legacy shape is now exported (from `fillOrderCodec`, re-exported on the `intents-helpers` sub-path) so that
+decoder can share this definition instead of keeping a second copy. A duplicated ABI that drifts out of step with
+this one is exactly the failure being fixed, so the constant is exported rather than re-declared downstream.
+
+Only the constant is exported on the VM2-safe sub-path; `decodeFillOrder` itself stays off it.
+
+Files: `src/protocols/intents/fillOrderCodec.ts`, `src/protocols/intents/index.ts`, `src/intents-helpers.ts`.
+
 ## 2026-08-27 — `FillOptions` carries a `validUntil`, and `fillOrder` has two shapes
 
 `FillOptions` gained `validUntil` (a block number; `0n` means unbounded), enforced by `fillOrder`, which now reverts

--- a/sdk/packages/sdk/docs/ai/Decisions.md
+++ b/sdk/packages/sdk/docs/ai/Decisions.md
@@ -4,6 +4,24 @@ AI-maintained record of non-obvious choices made in `sdk/packages/sdk`: what was
 
 Entry format: heading with the decision, then alternatives considered and the reasoning. Newest first.
 
+## 2026-08-28 — The legacy `fillOrder` ABI is exported, not re-declared downstream
+
+The indexer needs the v1 shape to decode bids with ethers. Two ways to give it one:
+
+- **Re-declare it there.** No SDK change, but then two definitions of the same historical ABI have to stay
+  identical forever, with nothing enforcing it. The bug being fixed is precisely a decoder that fell out of step
+  with the shapes in the wild, so adding a second source of truth for those shapes is the wrong direction.
+- **Export the existing constant.** One definition. Costs a public export of something that is otherwise an
+  implementation detail — acceptable, since the reason it exists (deployments predating `validUntil`) is a fact
+  about the network rather than about this package.
+
+Exported from `fillOrderCodec` and re-exported on the `intents-helpers` sub-path, which is the entry point that
+exists for tools that cannot load the full bundle. Pulling `fillOrderCodec` onto that sub-path adds no new
+runtime dependency — it imports only viem, the gateway ABI, and types, all already reachable there.
+
+`decodeFillOrder` is deliberately not exported alongside it: it is viem-based, and the callers that need this
+constant are the ones that cannot run viem.
+
 ## 2026-08-27 — The bid expiry rides in `FillOptions`, not in the bid signature
 
 Chosen: `validUntil` is a field on `FillOptions`, checked by `fillOrder` at execution.

--- a/sdk/packages/sdk/src/intents-helpers.ts
+++ b/sdk/packages/sdk/src/intents-helpers.ts
@@ -4,6 +4,8 @@ export { decodeERC7821ExecuteBatch, encodeERC7821ExecuteBatch } from "@/protocol
 export { decodeUserOpScale, encodeUserOpScale } from "@/chains/intentsCoprocessor"
 export { default as IntentGatewayV2 } from "@/abis/IntentGatewayV2"
 export { poolSlug, sortPoolSymbols } from "@/protocols/intents/liquidity-pool"
+// Only the ABI constant — `decodeFillOrder` itself is viem-based and unusable in VM2.
+export { FILL_ORDER_V1_ABI } from "@/protocols/intents/fillOrderCodec"
 export {
 	aggregatePhantomBids,
 	applyPhantomQuoteHaircut,

--- a/sdk/packages/sdk/src/protocols/intents/fillOrderCodec.ts
+++ b/sdk/packages/sdk/src/protocols/intents/fillOrderCodec.ts
@@ -15,8 +15,15 @@ import type { FillOptions, HexString, Order } from "@/types"
  */
 export type FillOptionsVersion = 1 | 2
 
-/** The v1 `fillOrder`, kept only so we can still talk to deployments that predate `validUntil`. */
-const FILL_ORDER_V1_ABI = [
+/**
+ * The v1 `fillOrder`, kept only so we can still talk to deployments that predate `validUntil`.
+ *
+ * Exported because consumers that cannot use {@link decodeFillOrder} still have to accept both
+ * shapes. The indexer decodes bid calldata with ethers rather than viem (viem's byte handling
+ * throws inside SubQuery's VM2 sandbox), so it rebuilds this decode itself and needs the same
+ * definition rather than a second copy that can drift out of step with this one.
+ */
+export const FILL_ORDER_V1_ABI = [
 	{
 		type: "function",
 		name: "fillOrder",

--- a/sdk/packages/sdk/src/protocols/intents/index.ts
+++ b/sdk/packages/sdk/src/protocols/intents/index.ts
@@ -44,6 +44,7 @@ export {
 	resetFillOptionsVersionCache,
 	LEGACY_FILL_OPTIONS_IMPLEMENTATIONS,
 	CHAINS_WITHOUT_VALID_UNTIL,
+	FILL_ORDER_V1_ABI,
 } from "./fillOrderCodec"
 export type { FillOptionsVersion } from "./fillOrderCodec"
 export {


### PR DESCRIPTION
`extractFillDataVm2` built a single ethers `Interface` from `FILL_ORDER_ABI`. When `FillOptions` gained `validUntil` that ABI moved to the v2 shape, and ethers validates the selector before decoding, so every v1-shaped bid began throwing. The throw was swallowed by a `continue`, the function returned null, and `aggregatePhantomBids` drops a null bid with no log line — so the loss was silent.

This is live, not hypothetical. `@hyperbridge/sdk` is a `workspace:*` dependency, so the indexer picked up the v2 ABI immediately, while every mainnet gateway still runs the pre-`validUntil` implementation. `getFillOptionsVersion` therefore returns 1 and simplex encodes v1 bids — all of which were being discarded, yielding no bidder rows, no median and no pool-rate snapshot from any phantom order.

Decode now tries both shapes, mirroring the SDK's `decodeFillOrder`. The selectors differ (0x5cfb1ea5 vs 0xa5470064), so neither can mis-decode the other's payload. The v1 ABI is exported from the SDK and imported here rather than re-declared, since a second copy that drifts out of step is the failure being fixed.

Verified by running the real function against both shapes: before, v1 returned null and v2 decoded; after, both decode, and a wrong target or non-fillOrder calldata still returns null.

Also adds `transformIgnorePatterns` to the indexer's jest config. The SDK's CJS bundles `require()` ESM-only packages (p-queue -> eventemitter3/p-timeout, lodash-es), which jest cannot parse untransformed, so any test importing `@hyperbridge/sdk` or its `intents-helpers` sub-path failed to load against a freshly built SDK. That blocked the new test and had also been keeping the existing `phantom-decode.test.ts` from running; it passes again now.