### PR TITLE
[simplex]: retry MPCVault execute on the create/execute race and name failing RPCs

### DIFF
--- a/sdk/packages/simplex/CHANGELOG.md
+++ b/sdk/packages/simplex/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @hyperbridge/filler
 
+## 0.12.1
+
+### Patch Changes
+
+- MPCVault signing failures now name the failing RPC, the signing-request uuid and MPCVault's x-request-id, and the error guard also trips on code-only errors (MPCVault sends empty messages with only a code set). `executeSigningRequests` retries INVALID_ARGUMENT/NOT_FOUND twice with short backoff: MPCVault intermittently rejects a uuid its own createSigningRequest just returned, which failed live fills with `3 INVALID_ARGUMENT: Invalid uuid` before the callback co-signer was contacted.
+
 ## 0.12.0
 
 ### Minor Changes

--- a/sdk/packages/simplex/CHANGELOG.md
+++ b/sdk/packages/simplex/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Patch Changes
 
-- MPCVault signing failures now name the failing RPC, the signing-request uuid and MPCVault's x-request-id, and the error guard also trips on code-only errors (MPCVault sends empty messages with only a code set). `executeSigningRequests` retries INVALID_ARGUMENT/NOT_FOUND twice with short backoff: MPCVault intermittently rejects a uuid its own createSigningRequest just returned, which failed live fills with `3 INVALID_ARGUMENT: Invalid uuid` before the callback co-signer was contacted.
+- MPCVault signing failures now name the failing RPC, the signing-request uuid and MPCVault's x-request-id, and the error guard defensively trips on errors that carry only a non-zero code with an empty message. `executeSigningRequests` retries INVALID_ARGUMENT/NOT_FOUND twice with short backoff: MPCVault intermittently rejects a uuid its own createSigningRequest just returned, which failed live fills with `3 INVALID_ARGUMENT: Invalid uuid` before the callback co-signer was contacted.
+- A signing request whose execute fails terminally is best-effort rejected in the vault instead of staying pending forever, and `MpcVaultClientConfig` accepts an injected `logger` (embedded fillers passing `SimplexOptions.logger` otherwise never see MPCVault retry warnings) and channel `credentials`.
 
 ## 0.12.0
 

--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -12,6 +12,23 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-08-31 — Review fixes: zero-code guard, abandoned-request cleanup, logger and credentials injection, unit tests
+
+Four fixes from review of the MPCVault retry change. `apiErrorText` no longer treats enum value 0
+as an error — both code fields define 0 as UNSPECIFIED, so the previous `!== undefined` check would
+have failed every signature against a server that sends an explicit zero; the guard is also now
+framed as defensive, since the observed `{"code":16,"message":""}` was a gRPC status envelope, not
+the in-band `Error` message. A signing request whose execute fails terminally is best-effort
+rejected in the vault (`rejectSigningRequest`) instead of staying pending forever — a pending
+request nobody will execute is a standing authorization to sign a stale payload. `MpcVaultClientConfig`
+and `MpcVaultSignerConfig` accept an injected `logger` (the default process-wide context is
+invisible to embedded fillers that pass `SimplexOptions.logger`) and `credentials` (the TLS
+hardcoding left no test seam). New unit tests run `MpcVaultService` against an in-process gRPC
+server: retry-then-sign, retries-exhausted with reject and error naming, code-only errors,
+UNSPECIFIED-zero, and create-failure naming. Create deliberately gets no retry — see Decisions.md.
+Files: src/services/wallet/mpcvault.ts, src/services/wallet/types.ts,
+src/services/wallet/accounts/mpc.ts, src/tests/wallet/mpcvault.test.ts.
+
 ## 2026-08-31 — MPCVault RPC failures name their call, and execute retries the create/execute race
 
 `MpcVaultService` rethrows gRPC failures naming the RPC, the signing-request uuid and MPCVault's

