### PR TITLE
[evm, sdk, host-executive]: gate cross-chain deliveries behind a whitelisted relayer and fix HostManager rotation addressing

### DIFF
--- a/evm/script/DeployBridgeToken.s.sol
+++ b/evm/script/DeployBridgeToken.s.sol
@@ -9,14 +9,21 @@ import {BaseScript} from "./BaseScript.sol";
 contract DeployBridgeToken is BaseScript {
     function deploy() internal override {
         address dispatcher = config.get("CALL_DISPATCHER").toAddress();
+        // The only account allowed to deliver messages to the token, on every chain. Read here rather
+        // than in BaseScript so the other scripts do not require it.
+        address relayer = vm.envAddress("BRIDGE_RELAYER");
         BridgeToken bridge = new BridgeToken{salt: salt}(admin);
 
+        // Set before `configure`: until the host is set nothing can reach `onAccept`, so the token
+        // is never live without its relayer.
+        bridge.setRelayer(relayer);
         bridge.configure(HyperFungibleToken.ConfigOptions({host: HOST_ADDRESS, dispatcher: dispatcher}));
 
         vm.stopBroadcast();
         console.log("=== BridgeToken Deployment ===");
         console.log("BridgeToken:", address(bridge));
         console.log("CallDispatcher:", dispatcher);
+        console.log("Relayer:", relayer);
         console.log("Nexus peer:", string(bridge.nexus()));
     }
 }

--- a/evm/script/DeployHostManager.s.sol
+++ b/evm/script/DeployHostManager.s.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "forge-std/Script.sol";
+import "stringutils/strings.sol";
+
+import {HostManager, HostManagerParams} from "../src/core/HostManager.sol";
+import {BaseScript} from "./BaseScript.sol";
+
+/// @notice Deploys a replacement HostManager for a host that already exists, bound to that host
+/// and to the governance relayer. The host is pointed at it afterwards through a `SetHostParam`
+/// governance request, which the HostManager currently in place delivers.
+contract DeployHostManager is BaseScript {
+    using strings for *;
+
+    function deploy() internal override {
+        address relayer = vm.envAddress("GOVERNANCE_RELAYER");
+
+        HostManager manager = new HostManager{salt: salt}(HostManagerParams({admin: admin, host: address(0)}));
+        manager.setIsmpHost(HOST_ADDRESS);
+        // Requires the broadcaster to be the host admin.
+        manager.setRelayer(relayer);
+
+        vm.stopBroadcast();
+
+        console.log("HostManager deployed at:", address(manager));
+        console.log("Governance relayer:", relayer);
+
+        config.set("HOST_MANAGER", address(manager));
+    }
+}

