### PR TITLE
[indexer]: Refresh pool LP balances on order fills

### DIFF
--- a/sdk/packages/indexer/docs/ai/ChangeLog.md
+++ b/sdk/packages/indexer/docs/ai/ChangeLog.md
@@ -12,6 +12,58 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-09-01 — Refresh a pool's LP balances on every order fill
+
+A pool's published depth is the sum of its bidders' output-token inventory, measured when the last phantom bid
+window closed. A fill spends some of that inventory, so between windows the depth advertises capacity the
+solvers no longer hold — and the depth is what a taker sizes an order against.
+
+`OrderFilled` now re-reads the balances of every LP recorded as backing the pools the fill traded through and
+republishes the depths from them: `PoolBidder.liquidity`, `PoolChainLiquidity.depth`/`bidCount`/unrestricted
+slice, `PoolRoute.depth`/`bidCount`, and the pool's own `sellDepth`/`buyDepth`/bid counts. A bidder left holding
+nothing loses its row, so the "every row is a bidder with capacity" invariant survives, and the routes it alone
+declared go with it. Rates are untouched — nothing here observes a quote — though a pool's merged rate can still
+move, because the chains are weighted by the depths that just changed.
+
+`PartialFill` refreshes on the same terms, through the same service method: it spends inventory identically, and
+being the same-chain path (`IntrinsicIntents`) its source and destination are one chain. Cross-chain fills are
+all-or-nothing, so between the two handlers every fill that moves inventory now triggers a refresh.
+
+The pools are resolved from the order's own two sides: the input symbols on its source chain paired with the
+output symbols on the destination chain, via the same token registry the snapshot path uses. An order in
+untracked assets resolves to no pool and costs nothing, which is most of them.
+
+Two guards keep the cost bounded and the data honest. A pool whose last snapshot postdates the fill is skipped
+entirely — that snapshot already read balances this fill had moved, and during a resync it is every pool, so
+replaying history triggers no RPC at all. And a chain whose balances cannot be read in full is left exactly as
+indexed rather than partially republished: a failed read is indistinguishable from a zero balance, so half a
+chain would report the unread bidders as departed.
+
+`lastUpdatedBlock`/`lastUpdatedAt` are deliberately not moved anywhere. They date the snapshot that priced the
+pool, in Hyperbridge blocks; a fill carries an EVM block number of another chain, which is not comparable with
+them and would wreck the `MAX_SAMPLE_AGE_BLOCKS` staleness filter.
+
+The balance-reader wiring (`setAggregationFetch(safeFetch)`, the per-chain RPC map, the per-block memo) moved out
+of `handlePhantomOrderPrices.handler.ts` into `src/utils/solverBalance.ts` so both paths read balances the same
+way; the memo key is now a string so it can identify a block of either chain. The pool-level merge and the
+unrestricted-slice split were extracted into `mergeChainRowsIntoPool` and `bidderDepths`, shared by the snapshot
+writer and the refresh — the two must publish the same numbers from the same bidders.
+
+Unrelated but in the way: `phantomOrder.handlers.test.ts` was red before this change — all 14 of its
+`handlePhantomOrderPrices` cases threw `sortPoolSymbols is not a function`. Its `@hyperbridge/sdk/intents-helpers`
+mock lists only the three entry points the handlers call, and the pool-token registry re-exports its symbol
+ordering from that same module, so mocking it dropped `poolSlug`/`sortPoolSymbols` and every pool attribution
+threw. The mock now spreads `jest.requireActual` and overrides only those three; importing the SDK under jest has
+worked since `transformIgnorePatterns` was added. That suite covers the handler wiring this change moved, so it
+had to run to verify the move — all 16 cases pass.
+
+Files: `src/services/liquidityPool.service.ts`, `src/services/intentGatewayV3.service.ts`,
+`src/handlers/events/intentGatewayV3/orderFilledV3.event.handler.ts`,
+`src/handlers/events/intentGatewayV3/partialFilledV3.event.handler.ts`,
+`src/handlers/events/substrateChains/handlePhantomOrderPrices.handler.ts`, `src/utils/solverBalance.ts` (new),
+`src/services/__tests__/liquidityPoolRefresh.service.test.ts` (new),
+`src/handlers/events/substrateChains/__tests__/phantomOrder.handlers.test.ts`.
+
 ## 2026-08-28 — Decode phantom bids of either `fillOrder` shape
 
 `extractFillDataVm2` built one ethers `Interface` from `FILL_ORDER_ABI`. When `FillOptions` gained `validUntil`

--- a/sdk/packages/indexer/docs/ai/ChangeLog.md
+++ b/sdk/packages/indexer/docs/ai/ChangeLog.md
@@ -39,6 +39,13 @@ replaying history triggers no RPC at all. And a chain whose balances cannot be r
 indexed rather than partially republished: a failed read is indistinguishable from a zero balance, so half a
 chain would report the unread bidders as departed.
 
+The refresh also extends `LiquidityProviderBalanceV2` with what it read, so a provider's latest balance row does
+not keep reporting inventory the pool rows already know is spent. That series is keyed by Hyperbridge block and a
+fill has none, so it borrows Hyperbridge's head via `chain_getHeader` on the configured node — one read per
+indexed block, shared by every fill in it. Two readings on one key resolve to the larger, the same rule the sweep
+follows, because a refresh can never see a solver's Uniswap V4 positions and the smaller reading is the
+incomplete one. An unreachable Hyperbridge node costs the data point, not the refresh.
+
 `lastUpdatedBlock`/`lastUpdatedAt` are deliberately not moved anywhere. They date the snapshot that priced the
 pool, in Hyperbridge blocks; a fill carries an EVM block number of another chain, which is not comparable with
 them and would wreck the `MAX_SAMPLE_AGE_BLOCKS` staleness filter.
@@ -61,6 +68,7 @@ Files: `src/services/liquidityPool.service.ts`, `src/services/intentGatewayV3.se
 `src/handlers/events/intentGatewayV3/orderFilledV3.event.handler.ts`,
 `src/handlers/events/intentGatewayV3/partialFilledV3.event.handler.ts`,
 `src/handlers/events/substrateChains/handlePhantomOrderPrices.handler.ts`, `src/utils/solverBalance.ts` (new),
+`src/configs/schema.graphql` (descriptions only),
 `src/services/__tests__/liquidityPoolRefresh.service.test.ts` (new),
 `src/handlers/events/substrateChains/__tests__/phantomOrder.handlers.test.ts`.
 

--- a/sdk/packages/indexer/docs/ai/Decisions.md
+++ b/sdk/packages/indexer/docs/ai/Decisions.md
@@ -49,9 +49,26 @@ Cross-chain fills are all-or-nothing (`ExtrinsicIntents` emits only `OrderFilled
 every fill that moves inventory now triggers a refresh. The per-block balance memo means a partial fill and the
 full fill that follows it in the same block read balances once.
 
-Not changed, deliberately: `LiquidityProviderBalanceV2` is not written by a refresh. That series is keyed by
-Hyperbridge block number, which a fill does not have, so a refresh has no row to write there without inventing a
-key.
+Chosen: a refresh extends `LiquidityProviderBalanceV2` too, stamping its rows with Hyperbridge's head block read
+live from the configured node. The series is keyed by Hyperbridge block and a fill has none of its own, so
+something has to supply one, and the head is the only number that keeps the series monotonic — which is the single
+property consumers read it for ("greatest blockNumber is the current balance").
+
+Alternative rejected — leave the series to snapshots. It is what the first cut did, and it leaves the pool rows
+and the balance rows disagreeing between windows: the depth knows the inventory is spent while the newest balance
+row still reports it, and those two are meant to be the same measurement.
+
+Alternative rejected — overwrite the newest existing row in place. No RPC and no new key, but it rewrites history:
+that row claims to be the balance at its Hyperbridge block, and after the overwrite it is not.
+
+Alternative rejected — a fill-shaped key (`…-fill-{evmBlock}-…`). Append-only and honest about provenance, but it
+puts two unrelated block sequences in one column, so the greatest-blockNumber rule stops meaning "latest".
+
+The stamp is a borrowed clock, not a claim: the balance was read at the EVM chain's head, not reconstructed at
+that Hyperbridge block, and the schema description now says so. Two readings landing on one key resolve to the
+larger, the rule the sweep already follows — a refresh is always the V4-blind reading, so it must not replace a
+complete one. The cost is that a second fill while Hyperbridge is still on the same block does not lower the row;
+one block later it does.
 
 ## 2026-08-28 — The VM2 decoder tries both `fillOrder` shapes, and the new test avoids the SDK root import
 

--- a/sdk/packages/indexer/docs/ai/Decisions.md
+++ b/sdk/packages/indexer/docs/ai/Decisions.md
@@ -4,6 +4,55 @@ AI-maintained record of non-obvious choices made in `sdk/packages/indexer`: what
 
 Entry format: heading with the decision, then alternatives considered and the reasoning. Newest first.
 