--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -12,6 +12,18 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-08-31 — MPCVault RPC failures name their call, and execute retries the create/execute race
+
+`MpcVaultService` rethrows gRPC failures naming the RPC, the signing-request uuid and MPCVault's
+x-request-id (previously the bare grpc-js error propagated, so a production
+`3 INVALID_ARGUMENT: Invalid uuid` could not be attributed to create vs execute from the order
+log). The app-level error guard now also trips on code-only errors — MPCVault sends `message: ""`
+with only a code set. `executeSigningRequest` retries INVALID_ARGUMENT/NOT_FOUND twice with short
+backoff because MPCVault intermittently rejects a uuid its own createSigningRequest just returned,
+before the callback co-signer is contacted. Created uuids are logged at debug for dashboard
+correlation.
+Files: src/services/wallet/mpcvault.ts.
+
 ## 2026-08-27 — Phantom orders are validated against the pallet's shape before they are quoted
 
 `IntentFiller.preparePhantomBid` now refuses any phantom order that does not look like one

--- a/sdk/packages/simplex/docs/ai/Decisions.md
+++ b/sdk/packages/simplex/docs/ai/Decisions.md
@@ -4,6 +4,20 @@ AI-maintained record of non-obvious choices made in `sdk/packages/simplex`: what
 
 Entry format: heading with the decision, then alternatives considered and the reasoning. Newest first.
 
