### PR TITLE
[simplex]: gate paymaster selection on EntryPoint deposit

### DIFF
--- a/sdk/packages/simplex/CHANGELOG.md
+++ b/sdk/packages/simplex/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @hyperbridge/filler
 
+## 0.12.2
+
+### Patch Changes
+
+- Paymaster selection now skips any candidate whose EntryPoint deposit cannot cover the operation's max prefund with 150% headroom, falling through Circle to Simplex and reporting per-candidate reasons when none qualifies. Previously the Circle paymaster was chosen on solver balance alone, so a drained deposit (as happened on Base) meant every bid was signed against a paymaster the bundler was bound to reject at precheck. Deposit reads fail open so a transient RPC error degrades to the bundler's own check.
+
 ## 0.12.1
 
 ### Patch Changes

--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -12,6 +12,24 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-09-01 — Paymaster selection gated on EntryPoint deposit
+
+`buildPaymasterAndData` now skips a candidate paymaster whose EntryPoint deposit cannot cover the
+op's max prefund with 150% headroom, falling through Circle to Simplex to `type: "none"` with a
+per-candidate reason. Motivated by a live incident: on Base the Circle paymaster's deposit was
+drained (5.04e12 wei against a 1.49e13 prefund) and the Simplex paymaster's deposit was zero, so
+every bid was signed against a paymaster the bundler was bound to reject
+("precheck failed: paymaster deposit is X but must be at least Y") — the paymaster is baked into
+the signed bid UserOp, so nothing could re-select at execution. Callers pass the op's gas terms:
+`prepareBidUserOp` from the cached estimate, `trySendSponsored` from the caller's fixed limits or
+the fallbacks — for which `getGasPrice` moved above paymaster selection (also turning a gas-price
+failure into the safe never-submitted null). The Simplex gate runs before its builder, which can
+send a bootstrap approve tx. Deposit-read failures fail open. Skips are warn-logged with deposit
+and required figures.
+Files: src/services/paymaster/types.ts, src/services/paymaster/index.ts,
+src/services/UserOpSender.ts, src/services/ContractInteractionService.ts,
+src/tests/services/PaymasterSelection.test.ts.
+
 ## 2026-08-31 — Review fixes: zero-code guard, abandoned-request cleanup, logger and credentials injection, unit tests
 
 Four fixes from review of the MPCVault retry change. `apiErrorText` no longer treats enum value 0

--- a/sdk/packages/simplex/docs/ai/Decisions.md
+++ b/sdk/packages/simplex/docs/ai/Decisions.md
@@ -4,6 +4,31 @@ AI-maintained record of non-obvious choices made in `sdk/packages/simplex`: what
 
 Entry format: heading with the decision, then alternatives considered and the reasoning. Newest first.
 
+## 2026-09-01 — Paymaster deposit gate: 150% headroom, fail-open reads, checked at selection time
+
+Chosen: a candidate paymaster is skipped unless `EntryPoint.balanceOf(paymaster)` covers the op's
+max prefund times `DEPOSIT_HEADROOM_PERCENT` (150%), computed from the caller-supplied base gas
+plus the candidate's worst-case verification and postOp constants.
+
+Exact-prefund (100%) was rejected because the bundler applies its exact check at execution — for a
+bid, minutes after selection — and concurrent in-flight ops draw on the same deposit; passing the
+exact check at selection and failing it at execution reproduces the original failure. A larger
+multiplier (2x+) was rejected as arbitrary: healthy keeper-maintained deposits exceed one prefund
+by orders of magnitude, so any near-1 multiplier only bites when the deposit is effectively empty,
+and 150% buys roughly one concurrent op's share without rejecting a merely modest deposit.
+
+The deposit read fails open (candidate kept, warn logged). Fail-closed would turn every transient
+RPC error into a lost bid or a native-gas fallback; failing open degrades to exactly the status quo
+— the bundler's own precheck — and never worse. The check is skipped entirely when the caller
+passes no `prefund` or the chain has no EntryPoint, preserving balance-only selection for callers
+that cannot price the op.
+
+Known gap, deliberately left: `filler.ts` skips solver EntryPoint deposit top-ups whenever
+`hasPaymaster(chain)` is true, so a chain whose paymasters are all deposit-drained now produces
+`type: "none"` bids that draw on a solver deposit nothing maintains. The durable fix is the
+paymaster keeper maintaining the deposits, not the filler funding a fallback it was configured to
+avoid.
+
 ## 2026-08-31 — createSigningRequest gets no retry
 
 Chosen: only execute retries; a create failure propagates immediately. Review asked whether create

