### PR TITLE
[simplex]: Reject DNS-name Host headers in the UI loopback guard

### DIFF
--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -12,6 +12,22 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-09-05 — Close the DNS-rebinding bypass in the UI server's loopback Host check
+
+`isLoopbackHost` decided loopback with `host.startsWith("127.")`, a string-prefix test on a
+hostname. A leading-digit DNS label is legal, so `127.0.0.1.evil.com` (and `127.evil.com`,
+`127.0.0.1.nip.io`, the bare `127.`) passed it. That predicate is the whole of the UI server's
+auth — `hostHeaderAllowed` delegates to it on the `boundLoopback` path, and there is no
+Origin/CORS check — so a page an operator visits could rebind DNS to `127.0.0.1`, become
+same-origin, and reach `POST /api/send` (drains the solver wallet + vault positions) and the
+unmasked keys in `GET /api/chains`. Now the host must parse as an IPv4 literal via `node:net`
+`isIP` before its `127.` octet is trusted; `localhost`, `::1`, and the IPv4-mapped `::ffff:127.0.0.1`
+stay allowed. The same change fixes the `--ui 127.x.evil.com` bind-gate bypass (same function) and
+replaces the non-loopback branch's `hostname.includes(":")` IPv6 test with `isIP`, which also
+rejects a stray non-numeric port like `evil.com:abc`. Extended the rebinding test with the bypass
+vectors; it fails on the old prefix code and passes now (60/60).
+Files: src/services/server/http-util.ts, src/tests/ui-server.test.ts.
+
 ## 2026-09-04 — Say why a vault sweep did nothing, and restore the restart notice for vault saves
 
 Diagnosed on a running solver: the periodic sweep ran every five minutes against a wallet holding

--- a/sdk/packages/simplex/docs/ai/Decisions.md
+++ b/sdk/packages/simplex/docs/ai/Decisions.md
@@ -4,6 +4,27 @@ AI-maintained record of non-obvious choices made in `sdk/packages/simplex`: what
 
 Entry format: heading with the decision, then alternatives considered and the reasoning. Newest first.
 
+## 2026-09-05 — Loopback Host detection parses the address instead of prefix-matching the string
+
+Chosen: `isLoopbackHost` returns true only for `localhost`, `::1`, `::ffff:127.0.0.1`, or a string
+that `node:net` `isIP` confirms is an IPv4 literal whose first octet is `127`. The DNS-rebinding
+guard (`hostHeaderAllowed`) and the wizard bind-gate both hang off this one function, so it is the
+security boundary for an unauthenticated API that can move funds.
+
+Alternatives rejected:
+- Keeping `startsWith("127.")` and adding a separate DNS-name blocklist — the prefix test is the
+  vulnerability (a leading-digit label like `127.0.0.1.evil.com` is a legal hostname); anything that
+  still trusts the raw string is one creative label away from another bypass.
+- A hand-rolled `/^127(\.\d{1,3}){3}$/` regex — narrower than the real loopback block, and it would
+  reject valid forms like `127.1`; delegating to `isIP` uses the platform's own parser and stays
+  correct for every IPv4 spelling.
+- An allowlist of exact strings (`127.0.0.1`, `localhost`) — would break operators who legitimately
+  bind another `127.0.0.0/8` address, and still needs `isIP` to reject look-alikes safely.
+
+Also folded in: the non-loopback branch of `hostHeaderAllowed` used `hostname.includes(":")` as its
+IPv6 test, which accepted a non-numeric port that survived the `:\d+$` strip (`evil.com:abc`).
+Replacing it with `isIP(hostname) !== 0` closes that and unifies the two branches on one parser.
+
 ## 2026-09-04 — A sweep pass reports its outcome instead of resolving to void
 
 Chosen: `sweepExcessToVault` returns `VaultSweepResult` — submissions plus a `skipped` entry per

--- a/sdk/packages/simplex/src/services/server/http-util.ts
+++ b/sdk/packages/simplex/src/services/server/http-util.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs"
 import type { IncomingMessage, ServerResponse } from "node:http"
+import { isIP } from "node:net"
 
 export const MAX_BODY_BYTES = 1_048_576
 