+## 2026-08-31 — createSigningRequest gets no retry
+
+Chosen: only execute retries; a create failure propagates immediately. Review asked whether create
+should retry symmetrically, since the production timing alone did not prove which RPC failed.
+
+Rejected because the retry exists to absorb a read-after-write race on a freshly issued uuid, and
+create references nothing freshly issued — its only uuid is the constant vault uuid, so an
+INVALID_ARGUMENT there is deterministic and three attempts just triple the latency of a real config
+error. Retrying create on ambiguous errors is actively harmful: each ambiguous failure may have
+created a request, so retries would leak pending signing requests — the exact orphaning the
+abandoned-request cleanup exists to prevent. If the create-is-fine assumption is wrong, failures now
+name their RPC, so the next live failure identifies create and the decision gets revisited with
+evidence.
+
 ## 2026-08-31 — MPCVault execute retries the create/execute race instead of pausing before execute
 
 Chosen: `executeSigningRequest` retries INVALID_ARGUMENT and NOT_FOUND up to twice (300ms, then

--- a/sdk/packages/simplex/docs/ai/Decisions.md
+++ b/sdk/packages/simplex/docs/ai/Decisions.md
@@ -4,6 +4,23 @@ AI-maintained record of non-obvious choices made in `sdk/packages/simplex`: what
 
 Entry format: heading with the decision, then alternatives considered and the reasoning. Newest first.
 
+## 2026-08-31 — MPCVault execute retries the create/execute race instead of pausing before execute
+
+Chosen: `executeSigningRequest` retries INVALID_ARGUMENT and NOT_FOUND up to twice (300ms, then
+600ms) before failing. MPCVault's backend intermittently does not recognise a signing-request uuid
+its own `createSigningRequest` just returned: live fills failed with
+`3 INVALID_ARGUMENT: Invalid uuid` and no callback-server contact, and since MPCVault only contacts
+the callback co-signer during execute, the rejection precedes any approval step — the request
+exists but the execute handler cannot see it yet.
+
+Alternatives. An unconditional sleep between create and execute taxes every signature to paper over
+a fault that shows up in a small minority of calls. Retrying every gRPC error is unsafe: after an
+ambiguous failure (DEADLINE_EXCEEDED, UNAVAILABLE mid-call) the ceremony may already be running,
+whereas INVALID_ARGUMENT/NOT_FOUND mean the server did nothing, so re-sending is idempotent. The
+retry lives inside `executeSigningRequest` rather than in callers because the uuid is what is being
+retried — recreating the request instead would orphan one pending signing request per attempt in
+the vault.
+
 ## 2026-08-27 — Phantom orders are gated on the pallet's structural invariants, not on a re-derived commitment
 
 Chosen: `preparePhantomBid` checks `session == 0`, all output amounts zero, and

--- a/sdk/packages/simplex/docs/ai/Flow.md
+++ b/sdk/packages/simplex/docs/ai/Flow.md
@@ -112,9 +112,12 @@ returns a signing-request uuid, then `executeSigningRequests` triggers MPCVault'
 the callback co-signer approval and the MPC ceremony. The callback server is only contacted during
 execute — a failure before that step leaves no callback log at all. Execute retries
 INVALID_ARGUMENT/NOT_FOUND twice with short backoff because MPCVault intermittently rejects a uuid
-its own create just returned; any other failure propagates as an error naming the RPC, the uuid and
-MPCVault's x-request-id, and both RPCs also fail on app-level errors that carry only a code with an
-empty message.
+its own create just returned; when execute fails terminally the created request is best-effort
+rejected in the vault so it does not stay pending as a signable stale payload. Any failure
+propagates as an error naming the RPC, the uuid and MPCVault's x-request-id, and both RPCs also
+fail on app-level errors that carry only a non-zero code with an empty message (zero is
+UNSPECIFIED, not an error). Lifecycle logs default to the process-wide logger context, which an
+embedded filler's `SimplexOptions.logger` never sees — `MpcVaultClientConfig.logger` injects one.
 
 ### The viem boundary
 

--- a/sdk/packages/simplex/docs/ai/Flow.md
+++ b/sdk/packages/simplex/docs/ai/Flow.md
@@ -105,6 +105,17 @@ There are two entry points, and they meet at `bootFiller`.
 - **`address`.** Read directly everywhere the solver's identity is needed (`fillerAddress`, delegation authority, balance lookups, vault initialisation).
 - **`mode`.** Logs only: the boot line and the two delegation log lines.
 
+### MPCVault's two-RPC ceremony
+
+Every `mpcVaultSigner` operation is two gRPC calls in `MpcVaultService`: `createSigningRequest`
+returns a signing-request uuid, then `executeSigningRequests` triggers MPCVault's policy checks,
+the callback co-signer approval and the MPC ceremony. The callback server is only contacted during
+execute — a failure before that step leaves no callback log at all. Execute retries
+INVALID_ARGUMENT/NOT_FOUND twice with short backoff because MPCVault intermittently rejects a uuid
+its own create just returned; any other failure propagates as an error naming the RPC, the uuid and
+MPCVault's x-request-id, and both RPCs also fail on app-level errors that carry only a code with an
+empty message.
+
 ### The viem boundary
 
 `Signer` names no viem type. `accountFor(signer)` (`src/services/wallet/account.ts`) builds the `LocalAccount` viem wants from one, and `ChainClientManager` derives it once in its constructor and hands it to every wallet client. The mapping is:

--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/simplex",
-	"version": "0.12.0",
+	"version": "0.12.1",
 	"license": "Apache-2.0",
 	"description": "Automated intent filler for the Hyperbridge IntentGateway \u2014 run it as a binary or embed it as a library",
 	"main": "dist/index.js",

--- a/sdk/packages/simplex/src/services/wallet/accounts/mpc.ts
+++ b/sdk/packages/simplex/src/services/wallet/accounts/mpc.ts
@@ -24,6 +24,8 @@ export function mpcVaultSigner(config: MpcVaultSignerConfig): Signer {
 		accountAddress: config.accountAddress,
 		callbackClientSignerPublicKey: config.callbackClientSignerPublicKey,
 		grpcTarget: config.grpcTarget,
+		logger: config.logger,
+		credentials: config.credentials,
 	})
 
 	return {

--- a/sdk/packages/simplex/src/services/wallet/mpcvault.ts
+++ b/sdk/packages/simplex/src/services/wallet/mpcvault.ts
@@ -9,9 +9,11 @@ import {
 	type CreateSigningRequestResponse,
 	type ExecuteSigningRequestsRequest,
 	type ExecuteSigningRequestsResponse,
+	type RejectSigningRequestRequest,
+	type RejectSigningRequestResponse,
 	type SignatureContainer_ECDSASignature,
 } from "../../proto/mpcvault/platform/v1/api"
-import { getLogger } from "../Logger"
+import { getLogger, type Logger } from "../Logger"
 import type { MpcVaultClientConfig } from "./types"
 
 // ---------------------------------------------------------------------------
@@ -45,12 +47,12 @@ function rpcFailure(rpc: string, err: unknown, uuid?: string): Error {
 
 type MpcVaultApiError = NonNullable<CreateSigningRequestResponse["error"]>
 
-// MPCVault reports failures with an empty message and only a code set, so the
-// message alone cannot be the error signal.
+// Defensive: an Error carrying only a non-zero code with an empty message is
+// still a failure. Zero is UNSPECIFIED on both enums, not an error.
 function apiErrorText(error: MpcVaultApiError): string | undefined {
 	if (error.message) return error.message
-	if (error.serviceErrorCode !== undefined) return `service error code ${error.serviceErrorCode}`
-	if (error.executeSigningRequestsErrorCode !== undefined) {
+	if (error.serviceErrorCode) return `service error code ${error.serviceErrorCode}`
+	if (error.executeSigningRequestsErrorCode) {
 		return `execute error code ${error.executeSigningRequestsErrorCode}`
 	}
 	return undefined
@@ -83,7 +85,7 @@ export class MpcVaultService {
 	private readonly callbackClientSignerPublicKey: string
 	private readonly client: PlatformAPIClient
 	private readonly metadata: grpc.Metadata
-	private readonly logger = getLogger("mpc-vault")
+	private readonly logger: Logger
 
 	constructor(config: MpcVaultClientConfig) {
 		this.vaultUuid = config.vaultUuid
@@ -91,7 +93,8 @@ export class MpcVaultService {
 		this.callbackClientSignerPublicKey = config.callbackClientSignerPublicKey
 
 		const grpcTarget = config.grpcTarget ?? "api.mpcvault.com:443"
-		this.client = new PlatformAPIClient(grpcTarget, grpc.credentials.createSsl())
+		this.client = new PlatformAPIClient(grpcTarget, config.credentials ?? grpc.credentials.createSsl())
+		this.logger = config.logger ?? getLogger("mpc-vault")
 
 		this.metadata = new grpc.Metadata()
 		this.metadata.add("x-mtoken", config.apiToken)
@@ -160,6 +163,7 @@ export class MpcVaultService {
 					await delay(EXECUTE_RETRY_BASE_DELAY_MS * (attempt + 1))
 					continue
 				}
+				await this.rejectAbandonedRequest(uuid)
 				throw rpcFailure("executeSigningRequests", err, uuid)
 			}
 
@@ -168,6 +172,25 @@ export class MpcVaultService {
 				throw new Error(`MPCVault executeSigningRequests error: ${errorText}`)
 			}
 			return response
+		}
+	}
+
+	// A request that will never be executed stays PENDING in the vault — dead
+	// weight and a standing authorization to sign a stale payload. Best-effort:
+	// the original failure is what propagates.
+	private async rejectAbandonedRequest(uuid: string): Promise<void> {
+		try {
+			await promisifyUnary<RejectSigningRequestRequest, RejectSigningRequestResponse>(
+				this.client.rejectSigningRequest.bind(this.client),
+				{ uuid },
+				this.metadata,
+			)
+			this.logger.debug({ uuid }, "Rejected abandoned signing request")
+		} catch (err) {
+			this.logger.warn(
+				{ uuid, err },
+				"Could not reject abandoned signing request; it stays pending in the vault",
+			)
 		}
 	}
 

--- a/sdk/packages/simplex/src/services/wallet/mpcvault.ts
+++ b/sdk/packages/simplex/src/services/wallet/mpcvault.ts
@@ -11,11 +11,50 @@ import {
 	type ExecuteSigningRequestsResponse,
 	type SignatureContainer_ECDSASignature,
 } from "../../proto/mpcvault/platform/v1/api"
+import { getLogger } from "../Logger"
 import type { MpcVaultClientConfig } from "./types"
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+const EXECUTE_RETRY_ATTEMPTS = 2
+const EXECUTE_RETRY_BASE_DELAY_MS = 300
+
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function isServiceError(err: unknown): err is grpc.ServiceError {
+	return typeof (err as grpc.ServiceError | undefined)?.code === "number"
+}
+
+/** Names the RPC, the signing request and MPCVault's x-request-id, so a failure is attributable from the order log alone. */
+function rpcFailure(rpc: string, err: unknown, uuid?: string): Error {
+	const context: string[] = []
+	if (uuid) context.push(`signing request ${uuid}`)
+	if (isServiceError(err)) {
+		const requestId = err.metadata?.get("x-request-id")?.[0]
+		if (requestId) context.push(`x-request-id ${requestId}`)
+	}
+	const detail = err instanceof Error ? err.message : String(err)
+	const failure = new Error(`MPCVault ${rpc} failed${context.length ? ` (${context.join(", ")})` : ""}: ${detail}`)
+	;(failure as { cause?: unknown }).cause = err
+	return failure
+}
+
+type MpcVaultApiError = NonNullable<CreateSigningRequestResponse["error"]>
+
+// MPCVault reports failures with an empty message and only a code set, so the
+// message alone cannot be the error signal.
+function apiErrorText(error: MpcVaultApiError): string | undefined {
+	if (error.message) return error.message
+	if (error.serviceErrorCode !== undefined) return `service error code ${error.serviceErrorCode}`
+	if (error.executeSigningRequestsErrorCode !== undefined) {
+		return `execute error code ${error.executeSigningRequestsErrorCode}`
+	}
+	return undefined
+}
 
 function promisifyUnary<TReq, TRes>(
 	method: (
@@ -44,6 +83,7 @@ export class MpcVaultService {
 	private readonly callbackClientSignerPublicKey: string
 	private readonly client: PlatformAPIClient
 	private readonly metadata: grpc.Metadata
+	private readonly logger = getLogger("mpc-vault")
 
 	constructor(config: MpcVaultClientConfig) {
 		this.vaultUuid = config.vaultUuid
@@ -71,34 +111,64 @@ export class MpcVaultService {
 	// -----------------------------------------------------------------------
 
 	private async createSigningRequest(request: CreateSigningRequestRequest): Promise<string> {
-		const response = await promisifyUnary<CreateSigningRequestRequest, CreateSigningRequestResponse>(
-			this.client.createSigningRequest.bind(this.client),
-			request,
-			this.metadata,
-		)
+		let response: CreateSigningRequestResponse
+		try {
+			response = await promisifyUnary<CreateSigningRequestRequest, CreateSigningRequestResponse>(
+				this.client.createSigningRequest.bind(this.client),
+				request,
+				this.metadata,
+			)
+		} catch (err) {
+			throw rpcFailure("createSigningRequest", err)
+		}
 
-		if (response.error?.message) {
-			throw new Error(`MPCVault createSigningRequest error: ${response.error.message}`)
+		const errorText = response.error && apiErrorText(response.error)
+		if (errorText) {
+			throw new Error(`MPCVault createSigningRequest error: ${errorText}`)
 		}
 
 		const uuid = response.signingRequest?.uuid
 		if (!uuid) {
 			throw new Error("MPCVault createSigningRequest response did not include signing request uuid")
 		}
+		this.logger.debug({ uuid }, "MPCVault signing request created")
 		return uuid
 	}
 
+	// MPCVault intermittently rejects a uuid its own create just returned
+	// (INVALID_ARGUMENT "Invalid uuid"), before the callback co-signer is
+	// contacted. Those codes mean the server did nothing, so re-sending is safe
+	// and a short retry absorbs the lag.
 	private async executeSigningRequest(uuid: string): Promise<ExecuteSigningRequestsResponse> {
-		const response = await promisifyUnary<ExecuteSigningRequestsRequest, ExecuteSigningRequestsResponse>(
-			this.client.executeSigningRequests.bind(this.client),
-			{ uuid },
-			this.metadata,
-		)
+		for (let attempt = 0; ; attempt++) {
+			let response: ExecuteSigningRequestsResponse
+			try {
+				response = await promisifyUnary<ExecuteSigningRequestsRequest, ExecuteSigningRequestsResponse>(
+					this.client.executeSigningRequests.bind(this.client),
+					{ uuid },
+					this.metadata,
+				)
+			} catch (err) {
+				const retryable =
+					isServiceError(err) &&
+					(err.code === grpc.status.INVALID_ARGUMENT || err.code === grpc.status.NOT_FOUND)
+				if (retryable && attempt < EXECUTE_RETRY_ATTEMPTS) {
+					this.logger.warn(
+						{ uuid, attempt: attempt + 1, code: err.code, details: err.details },
+						"MPCVault rejected a just-created signing request; retrying",
+					)
+					await delay(EXECUTE_RETRY_BASE_DELAY_MS * (attempt + 1))
+					continue
+				}
+				throw rpcFailure("executeSigningRequests", err, uuid)
+			}
 
-		if (response.error?.message) {
-			throw new Error(`MPCVault executeSigningRequests error: ${response.error.message}`)
+			const errorText = response.error && apiErrorText(response.error)
+			if (errorText) {
+				throw new Error(`MPCVault executeSigningRequests error: ${errorText}`)
+			}
+			return response
 		}
-		return response
 	}
 
 	// -----------------------------------------------------------------------

--- a/sdk/packages/simplex/src/services/wallet/types.ts
+++ b/sdk/packages/simplex/src/services/wallet/types.ts
@@ -9,6 +9,8 @@
  * is given.
  */
 import type { HexString } from "@hyperbridge/sdk"
+import type { ChannelCredentials } from "@grpc/grpc-js"
+import type { Logger } from "../Logger"
 
 export interface MpcVaultClientConfig {
 	apiToken: string
@@ -20,6 +22,14 @@ export interface MpcVaultClientConfig {
 	 * Replaces the previous REST `baseUrl` field.
 	 */
 	grpcTarget?: string
+	/**
+	 * Destination for signing lifecycle logs. Defaults to the process-wide
+	 * context, which an embedded filler's `SimplexOptions.logger` never sees —
+	 * pass your own to capture retries and failures in that setup.
+	 */
+	logger?: Logger
+	/** Channel credentials override for tests against a plaintext server. Defaults to TLS. */
+	credentials?: ChannelCredentials
 }
 
 export interface MpcVaultSignerConfig {
@@ -32,6 +42,14 @@ export interface MpcVaultSignerConfig {
 	 * Replaces the previous REST `baseUrl` field.
 	 */
 	grpcTarget?: string
+	/**
+	 * Destination for signing lifecycle logs. Defaults to the process-wide
+	 * context, which an embedded filler's `SimplexOptions.logger` never sees —
+	 * pass your own to capture retries and failures in that setup.
+	 */
+	logger?: Logger
+	/** Channel credentials override for tests against a plaintext server. Defaults to TLS. */
+	credentials?: ChannelCredentials
 }
 
 export enum SignerType {

--- a/sdk/packages/simplex/src/tests/wallet/mpcvault.test.ts
+++ b/sdk/packages/simplex/src/tests/wallet/mpcvault.test.ts
@@ -1,0 +1,174 @@
+import * as grpc from "@grpc/grpc-js"
+import { describe, expect, it, afterEach } from "vitest"
+import { isHex } from "viem"
+import {
+	PlatformAPIService,
+	CreateSigningRequestResponse,
+	ExecuteSigningRequestsResponse,
+	RejectSigningRequestResponse,
+} from "@/proto/mpcvault/platform/v1/api"
+import { MpcVaultService } from "@/services/wallet/mpcvault"
+import type { Logger } from "@/services/Logger"
+
+const HASH = "0x00000000000000000000000000000000000000000000000000000000000000aa" as const
+
+type Handlers = Partial<Record<"createSigningRequest" | "executeSigningRequests" | "rejectSigningRequest", grpc.handleUnaryCall<unknown, unknown>>>
+
+const cleanups: Array<() => void> = []
+
+afterEach(() => {
+	while (cleanups.length) cleanups.pop()?.()
+})
+
+async function startServer(handlers: Handlers): Promise<string> {
+	const server = new grpc.Server()
+	server.addService(PlatformAPIService, handlers as grpc.UntypedServiceImplementation)
+	const port = await new Promise<number>((resolve, reject) =>
+		server.bindAsync("127.0.0.1:0", grpc.ServerCredentials.createInsecure(), (err, bound) =>
+			err ? reject(err) : resolve(bound),
+		),
+	)
+	cleanups.push(() => server.forceShutdown())
+	return `127.0.0.1:${port}`
+}
+
+function recordingLogger(): { logger: Logger; warns: string[] } {
+	const warns: string[] = []
+	const noop = (..._args: unknown[]) => {}
+	const logger: Logger = {
+		trace: noop,
+		debug: noop,
+		info: noop,
+		warn: (...args: unknown[]) => {
+			const msg = args.find((arg) => typeof arg === "string")
+			warns.push(typeof msg === "string" ? msg : String(args[0]))
+		},
+		error: noop,
+		fatal: noop,
+	}
+	return { logger, warns }
+}
+
+function makeService(target: string, logger: Logger): MpcVaultService {
+	const service = new MpcVaultService({
+		apiToken: "test-token",
+		vaultUuid: "test-vault",
+		accountAddress: "0x0000000000000000000000000000000000000001",
+		callbackClientSignerPublicKey: "test-key",
+		grpcTarget: target,
+		credentials: grpc.credentials.createInsecure(),
+		logger,
+	})
+	cleanups.push(() => service.close())
+	return service
+}
+
+function createOk(uuid: string): grpc.handleUnaryCall<unknown, unknown> {
+	return (_call, callback) =>
+		callback(null, CreateSigningRequestResponse.fromPartial({ signingRequest: { uuid } }))
+}
+
+function executeOk(): grpc.handleUnaryCall<unknown, unknown> {
+	return (_call, callback) =>
+		callback(
+			null,
+			ExecuteSigningRequestsResponse.fromPartial({
+				signatures: { signatures: [{ ecdsaSignature: { R: "1", S: "2", V: "27" } }] },
+			}),
+		)
+}
+
+function invalidUuidError(requestId?: string): grpc.ServiceError {
+	const metadata = new grpc.Metadata()
+	if (requestId) metadata.add("x-request-id", requestId)
+	return Object.assign(new Error("Invalid uuid"), {
+		code: grpc.status.INVALID_ARGUMENT,
+		metadata,
+	}) as grpc.ServiceError
+}
+
+describe("MpcVaultService", () => {
+	it("signs after execute is retried past the create/execute race", async () => {
+		let executeCalls = 0
+		const target = await startServer({
+			createSigningRequest: createOk("req-1"),
+			executeSigningRequests: (_call, callback) => {
+				executeCalls++
+				if (executeCalls < 3) return callback(invalidUuidError(), null)
+				executeOk()(_call, callback)
+			},
+		})
+		const { logger, warns } = recordingLogger()
+		const service = makeService(target, logger)
+
+		const signature = await service.signRawHash(HASH)
+
+		expect(isHex(signature)).toBe(true)
+		expect(signature).toHaveLength(132)
+		expect(executeCalls).toBe(3)
+		expect(warns.filter((w) => w.includes("retrying"))).toHaveLength(2)
+	})
+
+	it("rejects the abandoned request and names the failure once retries exhaust", async () => {
+		const rejected: string[] = []
+		const target = await startServer({
+			createSigningRequest: createOk("req-1"),
+			executeSigningRequests: (_call, callback) => callback(invalidUuidError("test-req-id"), null),
+			rejectSigningRequest: (call, callback) => {
+				rejected.push((call.request as { uuid: string }).uuid)
+				callback(null, RejectSigningRequestResponse.fromPartial({}))
+			},
+		})
+		const { logger } = recordingLogger()
+		const service = makeService(target, logger)
+
+		await expect(service.signRawHash(HASH)).rejects.toThrow(
+			/executeSigningRequests failed \(signing request req-1, x-request-id test-req-id\)/,
+		)
+		expect(rejected).toEqual(["req-1"])
+	})
+
+	it("fails on an app-level error that carries only a code", async () => {
+		const target = await startServer({
+			createSigningRequest: (_call, callback) =>
+				callback(null, CreateSigningRequestResponse.fromPartial({ error: { message: "", serviceErrorCode: 1 } })),
+		})
+		const { logger } = recordingLogger()
+		const service = makeService(target, logger)
+
+		await expect(service.signRawHash(HASH)).rejects.toThrow(/createSigningRequest error: service error code 1/)
+	})
+
+	it("does not treat an UNSPECIFIED zero error code as a failure", async () => {
+		const target = await startServer({
+			createSigningRequest: (_call, callback) =>
+				callback(
+					null,
+					CreateSigningRequestResponse.fromPartial({
+						signingRequest: { uuid: "req-1" },
+						error: { message: "", serviceErrorCode: 0, executeSigningRequestsErrorCode: 0 },
+					}),
+				),
+			executeSigningRequests: executeOk(),
+		})
+		const { logger } = recordingLogger()
+		const service = makeService(target, logger)
+
+		const signature = await service.signRawHash(HASH)
+		expect(isHex(signature)).toBe(true)
+	})
+
+	it("names createSigningRequest when create fails at the gRPC level", async () => {
+		const target = await startServer({
+			createSigningRequest: (_call, callback) =>
+				callback(
+					Object.assign(new Error("boom"), { code: grpc.status.UNAVAILABLE }) as grpc.ServiceError,
+					null,
+				),
+		})
+		const { logger } = recordingLogger()
+		const service = makeService(target, logger)
+
+		await expect(service.signRawHash(HASH)).rejects.toThrow(/createSigningRequest failed/)
+	})
+})


### PR DESCRIPTION
MPCVault intermittently rejects a signing-request uuid its own createSigningRequest just returned (`3 INVALID_ARGUMENT: Invalid uuid`), before the callback co-signer is contacted. Execute now retries INVALID_ARGUMENT/NOT_FOUND twice with short backoff. gRPC failures are rethrown naming the RPC, the signing-request uuid and MPCVault's x-request-id, and the app-level error guard also trips on code-only errors (MPCVault sends empty messages with only a code set).

## Assumptions

- The bug is a race between create and execute: MPCVault's backend has a replication lag, so execute can run before the request it is executing is visible. This is inferred from logs, not confirmed by MPCVault.
- The failing call is execute, not create. Create's only uuid is the vault uuid, which never changes and worked minutes before and after every failure.
- The failures left no callback-server logs because MPCVault only contacts the callback during execute, and the rejection happens before that step.
- Retrying is safe: INVALID_ARGUMENT and NOT_FOUND mean MPCVault did nothing, so nothing can be signed twice.