--- a/sdk/packages/simplex/docs/ai/Flow.md
+++ b/sdk/packages/simplex/docs/ai/Flow.md
@@ -6,7 +6,7 @@ AI-maintained map of how code paths in `sdk/packages/simplex` actually execute, 
 
 Entry points: `UserOpSender.trySendSponsored` (delegation, vault sweeps/redeems, token sends) and `ContractInteractionService.prepareBidUserOp` (bids). Both call `buildPaymasterAndData` in `src/services/paymaster/index.ts`.
 
-1. `buildPaymasterAndData` tries the Circle paymaster first when it is configured and the solver holds at least 1 USDC (`provider/circle.ts`), then the Simplex paymaster (`provider/simplex.ts`), else returns `type: "none"` and the caller falls back to native / the EntryPoint deposit.
+1. `buildPaymasterAndData` tries the Circle paymaster first when it is configured and the solver holds at least 1 USDC (`provider/circle.ts`), then the Simplex paymaster (`provider/simplex.ts`), else returns `type: "none"` and the caller falls back to native / the EntryPoint deposit. When the caller passes `prefund` (both do) and the chain has an EntryPoint configured, each candidate is additionally gated on its own EntryPoint deposit: `EntryPoint.balanceOf(paymaster)` must cover `(baseGas + candidate's worst-case verification + postOp gas) * maxFeePerGas * DEPOSIT_HEADROOM_PERCENT / 100` or the candidate is skipped with a warn and a per-candidate reason accumulated into the `type: "none"` result. The Simplex gate runs *before* `buildSimplexPaymasterData`, which may send a bootstrap approve tx that must not happen for a paymaster that cannot sponsor. A failed deposit read fails open (candidate kept) — a transient RPC error degrades to the bundler's own precheck, never worse.
 
 2. `buildSimplexPaymasterData` picks the first configured stablecoin (USDC, then USDT) with a balance of at least one whole token, then the authorization mode:
    - `tokenSupportsPermit` (probes `version()`) and not `skipPermit`: `buildPermitMode` — if the allowance to the paymaster already covers the $5 permit amount, APPROVE mode; else sign an EIP-2612 permit (`permit.ts`, `deadline = maxUint256`) and pack mode `0x00` (150 bytes).
