### PR TITLE
[sdk]: increase Ethereum order fee gas buffer

### DIFF
--- a/sdk/packages/sdk/CHANGELOG.md
+++ b/sdk/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @hyperbridge/sdk
 
+## 2.8.10
+
+### Patch Changes
+
+- Increased the gas-price headroom used by SDK-generated cross-chain Intent Gateway order-fee quotes from 10% to 50% when Ethereum mainnet is the source chain. Other source chains remain at 10%; same-chain quotes and direct solver estimates remain unchanged.
+
 ## 2.8.8
 
 ### Patch Changes

--- a/sdk/packages/sdk/package.json
+++ b/sdk/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/sdk",
-	"version": "2.8.9",
+	"version": "2.8.10",
 	"description": "The hyperclient SDK provides utilities for querying proofs and statuses for cross-chain requests from HyperBridge.",
 	"type": "module",
 	"types": "./dist/node/index.d.ts",

--- a/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
+++ b/sdk/packages/sdk/src/protocols/intents/IntentGateway.ts
@@ -29,7 +29,7 @@ import type { ResumeIntentOrderOptions } from "@/types"
 import type { IEvmChain } from "@/chain"
 import type { IntentsCoprocessor } from "@/chains/intentsCoprocessor"
 import type { IsmpClient } from "@/client"
-import { chainConfigs, getConfigByStateMachineId } from "@/configs/chain"
+import { Chains, chainConfigs, getConfigByStateMachineId } from "@/configs/chain"
 import { _queryOrderInternal } from "@/queryClient"
 import type { IntentGatewayContext } from "./types"
 import type { CancelEvent } from "./types"
@@ -65,7 +65,28 @@ import {
 } from "@/utils"
 import { getFeeToken } from "./utils"
 
