### PR TITLE
[simplex]: pin the image build to pnpm 11 and make the npm publish step idempotent

### DIFF
--- a/.github/workflows/publish-simplex.yml
+++ b/.github/workflows/publish-simplex.yml
@@ -259,6 +259,13 @@ jobs:
             - name: Publish to npm
               run: |
                   cd packages/simplex
+                  VERSION="$(node -p "require('./package.json').version")"
+                  # A re-fired tag (say, after an image build failure) must not fail here on
+                  # the version it already published; skipping lets the image and release finish.
+                  if npm view "@hyperbridge/simplex@${VERSION}" version >/dev/null 2>&1; then
+                    echo "@hyperbridge/simplex@${VERSION} is already on npm; skipping publish."
+                    exit 0
+                  fi
                   pnpm pack --pack-destination /tmp/npm-pkg
                   npm publish /tmp/npm-pkg/*.tgz --access public
 

--- a/sdk/packages/simplex/scripts/Dockerfile
+++ b/sdk/packages/simplex/scripts/Dockerfile
@@ -29,8 +29,9 @@ FROM node:24.19.0 AS builder
 # path for native modules (better-sqlite3) on an arch with no matching prebuild.
 RUN apt-get update && apt-get install -y python3 make g++ git curl protobuf-compiler libprotobuf-dev --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-# Install pnpm
-RUN npm install -g pnpm
+# Install pnpm, pinned to the major the workspace's packageManager field names: pnpm 12
+# refuses to resolve pnpm@11.0.0 as a trust downgrade, so an unpinned install broke the image.
+RUN npm install -g pnpm@11
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
The `simplex-v0.13.1` tag published `@hyperbridge/simplex` 0.13.1 to npm but produced no image or release: both Docker builds failed at `pnpm install` inside the image. The Dockerfile installed pnpm unpinned (`npm install -g pnpm`), so once npm's `latest` tag moved to 12 on 2026-09-05 the image got pnpm 12, which refuses to resolve the `pnpm@11.0.0` the workspace's `packageManager` field pins, as a trust downgrade. #1208 pinned the runner side; this pins the container side, the last unpinned pnpm install in the repo.

The npm publish step also gains a guard: when the version is already on the registry it skips instead of failing. Re-firing the tag after this merges then builds the image, merges the manifest, skips the npm step for the 0.13.1 already published, and creates the release. The sdk tag stays where it is, since nothing under `packages/sdk` changes here and simplex's guard compares against it.