### PR TITLE
[ci]: pin the publish workflows to pnpm 11

### DIFF
--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -27,9 +27,9 @@ jobs:
                   registry-url: "https://registry.npmjs.org"
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v2
+              uses: pnpm/action-setup@v4
               with:
-                  version: "latest"
+                  version: "11"
 
             - name: Install dependencies
               run: pnpm install

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -31,9 +31,9 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
-          version: "latest"
+          version: "11"
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/publish-simplex.yml
+++ b/.github/workflows/publish-simplex.yml
@@ -203,9 +203,9 @@ jobs:
                   registry-url: "https://registry.npmjs.org"
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v2
+              uses: pnpm/action-setup@v4
               with:
-                  version: "latest"
+                  version: "11"
 
             # Straight from GitHub releases, not apt: the runners' default apt
             # mirror (azure.archive.ubuntu.com) has repeatedly hung apt-get


### PR DESCRIPTION
npm moved pnpm's `latest` dist-tag to 12.x on 2026-09-05, so `pnpm/action-setup` with `version: "latest"` started installing pnpm 12 in the publish workflows. pnpm 12 refuses to resolve the `pnpm@11.0.0` the workspace's `packageManager` field pins, failing `pnpm install` with a trust-downgrade error before anything is built; the `sdk-v2.8.11` publish died that way while the simplex 0.13.0 publish four hours earlier had still received 11.25.0 from the same input.

The sdk, simplex and core publish workflows now pin pnpm 11 through `action-setup@v4`, as the test workflow already does. Six lines, no behaviour change beyond the version installed.

Moving to pnpm 12 is a separate job: it stops reading the `pnpm` block in package.json, adds its own binaries to the lockfile, and its supply-chain policy rejects an existing lockfile entry under the workspace's `no-downgrade` trust policy.