+## 2026-09-01 — The fill refresh re-reads balances, publishes no provenance of its own, and skips replayed fills
+
+Chosen: on `OrderFilled`, re-read every recorded bidder's balance for the pools the fill traded through and
+rewrite the depths from them, leaving rates and every `lastUpdatedBlock`/`lastUpdatedAt` alone.
+
+Alternative rejected — subtract the filled amount from the filler's row. No RPC, exact for the one solver that
+filled, and wrong for everyone else: a fill is not the only thing that moves inventory between windows
+(rebalances, other pools' fills, withdrawals), and the arithmetic would drift from the chain with nothing to
+correct it until the next window. Re-reading measures the thing the depth is defined as.
+
+Alternative rejected — refresh only the fill's own chain. Cheaper, and it is the only chain this fill changed.
+But the pool's depth is a cross-chain sum, and the request is for the pool's liquidity, not one chain's slice;
+the per-chain memo already collapses the extra reads, and the two guards below mean this only ever runs at the
+tip.
+
+Alternative rejected — stamp the refresh with the fill's block and timestamp. `lastUpdatedBlock` is a Hyperbridge
+block number, and the staleness window (`MAX_SAMPLE_AGE_BLOCKS`) is measured in those; an EVM block number is
+numerically unrelated and would make every row look either astronomically fresh or unusably stale. Writing only
+`lastUpdatedAt` would leave the pair describing two different events. A dedicated `refreshedAt` field was the
+honest version of this and was dropped deliberately: it buys provenance metadata at the price of a schema change
+on live pool entities, and the depth being fresher than its timestamp claims is the safe direction to be wrong in.
+
+Chosen: a pool whose `lastUpdatedAt` is newer than the fill is skipped without reading a balance. Balances are
+read at the chain head — as the snapshot path also reads them — so refreshing against a fill the pool has already
+been sampled after would replace fresher data with a partial view of it. It also makes a historical resync free:
+every replayed fill is older than the pools' current samples, so no RPC is issued at all.
+
+Chosen: a chain whose balances cannot be read in full is left exactly as indexed. A failed read and a zero
+balance are indistinguishable downstream, so publishing the reads that succeeded would report the rest of that
+chain's bidders as having withdrawn — worse than a stale number, because it looks like news.
+
+Accepted blind spot, documented at `refreshPoolLiquidity`: the refresh reads wallet ERC-20 plus redeemable
+ERC-4626 positions, but a snapshot's weight can also include Uniswap V4 positions the bid declared, and only a
+bid names those. A V4-funded bidder therefore shrinks to its liquid inventory until the next window restores it.
+Errs downward, which costs a quote rather than a failed fill. The fix, if V4-funded solvers become material, is to
+split the position share out in the SDK aggregation and persist it on `PoolBidder` so it can be carried forward —
+which is a schema change, hence not done pre-emptively.
+
+Chosen: `PartialFill` refreshes on the same terms as `OrderFilled`, through the same service method. It spends
+output-token inventory identically — the only difference is that it is emitted by the same-chain path
+(`IntrinsicIntents`), where source and destination are one chain, so the pair resolves against a single registry.
+Cross-chain fills are all-or-nothing (`ExtrinsicIntents` emits only `OrderFilled`), so between the two handlers
+every fill that moves inventory now triggers a refresh. The per-block balance memo means a partial fill and the
+full fill that follows it in the same block read balances once.
+
+Not changed, deliberately: `LiquidityProviderBalanceV2` is not written by a refresh. That series is keyed by
+Hyperbridge block number, which a fill does not have, so a refresh has no row to write there without inventing a
+key.
+
 ## 2026-08-28 — The VM2 decoder tries both `fillOrder` shapes, and the new test avoids the SDK root import
 
 Alternatives to trying both shapes:

--- a/sdk/packages/indexer/docs/ai/Flow.md
+++ b/sdk/packages/indexer/docs/ai/Flow.md
@@ -24,6 +24,8 @@ The indexer is a SubQuery project: per-network YAML files in `src/configs/` bind
    - `updateDailyVolume` upserts `DailyVolumeUSD` with ID `<baseId>.<chain>.<YYYY-MM-DD>` (UTC day bucket). It has no same-timestamp guard, so every call increments the daily counter.
    - USD amounts are stored as bigints scaled by 1e18 (`toScaledUsd`).
 
+5. Back in the handler, a third independent try/catch calls `IntentGatewayV3Service.refreshPoolLiquidityAfterFill`. Unlike the two above it is not a volume path: it re-reads the balances behind the pools this fill traded through (see the pool liquidity refresh flow below). Like `recordOrderVolume` it runs whether or not the order is indexed yet — but it needs the order row for the source chain, so a fill-before-place race resolves no pool and it returns immediately.
+
 Parallel paths that look similar but are not the same: `recordOrderVolume` (step 1) writes `IntentGatewayTokenVolume` and `CumulativeIntentGatewayVolumeUSD` (IDs keyed `chain-token-volumeType` / `chain-volumeType`). It does its own token pricing and skips tokens with no known price, while the `updateOrderStatus` path prices unknown tokens as zero through `getOutputValuesUSD`; their USD totals can therefore differ for the same fill. Do not expect `CumulativeIntentGatewayVolumeUSD` for FILLED to equal `CumulativeVolumeUSD` for `IntentGatewayV3.FILLED`: they also diverge on fill-before-place races (only `recordOrderVolume` runs) and same-block fills (only the `VolumeService` cumulative counter deduplicates).
 
 ## Phantom price snapshot to pool rates (PhantomBidWindowExhausted)
@@ -47,6 +49,46 @@ Verified 2026-08-19 against live mainnet data.
 5. Chain rows (`PoolChainLiquidity`, one per pool/chain/direction) are merged into the pool's single `sellRate`/`buyRate` by `weightedRate` — a depth-weighted **mean**, which unlike the median in step 3 does produce values no filler quoted. Samples older than `MAX_SAMPLE_AGE_BLOCKS` are excluded unless every sample is stale.
 
 Precision note: a leg's quoted output integer *is* the price, to whatever resolution the output token's decimals allow. cNGN into 6-decimal USDC quotes ~715 base units, so the grid is 1/715 = 0.14% and the filler's floor rounding costs up to one full step. Chains whose output token has 18 decimals carry full precision on the same leg — which is why EVM-56 publishes `716845878136200` where Base publishes a bare `715`. The fix is a larger `standardAmount`, which step 4 now supports; see Decisions.md for why the filler's flooring must stay.
+
+## Pool liquidity refresh (OrderFilled)
+
+Verified 2026-09-01 by unit test against a mocked store; the RPC read itself is the same
+`memoizedSolverBalance` the snapshot flow above uses.
+
+The snapshot flow measures a pool's depth once per bid window. This flow keeps it honest in between, when
+fills have spent some of the inventory it is a sum of.
+
+1. `handleOrderFilledEventV3` and `handlePartialFilledEventV3` both call
+   `IntentGatewayV3Service.refreshPoolLiquidityAfterFill` in their own try/catch — it reads external RPCs, and
+   stale depth is recoverable, so a failure must never stall indexing. `PartialFill` only ever comes from the
+   same-chain path (`IntrinsicIntents`); cross-chain fills are all-or-nothing and emit only `OrderFilled`
+   (`ExtrinsicIntents`), so between the two handlers every fill that spends inventory reaches this flow.
+2. That method loads the order row for its **source** chain (a fill event carries the inputs' addresses but
+   not the chain they live on) and calls `poolsForFill`, which pairs the input symbols on the source chain
+   with the output symbols on the destination chain through the same token registry `resolvePoolLeg` uses.
+   No order row, or no registry-tracked pair, means no pool and an immediate return — which is the common
+   case, and is what keeps this off the critical path of most fills.
+3. `refreshPoolLiquidity` (`src/services/liquidityPool.service.ts`) then, per pool:
+   - **skips the pool entirely if `pool.lastUpdatedAt` is newer than the fill.** That snapshot already read
+     balances this fill had moved. During a resync this is true of every replayed fill, so backfilling costs
+     no RPC at all.
+   - reads every `PoolBidder` row of the pool (all chains, paged to exhaustion) and groups them by chain.
+   - per chain, re-reads each bidder's balance of that row's `outputToken` and scales it to 1e18. **If any
+     read fails, or the chain has no configured RPC, the whole chain is abandoned untouched** — a failed
+     read looks exactly like a zero balance, so a partial write would report the unread bidders as departed.
+   - writes the survivors: a row whose balance is now zero is removed (every row is a bidder with capacity),
+     the chain's `PoolChainLiquidity` depth/bidCount/unrestricted slice is recomputed from the survivors, and
+     `PoolRoute` rows are updated or removed. Routes are never *created* here: declarations only come from
+     bids, so the surviving set can only shrink.
+   - re-merges the pool's chain rows into `sellDepth`/`buyDepth` through the same `mergeChainRowsIntoPool`
+     the snapshot writer uses, with the freshest row's block as the staleness reference (the fill's own EVM
+     block number is not comparable with the Hyperbridge blocks these rows are stamped with).
+4. Nothing here writes `lastUpdatedBlock` or `lastUpdatedAt`, and nothing re-derives a rate. A pool's merged
+   rate can still move, because the per-chain samples are depth-weighted and the depths just changed.
+
+Blind spot to know about when reading a depth that dropped right after a fill: the balance read covers wallet
+ERC-20 and redeemable ERC-4626 positions, not the Uniswap V4 positions a bid can declare (only a bid names
+them). A V4-funded bidder therefore reads low until the next bid window restores it.
 
 ## Phantom bid calldata decoding (`extractFillDataVm2`)
 

--- a/sdk/packages/indexer/docs/ai/Flow.md
+++ b/sdk/packages/indexer/docs/ai/Flow.md
@@ -83,7 +83,13 @@ fills have spent some of the inventory it is a sum of.
    - re-merges the pool's chain rows into `sellDepth`/`buyDepth` through the same `mergeChainRowsIntoPool`
      the snapshot writer uses, with the freshest row's block as the staleness reference (the fill's own EVM
      block number is not comparable with the Hyperbridge blocks these rows are stamped with).
-4. Nothing here writes `lastUpdatedBlock` or `lastUpdatedAt`, and nothing re-derives a rate. A pool's merged
+4. Each chain that was written also extends `LiquidityProviderBalanceV2` with the raw balances just read,
+   keyed by Hyperbridge's head block (`chain_getHeader` on the configured Hyperbridge node, memoized per
+   indexed block). A zero balance is not a row, matching the sweep; an existing row for that key is only ever
+   raised, never lowered, because a refresh cannot see declared Uniswap V4 positions and the sweep's rule is
+   that the larger of two readings is the complete one. A null head (no Hyperbridge RPC, or unreachable) skips
+   the row and nothing else.
+5. Nothing here writes `lastUpdatedBlock` or `lastUpdatedAt`, and nothing re-derives a rate. A pool's merged
    rate can still move, because the per-chain samples are depth-weighted and the depths just changed.
 
 Blind spot to know about when reading a depth that dropped right after a fill: the balance read covers wallet

--- a/sdk/packages/indexer/src/configs/schema.graphql
+++ b/sdk/packages/indexer/src/configs/schema.graphql
@@ -2457,9 +2457,15 @@ type LiquidityProviderBalanceV2 @entity {
 	Composite identifier: {chain}-{tokenAddress}-{blockNumber}-{providerAddress}. One row per
 	provider per (chain, token) per Hyperbridge block, so liquidity is a time series rather than a
 	single overwritten latest value. Every phantom order whose bid window closes on a block shares
-	that block's rows — balances are point-in-time reads, identical across the block's snapshots —
-	so rows correlate to snapshots via blockNumber. For a provider's current liquidity, take the
-	row with the greatest blockNumber for that (provider, chain, tokenAddress).
+	that block's rows — balances are point-in-time reads, identical across the block's snapshots.
+	For a provider's current liquidity, take the row with the greatest blockNumber for that
+	(provider, chain, tokenAddress).
+
+	Most rows come from a bid window closing, but an order fill also appends one: it re-reads the
+	balances backing the pools it traded through and stamps them with Hyperbridge's head block at
+	that moment, since a fill has no Hyperbridge block of its own. A row therefore does not imply a
+	snapshot at that block, and the two kinds are not distinguishable from the row — what they share
+	is the property this series is read for, that a greater blockNumber is a later reading.
 	"""
 	id: ID!
 
@@ -2490,6 +2496,10 @@ type LiquidityProviderBalanceV2 @entity {
 	V4 share is only visible on the chain whose bid declared it — a bid is per chain, so no other
 	chain's sweep can see those positions — and only for a token some yield-vault entry tracks,
 	since the sweep has no row to attach it to otherwise.
+
+	A row written by a fill refresh never carries the V4 share at all: only a bid names those
+	positions, and a fill has no bid to read. Two readings landing on one key resolve to the larger,
+	which is the rule that keeps the V4-blind one from replacing a complete one.
 	"""
 	balance: BigInt! @index
 

--- a/sdk/packages/indexer/src/handlers/events/intentGatewayV3/orderFilledV3.event.handler.ts
+++ b/sdk/packages/indexer/src/handlers/events/intentGatewayV3/orderFilledV3.event.handler.ts
@@ -27,22 +27,17 @@ export const handleOrderFilledEventV3 = wrap(async (event: OrderFilledLog): Prom
 		token: token.token as Hex,
 		amount: BigInt(token.amount.toString()),
 	}))