@@ -15,7 +15,7 @@ Entry points: `UserOpSender.trySendSponsored` (delegation, vault sweeps/redeems,
      - Paymaster allowance at or above $2: APPROVE mode `0x01`, no tx.
      - Else bootstrap with `sendFundedApprove`: pre-check the native balance against the whole sequence, reset a stale non-zero allowance to zero first (USDT rule), then `approve` from the solver EOA — up to two txs, each waiting two confirmations. `approve(Permit2, max)` then PERMIT2 when Permit2 is usable, else `approve(paymaster, $5)` then APPROVE.
 
-3. Back in `UserOpSender.trySendSponsored`, the EIP-7702 authorization thunk is resolved only after paymaster data is built, because the bootstrap approve is a tx from the same EOA and an authorization signed earlier would carry a stale nonce (bundler reject). Then bundler gas price, `EntryPoint.getNonce`, estimation (or the caller's fixed limits), signing of the packed userOp typed data, `eth_sendUserOperation`, and receipt polling.
+3. Back in `UserOpSender.trySendSponsored`, the bundler gas price is fetched *before* paymaster selection so the deposit gate can price the op's max prefund (from the caller's fixed limits, or the generous fallbacks when estimating later). The EIP-7702 authorization thunk is still resolved only after paymaster data is built, because the bootstrap approve is a tx from the same EOA and an authorization signed earlier would carry a stale nonce (bundler reject). Then `EntryPoint.getNonce`, estimation (or the caller's fixed limits), signing of the packed userOp typed data, `eth_sendUserOperation`, and receipt polling.
 
 4. On chain (`evm/src/utils/SimplexPaymaster.sol`): `_fetchDetails` validates the mode byte and token registry and, for mode 2, returns the permit deadline as `validUntil`; `_prefund` pulls the prefund through `Permit2.permitTransferFrom` (owner = `userOp.sender`, to = paymaster, requestedAmount = oracle-derived prefund, capped by the signed amount) and postOp refunds the unused part to the sender.
 ## Order intake: what reaches the filler at all
@@ -72,7 +72,7 @@ That is what `paymasterReserveForToken` exists to absorb. Without it, a balance-
 
 ### Which token the paymaster charges
 
-Decided at submit time, not at sizing time, by `buildPaymasterAndData` (`src/services/paymaster/index.ts`): the Circle paymaster if configured and USDC balance >= 1 USDC, else the Simplex paymaster over the first of `[USDC, USDT]` with a balance >= 1 token (`selectToken`), else no paymaster. Because the sizing decision feeds the balances that decide this, the reserve covers both eligible tokens instead of predicting one.
+Decided at submit time, not at sizing time, by `buildPaymasterAndData` (`src/services/paymaster/index.ts`): the Circle paymaster if configured, USDC balance >= 1 USDC, and its EntryPoint deposit covers the op's max prefund with headroom; else the Simplex paymaster if its deposit does, over the first of `[USDC, USDT]` with a balance >= 1 token (`selectToken`); else no paymaster. Because the sizing decision feeds the balances that decide this, the reserve covers both eligible tokens instead of predicting one.
 
 ## Signing: from construction to each signature
 

--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/simplex",
-	"version": "0.12.1",
+	"version": "0.12.2",
 	"license": "Apache-2.0",
 	"description": "Automated intent filler for the Hyperbridge IntentGateway \u2014 run it as a binary or embed it as a library",
 	"main": "dist/index.js",

--- a/sdk/packages/simplex/src/services/ContractInteractionService.ts
+++ b/sdk/packages/simplex/src/services/ContractInteractionService.ts
@@ -721,10 +721,18 @@ export class ContractInteractionService {
 			walletClient: this.clientManager.getWalletClient(order.destination),
 			signer: this.signer,
 			configService: this.configService,
+			prefund: {
+				baseGas:
+					cachedEstimate.callGasLimit + cachedEstimate.verificationGasLimit + cachedEstimate.preVerificationGas,
+				maxFeePerGas: cachedEstimate.maxFeePerGas,
+			},
+			logger: this.logger,
 		})
 		const paymasterAndData = pmResult.paymasterAndData
 		if (pmResult.type !== "none") {
 			this.logger.info({ paymaster: pmResult.address, type: pmResult.type }, "Using paymaster for bid UserOp")
+		} else {
+			this.logger.warn({ reason: pmResult.reason }, "No paymaster for bid UserOp; relying on EntryPoint deposit")
 		}
 
 		const userOp = await sdkHelper.prepareSubmitBid({

--- a/sdk/packages/simplex/src/services/UserOpSender.ts
+++ b/sdk/packages/simplex/src/services/UserOpSender.ts
@@ -132,7 +132,21 @@ export class UserOpSender {
 
 		let pm: PaymasterDataResult
 		let auth: Eip7702Authorization | undefined
+		let fees: { maxFeePerGas: bigint; maxPriorityFeePerGas: bigint }
 		try {
+			// Fetched before paymaster selection so the deposit gate can price the op's
+			// max prefund; a failure here means nothing was submitted, safe to fall back.
+			fees = await this.getGasPrice(bundlerUrl, publicClient, chainId)
+
+			// Without explicit limits the fallbacks (~1.9M gas) over-require the deposit;
+			// a false skip degrades to the caller's native fallback, which is safe —
+			// under-requiring would sign an op the bundler is bound to reject.
+			const gasForPrefund = gas ?? {
+				verificationGasLimit: FALLBACK_VERIFICATION_GAS_LIMIT,
+				callGasLimit: FALLBACK_CALL_GAS_LIMIT,
+				preVerificationGas: FALLBACK_PRE_VERIFICATION_GAS,
+			}
+
 			pm = await buildPaymasterAndData({
 				chain,
 				solverAccount,
@@ -142,6 +156,12 @@ export class UserOpSender {
 				configService: this.configService,
 				paymasterVerificationGasLimit,
 				skipPermit,
+				prefund: {
+					baseGas:
+						gasForPrefund.callGasLimit + gasForPrefund.verificationGasLimit + gasForPrefund.preVerificationGas,
+					maxFeePerGas: fees.maxFeePerGas,
+				},
+				logger: this.logger,
 			})
 			if (pm.type === "none") {
 				this.logger.warn(
@@ -163,8 +183,7 @@ export class UserOpSender {
 		}
 		this.logger.info({ chain, paymaster: pm.address, type: pm.type, token: pm.token }, "Paymaster selected")
 		const paymasterAndData = pm.paymasterAndData
-
-		const { maxFeePerGas, maxPriorityFeePerGas } = await this.getGasPrice(bundlerUrl, publicClient, chainId)
+		const { maxFeePerGas, maxPriorityFeePerGas } = fees
 
 		const nonce = (await publicClient.readContract({
 			address: entryPoint,

--- a/sdk/packages/simplex/src/services/paymaster/index.ts
+++ b/sdk/packages/simplex/src/services/paymaster/index.ts
@@ -1,12 +1,20 @@
 import { erc20Abi } from "viem"
 import type { HexString } from "@hyperbridge/sdk"
+import { ENTRYPOINT_ABI } from "@/config/abis/Entrypoint"
 import type { FillerConfigService } from "@/services/FillerConfigService"
 import { buildCirclePaymasterData } from "./provider/circle"
 import { buildSimplexPaymasterData } from "./provider/simplex"
-import { packPaymasterAndData } from "./types"
+import {
+	DEPOSIT_HEADROOM_PERCENT,
+	packPaymasterAndData,
+	POST_OP_GAS_LIMIT_CIRCLE,
+	POST_OP_GAS_LIMIT_SIMPLEX,
+	VERIFICATION_GAS_LIMIT_CIRCLE,
+	VERIFICATION_GAS_LIMIT_PERMIT,
+} from "./types"
 import type { PaymasterOptions, PaymasterDataResult } from "./types"
 
-export type { PaymasterOptions, PaymasterDataResult } from "./types"
+export type { PaymasterOptions, PaymasterDataResult, PaymasterPrefund } from "./types"
 
 /**
  * Returns true if the chain has any paymaster (Circle or Simplex) configured.
@@ -20,9 +28,14 @@ export function hasPaymaster(chain: string, configService: FillerConfigService):
  * Unified paymaster data builder.
  *
  * Selection:
- * 1. Circle Paymaster — when configured AND solver has ≥1 USDC balance
- * 2. Simplex Paymaster — when configured AND solver has ≥1 balance in USDC or USDT
+ * 1. Circle Paymaster — when configured AND solver has ≥1 USDC balance AND its
+ *    EntryPoint deposit covers the op's max prefund
+ * 2. Simplex Paymaster — when configured AND its EntryPoint deposit covers the op's
+ *    max prefund AND solver has ≥1 balance in USDC or USDT
  * 3. None — returns "0x" with a reason (caller falls back to EntryPoint deposit)
+ *
+ * The deposit gate only runs when the caller passes `prefund` and the chain has an
+ * EntryPoint configured; without either, selection is balance-only as before.
  */
 export async function buildPaymasterAndData(options: PaymasterOptions): Promise<PaymasterDataResult> {
 	const {
@@ -43,58 +56,138 @@ export async function buildPaymasterAndData(options: PaymasterOptions): Promise<
 		return { paymasterAndData: "0x" as HexString, type: "none", reason: "no paymaster configured" }
 	}
 
+	const skipReasons: string[] = []
+
 	if (circleAddr) {
 		const usdcAddress = configService.getUsdcAsset(chain)
 		const usdcDecimals = configService.getUsdcDecimals(chain)
 
 		if (usdcAddress && usdcAddress !== "0x") {
-			const { sufficient } = await getUsdcBalanceStatus(publicClient, solverAccount, usdcAddress, usdcDecimals)
+			const { balance, required, sufficient } = await getUsdcBalanceStatus(
+				publicClient,
+				solverAccount,
+				usdcAddress,
+				usdcDecimals,
+			)
 			if (sufficient) {
-				const pm = await buildCirclePaymasterData(
-					publicClient,
-					signer,
-					solverAccount,
+				// The override only ever lowers the signed limit, so the default is the
+				// worst case the deposit must cover.
+				const shortfall = await depositShortfall(
+					options,
 					circleAddr,
-					chain,
-					configService,
-					paymasterVerificationGasLimit,
+					VERIFICATION_GAS_LIMIT_CIRCLE + POST_OP_GAS_LIMIT_CIRCLE,
+					"circle",
 				)
-				return {
-					paymasterAndData: packPaymasterAndData(pm),
-					type: "circle",
-					address: circleAddr,
-					token: usdcAddress,
+				if (!shortfall) {
+					const pm = await buildCirclePaymasterData(
+						publicClient,
+						signer,
+						solverAccount,
+						circleAddr,
+						chain,
+						configService,
+						paymasterVerificationGasLimit,
+					)
+					return {
+						paymasterAndData: packPaymasterAndData(pm),
+						type: "circle",
+						address: circleAddr,
+						token: usdcAddress,
+					}
 				}
+				skipReasons.push(shortfall)
+			} else {
+				skipReasons.push(`circle: solver USDC balance ${balance} < ${required}`)
 			}
 		}
 	}
 
 	if (simplexAddr) {
-		const pm = await buildSimplexPaymasterData(
-			publicClient,
-			walletClient,
-			signer,
-			solverAccount,
+		// Checked before the builder: buildSimplexPaymasterData can send a bootstrap
+		// approve tx, which must not happen for a paymaster that cannot sponsor.
+		const shortfall = await depositShortfall(
+			options,
 			simplexAddr,
-			chain,
-			configService,
-			{ skipPermit },
+			VERIFICATION_GAS_LIMIT_PERMIT + POST_OP_GAS_LIMIT_SIMPLEX,
+			"simplex",
 		)
-		if (pm) {
-			return {
-				paymasterAndData: packPaymasterAndData(pm),
-				type: "simplex",
-				address: simplexAddr,
-				token: pm.token,
+		if (!shortfall) {
+			const pm = await buildSimplexPaymasterData(
+				publicClient,
+				walletClient,
+				signer,
+				solverAccount,
+				simplexAddr,
+				chain,
+				configService,
+				{ skipPermit },
+			)
+			if (pm) {
+				return {
+					paymasterAndData: packPaymasterAndData(pm),
+					type: "simplex",
+					address: simplexAddr,
+					token: pm.token,
+				}
 			}
+			skipReasons.push("simplex: insufficient stablecoin balance")
+		} else {
+			skipReasons.push(shortfall)
 		}
 	}
 
 	return {
 		paymasterAndData: "0x" as HexString,
 		type: "none",
-		reason: "insufficient stablecoin balance for all configured paymasters",
+		reason:
+			skipReasons.length > 0
+				? skipReasons.join("; ")
+				: "insufficient stablecoin balance for all configured paymasters",
 	}
+}
+
+/**
+ * Returns a skip reason when `paymaster`'s EntryPoint deposit cannot cover this
+ * op's max prefund with {@link DEPOSIT_HEADROOM_PERCENT} headroom, undefined when
+ * it can. `pmGas` is the candidate's worst-case verification + postOp gas.
+ *
+ * Fails open (undefined) when the check cannot run — no prefund info, no
+ * EntryPoint configured, or a failed read: a transient RPC error must not disable
+ * sponsorship on a healthy chain, and the worst case is today's bundler rejection.
+ */
+async function depositShortfall(
+	options: PaymasterOptions,
+	paymaster: HexString,
+	pmGas: bigint,
+	label: "circle" | "simplex",
+): Promise<string | undefined> {
+	const { chain, publicClient, configService, prefund, logger } = options
+	if (!prefund) return undefined
+	const entryPoint = configService.getEntryPointAddress(chain)
+	if (!entryPoint) return undefined
+
+	const required = ((prefund.baseGas + pmGas) * prefund.maxFeePerGas * DEPOSIT_HEADROOM_PERCENT) / 100n
+
+	let deposit: bigint
+	try {
+		deposit = (await publicClient.readContract({
+			address: entryPoint,
+			abi: ENTRYPOINT_ABI,
+			functionName: "balanceOf",
+			args: [paymaster],
+		})) as bigint
+	} catch (error) {
+		logger?.warn({ chain, paymaster, error }, `Failed to read ${label} paymaster EntryPoint deposit; assuming sufficient`)
+		return undefined
+	}
+
+	if (deposit >= required) return undefined
+
+	logger?.warn(
+		{ chain, paymaster, deposit: deposit.toString(), required: required.toString() },
+		`Skipping ${label} paymaster: EntryPoint deposit below required prefund`,
+	)
+	return `${label}: EntryPoint deposit ${deposit} < ${required} required`
 }
 
 // ── Wallet reserve ───────────────────────────────────────────────────

--- a/sdk/packages/simplex/src/services/paymaster/types.ts
+++ b/sdk/packages/simplex/src/services/paymaster/types.ts
@@ -1,6 +1,7 @@
 import { encodePacked, type PublicClient, type WalletClient } from "viem"
 import type { HexString } from "@hyperbridge/sdk"
 import type { FillerConfigService } from "@/services/FillerConfigService"
+import type { Logger } from "@/services/Logger"
 import type { Signer } from "@/services/wallet/types"
 
 // ── Shared paymaster result type ────────────────────────────────────
@@ -13,6 +14,18 @@ export interface PaymasterResult {
 }
 
 // ── Unified orchestration types ─────────────────────────────────────
+
+/**
+ * Gas terms of the UserOp being sponsored, used to check a candidate paymaster's
+ * EntryPoint deposit against the op's max prefund before selecting it. The
+ * paymaster's own gas limits are not included — selection adds each candidate's
+ * worst-case limits, since they are only known once a candidate is chosen.
+ */
+export interface PaymasterPrefund {
+	/** callGasLimit + verificationGasLimit + preVerificationGas */
+	baseGas: bigint
+	maxFeePerGas: bigint
+}
 
 export interface PaymasterOptions {
 	chain: string
@@ -36,6 +49,14 @@ export interface PaymasterOptions {
 	 * verification gas and would invalidate them.
 	 */
 	skipPermit?: boolean
+	/**
+	 * When set, each candidate paymaster is skipped unless its EntryPoint deposit
+	 * covers this op's max prefund with {@link DEPOSIT_HEADROOM_PERCENT} headroom.
+	 * Omitted (or with no EntryPoint configured), selection is balance-only.
+	 */
+	prefund?: PaymasterPrefund
+	/** Receives a warning for every candidate skipped or deposit read that fails. */
+	logger?: Pick<Logger, "warn">
 }
 
 export interface PaymasterDataResult {
@@ -89,6 +110,16 @@ export const POST_OP_GAS_LIMIT_CIRCLE = 100_000n
  * and both USDC and USDT execute postOp at 30k.
  */
 export const POST_OP_GAS_LIMIT_SIMPLEX = 40_000n
+
+/**
+ * A candidate paymaster needs its EntryPoint deposit to cover the op's max prefund
+ * times this percentage. The bundler checks deposit >= exact prefund at execution,
+ * which for a bid is minutes after selection, and concurrent in-flight ops draw on
+ * the same deposit — 150% buys roughly one other op's share. Healthy deposits are
+ * orders of magnitude above one prefund, so the headroom only bites near-empty,
+ * exactly when skipping the paymaster is right.
+ */
+export const DEPOSIT_HEADROOM_PERCENT = 150n
 
 // ── Shared helpers ──────────────────────────────────────────────────
 

--- a/sdk/packages/simplex/src/tests/services/PaymasterSelection.test.ts
+++ b/sdk/packages/simplex/src/tests/services/PaymasterSelection.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { PublicClient, WalletClient } from "viem"
+import type { HexString } from "@hyperbridge/sdk"
+import type { FillerConfigService } from "@/services/FillerConfigService"
+import { buildPaymasterAndData } from "@/services/paymaster"
+import {
+	DEPOSIT_HEADROOM_PERCENT,
+	POST_OP_GAS_LIMIT_CIRCLE,
+	POST_OP_GAS_LIMIT_SIMPLEX,
+	VERIFICATION_GAS_LIMIT_CIRCLE,
+	VERIFICATION_GAS_LIMIT_PERMIT,
+} from "@/services/paymaster/types"
+import { buildCirclePaymasterData } from "@/services/paymaster/provider/circle"
+import { buildSimplexPaymasterData } from "@/services/paymaster/provider/simplex"
+
+vi.mock("@/services/paymaster/provider/circle", () => ({
+	buildCirclePaymasterData: vi.fn(async () => ({
+		paymaster: "0x00000000000000000000000000000000000c17c1" as HexString,
+		paymasterData: "0x" as HexString,
+		paymasterVerificationGasLimit: 200_000n,
+		paymasterPostOpGasLimit: 100_000n,
+	})),
+}))
+
+vi.mock("@/services/paymaster/provider/simplex", () => ({
+	buildSimplexPaymasterData: vi.fn(async () => ({
+		paymaster: "0x000000000000000000000000000000000051391e" as HexString,
+		paymasterData: "0x" as HexString,
+		paymasterVerificationGasLimit: 250_000n,
+		paymasterPostOpGasLimit: 40_000n,
+		token: "0x000000000000000000000000000000000000a5d0" as HexString,
+	})),
+}))
+
+const CIRCLE = "0x00000000000000000000000000000000000c17c1" as HexString
+const SIMPLEX = "0x000000000000000000000000000000000051391e" as HexString
+const ENTRY_POINT = "0x0000000000000000000000000000000000004337" as HexString
+const USDC = "0x000000000000000000000000000000000000a5d0" as HexString
+const SOLVER = "0x0000000000000000000000000000000000501e13" as HexString
+
+const BASE_GAS = 1_000_000n
+const MAX_FEE = 1_000_000n
+const PREFUND = { baseGas: BASE_GAS, maxFeePerGas: MAX_FEE }
+
+const requiredFor = (pmGas: bigint) => ((BASE_GAS + pmGas) * MAX_FEE * DEPOSIT_HEADROOM_PERCENT) / 100n
+const CIRCLE_REQUIRED = requiredFor(VERIFICATION_GAS_LIMIT_CIRCLE + POST_OP_GAS_LIMIT_CIRCLE)
+const SIMPLEX_REQUIRED = requiredFor(VERIFICATION_GAS_LIMIT_PERMIT + POST_OP_GAS_LIMIT_SIMPLEX)
+
+const AMPLE = CIRCLE_REQUIRED + SIMPLEX_REQUIRED
+
+function configService(entryPoint: HexString | null = ENTRY_POINT): FillerConfigService {
+	return {
+		getCirclePaymasterAddress: () => CIRCLE,
+		getSimplexPaymasterAddress: () => SIMPLEX,
+		getUsdcAsset: () => USDC,
+		getUsdcDecimals: () => 6,
+		getEntryPointAddress: () => entryPoint ?? undefined,
+	} as unknown as FillerConfigService
+}
+
+function client(opts: { solverUsdc?: bigint; circleDeposit?: bigint; simplexDeposit?: bigint; depositError?: boolean }) {
+	const readContract = vi.fn(
+		async ({ address, functionName, args }: { address: HexString; functionName: string; args: unknown[] }) => {
+			if (address === USDC && functionName === "balanceOf") return opts.solverUsdc ?? 2_000_000n
+			if (address === ENTRY_POINT && functionName === "balanceOf") {
+				if (opts.depositError) throw new Error("rpc down")
+				if (args[0] === CIRCLE) return opts.circleDeposit ?? AMPLE
+				if (args[0] === SIMPLEX) return opts.simplexDeposit ?? AMPLE
+			}
+			throw new Error(`unexpected read: ${address}.${functionName}`)
+		},
+	)
+	return { readContract } as unknown as PublicClient & { readContract: ReturnType<typeof vi.fn> }
+}
+
+function options(
+	publicClient: PublicClient,
+	overrides: { prefund?: typeof PREFUND; configService?: FillerConfigService; logger?: { warn: ReturnType<typeof vi.fn> } } = {},
+) {
+	return {
+		chain: "EVM-8453",
+		solverAccount: SOLVER,
+		publicClient,
+		walletClient: {} as unknown as WalletClient,
+		signer: { signTypedData: async () => "0x" as HexString },
+		configService: overrides.configService ?? configService(),
+		prefund: "prefund" in overrides ? overrides.prefund : PREFUND,
+		logger: overrides.logger,
+	}
+}
+
+beforeEach(() => {
+	vi.clearAllMocks()
+})
+
+describe("buildPaymasterAndData deposit-aware selection", () => {
+	it("picks Circle when its deposit and the solver USDC balance suffice", async () => {
+		const result = await buildPaymasterAndData(options(client({})))
+		expect(result.type).toBe("circle")
+		expect(result.address).toBe(CIRCLE)
+		expect(buildSimplexPaymasterData).not.toHaveBeenCalled()
+	})
+
+	it("falls through to Simplex when the Circle deposit is one wei short", async () => {
+		const logger = { warn: vi.fn() }
+		const result = await buildPaymasterAndData(
+			options(client({ circleDeposit: CIRCLE_REQUIRED - 1n }), { logger }),
+		)
+		expect(result.type).toBe("simplex")
+		expect(result.address).toBe(SIMPLEX)
+		expect(buildCirclePaymasterData).not.toHaveBeenCalled()
+		expect(logger.warn).toHaveBeenCalledOnce()
+	})
+
+	it("returns none, naming both shortfalls, without invoking either builder", async () => {
+		const result = await buildPaymasterAndData(
+			options(client({ circleDeposit: CIRCLE_REQUIRED - 1n, simplexDeposit: SIMPLEX_REQUIRED - 1n })),
+		)
+		expect(result.type).toBe("none")
+		expect(result.reason).toContain(`circle: EntryPoint deposit ${CIRCLE_REQUIRED - 1n} < ${CIRCLE_REQUIRED}`)
+		expect(result.reason).toContain(`simplex: EntryPoint deposit ${SIMPLEX_REQUIRED - 1n} < ${SIMPLEX_REQUIRED}`)
+		expect(buildCirclePaymasterData).not.toHaveBeenCalled()
+		expect(buildSimplexPaymasterData).not.toHaveBeenCalled()
+	})
+
+	it("skips the deposit check entirely when no prefund is given", async () => {
+		const publicClient = client({ circleDeposit: 0n, simplexDeposit: 0n })
+		const result = await buildPaymasterAndData(options(publicClient, { prefund: undefined }))
+		expect(result.type).toBe("circle")
+		const entryPointReads = publicClient.readContract.mock.calls.filter(
+			(call) => (call[0] as { address: HexString }).address === ENTRY_POINT,
+		)
+		expect(entryPointReads).toHaveLength(0)
+	})
+
+	it("still gates Circle on the solver USDC balance before the deposit", async () => {
+		const result = await buildPaymasterAndData(options(client({ solverUsdc: 999_999n })))
+		expect(result.type).toBe("simplex")
+		expect(buildCirclePaymasterData).not.toHaveBeenCalled()
+	})
+
+	it("fails open when the deposit read errors", async () => {
+		const logger = { warn: vi.fn() }
+		const result = await buildPaymasterAndData(options(client({ depositError: true }), { logger }))
+		expect(result.type).toBe("circle")
+		expect(logger.warn).toHaveBeenCalledOnce()
+	})
+
+	it("accepts a deposit exactly at the headroom boundary", async () => {
+		const result = await buildPaymasterAndData(options(client({ circleDeposit: CIRCLE_REQUIRED })))
+		expect(result.type).toBe("circle")
+	})
+
+	it("skips the deposit check when no EntryPoint is configured", async () => {
+		const publicClient = client({ circleDeposit: 0n })
+		const result = await buildPaymasterAndData(
+			options(publicClient, { configService: configService(null) }),
+		)
+		expect(result.type).toBe("circle")
+		const entryPointReads = publicClient.readContract.mock.calls.filter(
+			(call) => (call[0] as { address: HexString }).address === ENTRY_POINT,
+		)
+		expect(entryPointReads).toHaveLength(0)
+	})
+
+	it("reports both balance and deposit skip reasons when nothing is eligible", async () => {
+		vi.mocked(buildSimplexPaymasterData).mockResolvedValueOnce(null)
+		const result = await buildPaymasterAndData(options(client({ solverUsdc: 0n })))
+		expect(result.type).toBe("none")
+		expect(result.reason).toContain("circle: solver USDC balance 0 < 1000000")
+		expect(result.reason).toContain("simplex: insufficient stablecoin balance")
+	})
+})


### PR DESCRIPTION
Bid fills on Base failed with "precheck failed: paymaster deposit is 5040291504712 but must be at least 14962500000000" — the Circle paymaster's EntryPoint deposit was drained and selection never checked it, so every bid was signed against a paymaster the bundler was bound to reject.

`buildPaymasterAndData` still prefers Circle, then Simplex, but now skips any candidate whose EntryPoint deposit cannot cover the op's max prefund with 150% headroom, and reports per-candidate reasons when none qualifies. Deposit reads fail open so an RPC blip degrades to the bundler's own precheck. The Simplex gate runs before its builder, which can send a bootstrap approve tx.