### PR TITLE
[evm]: arm the IntentGatewayV2 relayer in the deploy script and reject a zero owner

### DIFF
--- a/evm/script/DeployIntentGateway.s.sol
+++ b/evm/script/DeployIntentGateway.s.sol
@@ -23,6 +23,13 @@ contract DeployScript is BaseScript {
         // only — `initialize` binds each to `address(this)` — so no peer address is embedded in the
         // init data. The address depends on (impl address, salt, params, peer chain ids), all of
         // which are identical across chains, keeping the proxy address identical everywhere.
+        // The gateway refuses every delivery until `setRelayer` is called, and only `_owner` can
+        // call it, so the deploy key must be the admin and the relayer is read here rather than in
+        // BaseScript so the other scripts do not require it.
+        address relayer = vm.envAddress("GATEWAY_RELAYER");
+        require(relayer != address(0), "GATEWAY_RELAYER is unset");
+        require(vm.addr(uint256(privateKey)) == admin, "deploy key must be ADMIN to arm the relayer");
+
         address priceOracle = address(0);
         IntentGatewayV2 implementation = new IntentGatewayV2{salt: salt}(admin);
         bytes[] memory peerChains;
@@ -59,12 +66,16 @@ contract DeployScript is BaseScript {
         );
         ERC1967Proxy proxy = new ERC1967Proxy{salt: salt}(address(implementation), initData);
         IntentGatewayV2 intentGateway = IntentGatewayV2(payable(address(proxy)));
+        intentGateway.setRelayer(relayer);
         SolverAccount solverAccount = new SolverAccount{salt: salt}(address(intentGateway));
 
         vm.stopBroadcast();
 
+        require(intentGateway._relayer() == relayer, "relayer not armed");
+
         console.log("IntentGateway implementation deployed at:", address(implementation));
         console.log("IntentGateway proxy deployed at:", address(intentGateway));
+        console.log("IntentGateway relayer:", relayer);
         console.log("SolverAccount deployed at:", address(solverAccount));
 
         config.set("INTENT_GATEWAY_V2", address(intentGateway));

--- a/evm/src/apps/IntentGatewayV2.sol
+++ b/evm/src/apps/IntentGatewayV2.sol
@@ -69,6 +69,7 @@ contract IntentGatewayV2 is IntrinsicIntents, ExtrinsicIntents, ReentrancyGuardT
     /// implementation against direct initialization.
     /// @param owner The privileged admin address.
     constructor(address owner) EIP712("IntentGateway", "2") {
+        if (owner == address(0)) revert InvalidInput();
         _owner = owner;
         _disableInitializers();
     }

--- a/evm/tests/foundry/IntentGatewayV2Test.sol
+++ b/evm/tests/foundry/IntentGatewayV2Test.sol
@@ -4226,6 +4226,11 @@ contract IntentGatewayV2Test is MainnetForkBaseTest {
         assertEq(vm.load(address(intentGateway), bytes32(uint256(14))), bytes32(0), "slot 14 unused");
     }
 
+    function testConstructorRejectsZeroOwner() public {
+        vm.expectRevert(IntentsBase.InvalidInput.selector);
+        new IntentGatewayV2(address(0));
+    }
+
     function testSetRelayerRejectsNonOwner() public {
         vm.prank(user);
         vm.expectRevert(IntentsBase.Unauthorized.selector);

--- a/sdk/packages/core/docs/ai/ChangeLog.md
+++ b/sdk/packages/core/docs/ai/ChangeLog.md
@@ -12,6 +12,20 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-09-04 — Fresh gateway deployments arm the relayer in the deploy script
+
+`DeployIntentGateway.s.sol` deployed the gated gateway with `_relayer` unset, so a proxy on a new
+chain refused every delivery, including the `upgrade_gateway` message that could have armed it;
+only the owner key could, and nothing called it. The script now reads `GATEWAY_RELAYER`, requires
+the deploy key to be the admin (the only caller of `setRelayer`), calls `setRelayer` right after
+the proxy is deployed, and asserts the relayer afterwards. `initialize` is unchanged so the
+deterministic proxy address is unchanged. The gateway constructor now rejects a zero owner, since
+a mis-set `ADMIN` would leave no key able to arm a fresh proxy; runtime size is unaffected. No
+file in this package changed.
+
+Files: `evm/script/DeployIntentGateway.s.sol`, `evm/src/apps/IntentGatewayV2.sol`,
+`evm/tests/foundry/IntentGatewayV2Test.sol`, `docs/ai/Flow.md`.
+
 ## 2026-09-03 — Host manager rotation addressed to the manager the host still trusts
 
 `pallet-ismp-host-executive::update_host_params` applied the update before reading the request

--- a/sdk/packages/core/docs/ai/Flow.md
+++ b/sdk/packages/core/docs/ai/Flow.md
@@ -71,7 +71,9 @@ sends `UpgradeContract` with `abi.encodeCall(setRelayer, (relayer))` as migratio
 `ERC1967Utils.upgradeToAndCall` delegatecalls that calldata into the new implementation with
 `msg.sender` still the host from step 2, so the relayer is set in the same transaction as the
 implementation swap. The upgrade message itself must already pass the relayer gate of the
-implementation being replaced.
+implementation being replaced, which is why a fresh proxy cannot be armed that way:
+`DeployIntentGateway.s.sol` calls `setRelayer` from the admin key immediately after deploying the
+proxy, before anything can be escrowed into it.
 
 ## The same gate on `HyperFungibleToken`, and how the BRIDGE token tightens it
 


### PR DESCRIPTION
`DeployIntentGateway.s.sol` now sets the relayer from `GATEWAY_RELAYER` right after deploying the proxy, and the gateway constructor rejects a zero owner.