+	const mappedInputs = inputs.map((token) => ({
+		token: token.token as Hex,
+		amount: BigInt(token.amount.toString()),
+	}))
 
-	await IntentGatewayV3Service.recordFill(
-		commitment,
-		filler,
-		mappedOutputs,
-		inputs.map((token) => ({
-			token: token.token as Hex,
-			amount: BigInt(token.amount.toString()),
-		})),
-		{
-			transactionHash,
-			blockNumber,
-			timestamp,
-			logIndex,
-		},
-	)
+	await IntentGatewayV3Service.recordFill(commitment, filler, mappedOutputs, mappedInputs, {
+		transactionHash,
+		blockNumber,
+		timestamp,
+		logIndex,
+	})
 
 	await IntentGatewayV3Service.updateOrderStatus(
 		commitment,
@@ -60,5 +55,21 @@ export const handleOrderFilledEventV3 = wrap(async (event: OrderFilledLog): Prom
 		await IntentGatewayV3Service.recordOrderVolume("FILLED", mappedOutputs, timestamp)
 	} catch (e: any) {
 		logger.error(`Failed to record FILLED volume for order ${commitment}: ${e.message}`)
+	}
+
+	// The fill just spent the filler's output-token inventory, which is what the pool's published
+	// depth is a sum of, so re-read the LPs backing those pools. Best-effort for the same reason as
+	// above, and doubly so here: it reads external RPCs, and stale depth is recoverable — the next
+	// phantom bid window republishes it from scratch.
+	try {
+		await IntentGatewayV3Service.refreshPoolLiquidityAfterFill({
+			commitment,
+			inputs: mappedInputs,
+			outputs: mappedOutputs,
+			timestamp,
+			blockNumber,
+		})
+	} catch (e: any) {
+		logger.error(`Failed to refresh pool liquidity for order ${commitment}: ${e.message}`)
 	}
 })