@@ -28,7 +29,15 @@ export function sendJson(res: ServerResponse, status: number, payload: unknown):
 
 export function isLoopbackHost(host: string): boolean {
 	const normalized = host.toLowerCase()
-	return normalized === "localhost" || normalized === "::1" || normalized.startsWith("127.")
+	if (normalized === "localhost") return true
+	// IPv6 loopback, plus the IPv4-mapped form some stacks present.
+	if (normalized === "::1" || normalized === "::ffff:127.0.0.1") return true
+	// Only a genuine IPv4 literal in 127.0.0.0/8 counts. A prefix test on the raw
+	// string would also match DNS names like "127.0.0.1.evil.com" (a leading-digit
+	// label is a legal hostname), which is exactly the DNS-rebinding bypass — so the
+	// host must first parse as an IPv4 address before its first octet is trusted.
+	if (isIP(normalized) === 4) return normalized.split(".")[0] === "127"
+	return false
 }
 
 /**
@@ -56,7 +65,9 @@ export function hostHeaderAllowed(hostHeader: string | undefined, boundLoopback:
 	const bracketed = hostHeader.match(/^\[([^\]]+)\](?::\d+)?$/)
 	const hostname = (bracketed ? bracketed[1] : hostHeader.replace(/:\d+$/, "")).toLowerCase()
 	if (boundLoopback) return isLoopbackHost(hostname)
-	const isIpv4 = /^\d{1,3}(\.\d{1,3}){3}$/.test(hostname)
-	const isIpv6 = hostname.includes(":")
-	return hostname === "localhost" || isIpv4 || isIpv6
+	// A rebound attacker origin always presents a DNS name; only IP literals (and the
+	// literal "localhost") are accepted. `isIP` rejects DNS names and a stray non-numeric
+	// port that survived the strip (e.g. "evil.com:abc"), which a bare `includes(":")`
+	// IPv6 test would have waved through.
+	return hostname === "localhost" || isIP(hostname) !== 0
 }

--- a/sdk/packages/simplex/src/tests/ui-server.test.ts
+++ b/sdk/packages/simplex/src/tests/ui-server.test.ts
@@ -274,8 +274,15 @@ describe("UiServer (operator mode)", () => {
 		expect(await rawRequest(port, "/api/status", "evil.example.com")).toContain("403")
 		expect(await rawRequest(port, "/api/status", "evil.example.com:1234")).toContain("403")
 		expect(await rawRequest(port, "/health", "evil.example.com")).toContain("403")
+		// DNS names that a "startsWith(127.)" prefix test would have accepted: a
+		// leading-digit label is a legal hostname, so these must all be rejected.
+		expect(await rawRequest(port, "/api/status", "127.0.0.1.evil.example.com")).toContain("403")
+		expect(await rawRequest(port, "/api/status", "127.evil.example.com")).toContain("403")
+		expect(await rawRequest(port, "/api/status", `127.0.0.1.nip.io:${port}`)).toContain("403")
+		expect(await rawRequest(port, "/api/status", "127.")).toContain("403")
 		// Legitimate local access keeps working.
 		expect(await rawRequest(port, "/api/status", `127.0.0.1:${port}`)).toContain("200")
+		expect(await rawRequest(port, "/api/status", `127.0.0.2:${port}`)).toContain("200")
 		expect(await rawRequest(port, "/api/status", "localhost")).toContain("200")
 	})
 


### PR DESCRIPTION
isLoopbackHost decided loopback with startsWith("127."), a string-prefix test on a hostname. A leading-digit label is a legal DNS name, so 127.0.0.1.evil.com (and 127.evil.com, 127.0.0.1.nip.io, bare 127.) passed it. That predicate is the whole of the UI server's auth — hostHeaderAllowed delegates to it on the boundLoopback path and there is no Origin/CORS check — so a page the operator visits could rebind DNS to 127.0.0.1, become same-origin, and reach POST /api/send (drains the solver wallet and vault positions) and the unmasked RPC/bundler keys in GET /api/chains.

Require the host to parse as an IPv4 literal via node:net isIP before its
127. octet is trusted; keep localhost, ::1, and IPv4-mapped ::ffff:127.0.0.1. The same function gates the wizard bind address, so this also closes the --ui 127.x.evil.com bind bypass. Replace the non-loopback branch's includes(":") IPv6 test with isIP, which additionally rejects a stray non-numeric port (evil.com:abc). Extend the rebinding test with the bypass vectors — it fails on the old prefix code, passes now.