### PR TITLE
[indexer]: use wget for the container healthcheck, not curl

### DIFF
--- a/sdk/packages/indexer/scripts/templates/partials/docker-service.hbs
+++ b/sdk/packages/indexer/scripts/templates/partials/docker-service.hbs
@@ -17,7 +17,10 @@ subquery-{{chainName}}:
     # once ready) and stays green during initial sync / catch-up. It returns 500
     # once the node stops advancing its target height (>60s) or stops processing
     # blocks (>--timeout). The check runs inside the container, so target localhost.
-    test: ['CMD', 'curl', '-f', 'http://localhost:3000/health']
+    # wget, not curl: the subql-node-ethereum image ships no curl, so the probe exits
+    # -1 every run, the container is permanently unhealthy, and an autoheal watcher
+    # restart-loops it. wget is present in both the ethereum and substrate images.
+    test: ['CMD', 'wget', '-q', '-O', '/dev/null', 'http://localhost:3000/health']
     interval: 30s
     timeout: 10s
     retries: 10


### PR DESCRIPTION
Follow-up to #1166. That PR pointed the healthcheck at `/health` on `localhost`, which was right — but it probes with `curl`, and **`subquerynetwork/subql-node-ethereum` ships no `curl`**:

```
exec: "curl": executable file not found in $PATH
```

Docker records that as exit `-1`, so the container is permanently unhealthy and the autoheal watcher the same PR labelled it for restarts it forever. `polytopelabs/subql-node-substrate` *does* ship `curl` — which is why this was missed: the substrate chains stayed green while every labelled EVM chain looped.

**Impact.** On mainnet, `bsc-mainnet`, `polygon-mainnet` and `polkadot-hub-mainnet` restarted every ~6m34s (`start_period` 120s + 10 × 30s retries) from 2026-08-28 until today — roughly 1,215 restarts each. `/health` returned `200` throughout and each chain was at tip between restarts; only the probe binary was missing. No data loss, since all three run `--unfinalized-blocks=false` and resume from the persisted height.

**Fix.** Use `wget -q -O /dev/null`, present in both images. It exits non-zero on HTTP error statuses and on connection refusal, so the check still fails when it genuinely should.

**Verification.** Rendered for both `unfinalizedBlocks` variants — valid YAML, `autoheal` label gating unchanged. The equivalent patch applied to the 11 generated ymls on the mainnet host took all three containers to `healthy` in ~48s, with zero autoheal restarts since.

Those host ymls are build artifacts, so the next `deploy.sh` regenerates them from this template and the loop returns until this lands.