--- a/sdk/packages/indexer/src/handlers/events/intentGatewayV3/partialFilledV3.event.handler.ts
+++ b/sdk/packages/indexer/src/handlers/events/intentGatewayV3/partialFilledV3.event.handler.ts
@@ -23,22 +23,34 @@ export const handlePartialFilledEventV3 = wrap(async (event: PartialFillLog): Pr
 		})} by ${stringify({ filler })}`,
 	)
 
-	await IntentGatewayV3Service.recordPartialFill(
-		commitment,
-		filler as Hex,
-		outputs.map((token) => ({
-			token: token.token as Hex,
-			amount: BigInt(token.amount.toString()),
-		})),
-		inputs.map((token) => ({
-			token: token.token as Hex,
-			amount: BigInt(token.amount.toString()),
-		})),
-		{
-			transactionHash,
-			blockNumber,
+	const mappedOutputs = outputs.map((token) => ({
+		token: token.token as Hex,
+		amount: BigInt(token.amount.toString()),
+	}))
+	const mappedInputs = inputs.map((token) => ({
+		token: token.token as Hex,
+		amount: BigInt(token.amount.toString()),
+	}))
+
+	await IntentGatewayV3Service.recordPartialFill(commitment, filler as Hex, mappedOutputs, mappedInputs, {
+		transactionHash,
+		blockNumber,
+		timestamp,
+		logIndex,
+	})
+
+	// A partial fill spends the filler's output-token inventory exactly as a full one does, so the
+	// pools it drew on are re-read the same way. Best-effort: it reads external RPCs, and stale
+	// depth is recoverable — the next phantom bid window republishes it from scratch.
+	try {
+		await IntentGatewayV3Service.refreshPoolLiquidityAfterFill({
+			commitment,
+			inputs: mappedInputs,
+			outputs: mappedOutputs,
 			timestamp,
-			logIndex,
-		},
-	)
+			blockNumber,
+		})
+	} catch (e: any) {
+		logger.error(`Failed to refresh pool liquidity for partially filled order ${commitment}: ${e.message}`)
+	}
 })

--- a/sdk/packages/indexer/src/handlers/events/substrateChains/__tests__/phantomOrder.handlers.test.ts
+++ b/sdk/packages/indexer/src/handlers/events/substrateChains/__tests__/phantomOrder.handlers.test.ts
@@ -2,13 +2,15 @@
 // token pair into a single order: one registration writes a row per directed leg, and one bid
 // window closing writes a price snapshot per leg.
 //
-// The SDK is mocked rather than imported. Its CJS bundle pulls in ESM-only packages that jest's
-// runtime cannot require, and the aggregation itself is already covered by the SDK's own tests; what
-// matters here is what the handlers do with its result.
+// The aggregation is stubbed rather than run: it is already covered by the SDK's own tests, and what
+// matters here is what the handlers do with its result. Only the entry points the handlers call are
+// replaced — the rest of the module is kept, because the pool-token registry re-exports its symbol
+// ordering from here, and a mock that drops those exports makes every pool attribution throw.
 
 const aggregatePhantomBids = jest.fn()
 
 jest.mock("@hyperbridge/sdk/intents-helpers", () => ({
+	...jest.requireActual("@hyperbridge/sdk/intents-helpers"),
 	aggregatePhantomBids: (...args: unknown[]) => aggregatePhantomBids(...args),
 	memoizedSolverBalance: jest.fn(() => jest.fn()),
 	setAggregationFetch: jest.fn(),

--- a/sdk/packages/indexer/src/handlers/events/substrateChains/handlePhantomOrderPrices.handler.ts
+++ b/sdk/packages/indexer/src/handlers/events/substrateChains/handlePhantomOrderPrices.handler.ts
@@ -15,13 +15,8 @@ import {
 	PhantomOrderPriceSnapshotV2,
 	PhantomOrderV2,
 } from "@/configs/src/types"
-import {
-	aggregatePhantomBids,
-	memoizedSolverBalance,
-	setAggregationFetch,
-	type SolverBalanceReader,
-} from "@hyperbridge/sdk/intents-helpers"
-import { safeFetch } from "@/utils/safeFetch"
+import { aggregatePhantomBids } from "@hyperbridge/sdk/intents-helpers"
+import { blockBalanceReader, evmRpcUrls } from "@/utils/solverBalance"
 import {
 	bidNonceKeyVm2,
 	extractFillDataVm2,
@@ -32,26 +27,6 @@ import {
 import { UNISWAP_V4_ADDRESSES } from "@/addresses/uniswap-v4.addresses"
 import { resolvePoolLeg, updateLiquidityPools, type AttributedLeg } from "@/services/liquidityPool.service"
 import { readAllPages } from "@/utils/store.helpers"
-
-// The aggregation's RPC helpers run inside the SubQuery VM2 sandbox, which has no global `fetch`.
-// Inject the indexer's sandbox-safe HTTP client so its JSON-RPC calls work here.
-setAggregationFetch(safeFetch)
-
-// Every configured chain's phantom order shares one generation interval, so all their bid windows
-// close on the same Hyperbridge block and this handler runs once per order back to back. Balances
-// are point-in-time reads that cannot differ within a block, so one memo serves every aggregation
-// on it — without this, the full liquidity sweep (every chain, every vault token, every solver)
-// would repeat identically per order. Blocks are processed in order, so keeping only the current
-// block's memo is enough.
-let balanceReaderBlock: bigint | null = null
-let balanceReader: SolverBalanceReader | null = null
-function blockBalanceReader(blockNumber: bigint, yieldVaults: Parameters<typeof memoizedSolverBalance>[0]) {
-	if (balanceReaderBlock !== blockNumber || !balanceReader) {
-		balanceReader = memoizedSolverBalance(yieldVaults)
-		balanceReaderBlock = blockNumber
-	}
-	return balanceReader
-}
 
 // Triggered by PhantomBidWindowExhausted once a phantom order's bid window closes, so every bid is
 // already in. The order prices several directed legs at once, so its bids aggregate into one
@@ -106,14 +81,9 @@ export const handlePhantomOrderPrices = wrap(async (event: SubstrateEvent): Prom
 
 	// RPC per supported EVM chain — the aggregation sweeps every LP's liquidity across all of them,
 	// not just the phantom order's destination chain.
-	const evmRpcUrls: Record<string, string> = {}
-	for (const [stateMachineId, url] of Object.entries(ENV_CONFIG)) {
-		if (!stateMachineId.startsWith("EVM-")) continue
-		const http = replaceWebsocketWithHttp(url ?? "")
-		if (http) evmRpcUrls[stateMachineId] = http
-	}
+	const rpcUrls = evmRpcUrls()
 	const gatewayAddress = INTENT_GATEWAY_V3_ADDRESSES[phantom.chain as keyof typeof INTENT_GATEWAY_V3_ADDRESSES]
-	if (!evmRpcUrls[phantom.chain] || !gatewayAddress) return
+	if (!rpcUrls[phantom.chain] || !gatewayAddress) return
 
 	// A bid only counts if its sender delegates to this, so with no configured address there is
 	// nothing to verify against and no snapshot to write. Worth a warning rather than a silent skip:
@@ -131,7 +101,7 @@ export const handlePhantomOrderPrices = wrap(async (event: SubstrateEvent): Prom
 	try {
 		aggregate = await aggregatePhantomBids({
 			nodeUrl,
-			evmRpcUrls,
+			evmRpcUrls: rpcUrls,
 			chain: phantom.chain,
 			gatewayAddress,
 			commitment,
@@ -146,7 +116,7 @@ export const handlePhantomOrderPrices = wrap(async (event: SubstrateEvent): Prom
 			// ownership check are read on-chain, so the bid only points at what to look at.
 			uniswapV4: UNISWAP_V4_ADDRESSES,
 			keccak: keccakVm2,
-			getBalance: blockBalanceReader(blockNumber, YIELD_VAULT_ADDRESSES),
+			getBalance: blockBalanceReader(`${host}-${blockNumber}`),
 			logger,
 		})
 	} catch (err) {

--- a/sdk/packages/indexer/src/services/__tests__/liquidityPoolRefresh.service.test.ts
+++ b/sdk/packages/indexer/src/services/__tests__/liquidityPoolRefresh.service.test.ts
@@ -1,0 +1,312 @@
+// The fill-driven half of the pool entities: which pools a fill traded through, and what
+// re-reading its LPs' balances does to the rows a taker reads. Exercised against the real generated
+// token registry, like the snapshot half — the registry's decimals are what turn a raw balance into
+// published depth, so what matters is that the shipped data resolves.
+
+;(global as any).logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+
+const records = new Map<string, any>()
+;(global as any).store = {
+	get: jest.fn(async (entity: string, id: string) => records.get(`${entity}:${id}`)),
+	set: jest.fn(async (entity: string, id: string, props: any) => {
+		records.set(`${entity}:${id}`, { ...props })
+	}),
+	remove: jest.fn(async (entity: string, id: string) => {
+		records.delete(`${entity}:${id}`)
+	}),
+	getByField: jest.fn(async (entity: string, field: string, value: any, options: any = {}) =>
+		page(
+			rowsOf(entity).filter((row) => row[field] === value),
+			options,
+		),
+	),
+	getByFields: jest.fn(async (entity: string, filter: [string, string, any][], options: any = {}) =>
+		page(
+			rowsOf(entity).filter((row) => filter.every(([field, , value]) => row[field] === value)),
+			options,
+		),
+	),
+}
+
+const rowsOf = (entity: string) =>
+	[...records.entries()]
+		.filter(([key]) => key.startsWith(`${entity}:`))
+		.map(([, props]) => props)
+		.sort((a, b) => (a.id < b.id ? -1 : 1))
+
+const page = (rows: any[], options: { limit?: number; offset?: number }) =>
+	rows.slice(options.offset ?? 0, (options.offset ?? 0) + (options.limit ?? rows.length))
+
+import { poolsForFill, refreshPoolLiquidity } from "@/services/liquidityPool.service"
+
+const BASE = "EVM-8453"
+const ETHEREUM = "EVM-1"
+const CNGN_BASE = "0x46c85152bfe9f96829aa94755d9f915f9b10ef5f"
+const USDC_BASE = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+const USDC_ETHEREUM = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+const POOL = "cNGN-USDC"
+const SOLVER_A = "0x1111111111111111111111111111111111111111"
+const SOLVER_B = "0x2222222222222222222222222222222222222222"
+
+// Both pool tokens are 6-decimal, so a raw balance is published at 1e12 times its value.
+const SCALE = 10n ** 12n
+const usdc = (whole: bigint) => whole * 10n ** 6n
+
+// The pool's rows were written by a Hyperbridge snapshot at this block and time; the fill that
+// triggers the refresh happens after it. Both are asserted to survive the refresh untouched — they
+// are the provenance of the RATE, which no balance read re-derives.
+const SNAPSHOT_BLOCK = 4_200_000n
+const SNAPSHOT_TIME = new Date("2026-08-01T12:00:00Z")
+const FILL_TIME = new Date("2026-08-01T12:00:30Z")
+const RATE = 715_000_000_000_000_000n
+
+const RPC_URLS = { [BASE]: "https://base.example", [ETHEREUM]: "https://ethereum.example" }
+
+/** Raw (unscaled) balances the refresh will read, keyed `chain|token|solver`. */
+let balances: Map<string, bigint>
+/** Chains whose reads must throw, standing in for an unreachable RPC. */
+let unreadable: Set<string>
+
+const getBalance = jest.fn(async (_url: string, chain: string, token: string, solver: string) => {
+	if (unreadable.has(chain)) throw new Error(`RPC unreachable for ${chain}`)
+	return balances.get(`${chain}|${token}|${solver}`) ?? 0n
+})
+
+function plantPool(): void {
+	records.set(`LiquidityPool:${POOL}`, {
+		id: POOL,
+		token0Symbol: "cNGN",
+		token1Symbol: "USDC",
+		sellRate: RATE,
+		sellDepth: usdc(1500n) * SCALE,
+		sellBidCount: 2,
+		buyDepth: 0n,
+		buyBidCount: 0,
+		lastUpdatedBlock: SNAPSHOT_BLOCK,
+		lastUpdatedAt: SNAPSHOT_TIME,
+	})
+	records.set(`PoolChainLiquidity:${POOL}-${BASE}-SELL`, {
+		id: `${POOL}-${BASE}-SELL`,
+		poolId: POOL,
+		chain: BASE,
+		direction: "SELL",
+		rate: RATE,
+		depth: usdc(1500n) * SCALE,
+		bidCount: 2,
+		unrestrictedDepth: usdc(500n) * SCALE,
+		unrestrictedBidCount: 1,
+		lastUpdatedBlock: SNAPSHOT_BLOCK,
+		lastUpdatedAt: SNAPSHOT_TIME,
+	})
+	// Solver A declares Ethereum as an accepted source; solver B declares nothing, so its capacity
+	// is only reachable through the chain row's unrestricted slice.
+	plantBidder(SOLVER_A, usdc(1000n), [ETHEREUM])
+	plantBidder(SOLVER_B, usdc(500n), undefined)
+	records.set(`PoolRoute:${POOL}-${BASE}-SELL-${ETHEREUM}`, {
+		id: `${POOL}-${BASE}-SELL-${ETHEREUM}`,
+		poolId: POOL,
+		chain: BASE,
+		direction: "SELL",
+		sourceChain: ETHEREUM,
+		depth: usdc(1000n) * SCALE,
+		bidCount: 1,
+		lastUpdatedBlock: SNAPSHOT_BLOCK,
+		lastUpdatedAt: SNAPSHOT_TIME,
+	})
+}
+
+function plantBidder(solver: string, rawBalance: bigint, acceptedSources: string[] | undefined): void {
+	const id = `${POOL}-${BASE}-SELL-${USDC_BASE}-${solver}`
+	records.set(`PoolBidder:${id}`, {
+		id,
+		poolId: POOL,
+		providerId: solver,
+		chain: BASE,
+		direction: "SELL",
+		outputToken: USDC_BASE,
+		liquidity: rawBalance * SCALE,
+		acceptedSources,
+		lastUpdatedBlock: SNAPSHOT_BLOCK,
+		lastUpdatedAt: SNAPSHOT_TIME,
+	})
+	balances.set(`${BASE}|${USDC_BASE}|${solver}`, rawBalance)
+}
+
+const refresh = (filledAt = FILL_TIME) =>
+	refreshPoolLiquidity({ poolIds: [POOL], filledAt, evmRpcUrls: RPC_URLS, getBalance })
+
+const read = (entity: string, id: string) => records.get(`${entity}:${id}`)
+
+describe("poolsForFill", () => {
+	// The fill's two sides live on two chains — inputs escrowed on the source, outputs delivered on
+	// the destination — and the same symbol carries different addresses and decimals on each, so the
+	// pair can only be resolved one chain at a time.
+	it("pairs the source chain's input symbol with the destination chain's output symbol", () => {
+		expect(
+			poolsForFill({
+				sourceChain: ETHEREUM,
+				inputTokens: [USDC_ETHEREUM],
+				destChain: BASE,
+				outputTokens: [CNGN_BASE],
+			}),
+		).toEqual([POOL])
+	})
+
+	// Event fields arrive as bytes32, and the registry is keyed by 20-byte addresses.
+	it("resolves tokens given as left-padded bytes32", () => {
+		expect(
+			poolsForFill({
+				sourceChain: ETHEREUM,
+				inputTokens: [`0x000000000000000000000000${USDC_ETHEREUM.slice(2)}`],
+				destChain: BASE,
+				outputTokens: [`0x000000000000000000000000${CNGN_BASE.slice(2)}`],
+			}),
+		).toEqual([POOL])
+	})
+
+	// Most orders are in assets no pool tracks. Resolving them to nothing is what keeps the refresh
+	// off the critical path of every fill the indexer sees.
+	it("resolves nothing when either side is not registry-tracked", () => {
+		expect(
+			poolsForFill({
+				sourceChain: ETHEREUM,
+				inputTokens: ["0x1f9840a85d5af5bf1d1762f925bdaddc4201f984"],
+				destChain: BASE,
+				outputTokens: [CNGN_BASE],
+			}),
+		).toEqual([])
+	})
+
+	// A token on the wrong chain is not the same token: the registry is per chain, so the Base USDC
+	// address means nothing on Ethereum and must not resolve to Ethereum's USDC.
+	it("does not resolve a token address against another chain's registry", () => {
+		expect(
+			poolsForFill({
+				sourceChain: ETHEREUM,
+				inputTokens: [USDC_BASE],
+				destChain: BASE,
+				outputTokens: [CNGN_BASE],
+			}),
+		).toEqual([])
+	})
+})
+
+describe("refreshPoolLiquidity", () => {
+	beforeEach(() => {
+		records.clear()
+		balances = new Map()
+		unreadable = new Set()
+		getBalance.mockClear()
+		plantPool()
+	})
+
+	it("republishes bidder, chain, route and pool depth from the re-read balances", async () => {
+		// Solver A filled 400 USDC worth of the order; solver B is untouched.
+		balances.set(`${BASE}|${USDC_BASE}|${SOLVER_A}`, usdc(600n))
+
+		await refresh()
+
+		expect(read("PoolBidder", `${POOL}-${BASE}-SELL-${USDC_BASE}-${SOLVER_A}`).liquidity).toBe(usdc(600n) * SCALE)
+		expect(read("PoolBidder", `${POOL}-${BASE}-SELL-${USDC_BASE}-${SOLVER_B}`).liquidity).toBe(usdc(500n) * SCALE)
+
+		const chainRow = read("PoolChainLiquidity", `${POOL}-${BASE}-SELL`)
+		expect(chainRow.depth).toBe(usdc(1100n) * SCALE)
+		expect(chainRow.bidCount).toBe(2)
+		// Solver B declares no accepted sources, so its capacity stays in the unrestricted slice.
+		expect(chainRow.unrestrictedDepth).toBe(usdc(500n) * SCALE)
+		expect(chainRow.unrestrictedBidCount).toBe(1)
+
+		expect(read("PoolRoute", `${POOL}-${BASE}-SELL-${ETHEREUM}`).depth).toBe(usdc(600n) * SCALE)
+
+		const pool = read("LiquidityPool", POOL)
+		expect(pool.sellDepth).toBe(usdc(1100n) * SCALE)
+		expect(pool.sellBidCount).toBe(2)
+	})
+
+	// The rate is the snapshot's, and so is the block and time that date it. A fill carries an EVM
+	// block number of another chain entirely, which would be meaningless against the Hyperbridge
+	// blocks these rows age by.
+	it("leaves the rate and the snapshot's provenance untouched", async () => {
+		balances.set(`${BASE}|${USDC_BASE}|${SOLVER_A}`, usdc(600n))
+
+		await refresh()
+
+		for (const [entity, id] of [
+			["LiquidityPool", POOL],
+			["PoolChainLiquidity", `${POOL}-${BASE}-SELL`],
+			["PoolRoute", `${POOL}-${BASE}-SELL-${ETHEREUM}`],
+			["PoolBidder", `${POOL}-${BASE}-SELL-${USDC_BASE}-${SOLVER_A}`],
+		] as const) {
+			expect(read(entity, id).lastUpdatedBlock).toBe(SNAPSHOT_BLOCK)
+			expect(read(entity, id).lastUpdatedAt).toEqual(SNAPSHOT_TIME)
+		}
+		expect(read("LiquidityPool", POOL).sellRate).toBe(RATE)
+		expect(read("PoolChainLiquidity", `${POOL}-${BASE}-SELL`).rate).toBe(RATE)
+	})
+
+	// Every bidder row is a bidder with capacity — that invariant is what lets consumers count the
+	// rows as well as sum them — so a solver that spent its inventory loses its row, and the route
+	// it was the only declarer of goes with it.
+	it("drops a bidder that now holds nothing, and the route it alone backed", async () => {
+		balances.set(`${BASE}|${USDC_BASE}|${SOLVER_A}`, 0n)
+
+		await refresh()
+
+		expect(read("PoolBidder", `${POOL}-${BASE}-SELL-${USDC_BASE}-${SOLVER_A}`)).toBeUndefined()
+		expect(read("PoolRoute", `${POOL}-${BASE}-SELL-${ETHEREUM}`)).toBeUndefined()
+
+		const chainRow = read("PoolChainLiquidity", `${POOL}-${BASE}-SELL`)
+		expect(chainRow.depth).toBe(usdc(500n) * SCALE)
+		expect(chainRow.bidCount).toBe(1)
+		expect(read("LiquidityPool", POOL).sellDepth).toBe(usdc(500n) * SCALE)
+	})
+
+	// Depth zeroed, rate kept: the same state a snapshot writes for a direction nobody backed this
+	// window. Nulling the rate would throw away the last thing known about the price.
+	it("zeroes a direction whose bidders have all gone, keeping its last rate", async () => {
+		balances.set(`${BASE}|${USDC_BASE}|${SOLVER_A}`, 0n)
+		balances.set(`${BASE}|${USDC_BASE}|${SOLVER_B}`, 0n)
+
+		await refresh()
+
+		const chainRow = read("PoolChainLiquidity", `${POOL}-${BASE}-SELL`)
+		expect(chainRow.depth).toBe(0n)
+		expect(chainRow.bidCount).toBe(0)
+		expect(chainRow.unrestrictedDepth).toBe(0n)
+		expect(chainRow.rate).toBe(RATE)
+		expect(read("LiquidityPool", POOL).sellDepth).toBe(0n)
+		expect(read("LiquidityPool", POOL).sellRate).toBe(RATE)
+	})
+
+	// A failed read is indistinguishable from a zero balance, so a chain that cannot be read in full
+	// is not written at all — publishing the half that answered would report the rest as departed.
+	it("leaves a chain exactly as indexed when a balance cannot be read", async () => {
+		unreadable.add(BASE)
+
+		await refresh()
+
+		expect(read("PoolBidder", `${POOL}-${BASE}-SELL-${USDC_BASE}-${SOLVER_A}`).liquidity).toBe(usdc(1000n) * SCALE)
+		expect(read("PoolChainLiquidity", `${POOL}-${BASE}-SELL`).depth).toBe(usdc(1500n) * SCALE)
+		expect(read("PoolRoute", `${POOL}-${BASE}-SELL-${ETHEREUM}`).depth).toBe(usdc(1000n) * SCALE)
+		expect(read("LiquidityPool", POOL).sellDepth).toBe(usdc(1500n) * SCALE)
+	})
+
+	// The guard that keeps a resync free: a replayed fill is older than the pool's current sample,
+	// and re-reading balances at the chain head would replace fresher data with a partial view of it.
+	it("skips a pool already sampled after the fill, without reading a balance", async () => {
+		balances.set(`${BASE}|${USDC_BASE}|${SOLVER_A}`, 0n)
+
+		await refresh(new Date(SNAPSHOT_TIME.getTime() - 60_000))
+
+		expect(getBalance).not.toHaveBeenCalled()
+		expect(read("LiquidityPool", POOL).sellDepth).toBe(usdc(1500n) * SCALE)
+	})
+
+	it("does nothing for a pool the indexer has never sampled", async () => {
+		records.delete(`LiquidityPool:${POOL}`)
+
+		await refreshPoolLiquidity({ poolIds: [POOL], filledAt: FILL_TIME, evmRpcUrls: RPC_URLS, getBalance })
+
+		expect(getBalance).not.toHaveBeenCalled()
+	})
+})

--- a/sdk/packages/indexer/src/services/__tests__/liquidityPoolRefresh.service.test.ts
+++ b/sdk/packages/indexer/src/services/__tests__/liquidityPoolRefresh.service.test.ts
@@ -132,8 +132,12 @@ function plantBidder(solver: string, rawBalance: bigint, acceptedSources: string
 	balances.set(`${BASE}|${USDC_BASE}|${solver}`, rawBalance)
 }
 
+// Hyperbridge's head when the fill lands: the block a refresh's balance rows are stamped with.
+const HEAD_BLOCK = SNAPSHOT_BLOCK + 12n
+const headBlock = jest.fn(async () => HEAD_BLOCK as bigint | null)
+
 const refresh = (filledAt = FILL_TIME) =>
-	refreshPoolLiquidity({ poolIds: [POOL], filledAt, evmRpcUrls: RPC_URLS, getBalance })
+	refreshPoolLiquidity({ poolIds: [POOL], filledAt, evmRpcUrls: RPC_URLS, getBalance, headBlock })
 
 const read = (entity: string, id: string) => records.get(`${entity}:${id}`)
 
@@ -197,6 +201,8 @@ describe("refreshPoolLiquidity", () => {
 		balances = new Map()
 		unreadable = new Set()
 		getBalance.mockClear()
+		headBlock.mockClear()
+		headBlock.mockResolvedValue(HEAD_BLOCK)
 		plantPool()
 	})
 
@@ -305,8 +311,98 @@ describe("refreshPoolLiquidity", () => {
 	it("does nothing for a pool the indexer has never sampled", async () => {
 		records.delete(`LiquidityPool:${POOL}`)
 
-		await refreshPoolLiquidity({ poolIds: [POOL], filledAt: FILL_TIME, evmRpcUrls: RPC_URLS, getBalance })
+		await refreshPoolLiquidity({
+			poolIds: [POOL],
+			filledAt: FILL_TIME,
+			evmRpcUrls: RPC_URLS,
+			getBalance,
+			headBlock,
+		})
 
 		expect(getBalance).not.toHaveBeenCalled()
+	})
+})
+
+// The pool rows are what a taker sizes against, but LiquidityProviderBalanceV2 is the series a
+// provider's own liquidity is read from, and it would otherwise keep reporting inventory the pool
+// rows already know is spent. A fill has no Hyperbridge block of its own, so it borrows the head.
+describe("refreshPoolLiquidity balance series", () => {
+	beforeEach(() => {
+		records.clear()
+		balances = new Map()
+		unreadable = new Set()
+		getBalance.mockClear()
+		headBlock.mockClear()
+		headBlock.mockResolvedValue(HEAD_BLOCK)
+		plantPool()
+	})
+
+	const balanceRow = (solver: string, block = HEAD_BLOCK) =>
+		read("LiquidityProviderBalanceV2", `${BASE}-${USDC_BASE}-${block}-${solver}`)
+
+	it("records the re-read balance at Hyperbridge's head block, in raw token units", async () => {
+		balances.set(`${BASE}|${USDC_BASE}|${SOLVER_A}`, usdc(600n))
+
+		await refresh()
+
+		// Raw units, not the 1e18-normalized depth the pool rows carry.
+		expect(balanceRow(SOLVER_A).balance).toBe(usdc(600n))
+		expect(balanceRow(SOLVER_A).chain).toBe(BASE)
+		expect(balanceRow(SOLVER_A).tokenAddress).toBe(USDC_BASE)
+		expect(balanceRow(SOLVER_A).providerId).toBe(SOLVER_A)
+		expect(balanceRow(SOLVER_A).snapshotTime).toEqual(FILL_TIME)
+		expect(balanceRow(SOLVER_B).balance).toBe(usdc(500n))
+	})
+
+	// The sweep skips tokens a solver does not hold, so a zero is an absent row there and here.
+	it("writes no row for a solver that now holds nothing", async () => {
+		balances.set(`${BASE}|${USDC_BASE}|${SOLVER_A}`, 0n)
+
+		await refresh()
+
+		expect(balanceRow(SOLVER_A)).toBeUndefined()
+		expect(balanceRow(SOLVER_B)).toBeDefined()
+	})
+
+	// The sweep's own convention for a key two readings land on: the larger one is the complete
+	// one, because the smaller is the one that could not see a solver's Uniswap V4 positions — and
+	// a refresh never can.
+	it("does not lower a reading already recorded at that block", async () => {
+		records.set(`LiquidityProviderBalanceV2:${BASE}-${USDC_BASE}-${HEAD_BLOCK}-${SOLVER_A}`, {
+			id: `${BASE}-${USDC_BASE}-${HEAD_BLOCK}-${SOLVER_A}`,
+			providerId: SOLVER_A,
+			chain: BASE,
+			blockNumber: HEAD_BLOCK,
+			tokenAddress: USDC_BASE,
+			balance: usdc(900n),
+			snapshotTime: SNAPSHOT_TIME,
+		})
+		balances.set(`${BASE}|${USDC_BASE}|${SOLVER_A}`, usdc(600n))
+
+		await refresh()
+
+		expect(balanceRow(SOLVER_A).balance).toBe(usdc(900n))
+		// The pool rows still take the fresh reading — they are not keyed by that block.
+		expect(read("PoolBidder", `${POOL}-${BASE}-SELL-${USDC_BASE}-${SOLVER_A}`).liquidity).toBe(usdc(600n) * SCALE)
+	})
+
+	// The series is secondary: an unreachable Hyperbridge node costs a data point, not the refresh.
+	it("still refreshes the pool when Hyperbridge's head cannot be read", async () => {
+		headBlock.mockResolvedValue(null)
+		balances.set(`${BASE}|${USDC_BASE}|${SOLVER_A}`, usdc(600n))
+
+		await refresh()
+
+		expect(balanceRow(SOLVER_A)).toBeUndefined()
+		expect(read("LiquidityPool", POOL).sellDepth).toBe(usdc(1100n) * SCALE)
+	})
+
+	it("records nothing for a chain whose balances could not be read", async () => {
+		unreadable.add(BASE)
+
+		await refresh()
+
+		expect(balanceRow(SOLVER_A)).toBeUndefined()
+		expect(balanceRow(SOLVER_B)).toBeUndefined()
 	})
 })

--- a/sdk/packages/indexer/src/services/intentGatewayV3.service.ts
+++ b/sdk/packages/indexer/src/services/intentGatewayV3.service.ts
@@ -39,7 +39,13 @@ import { LiquidityPool } from "@/configs/src/types/models/LiquidityPool"
 import { timestampToDate } from "@/utils/date.helpers"
 import { getHostStateMachine } from "@/utils/substrate.helpers"
 import { canonicalPoolSymbol, poolSlug } from "@/addresses/pool-tokens.addresses"
-import { orientedPoolRates, POOL_RATE_DECIMALS } from "@/services/liquidityPool.service"
+import {
+	orientedPoolRates,
+	poolsForFill,
+	POOL_RATE_DECIMALS,
+	refreshPoolLiquidity,
+} from "@/services/liquidityPool.service"
+import { blockBalanceReader, evmRpcUrls } from "@/utils/solverBalance"
 
 import { PointsService } from "./points.service"
 import { VolumeService, toScaledUsd } from "./volume.service"
@@ -741,6 +747,48 @@ export class IntentGatewayV3Service {
 				filler,
 			})}`,
 		)