--- a/evm/script/DeployIsmp.s.sol
+++ b/evm/script/DeployIsmp.s.sol
@@ -134,6 +134,9 @@ contract DeployScript is BaseScript {
         host.initialize(params);
         // set the host address on the host manager
         manager.setIsmpHost(address(host));
+        // Governance messages may only be delivered by this relayer; the broadcaster is the host
+        // admin at this point, which is what `setRelayer` requires.
+        manager.setRelayer(vm.envAddress("GOVERNANCE_RELAYER"));
 
         // Set the consensus state
         EvmHost(payable(address(host)))

--- a/evm/src/apps/BridgeToken.sol
+++ b/evm/src/apps/BridgeToken.sol
@@ -44,8 +44,8 @@ contract BridgeToken is HyperFungibleToken {
     /**
      * @notice Deploys the token with nexus already registered as a peer
      * @param initialOwner The address that will own this contract. It can register further peers,
-     * pause cross chain operations, and change the dispatcher, so it should be a multisig or a
-     * governance controlled account.
+     * pause cross chain operations, change the dispatcher, and set the relayer, so it should be a
+     * multisig or a governance controlled account.
      */
     constructor(address initialOwner) HyperFungibleToken("Hyperbridge", "BRIDGE", initialOwner) {
         _supportedChains[nexus()] = abi.encodePacked(NEXUS_MODULE_ID);
@@ -57,5 +57,17 @@ contract BridgeToken is HyperFungibleToken {
      */
     function nexus() public pure returns (bytes memory) {
         return StateMachine.polkadot(NEXUS_PARA_ID);
+    }
+
+    /**
+     * @dev Fails closed: every mint, whether from an incoming transfer or a timeout refund, must be
+     * delivered by the relayer the owner set with `setRelayer`, and with none set nobody may deliver.
+     * The base contract treats zero as unrestricted for the benefit of third-party tokens; the
+     * supply of this token is backed by the nexus escrow, so it must not mint on the strength of a
+     * consensus proof alone. The handler always forwards a real `msg.sender`, so zero never matches.
+     * @param incomingRelayer The account that submitted the message to the handler
+     */
+    function _checkRelayer(address incomingRelayer) internal view override {
+        if (incomingRelayer != _relayer) revert UnauthorizedRelayer();
     }
 }

--- a/evm/src/apps/IntentGatewayV2.sol
+++ b/evm/src/apps/IntentGatewayV2.sol
@@ -60,7 +60,7 @@ import {
 contract IntentGatewayV2 is IntrinsicIntents, ExtrinsicIntents, ReentrancyGuardTransient, Initializable {
     using SafeERC20 for IERC20;
 
-    /// @dev Privileged admin for future upgrade-gated actions (e.g. pausing). Immutable, so it must
+    /// @dev Privileged admin; rotates the authorised relayer via `setRelayer`. Immutable, so it must
     /// be identical across chains or the deterministic proxy address diverges. Does not gate
     /// `initialize`; atomic CREATE2 deployment already binds the init data to the canonical address.
     address public immutable _owner;
@@ -108,6 +108,23 @@ contract IntentGatewayV2 is IntrinsicIntents, ExtrinsicIntents, ReentrancyGuardT
         }
         _validateParams(p);
         _params = p;
+    }
+
+    /**
+     * @dev Replaces the relayer authorised to deliver cross-chain messages to this gateway.
+     * Callable by `_owner` directly, and by the host so that a governance `UpgradeContract`
+     * request can carry this call as its migration calldata and have the new implementation and
+     * the relayer take effect in the same transaction: `upgradeToAndCall` runs that calldata as a
+     * delegatecall, which keeps `msg.sender` as the host that invoked `onAccept`. The host never
+     * calls this contract with anything but the `IApp` callback selectors, so the host branch is
+     * reachable only through that migration calldata, behind the hyperbridge-source check and
+     * the relayer gate.
+     * @param relayer The account whose deliveries are accepted from now on. Zero rejects all.
+     */
+    function setRelayer(address relayer) external {
+        if (msg.sender != _owner && msg.sender != host()) revert Unauthorized();
+        emit RelayerUpdated({previous: _relayer, current: relayer});
+        _relayer = relayer;
     }
 
     /**

--- a/evm/src/apps/intentsv2/ExtrinsicIntents.sol
+++ b/evm/src/apps/intentsv2/ExtrinsicIntents.sol
@@ -67,6 +67,17 @@ abstract contract ExtrinsicIntents is IntentsBase, HyperApp {
     }
 
     /**
+     * @dev Rejects any delivery not submitted by `_relayer`. Runs before the message body is
+     * looked at, so it covers escrow redemptions and refunds as well as every governance action,
+     * including implementation upgrades. The host records a reverted dispatch as undelivered, so
+     * a rejected message can still be submitted later by the authorised relayer.
+     * @param relayer The account that submitted the message to the handler.
+     */
+    function _checkRelayer(address relayer) internal view {
+        if (relayer != _relayer) revert Unauthorized();
+    }
+
+    /**
      * @dev Fills a cross-chain order on the destination chain. The solver provides output
      * tokens directly to the beneficiary, and a Hyperbridge post request is dispatched
      * back to the source chain to release the escrowed input tokens to the solver.
@@ -295,6 +306,7 @@ abstract contract ExtrinsicIntents is IntentsBase, HyperApp {
      * @param incoming The incoming post request from Hyperbridge.
      */
     function onAccept(IncomingPostRequest calldata incoming) external override onlyHost {
+        _checkRelayer(incoming.relayer);
         RequestKind kind = RequestKind(uint8(incoming.request.body[0]));
         if (kind == RequestKind.RedeemEscrow || kind == RequestKind.RefundEscrow) {
             _authenticate(incoming.request);
@@ -325,6 +337,7 @@ abstract contract ExtrinsicIntents is IntentsBase, HyperApp {
      * @param incoming The incoming GET response from Hyperbridge containing the storage proof.
      */
     function onGetResponse(IncomingGetResponse calldata incoming) external override onlyHost {
+        _checkRelayer(incoming.relayer);
         if (incoming.response.values[0].value.length != 0) revert Filled();
 
         WithdrawalRequest memory body = abi.decode(incoming.response.request.context, (WithdrawalRequest));

--- a/evm/src/apps/intentsv2/IntentsBase.sol
+++ b/evm/src/apps/intentsv2/IntentsBase.sol
@@ -158,7 +158,15 @@ abstract contract IntentsBase is EIP712 {
     mapping(bytes32 => uint256) public _destinationProtocolFees;
 
     /// @dev Appended last to preserve existing storage slots.
-    bool public _paused;
+    bool internal _paused;
+
+    /**
+     * @dev The only relayer whose deliveries `onAccept` and `onGetResponse` accept. Every other
+     * delivery reverts, which the host treats as a failed dispatch and leaves retryable by this
+     * relayer. Zero authorises nobody. Appended after `_paused`, with which it shares slot 13;
+     * `_params` cannot grow because `_orders` sits directly behind it.
+     */
+    address public _relayer;
 
     /**
      * @dev Thrown when the caller is not authorized to perform the action.
@@ -338,6 +346,13 @@ abstract contract IntentsBase is EIP712 {
      * @param feeBps The protocol fee in basis points for orders targeting this destination.
      */
     event DestinationProtocolFeeUpdated(string chain, uint256 feeBps);
+
+    /**
+     * @dev Emitted when the authorised relayer is replaced.
+     * @param previous The relayer that was authorised before this change.
+     * @param current The relayer authorised from now on.
+     */
+    event RelayerUpdated(address previous, address current);
 
     /**
      * @dev Returns the address of the Hyperbridge host contract. This function is virtual

--- a/evm/src/core/HostManager.sol
+++ b/evm/src/core/HostManager.sol
@@ -50,8 +50,27 @@ contract HostManager is HyperApp, ERC165 {
 
     HostManagerParams private _params;
 
+    /**
+     * @dev The only relayer whose deliveries `onAccept` accepts. Governance messages are the one
+     * kind of traffic this contract receives, and they can replace the host's handler, which is
+     * what every app trusts to report the relayer address; so a forged governance message must
+     * not be deliverable by an arbitrary relayer even when the consensus proof behind it verifies.
+     * Zero authorises nobody. Set by the host admin, the key that can already freeze the host.
+     */
+    address private _relayer;
+
     // @dev Action is unauthorized
     error UnauthorizedAction();
+
+    // @dev The message was delivered by a relayer other than `_relayer`
+    error UnauthorizedRelayer();
+
+    /**
+     * @dev Emitted when the authorised relayer is replaced
+     * @param previous The relayer authorised before this change
+     * @param current The relayer authorised from now on
+     */
+    event RelayerUpdated(address previous, address current);
 
     // @dev restricts call to the provided `caller`
     modifier restrict(address caller) {
@@ -92,7 +111,29 @@ contract HostManager is HyperApp, ERC165 {
         _params.admin = address(0);
     }
 
+    /**
+     * @notice The relayer authorised to deliver governance messages, zero if none
+     */
+    function relayer() public view returns (address) {
+        return _relayer;
+    }
+
+    /**
+     * @notice Restricts `onAccept` to deliveries submitted by `newRelayer`
+     * @dev Only the host admin may call this. Ordinary relaying is unaffected: this contract
+     * never receives user traffic, only governance requests from Hyperbridge. The host records a
+     * refused delivery as undelivered, so a rejected message can still be submitted by the
+     * authorised relayer afterwards.
+     * @param newRelayer The relayer to authorise. Zero rejects every delivery.
+     */
+    function setRelayer(address newRelayer) external {
+        if (msg.sender != IHost(_params.host).admin()) revert UnauthorizedAction();
+        emit RelayerUpdated({previous: _relayer, current: newRelayer});
+        _relayer = newRelayer;
+    }
+
     function onAccept(IncomingPostRequest calldata incoming) external override restrict(_params.host) {
+        if (incoming.relayer == address(0) || incoming.relayer != _relayer) revert UnauthorizedRelayer();
         PostRequest calldata request = incoming.request;
         // Only the Hyperbridge parachain can send requests to this module.
         if (!request.source.equals(IHost(_params.host).hyperbridge())) revert UnauthorizedAction();

--- a/evm/tests/foundry/BaseTest.sol
+++ b/evm/tests/foundry/BaseTest.sol
@@ -89,6 +89,8 @@ contract BaseTest is Test {
         feeToken.grantBurnerRole(address(this));
 
         manager.setIsmpHost(address(host));
+        // This contract is the host admin, and the relayer the HostManager tests deliver as.
+        manager.setRelayer(address(this));
 
         mockUSDC.superApprove(tx.origin, address(host));
         mockUSDC.superApprove(address(this), address(host));

--- a/evm/tests/foundry/BridgeTokenTest.t.sol
+++ b/evm/tests/foundry/BridgeTokenTest.t.sol
@@ -5,20 +5,26 @@ import "forge-std/Test.sol";
 import {BaseTest} from "./BaseTest.sol";
 
 import {StateMachine} from "@hyperbridge/core/libraries/StateMachine.sol";
-import {PostRequest} from "@hyperbridge/core/libraries/Message.sol";
-import {IncomingPostRequest} from "@hyperbridge/core/interfaces/IApp.sol";
+import {PostRequest, Message} from "@hyperbridge/core/libraries/Message.sol";
+import {IncomingPostRequest, PostRequestTimeout} from "@hyperbridge/core/interfaces/IApp.sol";
 import {HyperFungibleToken} from "@hyperbridge/core/apps/HyperFungibleToken.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
 import {BridgeToken} from "../../src/apps/BridgeToken.sol";
 import {CallDispatcher} from "../../src/utils/CallDispatcher.sol";
 
 /// The behaviour inherited from `HyperFungibleToken` is covered by `HyperFungibleTokenTest`.
 /// What is specific to `BridgeToken` is the metadata and the nexus peer baked into the
-/// bytecode, so these tests deploy it exactly as the script does, with no owner setup at
-/// all, and check that it can already talk to nexus and nothing else.
+/// bytecode, and the relayer gate that fails closed, so these tests deploy it exactly as the
+/// script does (relayer set, then configured) and check that it can already talk to nexus,
+/// through that relayer, and nothing else.
 contract BridgeTokenTest is BaseTest {
+    using Message for PostRequest;
+
     BridgeToken internal bridge;
     CallDispatcher internal callDispatcher;
+    /// The only account allowed to deliver to the token, as the deploy script sets it
+    address internal relayer;
 
     /// nexus, the chain BRIDGE is native to
     bytes internal nexus;
@@ -39,7 +45,9 @@ contract BridgeTokenTest is BaseTest {
         palletId = abi.encodePacked(bytes8("pall_hft"));
 
         callDispatcher = new CallDispatcher();
+        relayer = makeAddr("relayer");
         bridge = new BridgeToken(address(this));
+        bridge.setRelayer(relayer);
         bridge.configure(
             HyperFungibleToken.ConfigOptions({host: address(host), dispatcher: address(callDispatcher)})
         );
@@ -80,7 +88,7 @@ contract BridgeTokenTest is BaseTest {
     function testOnAcceptFromNexusMints() public {
         vm.prank(address(host));
         bridge.onAccept(
-            IncomingPostRequest({request: _fromNexus(palletId, RECIPIENT, MINT_AMOUNT), relayer: address(0)})
+            IncomingPostRequest({request: _fromNexus(palletId, RECIPIENT, MINT_AMOUNT), relayer: relayer})
         );
 
         assertEq(bridge.balanceOf(RECIPIENT), MINT_AMOUNT);
@@ -94,7 +102,7 @@ contract BridgeTokenTest is BaseTest {
 
         vm.prank(address(host));
         vm.expectRevert(HyperFungibleToken.UnauthorizedSource.selector);
-        bridge.onAccept(IncomingPostRequest({request: request, relayer: address(0)}));
+        bridge.onAccept(IncomingPostRequest({request: request, relayer: relayer}));
     }
 
     /// Nexus is the only chain the deployment knows until its owner registers more.
@@ -104,7 +112,7 @@ contract BridgeTokenTest is BaseTest {
 
         vm.prank(address(host));
         vm.expectRevert(HyperFungibleToken.UnsupportedChain.selector);
-        bridge.onAccept(IncomingPostRequest({request: request, relayer: address(0)}));
+        bridge.onAccept(IncomingPostRequest({request: request, relayer: relayer}));
     }
 
     // ---------- send ----------
@@ -115,7 +123,7 @@ contract BridgeTokenTest is BaseTest {
         bridge.onAccept(
             IncomingPostRequest({
                 request: _fromNexus(palletId, address(this), MINT_AMOUNT),
-                relayer: address(0)
+                relayer: relayer
             })
         );
 
@@ -139,7 +147,7 @@ contract BridgeTokenTest is BaseTest {
         bridge.onAccept(
             IncomingPostRequest({
                 request: _fromNexus(palletId, address(this), MINT_AMOUNT),
-                relayer: address(0)
+                relayer: relayer
             })
         );
 
@@ -154,6 +162,157 @@ contract BridgeTokenTest is BaseTest {
                 data: ""
             })
         );
+    }
+
+    // ---------- relayer ----------
+
+    function testRelayerIsSetBeforeConfigure() public view {
+        assertEq(bridge.relayer(), relayer);
+    }
+
+    /// Unlike the base token, no relayer means nobody may deliver, so a deployment that skipped
+    /// `setRelayer` cannot mint.
+    function testFreshTokenRejectsEveryRelayerUntilSet() public {
+        BridgeToken fresh = new BridgeToken(address(this));
+        fresh.configure(
+            HyperFungibleToken.ConfigOptions({host: address(host), dispatcher: address(callDispatcher)})
+        );
+        assertEq(fresh.relayer(), address(0));
+        PostRequest memory request = _fromNexus(palletId, RECIPIENT, MINT_AMOUNT);
+        request.to = abi.encodePacked(address(fresh));
+
+        vm.prank(address(host));
+        vm.expectRevert(HyperFungibleToken.UnauthorizedRelayer.selector);
+        fresh.onAccept(IncomingPostRequest({request: request, relayer: relayer}));
+        vm.prank(address(host));
+        vm.expectRevert(HyperFungibleToken.UnauthorizedRelayer.selector);
+        fresh.onAccept(IncomingPostRequest({request: request, relayer: address(0xD00D)}));
+        assertEq(fresh.totalSupply(), 0);
+
+        fresh.setRelayer(relayer);
+        vm.prank(address(host));
+        fresh.onAccept(IncomingPostRequest({request: request, relayer: relayer}));
+        assertEq(fresh.balanceOf(RECIPIENT), MINT_AMOUNT);
+    }
+
+    function testOnAcceptRejectsUnlistedRelayer() public {
+        PostRequest memory request = _fromNexus(palletId, RECIPIENT, MINT_AMOUNT);
+
+        vm.prank(address(host));
+        vm.expectRevert(HyperFungibleToken.UnauthorizedRelayer.selector);
+        bridge.onAccept(IncomingPostRequest({request: request, relayer: address(0xD00D)}));
+        assertEq(bridge.totalSupply(), 0, "nothing minted");
+
+        vm.prank(address(host));
+        bridge.onAccept(IncomingPostRequest({request: request, relayer: relayer}));
+        assertEq(bridge.balanceOf(RECIPIENT), MINT_AMOUNT, "same message mints once the relayer delivers it");
+    }
+
+    /// A timeout refund is a mint too, so a forged timeout proof is refused the same way.
+    function testTimeoutRefundRejectsUnlistedRelayer() public {
+        vm.prank(address(host));
+        bridge.onAccept(
+            IncomingPostRequest({request: _fromNexus(palletId, address(this), MINT_AMOUNT), relayer: relayer})
+        );
+        bridge.send(
+            HyperFungibleToken.SendParams({
+                dest: nexus,
+                to: NEXUS_ACCOUNT,
+                amount: MINT_AMOUNT,
+                timeout: 3600,
+                relayerFee: 0,
+                data: ""
+            })
+        );
+        assertEq(bridge.totalSupply(), 0);
+
+        PostRequest memory timedOut = PostRequest({
+            source: StateMachine.evm(block.chainid),
+            dest: nexus,
+            nonce: 0,
+            from: abi.encodePacked(address(bridge)),
+            to: palletId,
+            timeoutTimestamp: 3600,
+            body: abi.encode(
+                HyperFungibleToken.Message({
+                    from: abi.encodePacked(address(this)),
+                    to: NEXUS_ACCOUNT,
+                    amount: MINT_AMOUNT,
+                    data: ""
+                })
+            )
+        });
+
+        vm.prank(address(host));
+        vm.expectRevert(HyperFungibleToken.UnauthorizedRelayer.selector);
+        bridge.onPostRequestTimeout(PostRequestTimeout(timedOut, address(0xD00D)));
+        assertEq(bridge.totalSupply(), 0, "no refund minted");
+
+        vm.prank(address(host));
+        bridge.onPostRequestTimeout(PostRequestTimeout(timedOut, relayer));
+        assertEq(bridge.balanceOf(address(this)), MINT_AMOUNT, "authorised relayer refunds");
+    }
+
+    function testSetRelayerOnlyOwner() public {
+        address outsider = address(0xD00D);
+        vm.prank(outsider);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, outsider));
+        bridge.setRelayer(outsider);
+
+        // The host delivers messages but does not administer the token.
+        vm.prank(address(host));
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(host)));
+        bridge.setRelayer(address(host));
+
+        assertEq(bridge.relayer(), relayer);
+    }
+
+    function testSetRelayerRotates() public {
+        address next = makeAddr("nextRelayer");
+        vm.expectEmit(true, true, true, true, address(bridge));
+        emit HyperFungibleToken.RelayerUpdated(relayer, next);
+        bridge.setRelayer(next);
+        assertEq(bridge.relayer(), next);
+
+        PostRequest memory request = _fromNexus(palletId, RECIPIENT, MINT_AMOUNT);
+        vm.prank(address(host));
+        vm.expectRevert(HyperFungibleToken.UnauthorizedRelayer.selector);
+        bridge.onAccept(IncomingPostRequest({request: request, relayer: relayer}));
+
+        vm.prank(address(host));
+        bridge.onAccept(IncomingPostRequest({request: request, relayer: next}));
+        assertEq(bridge.balanceOf(RECIPIENT), MINT_AMOUNT);
+    }
+
+    /// Zero does not reopen the token the way it does in the base contract.
+    function testSetRelayerToZeroFailsClosed() public {
+        bridge.setRelayer(address(0));
+        PostRequest memory request = _fromNexus(palletId, RECIPIENT, MINT_AMOUNT);
+
+        vm.prank(address(host));
+        vm.expectRevert(HyperFungibleToken.UnauthorizedRelayer.selector);
+        bridge.onAccept(IncomingPostRequest({request: request, relayer: relayer}));
+        vm.prank(address(host));
+        vm.expectRevert(HyperFungibleToken.UnauthorizedRelayer.selector);
+        bridge.onAccept(IncomingPostRequest({request: request, relayer: address(0xD00D)}));
+        assertEq(bridge.totalSupply(), 0);
+    }
+
+    /// Through the real host: a refused delivery leaves no receipt, so the relayer can deliver
+    /// the same message afterwards.
+    function testRejectedDeliveryStaysRetryableThroughHost() public {
+        PostRequest memory request = _fromNexus(palletId, RECIPIENT, MINT_AMOUNT);
+        bytes32 commitment = request.hash();
+
+        vm.prank(address(handler));
+        host.dispatchIncoming(request, address(0xD00D));
+        assertEq(host.requestReceipts(commitment), address(0), "refused delivery leaves no receipt");
+        assertEq(bridge.totalSupply(), 0, "nothing minted");
+
+        vm.prank(address(handler));
+        host.dispatchIncoming(request, relayer);
+        assertEq(host.requestReceipts(commitment), relayer, "delivery recorded");
+        assertEq(bridge.balanceOf(RECIPIENT), MINT_AMOUNT, "minted");
     }
 
     /// Builds an incoming transfer from nexus, `from` being the module id it was sent by.

--- a/evm/tests/foundry/HostManagerTest.sol
+++ b/evm/tests/foundry/HostManagerTest.sol
@@ -17,12 +17,183 @@ pragma solidity ^0.8.17;
 import "forge-std/Test.sol";
 
 import {BaseTest} from "./BaseTest.sol";
-import {PostRequest} from "@hyperbridge/core/libraries/Message.sol";
+import {PostRequest, Message} from "@hyperbridge/core/libraries/Message.sol";
 import {IncomingPostRequest} from "@hyperbridge/core/interfaces/IApp.sol";
+import {IHandlerV2} from "@hyperbridge/core/interfaces/IHandlerV2.sol";
+import {ERC165} from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import {HostManagerParams, HostManager} from "../../src/core/HostManager.sol";
 import {HostParams, EvmHost} from "../../src/core/EvmHost.sol";
 
+/// @dev What an attacker would install as the host's handler: it passes the host's interface
+/// check, verifies nothing, and reports whatever relayer address it is told to.
+contract MaliciousHandler is ERC165 {
+    function supportsInterface(bytes4 interfaceId) public view override returns (bool) {
+        return interfaceId == type(IHandlerV2).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    function deliver(EvmHost host, PostRequest memory request, address claimedRelayer) external {
+        host.dispatchIncoming(request, claimedRelayer);
+    }
+}
+
 contract HostManagerTest is BaseTest {
+    using Message for PostRequest;
+
+    address internal constant OUTSIDER = address(0xD00D);
+
+    // ---------- relayer gate ----------
+
+    /// @dev A SetHostParam governance request carrying `params`, addressed to the live HostManager.
+    function _setHostParamRequest(HostParams memory params) internal view returns (PostRequest memory) {
+        return PostRequest({
+            source: host.hyperbridge(),
+            dest: host.host(),
+            nonce: 0,
+            from: new bytes(0),
+            to: abi.encodePacked(host.hostParams().hostManager),
+            timeoutTimestamp: 0,
+            body: bytes.concat(bytes1(uint8(HostManager.OnAcceptActions.SetHostParam)), abi.encode(params))
+        });
+    }
+
+    function testRelayerIsSetInSetup() public view {
+        assertEq(manager.relayer(), address(this));
+    }
+
+    function testSetRelayerOnlyHostAdmin() public {
+        assertEq(host.admin(), address(this), "precondition: this contract is the host admin");
+
+        vm.prank(OUTSIDER);
+        vm.expectRevert(HostManager.UnauthorizedAction.selector);
+        manager.setRelayer(OUTSIDER);
+
+        // The host delivers governance messages but does not administer the manager.
+        vm.prank(address(host));
+        vm.expectRevert(HostManager.UnauthorizedAction.selector);
+        manager.setRelayer(OUTSIDER);
+
+        assertEq(manager.relayer(), address(this), "relayer unchanged");
+    }
+
+    function testOnAcceptRejectsUnlistedRelayer() public {
+        HostParams memory params = host.hostParams();
+        uint256 previousPeriod = params.challengePeriod;
+        params.challengePeriod = previousPeriod + 1234;
+        PostRequest memory request = _setHostParamRequest(params);
+
+        vm.prank(address(host));
+        vm.expectRevert(HostManager.UnauthorizedRelayer.selector);
+        manager.onAccept(IncomingPostRequest(request, OUTSIDER));
+        assertEq(host.hostParams().challengePeriod, previousPeriod, "params unchanged");
+
+        // The relayer as reported by the host is never zero, and zero must not match an unset slot.
+        vm.prank(address(host));
+        vm.expectRevert(HostManager.UnauthorizedRelayer.selector);
+        manager.onAccept(IncomingPostRequest(request, address(0)));
+
+        // The same message goes through from the authorised relayer.
+        vm.prank(address(host));
+        manager.onAccept(IncomingPostRequest(request, address(this)));
+        assertEq(host.hostParams().challengePeriod, previousPeriod + 1234, "params applied");
+    }
+
+    function testFreshManagerRejectsEveryoneUntilRelayerSet() public {
+        HostManager fresh = new HostManager(HostManagerParams({admin: address(this), host: address(0)}));
+        fresh.setIsmpHost(address(host));
+        assertEq(fresh.relayer(), address(0));
+        PostRequest memory request = _setHostParamRequest(host.hostParams());
+
+        vm.prank(address(host));
+        vm.expectRevert(HostManager.UnauthorizedRelayer.selector);
+        fresh.onAccept(IncomingPostRequest(request, address(this)));
+        vm.prank(address(host));
+        vm.expectRevert(HostManager.UnauthorizedRelayer.selector);
+        fresh.onAccept(IncomingPostRequest(request, OUTSIDER));
+
+        // Once set, the gate passes and the call reaches the host, which rejects this manager
+        // because it is not the one the host is bound to: the gate was the only thing in the way.
+        fresh.setRelayer(address(this));
+        vm.prank(address(host));
+        vm.expectRevert(EvmHost.UnauthorizedAction.selector);
+        fresh.onAccept(IncomingPostRequest(request, address(this)));
+    }
+
+    function testSetRelayerRotates() public {
+        address next = makeAddr("nextRelayer");
+        HostParams memory params = host.hostParams();
+        params.challengePeriod += 1;
+        PostRequest memory request = _setHostParamRequest(params);
+
+        vm.expectEmit(true, true, true, true, address(manager));
+        emit HostManager.RelayerUpdated(address(this), next);
+        manager.setRelayer(next);
+        assertEq(manager.relayer(), next);
+
+        vm.prank(address(host));
+        vm.expectRevert(HostManager.UnauthorizedRelayer.selector);
+        manager.onAccept(IncomingPostRequest(request, address(this)));
+
+        vm.prank(address(host));
+        manager.onAccept(IncomingPostRequest(request, next));
+        assertEq(host.hostParams().challengePeriod, params.challengePeriod);
+    }
+
+    function testSetRelayerToZeroFailsClosed() public {
+        manager.setRelayer(address(0));
+        PostRequest memory request = _setHostParamRequest(host.hostParams());
+
+        vm.prank(address(host));
+        vm.expectRevert(HostManager.UnauthorizedRelayer.selector);
+        manager.onAccept(IncomingPostRequest(request, address(this)));
+        vm.prank(address(host));
+        vm.expectRevert(HostManager.UnauthorizedRelayer.selector);
+        manager.onAccept(IncomingPostRequest(request, address(0)));
+    }
+
+    /// Through the real host: a refused governance delivery leaves no receipt, so the authorised
+    /// relayer can deliver the same message afterwards.
+    function testRejectedDeliveryStaysRetryableThroughHost() public {
+        HostParams memory params = host.hostParams();
+        uint256 previousPeriod = params.challengePeriod;
+        params.challengePeriod = previousPeriod + 99;
+        PostRequest memory request = _setHostParamRequest(params);
+        bytes32 commitment = request.hash();
+
+        vm.prank(address(handler));
+        host.dispatchIncoming(request, OUTSIDER);
+        assertEq(host.requestReceipts(commitment), address(0), "refused delivery leaves no receipt");
+        assertEq(host.hostParams().challengePeriod, previousPeriod, "params unchanged");
+
+        vm.prank(address(handler));
+        host.dispatchIncoming(request, address(this));
+        assertEq(host.requestReceipts(commitment), address(this), "delivery recorded");
+        assertEq(host.hostParams().challengePeriod, previousPeriod + 99, "params applied");
+    }
+
+    /// The attack the gate exists for: a forged SetHostParam that swaps the host's handler for a
+    /// contract that will report any relayer address. With the gate, an arbitrary relayer cannot
+    /// deliver the swap, so the handler stays honest and the attacker's contract never becomes
+    /// able to call the host.
+    function testForgedHandlerSwapIsRefused() public {
+        MaliciousHandler malicious = new MaliciousHandler();
+        HostParams memory params = host.hostParams();
+        address honestHandler = params.handler;
+        params.handler = address(malicious);
+        PostRequest memory swap = _setHostParamRequest(params);
+
+        // Delivered by the attacker (through the honest handler, proof assumed forged).
+        vm.prank(address(handler));
+        host.dispatchIncoming(swap, OUTSIDER);
+        assertEq(host.hostParams().handler, honestHandler, "handler unchanged");
+
+        // The attacker's contract is not the handler, so it cannot inject a relayer address.
+        PostRequest memory forged = _setHostParamRequest(host.hostParams());
+        vm.expectRevert(EvmHost.UnauthorizedAction.selector);
+        malicious.deliver(EvmHost(payable(address(host))), forged, address(this));
+    }
+
+    // ---------- pre-existing helpers and tests ----------
+
     function HostManagerWithdraw(PostRequest memory request) public {
         // add balance to the host
         feeToken.mint(address(host), 1000e18);

--- a/evm/tests/foundry/HostManagerTest.sol
+++ b/evm/tests/foundry/HostManagerTest.sol
@@ -192,6 +192,70 @@ contract HostManagerTest is BaseTest {
         malicious.deliver(EvmHost(payable(address(host))), forged, address(this));
     }
 
+    // ---------- manager rotation ----------
+
+    /// @dev A SetHostParam request carrying `params`, addressed to `to` rather than the live manager.
+    function _setHostParamRequestTo(HostParams memory params, address to) internal view returns (PostRequest memory) {
+        PostRequest memory request = _setHostParamRequest(params);
+        request.to = abi.encodePacked(to);
+        return request;
+    }
+
+    /// @dev A replacement manager, bound to the host and armed with this contract as relayer.
+    function _deployNextManager() internal returns (HostManager next) {
+        next = new HostManager(HostManagerParams({admin: address(this), host: address(0)}));
+        next.setIsmpHost(address(host));
+        next.setRelayer(address(this));
+    }
+
+    /// The host authorises `updateHostParams` only from the manager it currently knows, so the
+    /// request that installs a new manager has to be delivered through the current one. This is
+    /// the rotation the host-executive pallet dispatches; the pallet test pins its recipient.
+    function testRotationDeliveredThroughCurrentManagerSucceeds() public {
+        HostManager next = _deployNextManager();
+        HostParams memory params = host.hostParams();
+        params.hostManager = address(next);
+        PostRequest memory rotation = _setHostParamRequestTo(params, address(manager));
+
+        vm.prank(address(handler));
+        host.dispatchIncoming(rotation, address(this));
+        assertEq(host.requestReceipts(rotation.hash()), address(this), "rotation delivered");
+        assertEq(host.hostParams().hostManager, address(next), "host now bound to the new manager");
+
+        // Governance after the rotation goes through the new manager and no longer through the old.
+        HostParams memory afterwards = host.hostParams();
+        afterwards.challengePeriod += 7;
+        PostRequest memory viaNext = _setHostParamRequestTo(afterwards, address(next));
+        vm.prank(address(handler));
+        host.dispatchIncoming(viaNext, address(this));
+        assertEq(host.hostParams().challengePeriod, afterwards.challengePeriod, "new manager applies params");
+
+        afterwards.challengePeriod += 7;
+        PostRequest memory viaOld = _setHostParamRequestTo(afterwards, address(manager));
+        vm.prank(address(handler));
+        host.dispatchIncoming(viaOld, address(this));
+        assertEq(host.requestReceipts(viaOld.hash()), address(0), "old manager is refused by the host");
+        assertNotEq(host.hostParams().challengePeriod, afterwards.challengePeriod, "old manager applies nothing");
+    }
+
+    /// The same payload addressed to the manager it installs cannot land: that manager is not yet
+    /// authorised, so the host refuses it and stays bound to the current one.
+    function testRotationDeliveredToNewManagerIsRefused() public {
+        HostManager next = _deployNextManager();
+        HostParams memory params = host.hostParams();
+        params.hostManager = address(next);
+        PostRequest memory misaddressed = _setHostParamRequestTo(params, address(next));
+
+        vm.prank(address(host));
+        vm.expectRevert(EvmHost.UnauthorizedAction.selector);
+        next.onAccept(IncomingPostRequest(misaddressed, address(this)));
+
+        vm.prank(address(handler));
+        host.dispatchIncoming(misaddressed, address(this));
+        assertEq(host.requestReceipts(misaddressed.hash()), address(0), "no receipt");
+        assertEq(host.hostParams().hostManager, address(manager), "host still bound to the current manager");
+    }
+
     // ---------- pre-existing helpers and tests ----------
 
     function HostManagerWithdraw(PostRequest memory request) public {

--- a/evm/tests/foundry/HyperFungibleTokenTest.sol
+++ b/evm/tests/foundry/HyperFungibleTokenTest.sol
@@ -362,6 +362,97 @@ contract HyperFungibleTokenTest is BaseTest {
 
     // ========== Helpers ==========
 
+    // ========== Relayer allowlist Tests ==========
+
+    function _timedOutSend() internal returns (PostRequest memory request) {
+        hft.send(HyperFungibleToken.SendParams({
+            dest: destChain,
+            to: abi.encodePacked(address(0xCAFE)),
+            amount: SEND_AMOUNT,
+            timeout: 3600,
+            relayerFee: 0,
+            data: ""
+        }));
+        request = PostRequest({
+            source: StateMachine.evm(1),
+            dest: destChain,
+            nonce: 0,
+            from: abi.encodePacked(address(hft)),
+            to: abi.encodePacked(remoteContract),
+            timeoutTimestamp: 3600,
+            body: abi.encode(HyperFungibleToken.Message({
+                from: abi.encodePacked(address(this)),
+                to: abi.encodePacked(address(0xCAFE)),
+                amount: SEND_AMOUNT,
+                data: ""
+            }))
+        });
+    }
+
+    /// The base token is unrestricted until its owner opts in, so existing deployments keep working.
+    function testRelayerUnrestrictedByDefault() public {
+        assertEq(hft.relayer(), address(0));
+        PostRequest memory request = _makeIncomingRequest(address(0xCAFE), 50 ether, "");
+
+        vm.prank(address(host));
+        hft.onAccept(IncomingPostRequest({request: request, relayer: address(0xD00D)}));
+        assertEq(hft.balanceOf(address(0xCAFE)), 50 ether);
+    }
+
+    function testSetRelayerOnlyOwner() public {
+        vm.prank(address(0xBEEF));
+        vm.expectRevert();
+        hft.setRelayer(address(0xBEEF));
+        assertEq(hft.relayer(), address(0));
+    }
+
+    function testSetRelayerRestrictsOnAccept() public {
+        address relayer = address(0xAAA1);
+        vm.expectEmit(true, true, true, true, address(hft));
+        emit HyperFungibleToken.RelayerUpdated(address(0), relayer);
+        hft.setRelayer(relayer);
+        assertEq(hft.relayer(), relayer);
+
+        PostRequest memory request = _makeIncomingRequest(address(0xCAFE), 50 ether, "");
+        vm.prank(address(host));
+        vm.expectRevert(HyperFungibleToken.UnauthorizedRelayer.selector);
+        hft.onAccept(IncomingPostRequest({request: request, relayer: address(0xD00D)}));
+        assertEq(hft.balanceOf(address(0xCAFE)), 0, "nothing minted");
+
+        vm.prank(address(host));
+        hft.onAccept(IncomingPostRequest({request: request, relayer: relayer}));
+        assertEq(hft.balanceOf(address(0xCAFE)), 50 ether, "authorised relayer mints");
+    }
+
+    function testSetRelayerRestrictsTimeoutRefunds() public {
+        address relayer = address(0xAAA1);
+        hft.setRelayer(relayer);
+        PostRequest memory request = _timedOutSend();
+        uint256 balanceAfterSend = hft.balanceOf(address(this));
+
+        vm.prank(address(host));
+        vm.expectRevert(HyperFungibleToken.UnauthorizedRelayer.selector);
+        hft.onPostRequestTimeout(PostRequestTimeout(request, address(0xD00D)));
+        assertEq(hft.balanceOf(address(this)), balanceAfterSend, "no refund minted");
+
+        vm.prank(address(host));
+        hft.onPostRequestTimeout(PostRequestTimeout(request, relayer));
+        assertEq(hft.balanceOf(address(this)), balanceAfterSend + SEND_AMOUNT, "authorised relayer refunds");
+    }
+
+    /// Setting zero lifts the restriction again in the base token.
+    function testSetRelayerToZeroLiftsRestriction() public {
+        hft.setRelayer(address(0xAAA1));
+        vm.expectEmit(true, true, true, true, address(hft));
+        emit HyperFungibleToken.RelayerUpdated(address(0xAAA1), address(0));
+        hft.setRelayer(address(0));
+
+        PostRequest memory request = _makeIncomingRequest(address(0xCAFE), 50 ether, "");
+        vm.prank(address(host));
+        hft.onAccept(IncomingPostRequest({request: request, relayer: address(0xD00D)}));
+        assertEq(hft.balanceOf(address(0xCAFE)), 50 ether);
+    }
+
     function _makeIncomingRequest(address recipient, uint256 amount, bytes memory data)
         internal
         view

--- a/evm/tests/foundry/IntentGatewayV2Test.sol
+++ b/evm/tests/foundry/IntentGatewayV2Test.sol
@@ -42,11 +42,14 @@ import {IUniswapV2Router02} from "@uniswap/v2-periphery/contracts/interfaces/IUn
 import {ISwapRouter} from "@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol";
 import {IQuoter} from "@uniswap/v3-periphery/contracts/interfaces/IQuoter.sol";
 import {IncomingPostRequest, IncomingGetResponse} from "@hyperbridge/core/interfaces/IApp.sol";
-import {PostRequest} from "@hyperbridge/core/interfaces/IDispatcher.sol";
-import {GetRequest, GetResponse} from "@hyperbridge/core/libraries/Message.sol";
+import {PostRequest, IDispatcher} from "@hyperbridge/core/interfaces/IDispatcher.sol";
+import {GetRequest, GetResponse, Message} from "@hyperbridge/core/libraries/Message.sol";
+import {StateMachine} from "@hyperbridge/core/libraries/StateMachine.sol";
 import {StorageValue} from "@polytope-labs/solidity-merkle-trees/src/trie/Node.sol";
 
 contract IntentGatewayV2Test is MainnetForkBaseTest {
+    using Message for PostRequest;
+
     IntentGatewayV2 public intentGateway;
 
     // Mainnet addresses
@@ -57,6 +60,8 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
     // Test users
     address public user;
     address public filler;
+    // The only account whose deliveries the gateway accepts (see `_deployGatewayProxy`).
+    address public relayer;
 
     // Protocol fee in BPS (30 BPS = 0.3%)
     uint256 public constant PROTOCOL_FEE_BPS = 30;
@@ -70,6 +75,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         // Setup test accounts
         user = makeCleanAddr("user");
         filler = makeCleanAddr("filler");
+        relayer = makeCleanAddr("relayer");
 
         // Deploy IntentGatewayV2
         intentGateway = _deployGatewayProxy();
@@ -96,11 +102,15 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
     }
 
     /// @dev Proxy with empty init data so each test calls `initialize` with its own params and
-    /// peers. Production initializes atomically (see `testAtomicInitialization`).
+    /// peers. Production initializes atomically (see `testAtomicInitialization`). The relayer is
+    /// set here because a gateway with no relayer refuses every cross-chain delivery; this test
+    /// contract is `_owner`, so it may set it directly.
     function _deployGatewayProxy() internal returns (IntentGatewayV2) {
         IntentGatewayV2 implementation = new IntentGatewayV2(address(this));
         ERC1967Proxy proxy = new ERC1967Proxy(address(implementation), "");
-        return IntentGatewayV2(payable(address(proxy)));
+        IntentGatewayV2 gateway = IntentGatewayV2(payable(address(proxy)));
+        gateway.setRelayer(relayer);
+        return gateway;
     }
 
     function _fundTestAccounts() internal {
@@ -811,7 +821,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
 
         // Execute dust sweep
         vm.prank(address(host));
-        intentGateway.onAccept(IncomingPostRequest({relayer: address(0), request: request}));
+        intentGateway.onAccept(IncomingPostRequest({relayer: relayer, request: request}));
 
         // Verify dust was transferred
         assertEq(usdc.balanceOf(treasury) - treasuryBalanceBefore, feeAmount, "Treasury should receive protocol fees");
@@ -857,7 +867,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         assertEq(address(intentGateway).balance, feeAmount, "Gateway should have ETH before sweep");
 
         vm.prank(address(host));
-        intentGateway.onAccept(IncomingPostRequest({relayer: address(0), request: request}));
+        intentGateway.onAccept(IncomingPostRequest({relayer: relayer, request: request}));
 
         assertEq(treasury.balance - treasuryBalanceBefore, feeAmount, "Treasury should receive ETH dust");
         assertEq(address(intentGateway).balance, 0, "Gateway should have no ETH left");
@@ -905,7 +915,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         assertEq(address(intentGateway).balance, ethAmount, "Gateway should have ETH");
 
         vm.prank(address(host));
-        intentGateway.onAccept(IncomingPostRequest({relayer: address(0), request: request}));
+        intentGateway.onAccept(IncomingPostRequest({relayer: relayer, request: request}));
 
         // Verify all dust was swept
         assertEq(usdc.balanceOf(treasury) - usdcBalanceBefore, usdcAmount, "Treasury should receive USDC");
@@ -1263,7 +1273,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
 
         vm.prank(address(host));
         vm.expectRevert(IntentsBase.Unauthorized.selector);
-        intentGateway.onAccept(IncomingPostRequest({relayer: address(0), request: request}));
+        intentGateway.onAccept(IncomingPostRequest({relayer: relayer, request: request}));
     }
 
     function testFillOrderWithNoPostdispatch() public {
@@ -2281,7 +2291,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         uint256 fillerBalanceBefore = usdc.balanceOf(filler);
 
         vm.prank(address(host));
-        intentGateway.onAccept(IncomingPostRequest({relayer: address(0), request: request}));
+        intentGateway.onAccept(IncomingPostRequest({relayer: relayer, request: request}));
 
         assertEq(usdc.balanceOf(filler) - fillerBalanceBefore, inputAmount, "Filler should receive escrowed tokens");
     }
@@ -2339,7 +2349,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         uint256 userBalanceBefore = usdc.balanceOf(user);
 
         vm.prank(address(host));
-        intentGateway.onAccept(IncomingPostRequest({relayer: address(0), request: request}));
+        intentGateway.onAccept(IncomingPostRequest({relayer: relayer, request: request}));
 
         assertEq(usdc.balanceOf(user) - userBalanceBefore, inputAmount, "User should receive refunded tokens");
     }
@@ -2645,7 +2655,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         emit IntentsBase.EscrowRefunded(commitment, inputs);
 
         vm.prank(address(host));
-        intentGateway.onAccept(IncomingPostRequest({relayer: address(0), request: request}));
+        intentGateway.onAccept(IncomingPostRequest({relayer: relayer, request: request}));
 
         assertEq(usdc.balanceOf(user) - userBalanceBefore, inputAmount, "User should receive refunded tokens");
         assertEq(intentGateway._filled(commitment), user, "Order should be marked as refunded with user as beneficiary");
@@ -2756,7 +2766,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         vm.recordLogs();
 
         vm.prank(address(host));
-        intentGateway.onAccept(IncomingPostRequest({relayer: address(0), request: request}));
+        intentGateway.onAccept(IncomingPostRequest({relayer: relayer, request: request}));
 
         // Check DeploymentAdded event
         Vm.Log[] memory entries = vm.getRecordedLogs();
@@ -2803,7 +2813,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         vm.recordLogs();
 
         vm.prank(address(host));
-        intentGateway.onAccept(IncomingPostRequest({relayer: address(0), request: request}));
+        intentGateway.onAccept(IncomingPostRequest({relayer: relayer, request: request}));
 
         // Check ParamsUpdated event
         Vm.Log[] memory entries = vm.getRecordedLogs();
@@ -2866,7 +2876,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         vm.recordLogs();
 
         vm.prank(address(host));
-        intentGateway.onAccept(IncomingPostRequest({relayer: address(0), request: request}));
+        intentGateway.onAccept(IncomingPostRequest({relayer: relayer, request: request}));
 
         // Check events
         Vm.Log[] memory entries = vm.getRecordedLogs();
@@ -2927,7 +2937,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         vm.recordLogs();
 
         vm.prank(address(host));
-        intentGateway.onAccept(IncomingPostRequest({relayer: address(0), request: request}));
+        intentGateway.onAccept(IncomingPostRequest({relayer: relayer, request: request}));
 
         // Check events
         Vm.Log[] memory entries = vm.getRecordedLogs();
@@ -2980,7 +2990,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         emit IntentsBase.DestinationProtocolFeeUpdated(string(arbitrumStateMachineId), feeBps);
 
         vm.prank(address(host));
-        intentGateway.onAccept(IncomingPostRequest({relayer: address(0), request: request}));
+        intentGateway.onAccept(IncomingPostRequest({relayer: relayer, request: request}));
     }
 
     function testPlaceOrderWithDestinationSpecificFee() public {
@@ -3020,7 +3030,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         });
 
         vm.prank(address(host));
-        customGateway.onAccept(IncomingPostRequest({relayer: address(0), request: request}));
+        customGateway.onAccept(IncomingPostRequest({relayer: relayer, request: request}));
 
         // Place an order to the destination with specific fee
         uint256 inputAmount = 1000 * 1e6; // 1000 USDC
@@ -3162,7 +3172,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         });
 
         vm.prank(address(host));
-        intentGateway.onAccept(IncomingPostRequest({relayer: address(0), request: request}));
+        intentGateway.onAccept(IncomingPostRequest({relayer: relayer, request: request}));
 
         // Now should return the stored gateway
         address instance = intentGateway.instance(stateMachineId);
@@ -3255,7 +3265,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
 
         GetResponse memory getResponse = GetResponse({request: getRequest, values: values});
 
-        IncomingGetResponse memory incoming = IncomingGetResponse({response: getResponse, relayer: address(0)});
+        IncomingGetResponse memory incoming = IncomingGetResponse({response: getResponse, relayer: relayer});
 
         uint256 userBalanceBefore = usdc.balanceOf(user);
 
@@ -3389,7 +3399,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
 
         uint256 fillerBalanceBefore = usdc.balanceOf(filler);
         vm.prank(address(host));
-        customGateway.onAccept(IncomingPostRequest({relayer: address(0), request: request}));
+        customGateway.onAccept(IncomingPostRequest({relayer: relayer, request: request}));
 
         // Filler receives the REDUCED amount (after protocol fees)
         assertEq(
@@ -3900,7 +3910,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
 
         vm.prank(address(host));
         vm.expectRevert(IntentsBase.InvalidInput.selector);
-        intentGateway.onAccept(IncomingPostRequest({relayer: address(0), request: request}));
+        intentGateway.onAccept(IncomingPostRequest({relayer: relayer, request: request}));
     }
 
     // ============================================================
@@ -4013,7 +4023,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         PostRequest memory request = _upgradeRequest(host.hyperbridge(), address(newImpl), "");
 
         vm.prank(address(host));
-        intentGateway.onAccept(IncomingPostRequest({relayer: address(0), request: request}));
+        intentGateway.onAccept(IncomingPostRequest({relayer: relayer, request: request}));
 
         // The proxy now points at the new implementation and its new logic is reachable.
         assertEq(_implementationOf(address(intentGateway)), address(newImpl), "implementation slot updated");
@@ -4072,7 +4082,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
 
         vm.prank(address(host));
         vm.expectRevert(IntentsBase.Unauthorized.selector);
-        intentGateway.onAccept(IncomingPostRequest({relayer: address(0), request: request}));
+        intentGateway.onAccept(IncomingPostRequest({relayer: relayer, request: request}));
 
         assertEq(_implementationOf(address(intentGateway)), implBefore, "implementation must be unchanged");
     }
@@ -4085,7 +4095,7 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
 
         vm.prank(address(host));
         vm.expectRevert(abi.encodeWithSelector(ERC1967Utils.ERC1967InvalidImplementation.selector, noCode));
-        intentGateway.onAccept(IncomingPostRequest({relayer: address(0), request: request}));
+        intentGateway.onAccept(IncomingPostRequest({relayer: relayer, request: request}));
 
         assertEq(_implementationOf(address(intentGateway)), implBefore, "implementation must be unchanged");
     }
@@ -4117,6 +4127,397 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         });
         vm.expectRevert(Initializable.InvalidInitialization.selector);
         intentGateway.initialize(p, new bytes[](0));
+    }
+
+    // ============================================================
+    // Relayer allowlist Tests
+    // ============================================================
+
+    /// @dev Places a same-chain order so its input sits in escrow, and returns the RedeemEscrow
+    /// request a peer gateway would send to release that escrow to `filler`.
+    function _escrowedRedeemRequest()
+        internal
+        returns (PostRequest memory request, bytes32 commitment, uint256 amount)
+    {
+        amount = 1000 * 1e6;
+        Order memory order = _sameChainOrder(amount, 1000 * 1e18, 0);
+        vm.startPrank(user);
+        usdc.approve(address(intentGateway), amount);
+        intentGateway.placeOrder(order, bytes32(0));
+        vm.stopPrank();
+        commitment = keccak256(abi.encode(order));
+
+        bytes memory body = bytes.concat(
+            bytes1(uint8(IntentsBase.RequestKind.RedeemEscrow)),
+            abi.encode(
+                WithdrawalRequest({
+                    commitment: commitment,
+                    tokens: order.inputs,
+                    beneficiary: bytes32(uint256(uint160(filler)))
+                })
+            )
+        );
+        request = PostRequest({
+            source: host.host(),
+            dest: host.host(),
+            nonce: 0,
+            from: abi.encodePacked(address(intentGateway)),
+            to: abi.encodePacked(address(intentGateway)),
+            body: body,
+            timeoutTimestamp: 0
+        });
+    }
+
+    /// @dev Places a same-chain order and returns the GET response a source-chain cancel receives
+    /// when the destination reports the order unfilled.
+    function _cancelResponse() internal returns (GetResponse memory response, bytes32 commitment, uint256 amount) {
+        amount = 1000 * 1e6;
+        Order memory order = _sameChainOrder(amount, 1000 * 1e18, 0);
+        vm.startPrank(user);
+        usdc.approve(address(intentGateway), amount);
+        intentGateway.placeOrder(order, bytes32(0));
+        vm.stopPrank();
+        commitment = keccak256(abi.encode(order));
+
+        StorageValue[] memory values = new StorageValue[](1);
+        values[0] = StorageValue({key: new bytes(0), value: new bytes(0)});
+        GetRequest memory getRequest = GetRequest({
+            source: host.host(),
+            dest: order.destination,
+            nonce: 0,
+            from: abi.encodePacked(address(intentGateway)),
+            keys: new bytes[](0),
+            height: 0,
+            timeoutTimestamp: 0,
+            context: abi.encode(
+                WithdrawalRequest({commitment: commitment, tokens: order.inputs, beneficiary: order.user})
+            )
+        });
+        response = GetResponse({request: getRequest, values: values});
+    }
+
+    function _newDeploymentRequest(bytes memory chain, address gateway) internal view returns (PostRequest memory) {
+        return PostRequest({
+            source: host.hyperbridge(),
+            dest: host.host(),
+            nonce: 0,
+            from: abi.encodePacked(address(intentGateway)),
+            to: abi.encodePacked(address(intentGateway)),
+            body: bytes.concat(
+                bytes1(uint8(IntentsBase.RequestKind.NewDeployment)),
+                abi.encode(Deployment({chain: chain, gateway: gateway}))
+            ),
+            timeoutTimestamp: 0
+        });
+    }
+
+    /// @dev `_paused` (bool) sits at slot 13 offset 0 and `_relayer` packs behind it at offset 1.
+    function _packedRelayerSlot(address r) internal pure returns (bytes32) {
+        return bytes32(uint256(uint160(r)) << 8);
+    }
+
+    function testRelayerSharesSlotThirteenWithPaused() public view {
+        assertEq(intentGateway._relayer(), relayer, "getter");
+        assertEq(
+            vm.load(address(intentGateway), bytes32(uint256(13))),
+            _packedRelayerSlot(relayer),
+            "_relayer must sit at slot 13 offset 1, leaving the _paused byte zero"
+        );
+        assertEq(vm.load(address(intentGateway), bytes32(uint256(14))), bytes32(0), "slot 14 unused");
+    }
+
+    function testSetRelayerRejectsNonOwner() public {
+        vm.prank(user);
+        vm.expectRevert(IntentsBase.Unauthorized.selector);
+        intentGateway.setRelayer(user);
+
+        // The handler talks to the host, never to the gateway.
+        vm.prank(address(handler));
+        vm.expectRevert(IntentsBase.Unauthorized.selector);
+        intentGateway.setRelayer(user);
+
+        assertEq(intentGateway._relayer(), relayer, "relayer unchanged");
+    }
+
+    function testSetRelayerRotates() public {
+        address next = makeCleanAddr("nextRelayer");
+        (PostRequest memory request,, uint256 amount) = _escrowedRedeemRequest();
+
+        vm.expectEmit(true, true, true, true, address(intentGateway));
+        emit IntentsBase.RelayerUpdated(relayer, next);
+        intentGateway.setRelayer(next);
+        assertEq(intentGateway._relayer(), next);
+
+        // The previous relayer is locked out immediately.
+        vm.prank(address(host));
+        vm.expectRevert(IntentsBase.Unauthorized.selector);
+        intentGateway.onAccept(IncomingPostRequest({relayer: relayer, request: request}));
+
+        uint256 before = usdc.balanceOf(filler);
+        vm.prank(address(host));
+        intentGateway.onAccept(IncomingPostRequest({relayer: next, request: request}));
+        assertEq(usdc.balanceOf(filler) - before, amount, "new relayer releases escrow");
+    }
+
+    function testSetRelayerToZeroFailsClosed() public {
+        (PostRequest memory request, bytes32 commitment, uint256 amount) = _escrowedRedeemRequest();
+        intentGateway.setRelayer(address(0));
+
+        vm.prank(address(host));
+        vm.expectRevert(IntentsBase.Unauthorized.selector);
+        intentGateway.onAccept(IncomingPostRequest({relayer: relayer, request: request}));
+        assertEq(intentGateway._orders(commitment, address(usdc)), amount, "escrow untouched");
+    }
+
+    function testOnAcceptRejectsUnlistedRelayer() public {
+        (PostRequest memory request, bytes32 commitment, uint256 amount) = _escrowedRedeemRequest();
+
+        vm.prank(address(host));
+        vm.expectRevert(IntentsBase.Unauthorized.selector);
+        intentGateway.onAccept(IncomingPostRequest({relayer: filler, request: request}));
+        assertEq(intentGateway._orders(commitment, address(usdc)), amount, "escrow untouched");
+        assertEq(intentGateway._filled(commitment), address(0), "order not finalised");
+
+        // The very same message goes through once the authorised relayer submits it.
+        uint256 before = usdc.balanceOf(filler);
+        vm.prank(address(host));
+        intentGateway.onAccept(IncomingPostRequest({relayer: relayer, request: request}));
+        assertEq(usdc.balanceOf(filler) - before, amount, "authorised relayer releases escrow");
+        assertEq(intentGateway._filled(commitment), filler, "order finalised");
+    }
+
+    function testOnAcceptGovernanceRejectsUnlistedRelayer() public {
+        // UpgradeContract: a forged upgrade cannot land unless the relayer submits it.
+        address implBefore = _implementationOf(address(intentGateway));
+        IntentGatewayV2Upgraded newImpl = new IntentGatewayV2Upgraded(address(this));
+        PostRequest memory upgrade = _upgradeRequest(host.hyperbridge(), address(newImpl), "");
+
+        vm.prank(address(host));
+        vm.expectRevert(IntentsBase.Unauthorized.selector);
+        intentGateway.onAccept(IncomingPostRequest({relayer: filler, request: upgrade}));
+        assertEq(_implementationOf(address(intentGateway)), implBefore, "implementation unchanged");
+
+        // NewDeployment: the gate runs before the body is decoded, so every kind is covered.
+        PostRequest memory deployment = _newDeploymentRequest(bytes("NEW_CHAIN"), address(0xBEEF));
+        vm.prank(address(host));
+        vm.expectRevert(IntentsBase.Unauthorized.selector);
+        intentGateway.onAccept(IncomingPostRequest({relayer: filler, request: deployment}));
+        vm.expectRevert(IntentsBase.UnknownInstance.selector);
+        intentGateway.instance(bytes("NEW_CHAIN"));
+
+        vm.prank(address(host));
+        intentGateway.onAccept(IncomingPostRequest({relayer: relayer, request: deployment}));
+        assertEq(intentGateway.instance(bytes("NEW_CHAIN")), address(0xBEEF), "relayer-submitted governance applies");
+    }
+
+    function testOnGetResponseRejectsUnlistedRelayer() public {
+        (GetResponse memory response, bytes32 commitment, uint256 amount) = _cancelResponse();
+
+        vm.prank(address(host));
+        vm.expectRevert(IntentsBase.Unauthorized.selector);
+        intentGateway.onGetResponse(IncomingGetResponse({response: response, relayer: user}));
+        assertEq(intentGateway._orders(commitment, address(usdc)), amount, "escrow untouched");
+
+        uint256 before = usdc.balanceOf(user);
+        vm.prank(address(host));
+        intentGateway.onGetResponse(IncomingGetResponse({response: response, relayer: relayer}));
+        assertEq(usdc.balanceOf(user) - before, amount, "authorised relayer refunds escrow");
+    }
+
+    function testFreshProxyRejectsEveryDeliveryUntilRelayerSet() public {
+        IntentGatewayV2 implementation = new IntentGatewayV2(address(this));
+        ERC1967Proxy proxy = new ERC1967Proxy(address(implementation), "");
+        IntentGatewayV2 gateway = IntentGatewayV2(payable(address(proxy)));
+        Params memory p = Params({
+            host: address(host),
+            dispatcher: address(dispatcher),
+            solverSelection: false,
+            surplusShareBps: 10000,
+            protocolFeeBps: 0,
+            priceOracle: address(0)
+        });
+        gateway.initialize(p, new bytes[](0));
+        assertEq(gateway._relayer(), address(0), "no relayer after initialize");
+
+        PostRequest memory deployment = _newDeploymentRequest(bytes("NEW_CHAIN"), address(0xBEEF));
+        deployment.from = abi.encodePacked(address(gateway));
+        deployment.to = abi.encodePacked(address(gateway));
+
+        vm.prank(address(host));
+        vm.expectRevert(IntentsBase.Unauthorized.selector);
+        gateway.onAccept(IncomingPostRequest({relayer: relayer, request: deployment}));
+        vm.prank(address(host));
+        vm.expectRevert(IntentsBase.Unauthorized.selector);
+        gateway.onAccept(IncomingPostRequest({relayer: filler, request: deployment}));
+
+        gateway.setRelayer(relayer);
+        vm.prank(address(host));
+        gateway.onAccept(IncomingPostRequest({relayer: relayer, request: deployment}));
+        assertEq(gateway.instance(bytes("NEW_CHAIN")), address(0xBEEF));
+    }
+
+    function testUpgradeWithInitDataSetsRelayerAtomically() public {
+        (bytes32 filledCommitment, bytes32 escrowedCommitment, address inputToken, uint256 escrowedAmount) =
+            _seedUpgradeState();
+        address next = makeCleanAddr("nextRelayer");
+        IntentGatewayV2Upgraded newImpl = new IntentGatewayV2Upgraded(address(this));
+        bytes memory initData = abi.encodeCall(IntentGatewayV2.setRelayer, (next));
+        PostRequest memory request = _upgradeRequest(host.hyperbridge(), address(newImpl), initData);
+
+        // The upgrade itself must arrive through the relayer authorised at the time.
+        vm.prank(address(host));
+        vm.expectRevert(IntentsBase.Unauthorized.selector);
+        intentGateway.onAccept(IncomingPostRequest({relayer: next, request: request}));
+
+        // `upgradeToAndCall` delegatecalls the migration calldata with the host still as
+        // `msg.sender`, so `_owner` is not involved.
+        vm.recordLogs();
+        vm.prank(address(host));
+        intentGateway.onAccept(IncomingPostRequest({relayer: relayer, request: request}));
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bool sawRelayerUpdated;
+        for (uint256 i; i < logs.length; i++) {
+            bool ours = logs[i].emitter == address(intentGateway);
+            if (ours && logs[i].topics[0] == IntentsBase.RelayerUpdated.selector) {
+                sawRelayerUpdated = true;
+                assertEq(logs[i].data, abi.encode(relayer, next), "RelayerUpdated(previous, current)");
+            }
+        }
+        assertTrue(sawRelayerUpdated, "RelayerUpdated emitted from the upgrade transaction");
+
+        assertEq(_implementationOf(address(intentGateway)), address(newImpl), "implementation slot updated");
+        assertEq(intentGateway._relayer(), next, "relayer set in the upgrade transaction");
+        assertEq(intentGateway._nonce(), 2, "_nonce preserved");
+        assertEq(intentGateway._filled(filledCommitment), filler, "_filled preserved");
+        assertEq(intentGateway._orders(escrowedCommitment, inputToken), escrowedAmount, "_orders preserved");
+
+        // From here on only the new relayer is accepted.
+        PostRequest memory deployment = _newDeploymentRequest(bytes("NEW_CHAIN"), address(0xBEEF));
+        vm.prank(address(host));
+        vm.expectRevert(IntentsBase.Unauthorized.selector);
+        intentGateway.onAccept(IncomingPostRequest({relayer: relayer, request: deployment}));
+        vm.prank(address(host));
+        intentGateway.onAccept(IncomingPostRequest({relayer: next, request: deployment}));
+        assertEq(intentGateway.instance(bytes("NEW_CHAIN")), address(0xBEEF));
+    }
+
+    function testUpgradeWithoutInitDataKeepsExistingRelayer() public {
+        IntentGatewayV2Upgraded newImpl = new IntentGatewayV2Upgraded(address(this));
+        PostRequest memory request = _upgradeRequest(host.hyperbridge(), address(newImpl), "");
+        vm.prank(address(host));
+        intentGateway.onAccept(IncomingPostRequest({relayer: relayer, request: request}));
+
+        assertEq(_implementationOf(address(intentGateway)), address(newImpl));
+        assertEq(intentGateway._relayer(), relayer, "relayer survives an implementation swap");
+    }
+
+    /// @dev Through the real host: a delivery the gateway refuses is recorded as undelivered, so
+    /// the authorised relayer can submit the same message afterwards.
+    function testRejectedDeliveryStaysRetryableThroughHost() public {
+        (PostRequest memory request, bytes32 commitment, uint256 amount) = _escrowedRedeemRequest();
+        bytes32 requestCommitment = request.hash();
+
+        vm.prank(address(handler));
+        host.dispatchIncoming(request, filler);
+        assertEq(host.requestReceipts(requestCommitment), address(0), "refused delivery leaves no receipt");
+        assertEq(intentGateway._orders(commitment, address(usdc)), amount, "escrow untouched");
+
+        uint256 before = usdc.balanceOf(filler);
+        vm.prank(address(handler));
+        host.dispatchIncoming(request, relayer);
+        assertEq(host.requestReceipts(requestCommitment), relayer, "delivery recorded");
+        assertEq(usdc.balanceOf(filler) - before, amount, "escrow released");
+    }
+
+    // ============================================================
+    // Live mainnet proxy upgrade
+    // ============================================================
+
+    /// @dev The IntentGatewayV2 proxy deployed on Ethereum mainnet (identical address on every chain).
+    address internal constant LIVE_GATEWAY = 0xAe041F7B0CB581876832830baeB6a2Aa2a3C9716;
+
+    function _livePeers() internal pure returns (bytes[] memory peers) {
+        uint256[9] memory ids = [uint256(1), 10, 42161, 8453, 56, 100, 137, 1868, 420420419];
+        peers = new bytes[](ids.length);
+        for (uint256 i; i < ids.length; i++) {
+            peers[i] = StateMachine.evm(ids[i]);
+        }
+    }
+
+    /// @dev Upgrades the proxy that is actually live on mainnet, on the fork, and checks that every
+    /// readable piece of state is identical afterwards and that the relayer gate is armed.
+    function testLiveProxyUpgradeKeepsStateAndArmsRelayer() public {
+        IntentGatewayV2 live = IntentGatewayV2(payable(LIVE_GATEWAY));
+        assertGt(LIVE_GATEWAY.code.length, 0, "live gateway present on the fork");
+        address implBefore = _implementationOf(LIVE_GATEWAY);
+
+        uint256 nonce = live._nonce();
+        Params memory p = live.params();
+        address owner = live._owner();
+        bytes32 domain = live.DOMAIN_SEPARATOR();
+        address liveHost = live.host();
+        bytes[] memory peers = _livePeers();
+        address[] memory instances = new address[](peers.length);
+        uint256[] memory fees = new uint256[](peers.length);
+        for (uint256 i; i < peers.length; i++) {
+            instances[i] = live._instances(keccak256(peers[i]));
+            fees[i] = live._destinationProtocolFees(keccak256(peers[i]));
+        }
+        assertEq(vm.load(LIVE_GATEWAY, bytes32(uint256(13))), bytes32(0), "slot 13 holds only an unset _paused");
+
+        IntentGatewayV2 newImpl = new IntentGatewayV2(owner);
+        PostRequest memory request = PostRequest({
+            source: IDispatcher(liveHost).hyperbridge(),
+            dest: IDispatcher(liveHost).host(),
+            nonce: 0,
+            from: abi.encodePacked(LIVE_GATEWAY),
+            to: abi.encodePacked(LIVE_GATEWAY),
+            body: bytes.concat(
+                bytes1(uint8(IntentsBase.RequestKind.UpgradeContract)),
+                abi.encode(address(newImpl), abi.encodeCall(IntentGatewayV2.setRelayer, (relayer)))
+            ),
+            timeoutTimestamp: 0
+        });
+        // The implementation being replaced has no relayer gate, so any relayer may carry the upgrade.
+        vm.prank(liveHost);
+        live.onAccept(IncomingPostRequest({relayer: filler, request: request}));
+
+        assertEq(_implementationOf(LIVE_GATEWAY), address(newImpl), "implementation slot updated");
+        assertTrue(implBefore != address(newImpl), "implementation actually changed");
+        assertEq(live._relayer(), relayer, "relayer armed in the upgrade transaction");
+        assertEq(
+            vm.load(LIVE_GATEWAY, bytes32(uint256(13))), _packedRelayerSlot(relayer), "relayer packed into slot 13"
+        );
+
+        assertEq(live._nonce(), nonce, "_nonce preserved");
+        Params memory q = live.params();
+        assertEq(q.host, p.host, "params.host preserved");
+        assertEq(q.dispatcher, p.dispatcher, "params.dispatcher preserved");
+        assertEq(q.solverSelection, p.solverSelection, "params.solverSelection preserved");
+        assertEq(q.surplusShareBps, p.surplusShareBps, "params.surplusShareBps preserved");
+        assertEq(q.protocolFeeBps, p.protocolFeeBps, "params.protocolFeeBps preserved");
+        assertEq(q.priceOracle, p.priceOracle, "params.priceOracle preserved");
+        assertEq(live._owner(), owner, "_owner preserved");
+        assertEq(live.DOMAIN_SEPARATOR(), domain, "EIP-712 domain preserved");
+        assertEq(live.host(), liveHost, "host preserved");
+        for (uint256 i; i < peers.length; i++) {
+            assertEq(live._instances(keccak256(peers[i])), instances[i], "peer instance preserved");
+            assertEq(live._destinationProtocolFees(keccak256(peers[i])), fees[i], "destination fee preserved");
+        }
+
+        // The gate is live on the real state: governance through anyone else is refused, and the
+        // same message goes through from the relayer.
+        request.body = bytes.concat(
+            bytes1(uint8(IntentsBase.RequestKind.UpdateParams)),
+            abi.encode(ParamsUpdate({params: p, destinationFees: new DestinationFee[](0)}))
+        );
+        vm.prank(liveHost);
+        vm.expectRevert(IntentsBase.Unauthorized.selector);
+        live.onAccept(IncomingPostRequest({relayer: filler, request: request}));
+
+        vm.prank(liveHost);
+        live.onAccept(IncomingPostRequest({relayer: relayer, request: request}));
+        assertEq(live.params().host, p.host, "relayer-submitted governance applies");
     }
 }
 

--- a/evm/tests/rust/src/tests/abi_encode_apps.rs
+++ b/evm/tests/rust/src/tests/abi_encode_apps.rs
@@ -115,7 +115,7 @@ fn test_hft_message_encoding_parity() {
 	// Rust encodes — exactly as `pallets/hyper-fungible-token/src/lib.rs:296` does.
 	let rust_encoded = HftMessage::abi_encode(&msg);
 
-	// Solidity encodes — exactly as `HyperFungibleToken.sol:242` does.
+	// Solidity encodes — exactly as `HyperFungibleToken.sol:288` does.
 	let result = env.call(codec, encodeHftMessageCall { m: msg.clone() }.abi_encode());
 	let sol_encoded = Bytes::abi_decode(&result).unwrap().to_vec();
 

--- a/evm/tests/rust/src/tests/utils.rs
+++ b/evm/tests/rust/src/tests/utils.rs
@@ -56,6 +56,14 @@ fn host_manager_set_ismp_host(addr: Address) -> Vec<u8> {
 	calldata
 }
 
+fn host_manager_set_relayer(addr: Address) -> Vec<u8> {
+	let selector: [u8; 4] =
+		alloy_primitives::keccak256(b"setRelayer(address)").0[..4].try_into().unwrap();
+	let mut calldata = selector.to_vec();
+	calldata.extend_from_slice(&addr.abi_encode());
+	calldata
+}
+
 // ---------------------------------------------------------------------------
 // Constructor param types
 // ---------------------------------------------------------------------------
@@ -194,8 +202,10 @@ impl TestEnv {
 		);
 		env.evm.ctx.block.timestamp = U256::from(1);
 
-		// 8. Configure: setIsmpHost on HostManager
+		// 8. Configure: setIsmpHost on HostManager, then authorise `sender` (the host admin and
+		// the relayer every test delivers as) to deliver governance messages.
 		env.call(env.manager, host_manager_set_ismp_host(env.host));
+		env.call(env.manager, host_manager_set_relayer(env.sender));
 
 		// 9. Token approvals
 		env.call(

--- a/modules/pallets/host-executive/src/lib.rs
+++ b/modules/pallets/host-executive/src/lib.rs
@@ -194,6 +194,9 @@ pub mod pallet {
 
 			let (HostParam::EvmHostParam(mut inner), HostParamUpdate::EvmHostParam(update)) =
 				(params.clone(), update);
+			// The destination host only accepts `updateHostParams` from the manager it currently
+			// knows, so a manager rotation must be delivered through the outgoing manager.
+			let current_manager = inner.host_manager;
 			inner.update(update);
 
 			let body = inner.abi_encode_with_variant().map_err(|_| Error::<T>::DispatchFailed)?;
@@ -201,7 +204,7 @@ pub mod pallet {
 			let post = DispatchPost {
 				dest: state_machine,
 				from: PALLET_ID.to_bytes(),
-				to: inner.host_manager.0.to_vec(),
+				to: current_manager.0.to_vec(),
 				timeout: 0,
 				body,
 			};

--- a/modules/pallets/testsuite/src/tests/pallet_ismp_host_executive.rs
+++ b/modules/pallets/testsuite/src/tests/pallet_ismp_host_executive.rs
@@ -16,7 +16,8 @@
 #![cfg(test)]
 use polkadot_sdk::*;
 
-use crate::runtime::{last_event, new_test_ext, RuntimeEvent, RuntimeOrigin, Test};
+use crate::runtime::{last_event, new_test_ext, Ismp, RuntimeEvent, RuntimeOrigin, Test};
+use frame_support::traits::Get;
 use ismp::host::StateMachine;
 use pallet_ismp_host_executive::{EvmHostParam, EvmHostParamUpdate, HostParam, HostParamUpdate};
 use sp_core::{crypto::AccountId32, H160, H256};
@@ -64,4 +65,105 @@ fn test_host_executive() {
 
 		assert_eq!(state_machine, StateMachine::Polkadot(2000))
 	})
+}
+
+/// The request that rotates the host manager must be addressed to the manager the destination
+/// host currently authorises, while its payload installs the new one. Once the rotation is
+/// recorded locally, later governance traffic is addressed to the new manager.
+#[test]
+fn test_manager_rotation_is_addressed_to_the_current_manager() {
+	use ismp::{
+		messaging::hash_request,
+		router::{PostRequest, Request},
+	};
+	use pallet_ismp_host_executive::{WithdrawalParams, PALLET_ID};
+	use sp_core::U256;
+
+	new_test_ext().execute_with(|| {
+		let chain = StateMachine::Evm(1);
+		let current_manager = H160::random();
+		let new_manager = H160::random();
+
+		let mut initial = EvmHostParam::default();
+		initial.host_manager = current_manager;
+		let mut map = BTreeMap::new();
+		map.insert(chain, HostParam::EvmHostParam(initial.clone()));
+		pallet_ismp_host_executive::Pallet::<Test>::set_host_params(RuntimeOrigin::root(), map)
+			.unwrap();
+
+		let mut update = EvmHostParamUpdate::default();
+		update.host_manager = Some(new_manager);
+		pallet_ismp_host_executive::Pallet::<Test>::update_host_params(
+			RuntimeOrigin::root(),
+			chain,
+			HostParamUpdate::EvmHostParam(update),
+		)
+		.unwrap();
+
+		let (commitment, nonce) = last_dispatched_request();
+		let mut expected = initial.clone();
+		expected.host_manager = new_manager;
+		let addressed_to = |to: H160| {
+			hash_request::<Ismp>(&Request::Post(PostRequest {
+				source: <Test as pallet_ismp::Config>::HostStateMachine::get(),
+				dest: chain,
+				nonce,
+				from: PALLET_ID.to_bytes(),
+				to: to.0.to_vec(),
+				timeout_timestamp: 0,
+				body: expected.abi_encode_with_variant().unwrap(),
+			}))
+		};
+		assert_eq!(
+			commitment,
+			addressed_to(current_manager),
+			"rotation goes through the current manager"
+		);
+		assert_ne!(commitment, addressed_to(new_manager), "the new manager is not yet authorised");
+		assert_eq!(
+			pallet_ismp_host_executive::HostParams::<Test>::get(chain),
+			Some(HostParam::EvmHostParam(expected.clone())),
+			"the new manager is recorded locally"
+		);
+
+		// Everything after the rotation is addressed to the new manager.
+		let withdrawal = WithdrawalParams {
+			beneficiary_address: H160::random().0.to_vec(),
+			amount: U256::from(1u64),
+			token: H160::zero(),
+		};
+		pallet_ismp_host_executive::Pallet::<Test>::withdraw(
+			RuntimeOrigin::root(),
+			chain,
+			withdrawal.clone(),
+		)
+		.unwrap();
+		let (commitment, nonce) = last_dispatched_request();
+		assert_eq!(
+			commitment,
+			hash_request::<Ismp>(&Request::Post(PostRequest {
+				source: <Test as pallet_ismp::Config>::HostStateMachine::get(),
+				dest: chain,
+				nonce,
+				from: PALLET_ID.to_bytes(),
+				to: new_manager.0.to_vec(),
+				timeout_timestamp: 0,
+				body: withdrawal.abi_encode().unwrap(),
+			}))
+		);
+	})
+}
+
+/// Commitment and nonce of the most recently dispatched ISMP request.
+fn last_dispatched_request() -> (H256, u64) {
+	frame_system::Pallet::<Test>::events()
+		.into_iter()
+		.rev()
+		.find_map(|record| match record.event {
+			RuntimeEvent::Ismp(pallet_ismp::Event::Request {
+				commitment, request_nonce, ..
+			}) => Some((commitment, request_nonce)),
+			_ => None,
+		})
+		.expect("a request was dispatched")
 }

--- a/parachain/runtimes/nexus/src/lib.rs
+++ b/parachain/runtimes/nexus/src/lib.rs
@@ -240,7 +240,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: Cow::Borrowed("nexus"),
 	impl_name: Cow::Borrowed("nexus"),
 	authoring_version: 1,
-	spec_version: 8_400,
+	spec_version: 8_500,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/sdk/packages/core/contracts/apps/HyperFungibleToken.sol
+++ b/sdk/packages/core/contracts/apps/HyperFungibleToken.sol
@@ -104,6 +104,9 @@ contract HyperFungibleToken is ERC20, ERC165, HyperApp, Ownable, Pausable {
      */
     error UnauthorizedSource();
 
+    /// @notice Thrown when a delivery comes from a relayer other than the authorised one
+    error UnauthorizedRelayer();
+
     /// @notice Address of the ISMP host contract on this chain
     address internal _host;
 
@@ -115,6 +118,12 @@ contract HyperFungibleToken is ERC20, ERC165, HyperApp, Ownable, Pausable {
      * An empty value means the chain is not supported.
      */
     mapping(bytes => bytes) internal _supportedChains;
+
+    /**
+     * @notice The relayer whose `onAccept` and `onPostRequestTimeout` deliveries are accepted.
+     * Zero leaves deliveries open to any relayer; see `_checkRelayer`.
+     */
+    address internal _relayer;
 
     /**
      * @notice Emitted when tokens are burned and a cross-chain transfer is dispatched
@@ -141,6 +150,13 @@ contract HyperFungibleToken is ERC20, ERC165, HyperApp, Ownable, Pausable {
      * @param amount The amount of tokens refunded
      */
     event Refunded(address to, uint256 amount);
+
+    /**
+     * @notice Emitted when the authorised relayer is replaced
+     * @param previous The relayer authorised before this change
+     * @param current The relayer authorised from now on
+     */
+    event RelayerUpdated(address previous, address current);
 
     /**
      * @notice Initializes the token with a name, symbol, and owner
@@ -204,6 +220,36 @@ contract HyperFungibleToken is ERC20, ERC165, HyperApp, Ownable, Pausable {
      */
     function removeChain(bytes calldata chainId) external onlyOwner {
         delete _supportedChains[chainId];
+    }
+
+    /**
+     * @notice Returns the relayer authorised to deliver cross-chain messages, zero if unrestricted
+     * @return The authorised relayer address
+     */
+    function relayer() public view returns (address) {
+        return _relayer;
+    }
+
+    /**
+     * @notice Restricts `onAccept` and `onPostRequestTimeout` to deliveries submitted by `newRelayer`
+     * @dev Only callable by the contract owner. The host records a refused delivery as undelivered,
+     * so a message rejected here can still be submitted by the authorised relayer afterwards.
+     * @param newRelayer The relayer to authorise. Zero lifts the restriction in this contract;
+     * derived contracts may treat zero as "nobody" by overriding `_checkRelayer`.
+     */
+    function setRelayer(address newRelayer) external onlyOwner {
+        emit RelayerUpdated({previous: _relayer, current: newRelayer});
+        _relayer = newRelayer;
+    }
+
+    /**
+     * @dev Reverts with `UnauthorizedRelayer` when `incomingRelayer` may not deliver to this token.
+     * Unrestricted while no relayer is set, so existing deployments keep working until their
+     * owner opts in. Override to fail closed instead.
+     * @param incomingRelayer The account that submitted the message to the handler
+     */
+    function _checkRelayer(address incomingRelayer) internal view virtual {
+        if (_relayer != address(0) && incomingRelayer != _relayer) revert UnauthorizedRelayer();
     }
 
     /**
@@ -289,6 +335,7 @@ contract HyperFungibleToken is ERC20, ERC165, HyperApp, Ownable, Pausable {
      * @param incoming The incoming POST request containing the token transfer message
      */
     function onAccept(IncomingPostRequest calldata incoming) external override onlyHost whenNotPaused {
+        _checkRelayer(incoming.relayer);
         PostRequest calldata request = incoming.request;
 
         bytes memory expectedSource = _supportedChains[request.source];
@@ -318,6 +365,7 @@ contract HyperFungibleToken is ERC20, ERC165, HyperApp, Ownable, Pausable {
      * @param incoming The timed-out POST request and the relayer that submitted the timeout proof
      */
     function onPostRequestTimeout(PostRequestTimeout memory incoming) external override onlyHost whenNotPaused {
+        _checkRelayer(incoming.relayer);
         Message memory message = abi.decode(incoming.request.body, (Message));
         address refundee = _toAddr(message.from);
         _mint(refundee, message.amount);

--- a/sdk/packages/core/contracts/apps/IntentGatewayV2.sol
+++ b/sdk/packages/core/contracts/apps/IntentGatewayV2.sol
@@ -369,6 +369,13 @@ interface IIntentGatewayV2 {
      */
     event DestinationProtocolFeeUpdated(string chain, uint256 feeBps);
 
+    /**
+     * @notice Emitted when the relayer authorised to deliver cross-chain messages is replaced.
+     * @param previous The relayer that was authorised before this change
+     * @param current The relayer authorised from now on
+     */
+    event RelayerUpdated(address previous, address current);
+
     // ============================================
     // Constants
     // ============================================
@@ -411,6 +418,14 @@ interface IIntentGatewayV2 {
      * @return Params A struct containing the module's current parameters
      */
     function params() external view returns (Params memory);
+
+    /**
+     * @notice Replaces the only relayer whose `onAccept` and `onGetResponse` deliveries are
+     *         accepted. Callable by the gateway owner, or by the host as the migration calldata
+     *         of a governance upgrade so that the relayer is armed in the upgrade transaction.
+     * @param relayer The relayer authorised from now on. Zero rejects every delivery.
+     */
+    function setRelayer(address relayer) external;
 
     /**
      * @notice Calculates the commitment slot hash for storage proof verification.

--- a/sdk/packages/core/docs/ai/ChangeLog.md
+++ b/sdk/packages/core/docs/ai/ChangeLog.md
@@ -12,6 +12,21 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-09-03 — Governance deliveries to `HostManager` gated on the same relayer
+
+Closes the route around the app-level gates: `HostManager.onAccept` accepted `SetHostParam` from
+any relayer, and that request can replace the host's handler, the contract every app trusts to
+report the relayer address. `HostManager` now holds `_relayer`, set by the host admin through
+`setRelayer`, and `onAccept` reverts with `UnauthorizedRelayer` for any other relayer, zero
+included. Only governance traffic reaches this contract, so ordinary relaying is unaffected.
+No file in this package changed; the entry is here because the delivery flow documented in
+`Flow.md` is what it corrects.
+
+Files: `evm/src/core/HostManager.sol`, `evm/script/DeployIsmp.s.sol`,
+`evm/script/DeployHostManager.s.sol`, `evm/tests/foundry/HostManagerTest.sol`,
+`evm/tests/foundry/BaseTest.sol`, `evm/tests/rust/src/tests/utils.rs`, `docs/ai/Decisions.md`,
+`docs/ai/Flow.md`.
+
 ## 2026-09-03 — Relayer allowlist on `HyperFungibleToken`, fail-closed on the BRIDGE token
 
 `HyperFungibleToken` gains `_relayer`, `relayer()`, `setRelayer(address)` (owner only), the

--- a/sdk/packages/core/docs/ai/ChangeLog.md
+++ b/sdk/packages/core/docs/ai/ChangeLog.md
@@ -12,6 +12,20 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-09-03 — Host manager rotation addressed to the manager the host still trusts
+
+`pallet-ismp-host-executive::update_host_params` applied the update before reading the request
+recipient, so a rotation from one HostManager to another was addressed to the new one. The host
+accepts `updateHostParams` only from its current manager, so the delivery reverted, Hyperbridge
+recorded the new manager anyway, and every later host update and withdrawal for that chain was
+sent to a contract the host did not trust. The recipient is now captured before the update; the
+payload still installs the new manager. This is the path the HostManager relayer gate is rolled
+out through. No file in this package changed.
+
+Files: `modules/pallets/host-executive/src/lib.rs`,
+`modules/pallets/testsuite/src/tests/pallet_ismp_host_executive.rs`,
+`evm/tests/foundry/HostManagerTest.sol`, `docs/ai/Flow.md`.
+
 ## 2026-09-03 — Governance deliveries to `HostManager` gated on the same relayer
 
 Closes the route around the app-level gates: `HostManager.onAccept` accepted `SetHostParam` from

--- a/sdk/packages/core/docs/ai/ChangeLog.md
+++ b/sdk/packages/core/docs/ai/ChangeLog.md
@@ -12,6 +12,43 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-09-03 — Relayer allowlist on `HyperFungibleToken`, fail-closed on the BRIDGE token
+
+`HyperFungibleToken` gains `_relayer`, `relayer()`, `setRelayer(address)` (owner only), the
+`RelayerUpdated(address previous, address current)` event, the `UnauthorizedRelayer` error, and a
+virtual `_checkRelayer` that `onAccept` and `onPostRequestTimeout` call before anything else. Both
+callbacks mint, so both are gated. In the base the check is opt-in: zero leaves deliveries open, so
+tokens already deployed from this package behave as before until their owner sets a relayer.
+`evm/src/apps/BridgeToken.sol` overrides `_checkRelayer` to fail closed, and its deploy script sets
+the relayer from `BRIDGE_RELAYER` before `configure`, so the token is never live without one.
+`IHyperFungibleToken` is unchanged: `supportsInterface` keys on its `interfaceId`, so adding the
+new functions there would change what every existing deployment reports.
+
+Files: `contracts/apps/HyperFungibleToken.sol`, `docs/ai/ChangeLog.md`, `docs/ai/Decisions.md`,
+`docs/ai/Flow.md`. Outside the package: `evm/src/apps/BridgeToken.sol`,
+`evm/script/DeployBridgeToken.s.sol`, `evm/tests/foundry/BridgeTokenTest.t.sol`,
+`evm/tests/foundry/HyperFungibleTokenTest.sol`.
+
+## 2026-09-03 — Relayer allowlist on the intent gateway
+
+The gateway now accepts `onAccept` and `onGetResponse` deliveries only from a single authorised
+relayer stored at `_relayer` (slot 13, packed behind `_paused`). The check runs before the message
+body is decoded, so escrow redemptions, refunds and every governance action, upgrades included, are
+covered. A refused delivery reverts, which the host records as undelivered, so the authorised
+relayer can submit the same message later. `setRelayer(address)` is callable by the immutable
+`_owner` and by the host; the host branch exists so a governance `UpgradeContract` can carry the
+call as its migration calldata and arm the relayer in the upgrade transaction (`upgradeToAndCall`
+delegatecalls that calldata with the host still as `msg.sender`).
+
+The interface gains `RelayerUpdated(address previous, address current)` and `setRelayer`, keeping
+its declarations identical to `IntentsBase`. The unused `_paused` getter was dropped from the gateway
+to stay under the EIP-170 size limit; it was never declared here.
+
+Files: `contracts/apps/IntentGatewayV2.sol`, `package.json`, `docs/ai/ChangeLog.md`,
+`docs/ai/Decisions.md`, `docs/ai/Flow.md`. Gateway side: `evm/src/apps/IntentGatewayV2.sol`,
+`evm/src/apps/intentsv2/IntentsBase.sol`, `evm/src/apps/intentsv2/ExtrinsicIntents.sol`,
+`evm/tests/foundry/IntentGatewayV2Test.sol`.
+
 ## 2026-08-27 — `IIntentGatewayV2` brought back in sync with the gateway (#1160)
 
 `IIntentGatewayV2` had drifted from the deployed `IntentGatewayV2`. Every declaration in the

--- a/sdk/packages/core/docs/ai/Decisions.md
+++ b/sdk/packages/core/docs/ai/Decisions.md
@@ -4,6 +4,86 @@ AI-maintained record of non-obvious choices made in `sdk/packages/core`: what wa
 
 Entry format: heading with the decision, then alternatives considered and the reasoning. Newest first.
 
+## 2026-09-03 — `HyperFungibleToken` opts in to the relayer gate; `BridgeToken` fails closed
+
+Chosen: the base token's `_checkRelayer` only rejects when a relayer has been set, and
+`BridgeToken` overrides it so that an unset relayer matches nobody.
+
+`HyperFungibleToken` is a library contract that third parties deploy from this package. Failing
+closed there would leave every token deployed without a `setRelayer` call unable to receive
+anything, with no compile-time signal. The BRIDGE token is ours, its supply is backed by the nexus
+escrow, and a forged mint is exactly the attack the gate exists for, so it takes the strict
+semantics of the intent gateway. The two behaviours live in one virtual function so the difference
+is visible in one place rather than spread through the callbacks.
+
+Alternative rejected — override `onAccept` in `BridgeToken`. It is `external`, so an override
+cannot call the parent body and would have to duplicate the mint logic.
+
+Alternative rejected — make the base fail closed and bump the package major. Correct in principle,
+but the request was for the bridge token, and the base can be tightened later once every
+deployment from this package has a relayer set.
+
+## 2026-09-03 — `onPostRequestTimeout` is gated on the token, unlike the gateway
+
+Timeouts mint a refund to the original sender, so a forged timeout proof mints. The intent gateway
+does not gate its timeout callbacks because `HyperApp`'s defaults revert and it dispatches with no
+timeout.
+
+## 2026-09-03 — `IHyperFungibleToken` does not declare `setRelayer` or `relayer`
+
+`supportsInterface` returns true for `type(IHyperFungibleToken).interfaceId`. Extending the
+interface changes that id, so existing deployments would stop matching it and new ones would report
+an id integrators have not seen. The relayer functions are reachable through the contract type.
+
+## 2026-09-03 — The relayer is a separate storage variable, not a `Params` field
+
+Chosen: `address _relayer` appended after `_paused` in `IntentsBase`, set through its own
+`setRelayer` call.
+
+`Params` occupies slots 4 to 8 and `_orders` starts at slot 9. Adding a field to the struct would
+push every mapping behind it and corrupt escrow on the live proxy. Reusing `UpdateParams` was
+therefore never available, quite apart from it being a Hyperbridge-relayed message: the whole point
+is to hold even if Hyperbridge's consensus is compromised, so the setter must not depend on it.
+
+Alternative rejected — a new `RequestKind` for governance to set the relayer. It needs the
+`intents-coprocessor` pallet mirrored, and it is still a cross-chain message. Governance can already
+rotate the relayer through `UpgradeContract` migration calldata when it wants to; the owner path
+covers the case where it cannot.
+
+## 2026-09-03 — Zero relayer fails closed, and the upgrade arms it atomically
+
+Chosen: an unset `_relayer` matches no delivery, because the handler always forwards a real
+`msg.sender`. The rollout sets it in the upgrade transaction via `upgradeToAndCall` calldata.
+
+Alternative rejected — treat zero as "allowlist disabled". Convenient for tests and a forgotten
+init, but it makes the safe state opt-in, and a fresh proxy would run unguarded until someone
+noticed. A refused delivery costs nothing: the host deletes the receipt and the authorised relayer
+can resubmit.
+
+Alternative rejected — a `reinitializer(2)` taking the relayer. It is one-shot, so rotation would
+need the setter anyway, and it does not solve who may call it.
+
+## 2026-09-03 — `setRelayer` accepts the host, not `address(this)`
+
+Chosen: `msg.sender == _owner || msg.sender == host()`.
+
+The first draft allowed `address(this)`, expecting `upgradeToAndCall` to call the proxy. It does
+not: it delegatecalls the migration calldata, so `msg.sender` is still the host that invoked
+`onAccept`. The fork test against the live mainnet proxy failed with `Unauthorized` and exposed it.
+Accepting the host adds no trust: the host already gates every callback, and it never calls the
+gateway with any selector other than the `IApp` callbacks, so the branch is reachable only from
+governance migration calldata that has already passed the hyperbridge-source check and the relayer
+gate.
+
+## 2026-09-03 — The `_paused` getter was dropped to stay under EIP-170
+
+Chosen: `bool internal _paused`. The variable stays in slot 13 so the layout is unchanged.
+
+The gateway compiled to 10 bytes over the limit with the new storage, setter, event and checks.
+Nothing reads `_paused()` anywhere in the repo, so removing its getter was the only free saving.
+The revert reuses `Unauthorized()` instead of a dedicated error for the same reason; the second
+selector cost 15 bytes.
+
 ## 2026-08-27 — `NewDeploymentAdded` was renamed rather than kept for compatibility
 
 Chosen: the interface's `NewDeploymentAdded(bytes stateMachineId, address gateway)` was replaced

--- a/sdk/packages/core/docs/ai/Decisions.md
+++ b/sdk/packages/core/docs/ai/Decisions.md
@@ -4,6 +4,32 @@ AI-maintained record of non-obvious choices made in `sdk/packages/core`: what wa
 
 Entry format: heading with the decision, then alternatives considered and the reasoning. Newest first.
 
+## 2026-09-03 — `HostManager` deliveries are gated too, and that does not touch permissionless relaying
+
+Chosen: `HostManager.onAccept` refuses any relayer but the one the host admin set, zero included.
+
+The app gates check an address the host reports, and the host takes it from its handler. The
+handler is a host parameter that a `SetHostParam` governance message can replace, and until now
+any relayer could deliver that message once its consensus proof verified. Under a forged consensus
+an attacker would swap in a handler that reports the whitelisted relayer on every message, and the
+app gates would pass. Gating the HostManager closes that route.
+
+It does not weaken the open-relayer model because the HostManager never carries user traffic. Its
+first check already rejects anything not sourced from Hyperbridge, so the only messages it ever
+sees are Polytope's own `Withdraw` and `SetHostParam`. Third-party relayers keep delivering every
+ordinary message to every ordinary app exactly as before.
+
+Alternative rejected — a delay on host parameter changes with the admin freeze as a veto. Keeps
+delivery open but needs someone watching every chain, and adds latency to legitimate governance.
+
+Alternative rejected — move handler and consensus-client changes to the host admin key. Simplest,
+but it takes that power away from cross-chain governance rather than protecting it.
+
+The setter authority is the host admin rather than the HostManager's own admin, which is zeroed
+after `setIsmpHost`. The host admin is the key that can already freeze the host and reset its
+consensus state, so no new trust is introduced. Zero is checked explicitly here since there is no
+bytecode pressure; on the gateway the same guarantee comes from the handler never forwarding zero.
+
 ## 2026-09-03 — `HyperFungibleToken` opts in to the relayer gate; `BridgeToken` fails closed
 
 Chosen: the base token's `_checkRelayer` only rejects when a relayer has been set, and

--- a/sdk/packages/core/docs/ai/Flow.md
+++ b/sdk/packages/core/docs/ai/Flow.md
@@ -54,6 +54,18 @@ relayer the host admin set with `setRelayer`; `testForgedHandlerSwapIsRefused` i
 `evm/tests/foundry/HostManagerTest.sol` plays the swap through the real host and shows it refused.
 The HostManager sees no user traffic, so this leaves ordinary relaying open.
 
+Replacing the HostManager itself follows the same route. `update_host_params` on Hyperbridge
+(`modules/pallets/host-executive/src/lib.rs`) reads the stored params, remembers the current
+manager, applies the update, and dispatches the encoded result addressed to the manager it
+remembered. That manager's `onAccept` calls `EvmHost.updateHostParams`, which is restricted to
+`_hostParams.hostManager`, so the host swaps to the new manager only because the call arrived
+through the old one. Hyperbridge records the new manager as soon as the request is dispatched, and
+every later `update_host_params` and `withdraw` is addressed to it. The two rotation tests in
+`evm/tests/foundry/HostManagerTest.sol` play both addressings through the real host, and
+`test_manager_rotation_is_addressed_to_the_current_manager` in the pallet testsuite pins the
+recipient the runtime chooses. Because the new manager's relayer gate applies to everything after
+the swap, the host admin sets its relayer before the rotation is dispatched.
+
 `setRelayer` has two callers. `_owner` calls it directly. The host reaches it when governance
 sends `UpgradeContract` with `abi.encodeCall(setRelayer, (relayer))` as migration calldata:
 `ERC1967Utils.upgradeToAndCall` delegatecalls that calldata into the new implementation with

--- a/sdk/packages/core/docs/ai/Flow.md
+++ b/sdk/packages/core/docs/ai/Flow.md
@@ -46,6 +46,14 @@ So a delivery from anyone but the authorised relayer never decodes the body, nev
 takes the normal path. A gateway whose `_relayer` is zero refuses everything, since step 1 always
 supplies a real address.
 
+The address checked in step 3 is only as trustworthy as the contract in step 1, and that contract
+is `_hostParams.handler`, which `HostManager.onAccept` can replace through a `SetHostParam`
+request from Hyperbridge (`evm/src/core/HostManager.sol`, then `EvmHost.updateHostParams`). The
+HostManager therefore runs the same relayer check before decoding any governance action, against a
+relayer the host admin set with `setRelayer`; `testForgedHandlerSwapIsRefused` in
+`evm/tests/foundry/HostManagerTest.sol` plays the swap through the real host and shows it refused.
+The HostManager sees no user traffic, so this leaves ordinary relaying open.
+
 `setRelayer` has two callers. `_owner` calls it directly. The host reaches it when governance
 sends `UpgradeContract` with `abi.encodeCall(setRelayer, (relayer))` as migration calldata:
 `ERC1967Utils.upgradeToAndCall` delegatecalls that calldata into the new implementation with

--- a/sdk/packages/core/docs/ai/Flow.md
+++ b/sdk/packages/core/docs/ai/Flow.md
@@ -23,3 +23,57 @@ That split is the whole reason the events drift: nothing in the repo compiles ag
 wrong signature is silent locally and only wrong for whoever depends on the package. The
 declaration lists in this file and in `IntentsBase.sol` are kept identical; diffing them is the
 only check that exists.
+
+## How a cross-chain delivery reaches the gateway, and where the relayer gate sits
+
+Verified against `evm/src/core/HandlerV2.sol`, `evm/src/core/EvmHost.sol` and
+`evm/src/apps/intentsv2/ExtrinsicIntents.sol`, and exercised by
+`testRejectedDeliveryStaysRetryableThroughHost` in `evm/tests/foundry/IntentGatewayV2Test.sol`.
+
+1. A relayer calls `HandlerV2.handlePostRequests` (or `handleGetResponses`). After proof
+   verification the handler calls `host.dispatchIncoming(request, _msgSender())`. `_msgSender()` is
+   plain `msg.sender`; the handler has no trusted forwarder.
+2. `EvmHost.dispatchIncoming` (restricted to the handler) writes a receipt for the request
+   commitment, then low-level calls the module with `IApp.onAccept(IncomingPostRequest(request,
+   relayer))`. If that call fails the host deletes the receipt and returns without reverting, so the
+   rest of the batch proceeds and the message stays deliverable.
+3. `ExtrinsicIntents.onAccept` runs `onlyHost`, then `_checkRelayer(incoming.relayer)`, which reverts
+   with `Unauthorized` unless the relayer equals `_relayer`. Only then is the first body byte read as
+   a `RequestKind`. `onGetResponse` has the same two steps before touching the response.
+
+So a delivery from anyone but the authorised relayer never decodes the body, never runs
+`_authenticate`, and leaves no receipt. The authorised relayer submitting the same message later
+takes the normal path. A gateway whose `_relayer` is zero refuses everything, since step 1 always
+supplies a real address.
+
+`setRelayer` has two callers. `_owner` calls it directly. The host reaches it when governance
+sends `UpgradeContract` with `abi.encodeCall(setRelayer, (relayer))` as migration calldata:
+`ERC1967Utils.upgradeToAndCall` delegatecalls that calldata into the new implementation with
+`msg.sender` still the host from step 2, so the relayer is set in the same transaction as the
+implementation swap. The upgrade message itself must already pass the relayer gate of the
+implementation being replaced.
+
+## The same gate on `HyperFungibleToken`, and how the BRIDGE token tightens it
+
+Verified against `contracts/apps/HyperFungibleToken.sol` and `evm/src/apps/BridgeToken.sol`, and
+exercised by the relayer tests in `evm/tests/foundry/HyperFungibleTokenTest.sol` and
+`evm/tests/foundry/BridgeTokenTest.t.sol`.
+
+Steps 1 and 2 above are identical; the token is just another `IApp`. Timeouts take a parallel route:
+`HandlerV2.handlePostRequestTimeouts` calls `host.dispatchTimeOut(PostRequestTimeout(request,
+_msgSender()), ...)`, and the host calls `onPostRequestTimeout` on the module.
+
+3. `onAccept` and `onPostRequestTimeout` run `onlyHost`, `whenNotPaused`, then
+   `_checkRelayer(incoming.relayer)`. Only after that is the source checked against
+   `_supportedChains` or the body decoded, and only then does anything mint.
+
+`_checkRelayer` is virtual. In `HyperFungibleToken` it reverts with `UnauthorizedRelayer` only when
+`_relayer` is set and differs from the incoming relayer, so a token that never called `setRelayer`
+accepts every relayer. `BridgeToken` overrides it to revert whenever the two differ, so with
+`_relayer` unset nothing can mint; the deploy script therefore calls `setRelayer` before
+`configure`, and before `configure` the token cannot be reached at all since `onlyHost` compares
+against an unset `_host`.
+
+`setRelayer` is `onlyOwner` in both. The host is not the owner and never calls the token with
+anything but the callback selectors, so there is no equivalent of the gateway's host branch, and
+none is needed: the token is not behind a proxy, so there is no upgrade transaction to arm it in.

--- a/sdk/packages/core/package.json
+++ b/sdk/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/core",
-	"version": "2.3.2",
+	"version": "2.3.3",
 	"description": "Hyperbridge Solidity SDK for dispatching & receiving cross-chain messages",
 	"author": "Polytope Labs <hello@polytope.technology>",
 	"license": "Apache-2.0",


### PR DESCRIPTION
Adds a single authorised relayer to IntentGatewayV2, BridgeToken and HostManager. Their inbound callbacks revert unless the message was submitted by that relayer, so a forged consensus alone cannot land a message. The host records a refused delivery as undelivered and the relayer can resubmit it.

- Gateway: `_relayer` appended to storage (slot 13, packed behind `_paused`). `setRelayer` is callable by `_owner`, or as `UpgradeContract` migration calldata so the relayer is armed in the upgrade transaction. Zero fails closed. The unused `_paused` getter is dropped to stay under EIP-170.
- HyperFungibleToken: opt-in gate with an owner-only `setRelayer`. BridgeToken overrides `_checkRelayer` to fail closed; its deploy script sets the relayer from `BRIDGE_RELAYER` before `configure`.
- HostManager: same gate on governance deliveries, set by the host admin. This closes the route where a forged `SetHostParam` swaps the host's handler for one that reports the whitelisted relayer on any message. The HostManager carries no user traffic, so permissionless relaying is unaffected.
- Host executive: `update_host_params` addressed a HostManager rotation to the new manager, which the host does not yet trust, so the rotation could never land while Hyperbridge recorded it as done and every later update and withdrawal for that chain was sent to the wrong contract. The request is now addressed to the current manager; the payload still installs the new one. Covered by a pallet test that pins the recipient and Foundry tests that play both addressings through the real host.
- Tests include upgrading the live mainnet proxy on a fork with state compared before and after, and the forged handler swap played through the real host.

Rollout: deploy the new gateway implementation and `upgrade_gateway` per chain with `init_data = cast calldata "setRelayer(address)" <relayer>`; deploy a new HostManager per chain with `DeployHostManager.s.sol`, set its relayer, then point the host at it with `SetHostParam`. The rotation needs the runtime fix released first, since the current runtime addresses it to the new manager.