-const CROSS_CHAIN_ORDER_FEE_GAS_PRICE_BUMP_PERCENT = 10n
+interface OrderFeeGasPriceBumpPolicy {
+	defaultPercent: bigint
+	bySourceStateMachineId: Readonly<Record<string, bigint>>
+}
+
+const ORDER_FEE_GAS_PRICE_BUMP_POLICY: OrderFeeGasPriceBumpPolicy = {
+	defaultPercent: 10n,
+	bySourceStateMachineId: {
+		[Chains.MAINNET]: 50n,
+	},
+}
+
+function resolveOrderFeeGasPriceBump(sourceStateMachineId: string, isSameChain: boolean): bigint {
+	if (isSameChain) {
+		return 0n
+	}
+
+	return (
+		ORDER_FEE_GAS_PRICE_BUMP_POLICY.bySourceStateMachineId[sourceStateMachineId] ??
+		ORDER_FEE_GAS_PRICE_BUMP_POLICY.defaultPercent
+	)
+}
 
 /**
  * High-level facade for the IntentGatewayV2 protocol.
@@ -331,8 +352,9 @@ export class IntentGateway {
 	 * **Yield/receive protocol:**
 	 * 1. If `order.fees` is unset or zero, prices the fee on an internal copy
 	 *    via {@link quoteOrderFees}: same-chain fees are twice the fill-gas
-	 *    estimate without a gas-price bump; cross-chain gas is priced 10% above
-	 *    the live price before attaching (fill gas + the settlement relayer fee)
+	 *    estimate without a gas-price bump; cross-chain order fees originating on
+	 *    Ethereum price gas 50% above the live price, while other source chains use
+	 *    10%, before attaching (fill gas + the settlement relayer fee)
 	 *    with a further 5% buffer over the whole sum — strictly above the solver's
 	 *    unpadded requirement. Direct solver estimates remain unbumped. The wei
 	 *    cost used for the `value` field receives a 2% buffer.
@@ -780,7 +802,8 @@ export class IntentGateway {
 	 * transaction (check the native balance).
 	 *
 	 * @param order - The order to quote. `order.fees` is ignored and not mutated.
-	 * Gas prices used to derive cross-chain `fees` receive 10% SDK-only headroom.
+	 * Gas prices used to derive cross-chain `fees` receive 50% SDK-only headroom
+	 * when the source chain is Ethereum mainnet and 10% for other source chains.
 	 * Same-chain quotes and direct calls to {@link estimateFillOrder}, including
 	 * Simplex solver estimates, remain unbumped.
 	 *
@@ -794,15 +817,14 @@ export class IntentGateway {
 		options?: { maxPriorityFeePerGasBumpPercent?: number; maxFeePerGasBumpPercent?: number },
 	): Promise<OrderFeesQuote> {
 		const isSameChain = this.source.config.stateMachineId === this.dest.config.stateMachineId
+		const orderFeeGasPriceBumpPercent = resolveOrderFeeGasPriceBump(this.source.config.stateMachineId, isSameChain)
 		const estimate = await this.gasEstimator.estimateFillOrder(
 			{
 				order,
 				maxPriorityFeePerGasBumpPercent: options?.maxPriorityFeePerGasBumpPercent,
 				maxFeePerGasBumpPercent: options?.maxFeePerGasBumpPercent,
 			},
-			{
-				orderFeeGasPriceBumpPercent: isSameChain ? 0n : CROSS_CHAIN_ORDER_FEE_GAS_PRICE_BUMP_PERCENT,
-			},
+			{ orderFeeGasPriceBumpPercent },
 		)
 
 		if (estimate.totalGasCostWei === 0n || estimate.totalGasInFeeToken === 0n) {

--- a/sdk/packages/sdk/src/tests/orderFees.test.ts
+++ b/sdk/packages/sdk/src/tests/orderFees.test.ts
@@ -1,0 +1,71 @@
+import { IntentGateway } from "@/protocols/intents/IntentGateway"
+import type { FillOrderEstimate, HexString, Order } from "@/types"
+import { describe, expect, it, vi } from "vitest"
+
+const TOKEN = "0x0000000000000000000000000000000000000001" as HexString
+
+function makeOrder(source: string, destination: string): Order {
+	return {
+		user: TOKEN,
+		source,
+		destination,
+		deadline: 100n,
+		nonce: 0n,
+		fees: 0n,
+		session: TOKEN,
+		predispatch: { assets: [], call: "0x" },
+		inputs: [{ token: TOKEN, amount: 1_000n }],
+		output: { beneficiary: TOKEN, assets: [{ token: TOKEN, amount: 990n }], call: "0x" },
+	}
+}
+
+function makeEstimate(): FillOrderEstimate {
+	return {
+		fillOptions: { relayerFee: 0n, nativeDispatchFee: 0n, validUntil: 0n, outputs: [] },
+		callGasLimit: 1n,
+		verificationGasLimit: 1n,
+		preVerificationGas: 1n,
+		paymasterVerificationGasLimit: 0n,
+		paymasterPostOpGasLimit: 0n,
+		maxFeePerGas: 1n,
+		maxPriorityFeePerGas: 1n,
+		totalGasCostWei: 1_000n,
+		totalGasInFeeToken: 100n,
+		relayerFeeInSourceFeeToken: 20n,
+	}
+}
+
+function makeGateway(sourceStateMachineId: string, destinationStateMachineId: string) {
+	const estimateFillOrder = vi.fn().mockResolvedValue(makeEstimate())
+	return {
+		gateway: {
+			gasEstimator: { estimateFillOrder },
+			source: {
+				config: { stateMachineId: sourceStateMachineId },
+				getFeeTokenWithDecimals: vi.fn().mockResolvedValue({ address: TOKEN, decimals: 6 }),
+			},
+			dest: { config: { stateMachineId: destinationStateMachineId } },
+		},
+		estimateFillOrder,
+	}
+}
+
+describe("IntentGateway order-fee gas-price policy", () => {
+	it.each([
+		["EVM-1", "EVM-42161", 50n],
+		["EVM-42161", "EVM-1", 10n],
+		["EVM-42161", "EVM-8453", 10n],
+		["EVM-1", "EVM-1", 0n],
+	])(
+		"prices source %s and destination %s with the expected source-chain headroom",
+		async (source, destination, expectedBump) => {
+			const { gateway, estimateFillOrder } = makeGateway(source, destination)
+
+			await IntentGateway.prototype.quoteOrderFees.call(gateway as never, makeOrder(source, destination))
+
+			expect(estimateFillOrder.mock.calls[0][1]).toEqual({
+				orderFeeGasPriceBumpPercent: expectedBump,
+			})
+		},
+	)
+})

--- a/sdk/packages/sdk/src/types/index.ts
+++ b/sdk/packages/sdk/src/types/index.ts
@@ -1414,8 +1414,9 @@ export interface OrderFeesQuote {
 	/**
 	 * The amount to set as `Order.fees`, denominated in the source-chain fee
 	 * token. Same-chain fills carry a 2x margin over the estimated fill gas without
-	 * a gas-price bump. Cross-chain gas is priced with 10% SDK-only headroom before
-	 * adding the settlement relayer fee and a further 5% buffer over the whole sum.
+	 * a gas-price bump. Cross-chain orders originating on Ethereum mainnet use 50%
+	 * SDK-only gas-price headroom; other source chains use 10%. The settlement
+	 * relayer fee is then added with a further 5% buffer over the whole sum.
 	 */
 	fees: bigint
 	/**


### PR DESCRIPTION
- Increases the gas-price buffer for cross-chain Intent Gateway order fees from 10% to 50% when Ethereum mainnet is the source chain. 
- Other source chains remain at 10%, while same-chain orders remain unbumped