+	}
+
+	/**
+	 * Re-reads the liquidity behind the pools this fill traded through, so their published depth
+	 * stops advertising inventory the filler has just spent. The pool pair spans two chains — the
+	 * inputs are escrowed on the source chain, the outputs delivered here — so the order row is
+	 * what makes the pair resolvable; a fill indexed before its `OrderPlaced` has no source chain
+	 * to resolve against and is left to the next phantom snapshot.
+	 *
+	 * Balances are read at the chain head, as the snapshot path also reads them. That is only
+	 * meaningful for a fill at the tip, which is why `refreshPoolLiquidity` skips any pool already
+	 * sampled after this fill — during a resync that is every pool, and this costs nothing.
+	 */
+	static async refreshPoolLiquidityAfterFill(params: {
+		commitment: string
+		inputs: TokenInfo[]
+		outputs: TokenInfo[]
+		timestamp: bigint
+		blockNumber: number
+	}): Promise<void> {
+		const { commitment, inputs, outputs, timestamp, blockNumber } = params
+		const destChain = getHostStateMachine(chainId)
+
+		const order = await OrderV3Placed.get(commitment)
+		if (!order) return
+
+		const poolIds = poolsForFill({
+			sourceChain: decodeChain(order.sourceChain),
+			inputTokens: inputs.map((input) => input.token),
+			destChain,
+			outputTokens: outputs.map((output) => output.token),
+		})
+		if (poolIds.length === 0) return
+
+		await refreshPoolLiquidity({
+			poolIds,
+			filledAt: timestampToDate(timestamp),
+			evmRpcUrls: evmRpcUrls(),
+			// Several fills can land in one block, and a balance is one value per block, so they
+			// share a read. The key is block-scoped because the next block's balances differ.
+			getBalance: blockBalanceReader(`${destChain}-${blockNumber}`),
+		})
 	}
 
 	static async recordFill(

--- a/sdk/packages/indexer/src/services/intentGatewayV3.service.ts
+++ b/sdk/packages/indexer/src/services/intentGatewayV3.service.ts
@@ -45,7 +45,7 @@ import {
 	POOL_RATE_DECIMALS,
 	refreshPoolLiquidity,
 } from "@/services/liquidityPool.service"
-import { blockBalanceReader, evmRpcUrls } from "@/utils/solverBalance"
+import { blockBalanceReader, evmRpcUrls, hyperbridgeHeadBlock } from "@/utils/solverBalance"
 
 import { PointsService } from "./points.service"
 import { VolumeService, toScaledUsd } from "./volume.service"
@@ -788,6 +788,7 @@ export class IntentGatewayV3Service {
 			// Several fills can land in one block, and a balance is one value per block, so they
 			// share a read. The key is block-scoped because the next block's balances differ.
 			getBalance: blockBalanceReader(`${destChain}-${blockNumber}`),
+			headBlock: () => hyperbridgeHeadBlock(`${destChain}-${blockNumber}`),
 		})
 	}
 

