### PR TITLE
[simplex]: widen the dashboard container to 150rem

### DIFF
--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -12,6 +12,13 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-09-05 — Widen the dashboard container to 150rem
+
+`.app-container` capped the whole UI at 80rem (1280px), leaving the order history about 900px of
+usable width on wide screens after the 16rem sidebar and column padding. The cap is now 150rem
+(2400px); the setup wizard shares the container and widens with it.
+Files: `ui/src/styles/foundations.css`, `docs/ai/ChangeLog.md`.
+
 ## 2026-09-05 — 0.13.1: pick up the 2026-09-05 mainnet SolverAccount from sdk 2.8.11
 
 No code change in this package. The filler reads the SolverAccount per chain from the sdk chain

--- a/sdk/packages/simplex/ui/src/styles/foundations.css
+++ b/sdk/packages/simplex/ui/src/styles/foundations.css
@@ -202,7 +202,7 @@ select:focus-visible {
 }
 
 .app-container {
-	width: min(100%, 80rem);
+	width: min(100%, 150rem);
 	margin-inline: auto;
 }
 


### PR DESCRIPTION
The operator dashboard and setup wizard were capped at 80rem (1280px) by `.app-container`, which left the order history roughly 900px of usable width on wide screens once the 16rem sidebar and column padding were taken out. The cap is now 150rem (2400px).

## Test plan
- [x] `pnpm ui:check` (biome, tsc, vite) passes