--- a/sdk/packages/indexer/src/services/liquidityPool.service.ts
+++ b/sdk/packages/indexer/src/services/liquidityPool.service.ts
@@ -5,7 +5,8 @@
 import { getPoolToken, poolSlug, sortPoolSymbols } from "@/addresses/pool-tokens.addresses"
 import { LiquidityPool, LiquidityProvider, PoolBidder, PoolChainLiquidity, PoolRoute } from "@/configs/src/types"
 import { readAllPages } from "@/utils/store.helpers"
-import type { PhantomLegAggregation } from "@hyperbridge/sdk/intents-helpers"
+import { bytes32ToBytes20 } from "@/utils/transfer.helpers"
+import type { PhantomLegAggregation, SolverBalanceReader } from "@hyperbridge/sdk/intents-helpers"
 
 export const SELL = "SELL"
 export const BUY = "BUY"
@@ -151,6 +152,40 @@ function weightedRate(samples: { rate: bigint; depth: bigint }[]): bigint {
 	return depth > 0n
 		? samples.reduce((acc, sample) => acc + sample.rate * sample.depth, 0n) / depth
 		: samples.reduce((acc, sample) => acc + sample.rate, 0n) / BigInt(samples.length)
+}
+
+/** One bidder's contribution to a (chain, direction)'s published depth. */
+interface BidderLiquidity {
+	liquidity: bigint
+	/** Null or undefined for a bidder whose bid carried no accepted-source declaration. */
+	acceptedSources?: string[] | null
+}
+
+/**
+ * The depth a set of bidders on one (chain, direction) publishes, and the slice of it behind
+ * bidders with no accepted-source declaration — reported separately because those bidders have no
+ * PoolRoute rows for consumers to find their capacity under.
+ *
+ * The one home for that split: `updateLiquidityPools` derives it from a snapshot's bidders and
+ * `refreshPoolLiquidity` from the stored rows, and a disagreement between the two would show up as
+ * depth stepping between two numbers as fills and snapshots alternate.
+ */
+function bidderDepths(bidders: BidderLiquidity[]): {
+	depth: bigint
+	unrestrictedDepth: bigint
+	unrestrictedBidCount: number
+} {
+	let depth = 0n
+	let unrestrictedDepth = 0n
+	let unrestrictedBidCount = 0
+	for (const bidder of bidders) {
+		depth += bidder.liquidity
+		if (bidder.acceptedSources == null) {
+			unrestrictedDepth += bidder.liquidity
+			unrestrictedBidCount += 1
+		}
+	}
+	return { depth, unrestrictedDepth, unrestrictedBidCount }
 }
 
 interface PoolBidderSample {
@@ -354,18 +389,8 @@ export async function updateLiquidityPools(params: {
 		for (const [direction, entry] of directions) {
 			const id = `${poolId}-${chain}-${direction}`
 			if (entry.quoted) {
-				const depth = entry.samples.reduce((acc, sample) => acc + sample.depth, 0n)
 				const rate = weightedRate(entry.samples)
-				// The slice of depth behind no-declaration bidders, reported separately because
-				// they have no PoolRoute rows for consumers to find it under.
-				let unrestrictedDepth = 0n
-				let unrestrictedBidCount = 0
-				for (const bidder of entry.bidders.values()) {
-					if (bidder.acceptedSources === null) {
-						unrestrictedDepth += bidder.liquidity
-						unrestrictedBidCount += 1
-					}
-				}
+				const { depth, unrestrictedDepth, unrestrictedBidCount } = bidderDepths([...entry.bidders.values()])
 				const row = await PoolChainLiquidity.get(id)
 				if (row) {
 					row.rate = rate
@@ -410,36 +435,48 @@ export async function updateLiquidityPools(params: {
 
 	for (const [poolId, pool] of poolRows) {
 		const rows = await PoolChainLiquidity.getByPoolId(poolId, { limit: CHAIN_ROWS_LIMIT })
-
-		for (const direction of [SELL, BUY]) {
-			const directionRows = rows.filter((row) => row.direction === direction)
-			if (directionRows.length === 0) continue
-
-			// Blocks are processed in order, so the difference is non-negative in practice; a row
-			// from a "future" block would simply count as fresh, which is the right reading anyway.
-			const fresh = directionRows.filter((row) => blockNumber - row.lastUpdatedBlock <= MAX_SAMPLE_AGE_BLOCKS)
-			const merged = fresh.length > 0 ? fresh : directionRows
-
-			warnOnDivergentSample(poolId, direction, merged)
-
-			const depth = merged.reduce((acc, row) => acc + row.depth, 0n)
-			const rate = weightedRate(merged)
-			const bidCount = merged.reduce((acc, row) => acc + row.bidCount, 0)
-
-			if (direction === SELL) {
-				pool.sellRate = rate
-				pool.sellDepth = depth
-				pool.sellBidCount = bidCount
-			} else {
-				pool.buyRate = rate
-				pool.buyDepth = depth
-				pool.buyBidCount = bidCount
-			}
-		}
+		mergeChainRowsIntoPool(pool, rows, blockNumber)
 
 		pool.lastUpdatedBlock = blockNumber
 		pool.lastUpdatedAt = snapshotTime
 		await pool.save()
+	}
+}
+
+/**
+ * Collapses a pool's per-(chain, direction) rows into its single buy/sell rate, depth and bid
+ * count, in place. `referenceBlock` is the Hyperbridge block the sample ages are measured
+ * against — the block being processed when a snapshot writes, the freshest row when a fill
+ * refresh does, which is the same reading either way.
+ *
+ * Does not touch the pool's own `lastUpdatedBlock`/`lastUpdatedAt` or save it: those record which
+ * snapshot last priced the pool, and a caller that is not a snapshot must leave them alone.
+ */
+function mergeChainRowsIntoPool(pool: LiquidityPool, rows: PoolChainLiquidity[], referenceBlock: bigint): void {
+	for (const direction of [SELL, BUY]) {
+		const directionRows = rows.filter((row) => row.direction === direction)
+		if (directionRows.length === 0) continue
+
+		// Blocks are processed in order, so the difference is non-negative in practice; a row
+		// from a "future" block would simply count as fresh, which is the right reading anyway.
+		const fresh = directionRows.filter((row) => referenceBlock - row.lastUpdatedBlock <= MAX_SAMPLE_AGE_BLOCKS)
+		const merged = fresh.length > 0 ? fresh : directionRows
+
+		warnOnDivergentSample(pool.id, direction, merged)
+
+		const depth = merged.reduce((acc, row) => acc + row.depth, 0n)
+		const rate = weightedRate(merged)
+		const bidCount = merged.reduce((acc, row) => acc + row.bidCount, 0)
+
+		if (direction === SELL) {
+			pool.sellRate = rate
+			pool.sellDepth = depth
+			pool.sellBidCount = bidCount
+		} else {
+			pool.buyRate = rate
+			pool.buyDepth = depth
+			pool.buyBidCount = bidCount
+		}
 	}
 }
 
@@ -462,5 +499,240 @@ function warnOnDivergentSample(
 				"Pool chain sample diverges >5x from the other chains — check the token registry decimals",
 			)
 		}
+	}
+}
+
+/**
+ * The pools an order's fill traded through: every input token's symbol on the source chain paired
+ * with every output token's symbol on the destination chain. A token the registry does not track
+ * contributes no pool, so an order in unrelated assets resolves to nothing and costs nothing.
+ *
+ * The pair is resolved from the two chains separately because that is where the addresses live —
+ * the inputs are escrowed on the source chain, the outputs delivered on the destination one — and
+ * a symbol's decimals differ per chain. Same-symbol pairs are the same-asset pool, exactly as
+ * `resolvePoolLeg` treats them.
+ */
+export function poolsForFill(params: {
+	sourceChain: string
+	inputTokens: string[]
+	destChain: string
+	outputTokens: string[]
+}): string[] {
+	const symbols = (chain: string, tokens: string[]) => [
+		...new Set(
+			tokens
+				.map((token) => getPoolToken(chain, bytes32ToBytes20(token))?.symbol)
+				.filter((symbol): symbol is string => !!symbol),
+		),
+	]
+	const inputs = symbols(params.sourceChain, params.inputTokens)
+	const outputs = symbols(params.destChain, params.outputTokens)
+
+	const pools = new Set<string>()
+	for (const input of inputs) {
+		for (const output of outputs) pools.add(poolSlug(input, output))
+	}
+	return [...pools]
+}
+
+/**
+ * Re-reads the on-chain inventory of every LP recorded as backing `poolIds` and republishes the
+ * pools' depths from it. Called when a fill has just consumed some of that inventory, so the
+ * depth a taker reads reflects what the solvers still hold rather than what they held when the
+ * last phantom bid window closed.
+ *
+ * Only depths, bid counts and the bidder rows themselves move. `lastUpdatedBlock` and
+ * `lastUpdatedAt` are left exactly as the snapshot wrote them everywhere: they record which
+ * Hyperbridge block priced the pool, and a fill carries an EVM block number of another chain
+ * entirely, which is not comparable with them (writing one would make every row look
+ * astronomically fresh or stale to `MAX_SAMPLE_AGE_BLOCKS`). Rates are not re-derived either —
+ * nothing here observes a new quote — though a pool's merged rate can still shift, because the
+ * chains are weighted by the depths this refresh just changed.
+ *
+ * Known blind spot: the balance read here is wallet ERC-20 plus redeemable ERC-4626 positions,
+ * while a snapshot's weight can also include Uniswap V4 positions a bid declared. Only a bid names
+ * those positions, so between windows they are invisible and a V4-funded bidder's row shrinks to
+ * its liquid inventory until the next snapshot restores it. That errs downward — understating
+ * depth costs a quote, overstating it costs a failed fill — but if V4-funded solvers become
+ * material, the fix is to persist the position share on `PoolBidder` so it can be carried forward.
+ */
+export async function refreshPoolLiquidity(params: {
+	poolIds: string[]
+	/**
+	 * Wall-clock time of the fill. A pool whose last snapshot already postdates it is left alone:
+	 * that snapshot read balances this fill had already moved, so re-reading at the chain head
+	 * would only replace fresher data with a partial view of it. This is also what keeps a
+	 * historical resync free — every replayed fill is older than the pools' current samples.
+	 */
+	filledAt: Date
+	/** HTTP RPC per state machine id; a chain absent here is left as the snapshot wrote it. */
+	evmRpcUrls: Record<string, string>
+	getBalance: SolverBalanceReader
+}): Promise<void> {
+	const { filledAt, evmRpcUrls, getBalance } = params
+
+	for (const poolId of new Set(params.poolIds)) {
+		const pool = await LiquidityPool.get(poolId)
+		if (!pool) continue
+		if (pool.lastUpdatedAt > filledAt) continue
+
+		// Bidder rows scale with the number of solvers, which nothing bounds, and a truncated read
+		// would look exactly like the missing solvers having withdrawn.
+		const bidders = await readAllPages((limit, offset) =>
+			PoolBidder.getByFields([["poolId", "=", poolId]], {
+				limit,
+				offset,
+				orderBy: "id",
+				orderDirection: "ASC",
+			}),
+		)
+		if (bidders.length === 0) continue
+
+		// Chain by chain, because a chain is the unit that can fail: its RPC is one endpoint, and
+		// a partially read chain must not be republished — the unread bidders would look departed.
+		const byChain = new Map<string, PoolBidder[]>()
+		for (const row of bidders) {
+			const rows = byChain.get(row.chain) ?? []
+			rows.push(row)
+			byChain.set(row.chain, rows)
+		}
+
+		let refreshed = false
+		for (const [chain, rows] of byChain) {
+			const liquidity = await readChainLiquidity(chain, rows, evmRpcUrls[chain], getBalance)
+			if (!liquidity) continue
+			await writeChainLiquidity(poolId, chain, rows, liquidity)
+			refreshed = true
+		}
+		if (!refreshed) continue
+
+		const chainRows = await PoolChainLiquidity.getByPoolId(poolId, { limit: CHAIN_ROWS_LIMIT })
+		if (chainRows.length === 0) continue
+		// The freshest row defines "now" for the staleness window. The block being processed
+		// cannot: it belongs to an EVM chain, and these rows are stamped with Hyperbridge blocks.
+		const referenceBlock = chainRows.reduce(
+			(newest, row) => (row.lastUpdatedBlock > newest ? row.lastUpdatedBlock : newest),
+			0n,
+		)
+		mergeChainRowsIntoPool(pool, chainRows, referenceBlock)
+		await pool.save()
+	}
+}
+
+/**
+ * Each bidder row's current liquidity on one chain, 18-decimal normalized, or null when the chain
+ * cannot be read in full. Null is deliberately all-or-nothing: a bidder whose balance failed to
+ * read is indistinguishable from one holding zero, so a partial result would publish a depth that
+ * is short by however many reads happened to fail.
+ */
+async function readChainLiquidity(
+	chain: string,
+	rows: PoolBidder[],
+	evmRpcUrl: string | undefined,
+	getBalance: SolverBalanceReader,
+): Promise<Map<string, bigint> | null> {
+	if (!evmRpcUrl) return null
+
+	const liquidity = new Map<string, bigint>()
+	for (const row of rows) {
+		const token = getPoolToken(chain, row.outputToken)
+		if (!token || token.decimals > POOL_RATE_DECIMALS) {
+			logger.warn(
+				{ chain, outputToken: row.outputToken },
+				"Pool bidder's output token is no longer registry-tracked, leaving the chain's liquidity as indexed",
+			)
+			return null
+		}
+		try {
+			const balance = await getBalance(evmRpcUrl, chain, row.outputToken, row.providerId)
+			liquidity.set(row.id, balance * 10n ** BigInt(POOL_RATE_DECIMALS - token.decimals))
+		} catch (err) {
+			logger.warn(
+				{ err, chain, solver: row.providerId, outputToken: row.outputToken },
+				"Failed to re-read a pool bidder's balance, leaving the chain's liquidity as indexed",
+			)
+			return null
+		}
+	}
+	return liquidity
+}
+
+/**
+ * Writes one chain's re-read liquidity through the rows derived from it, mirroring the
+ * reconciliation `updateLiquidityPools` performs on a snapshot: a bidder holding nothing loses its
+ * row (every row is a bidder with capacity, so the row set can be counted as well as summed), and
+ * a route keeps only the bidders that survived.
+ */
+async function writeChainLiquidity(
+	poolId: string,
+	chain: string,
+	rows: PoolBidder[],
+	liquidity: Map<string, bigint>,
+): Promise<void> {
+	const survivors: PoolBidder[] = []
+	for (const row of rows) {
+		const current = liquidity.get(row.id) ?? 0n
+		if (current === 0n) {
+			await PoolBidder.remove(row.id)
+			continue
+		}
+		if (current !== row.liquidity) {
+			row.liquidity = current
+			await row.save()
+		}
+		survivors.push(row)
+	}
+
+	// Only the directions this chain had bidders on. A direction whose rows all just vanished is
+	// zeroed here rather than skipped — that is the same "registered but unbacked" state a
+	// snapshot writes, keeping the last known rate with no depth behind it.
+	for (const direction of new Set(rows.map((row) => row.direction))) {
+		const chainRow = await PoolChainLiquidity.get(`${poolId}-${chain}-${direction}`)
+		if (!chainRow) continue
+		const directionBidders = survivors.filter((row) => row.direction === direction)
+		const { depth, unrestrictedDepth, unrestrictedBidCount } = bidderDepths(directionBidders)
+		chainRow.depth = depth
+		// Counting rows, which is what the snapshot's bid count also amounts to: it counts backed
+		// quotes, and every backed quote wrote exactly one of these rows.
+		chainRow.bidCount = directionBidders.length
+		chainRow.unrestrictedDepth = unrestrictedDepth
+		chainRow.unrestrictedBidCount = unrestrictedBidCount
+		await chainRow.save()
+	}
+
+	// Routes are derived from declarations, which no balance read can change, so the surviving
+	// bidders can only shrink the set the snapshot wrote. Existing rows are therefore updated or
+	// removed and never created: a route with no row is one no snapshot published, and inventing
+	// it here would date it to a bid window this indexer never saw.
+	const desired = new Map<string, { depth: bigint; bidCount: number }>()
+	for (const bidder of survivors) {
+		if (!bidder.acceptedSources) continue
+		for (const sourceChain of new Set(bidder.acceptedSources)) {
+			const id = `${poolId}-${chain}-${bidder.direction}-${sourceChain}`
+			const route = desired.get(id) ?? { depth: 0n, bidCount: 0 }
+			route.depth += bidder.liquidity
+			route.bidCount += 1
+			desired.set(id, route)
+		}
+	}
+	// Route rows scale with bidders times declared sources, which nothing bounds.
+	const existingRoutes = await readAllPages((limit, offset) =>
+		PoolRoute.getByFields(
+			[
+				["poolId", "=", poolId],
+				["chain", "=", chain],
+			],
+			{ limit, offset, orderBy: "id", orderDirection: "ASC" },
+		),
+	)
+	for (const row of existingRoutes) {
+		const route = desired.get(row.id)
+		if (!route) {
+			await PoolRoute.remove(row.id)
+			continue
+		}
+		row.depth = route.depth
+		row.bidCount = route.bidCount
+		await row.save()
 	}
 }

--- a/sdk/packages/indexer/src/services/liquidityPool.service.ts
+++ b/sdk/packages/indexer/src/services/liquidityPool.service.ts
@@ -3,7 +3,14 @@
 // chain's sample only differs in depth, and the pool's single buy/sell number is the
 // depth-weighted merge of the chains' latest samples.
 import { getPoolToken, poolSlug, sortPoolSymbols } from "@/addresses/pool-tokens.addresses"
-import { LiquidityPool, LiquidityProvider, PoolBidder, PoolChainLiquidity, PoolRoute } from "@/configs/src/types"
+import {
+	LiquidityPool,
+	LiquidityProvider,
+	LiquidityProviderBalanceV2,
+	PoolBidder,
+	PoolChainLiquidity,
+	PoolRoute,
+} from "@/configs/src/types"
 import { readAllPages } from "@/utils/store.helpers"
 import { bytes32ToBytes20 } from "@/utils/transfer.helpers"
 import type { PhantomLegAggregation, SolverBalanceReader } from "@hyperbridge/sdk/intents-helpers"
@@ -568,8 +575,14 @@ export async function refreshPoolLiquidity(params: {
 	/** HTTP RPC per state machine id; a chain absent here is left as the snapshot wrote it. */
 	evmRpcUrls: Record<string, string>
 	getBalance: SolverBalanceReader
+	/**
+	 * Hyperbridge's head block, the clock `LiquidityProviderBalanceV2` is keyed by. Null skips the
+	 * balance rows — the pool entities are the ones consumers size orders against, so they are
+	 * refreshed whether or not the series can be extended.
+	 */
+	headBlock: () => Promise<bigint | null>
 }): Promise<void> {
-	const { filledAt, evmRpcUrls, getBalance } = params
+	const { filledAt, evmRpcUrls, getBalance, headBlock } = params
 
 	for (const poolId of new Set(params.poolIds)) {
 		const pool = await LiquidityPool.get(poolId)
@@ -599,9 +612,12 @@ export async function refreshPoolLiquidity(params: {
 
 		let refreshed = false
 		for (const [chain, rows] of byChain) {
-			const liquidity = await readChainLiquidity(chain, rows, evmRpcUrls[chain], getBalance)
-			if (!liquidity) continue
-			await writeChainLiquidity(poolId, chain, rows, liquidity)
+			const readings = await readChainLiquidity(chain, rows, evmRpcUrls[chain], getBalance)
+			if (!readings) continue
+			await writeChainLiquidity(poolId, chain, rows, readings)
+			// The balance series is secondary to the pool rows and keyed on another chain's clock,
+			// so it is extended after them and never in their way.
+			await recordProviderBalances(chain, rows, readings, await headBlock(), filledAt)
 			refreshed = true
 		}
 		if (!refreshed) continue
@@ -619,21 +635,27 @@ export async function refreshPoolLiquidity(params: {
 	}
 }
 
+/** One bidder row's re-read inventory: raw token units, and the same value 18-decimal normalized. */
+interface BidderReading {
+	balance: bigint
+	liquidity: bigint
+}
+
 /**
- * Each bidder row's current liquidity on one chain, 18-decimal normalized, or null when the chain
- * cannot be read in full. Null is deliberately all-or-nothing: a bidder whose balance failed to
- * read is indistinguishable from one holding zero, so a partial result would publish a depth that
- * is short by however many reads happened to fail.
+ * Each bidder row's current inventory on one chain, or null when the chain cannot be read in full.
+ * Null is deliberately all-or-nothing: a bidder whose balance failed to read is indistinguishable
+ * from one holding zero, so a partial result would publish a depth that is short by however many
+ * reads happened to fail.
  */
 async function readChainLiquidity(
 	chain: string,
 	rows: PoolBidder[],
 	evmRpcUrl: string | undefined,
 	getBalance: SolverBalanceReader,
-): Promise<Map<string, bigint> | null> {
+): Promise<Map<string, BidderReading> | null> {
 	if (!evmRpcUrl) return null
 
-	const liquidity = new Map<string, bigint>()
+	const readings = new Map<string, BidderReading>()
 	for (const row of rows) {
 		const token = getPoolToken(chain, row.outputToken)
 		if (!token || token.decimals > POOL_RATE_DECIMALS) {
@@ -645,7 +667,7 @@ async function readChainLiquidity(
 		}
 		try {
 			const balance = await getBalance(evmRpcUrl, chain, row.outputToken, row.providerId)
-			liquidity.set(row.id, balance * 10n ** BigInt(POOL_RATE_DECIMALS - token.decimals))
+			readings.set(row.id, { balance, liquidity: balance * 10n ** BigInt(POOL_RATE_DECIMALS - token.decimals) })
 		} catch (err) {
 			logger.warn(
 				{ err, chain, solver: row.providerId, outputToken: row.outputToken },
@@ -654,7 +676,55 @@ async function readChainLiquidity(
 			return null
 		}
 	}
-	return liquidity
+	return readings
+}
+
+/**
+ * Extends the `LiquidityProviderBalanceV2` series with what this refresh just read, so a provider's
+ * latest balance row does not keep reporting inventory the pool rows already know is spent.
+ *
+ * Rows are keyed by Hyperbridge block because that is the clock the phantom sweep writes on; a fill
+ * borrows Hyperbridge's head, which keeps the series monotonic and "greatest blockNumber is the
+ * current balance" true. A zero balance is not a row, matching the sweep, which skips tokens a
+ * solver does not hold.
+ *
+ * An existing row for the same key is only ever raised, never lowered — the convention the sweep
+ * itself follows, because a reading that missed a solver's Uniswap V4 positions is the incomplete
+ * one and a refresh always misses them. The cost is that a second fill while Hyperbridge is still
+ * on the same block does not lower the row; one block later it does.
+ */
+async function recordProviderBalances(
+	chain: string,
+	rows: PoolBidder[],
+	readings: Map<string, BidderReading>,
+	blockNumber: bigint | null,
+	snapshotTime: Date,
+): Promise<void> {
+	if (blockNumber === null) return
+
+	for (const row of rows) {
+		const balance = readings.get(row.id)?.balance ?? 0n
+		if (balance === 0n) continue
+
+		const id = `${chain}-${row.outputToken}-${blockNumber}-${row.providerId}`
+		const existing = await LiquidityProviderBalanceV2.get(id)
+		if (existing) {
+			if (balance > existing.balance) {
+				existing.balance = balance
+				await existing.save()
+			}
+			continue
+		}
+		await LiquidityProviderBalanceV2.create({
+			id,
+			providerId: row.providerId,
+			chain,
+			blockNumber,
+			tokenAddress: row.outputToken,
+			balance,
+			snapshotTime,
+		}).save()
+	}
 }
 
 /**
@@ -667,11 +737,11 @@ async function writeChainLiquidity(
 	poolId: string,
 	chain: string,
 	rows: PoolBidder[],
-	liquidity: Map<string, bigint>,
+	readings: Map<string, BidderReading>,
 ): Promise<void> {
 	const survivors: PoolBidder[] = []
 	for (const row of rows) {
-		const current = liquidity.get(row.id) ?? 0n
+		const current = readings.get(row.id)?.liquidity ?? 0n
 		if (current === 0n) {
 			await PoolBidder.remove(row.id)
 			continue

--- a/sdk/packages/indexer/src/utils/solverBalance.ts
+++ b/sdk/packages/indexer/src/utils/solverBalance.ts
@@ -2,7 +2,7 @@
 // snapshot on Hyperbridge and the pool liquidity refresh on every EVM fill — and both must read
 // balances exactly the same way, or a refresh would republish depth on a different basis than the
 // snapshot it is correcting.
-import { ENV_CONFIG } from "@/constants"
+import { ENV_CONFIG, HYPERBRIDGE } from "@/constants"
 import { replaceWebsocketWithHttp } from "@/utils/rpc.helpers"
 import { safeFetch } from "@/utils/safeFetch"
 import { YIELD_VAULT_ADDRESSES } from "@/yield-vault-addresses"
@@ -44,4 +44,48 @@ export function blockBalanceReader(key: string): SolverBalanceReader {
 		memoKey = key
 	}
 	return memo
+}
+
+// Hyperbridge's head is read once per block of the chain being indexed, for the same reason
+// balances are: several fills can land in one block, and they all record the same head.
+let headKey: string | null = null
+let head: Promise<bigint | null> | null = null
+
+/**
+ * Hyperbridge's current head block number, or null when there is no Hyperbridge RPC configured or
+ * it cannot be read.
+ *
+ * Balance rows are keyed by Hyperbridge block, because that is the clock the phantom snapshots
+ * write on. A balance re-read on an EVM fill has no such block of its own, so it borrows the one
+ * Hyperbridge is on at that moment: the number stays monotonic with the rest of the series, which
+ * is what keeps "greatest blockNumber is the current balance" true. It is a stamp, not a proof —
+ * the balance was read at the EVM chain's head, not reconstructed at this Hyperbridge block.
+ */
+export function hyperbridgeHeadBlock(key: string): Promise<bigint | null> {
+	if (headKey !== key || !head) {
+		// Evict on rejection so one unreachable moment does not pin null for the whole block.
+		head = readHyperbridgeHead().catch((err) => {
+			logger.warn({ err }, "Could not read Hyperbridge's head block, skipping the LP balance row")
+			return null
+		})
+		headKey = key
+	}
+	return head
+}
+
+async function readHyperbridgeHead(): Promise<bigint | null> {
+	// Whichever Hyperbridge this deployment indexes; only one of them is ever configured.
+	const host = [HYPERBRIDGE.mainnet, HYPERBRIDGE.testnet, HYPERBRIDGE.local].find((id) => ENV_CONFIG[id])
+	if (!host) return null
+	const url = replaceWebsocketWithHttp(ENV_CONFIG[host] ?? "")
+	if (!url) return null
+
+	const response = await safeFetch(url, {
+		method: "POST",
+		headers: { accept: "application/json", "content-type": "application/json" },
+		body: JSON.stringify({ id: 1, jsonrpc: "2.0", method: "chain_getHeader", params: [] }),
+	})
+	const number = (await response.json())?.result?.number
+	if (typeof number !== "string") return null
+	return BigInt(number)
 }

--- a/sdk/packages/indexer/src/utils/solverBalance.ts
+++ b/sdk/packages/indexer/src/utils/solverBalance.ts
@@ -1,0 +1,47 @@
+// Shared wiring for reading a solver's on-chain inventory. Two paths need it — the phantom price
+// snapshot on Hyperbridge and the pool liquidity refresh on every EVM fill — and both must read
+// balances exactly the same way, or a refresh would republish depth on a different basis than the
+// snapshot it is correcting.
+import { ENV_CONFIG } from "@/constants"
+import { replaceWebsocketWithHttp } from "@/utils/rpc.helpers"
+import { safeFetch } from "@/utils/safeFetch"
+import { YIELD_VAULT_ADDRESSES } from "@/yield-vault-addresses"
+import { memoizedSolverBalance, setAggregationFetch, type SolverBalanceReader } from "@hyperbridge/sdk/intents-helpers"
+
+// The aggregation's RPC helpers run inside the SubQuery VM2 sandbox, which has no global `fetch`.
+// Inject the indexer's sandbox-safe HTTP client so its JSON-RPC calls work here.
+setAggregationFetch(safeFetch)
+
+/**
+ * HTTP RPC per supported EVM chain. Both callers sweep balances across every chain, not just the
+ * one whose event they are handling, so a chain missing from here is simply one whose balances
+ * cannot be read.
+ */
+export function evmRpcUrls(): Record<string, string> {
+	const urls: Record<string, string> = {}
+	for (const [stateMachineId, url] of Object.entries(ENV_CONFIG)) {
+		if (!stateMachineId.startsWith("EVM-")) continue
+		const http = replaceWebsocketWithHttp(url ?? "")
+		if (http) urls[stateMachineId] = http
+	}
+	return urls
+}
+
+// Balances are point-in-time reads that cannot differ within a block, so one memo serves every
+// read on it — without this, several orders closing on the same Hyperbridge block would each
+// repeat the full liquidity sweep, and several fills in one EVM block would each re-read the same
+// bidders. Blocks are processed in order, so keeping only the current block's memo is enough.
+let memoKey: string | null = null
+let memo: SolverBalanceReader | null = null
+
+/**
+ * The balance reader for `key`, which must identify one block of one chain (handlers for
+ * different chains run in separate processes, so the key only has to be unique within one).
+ */
+export function blockBalanceReader(key: string): SolverBalanceReader {
+	if (memoKey !== key || !memo) {
+		memo = memoizedSolverBalance(YIELD_VAULT_ADDRESSES)
+		memoKey = key
+	}
+	return memo
+}


### PR DESCRIPTION
A pool's published depth is the sum of its bidders' output-token inventory, measured when the last phantom bid window closed. A fill spends some of that inventory, so between windows the depth advertises capacity the solvers no longer hold - and the depth is what a taker sizes an order against.

OrderFilled and PartialFill now re-read the balances of every LP recorded as backing the pools the fill traded through, and republish PoolBidder.liquidity, the chain rows' depth/bidCount/unrestricted slice, PoolRoute depths and the pool's own sell/buy depth from them. A bidder left holding nothing loses its row, keeping the "every row is a bidder with capacity" invariant, and the routes it alone declared go with it. Rates are untouched.

Two guards bound the cost: a pool whose last snapshot postdates the fill is skipped without any RPC (which makes a historical resync free), and a chain whose balances cannot be read in full is left exactly as indexed rather than partially republished. No lastUpdatedBlock/lastUpdatedAt is moved anywhere - they date the snapshot that priced the pool, in Hyperbridge blocks, which an EVM block number is not comparable with.

The balance-reader wiring moves into src/utils/solverBalance.ts so the snapshot and refresh paths read balances identically, and the pool-level merge and unrestricted-slice split are extracted so the two publish the same numbers from the same bidders.

Also fixes phantomOrder.handlers.test.ts, which was red: its SDK mock dropped the symbol-ordering exports the pool-token registry re-exports, so every pool attribution threw. It covers the wiring this change moves, so it had to run.