### PR TITLE
[simplex]: leave gas headroom when a send draws on a vault

### DIFF
--- a/docs/content/developers/evm/simplex/treasury.mdx
+++ b/docs/content/developers/evm/simplex/treasury.mdx
@@ -23,6 +23,13 @@ One vault list drives three behaviours:
 
 Omit `threshold`/`minBalance` on a vault to make it **withdraw-only** (sourcing + shutdown, no sweeping) for that token.
 
+<Callout type="warn">
+    A vault with no `minBalance` also has no floor for sends. A send that draws on it withdraws
+    exactly what the transfer is short by, so the wallet ends at zero — and on the sponsored path
+    the paymaster debits its gas from that same token during validation, before the transfer runs.
+    Set `minBalance` on any vault whose asset the paymaster charges in.
+</Callout>
+
 ```toml lineNumbers
 [vault]
 sweepIntervalMs = 300000   # optional, default 5 min
@@ -47,7 +54,7 @@ minBalance = "3000"
 | `chain` | yes | State-machine ID the vault lives on (e.g. `"EVM-8453"`) |
 | `vault` | yes | ERC-4626 vault address |
 | `threshold` | no | High-water balance (human units) that triggers a sweep down to `minBalance`. Omit to disable sweeping (withdraw-only). |
-| `minBalance` | conditional | Wallet floor (human units) the sweep deposits down to. Required when `threshold` is set, and must be less than it. |
+| `minBalance` | conditional | Wallet floor (human units). The sweep deposits down to it, and an operator send that draws on this vault withdraws it on top of the shortfall, so the wallet is left at the floor rather than at zero. Required when `threshold` is set, and must be less than it. |
 | `redeemOnShutdown` | no | Redeem this position back to the underlying asset on shutdown. Defaults to `false` (the position is kept across restarts). |
 
 ## Rebalancing

--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -23,9 +23,14 @@ batch rolled back. The vault position was untouched (share balance identical eit
 block), the paymaster still kept ~0.0097 USDC net, and a retry would fail the same way from a
 slightly smaller wallet.
 
-`vaultWithdrawalCall` now takes the token's decimals and adds the matched vault's `minBalance` to
-the shortfall, so a send that is already going to the vault leaves the wallet at its configured
-floor. A vault that cannot cover shortfall-plus-floor still funds the send with the bare
+`vaultWithdrawalCall` now takes the token's decimals and leaves headroom on top of the shortfall:
+the larger of the matched vault's `minBalance` and `paymasterReserveForToken`, the helper the fill
+path already uses for exactly this hazard — its own doc comment says the paymaster "pulls it from
+the same wallet during validatePaymasterUserOp — before the UserOp's callData runs". TokenSender
+never imported it. The reserve applies only when `userOpSender.canSponsor(chain)` is true, so an
+unsponsored chain and the native-tx fallback are unaffected, and it covers the case a floor alone
+cannot reach: a wallet that already covers the transfer but would be left with nothing for
+validation to take. That send skipped the vault branch entirely and reverted the same way. A vault that cannot cover shortfall-plus-floor still funds the send with the bare
 shortfall: a floor is a preference, not a reason to refuse a transfer the operator asked for. A
 send the wallet already covers is unchanged — it does not start pulling from the vault to top
 itself up. Withdraw-only vaults declare no `minBalance` and behave exactly as before, which means

--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -12,6 +12,28 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-09-08 — Sends leave the wallet at the vault's floor, not at zero
+
+A send on Base reverted with `ERC20: transfer amount exceeds balance` inside a UserOp that the
+outer transaction reported as successful (tx `0x737bdede…`, block 51039630). The batch was
+`withdraw(3990.010227)` then `transfer(4000)`, against a wallet holding 9.989773 USDC — sized to
+leave exactly zero. The SimplexPaymaster then debited 0.031564 USDC of gas from that same wallet
+during validation, before the batch ran, so the transfer was short by exactly that and the whole
+batch rolled back. The vault position was untouched (share balance identical either side of the
+block), the paymaster still kept ~0.0097 USDC net, and a retry would fail the same way from a
+slightly smaller wallet.
+
+`vaultWithdrawalCall` now takes the token's decimals and adds the matched vault's `minBalance` to
+the shortfall, so a send that is already going to the vault leaves the wallet at its configured
+floor. A vault that cannot cover shortfall-plus-floor still funds the send with the bare
+shortfall: a floor is a preference, not a reason to refuse a transfer the operator asked for. A
+send the wallet already covers is unchanged — it does not start pulling from the vault to top
+itself up. Withdraw-only vaults declare no `minBalance` and behave exactly as before, which means
+they keep the original failure mode; the treasury docs now say so.
+
+Files: src/services/TokenSender.ts, src/tests/token-sender.test.ts (9 tests, 4 new — the first
+replays the numbers from the reverted transaction), docs/content/developers/evm/simplex/treasury.mdx.
+
 ## 2026-09-08 — A paired device can no longer manage remote access
 
 A second review pointed out that a tunnelled request is indistinguishable from one the operator

--- a/sdk/packages/simplex/src/core/boot.ts
+++ b/sdk/packages/simplex/src/core/boot.ts
@@ -751,6 +751,7 @@ export async function bootFiller(config: FillerTomlConfig, options: BootOptions)
 			runtimeSigner.address as HexString,
 			() => config.vault?.vaults ?? [],
 			userOpSender,
+			configService,
 		),
 		vaultPreflight: async (vaults) => {
 			const byChain: Record<string, VaultConfig[]> = {}

--- a/sdk/packages/simplex/src/services/TokenSender.ts
+++ b/sdk/packages/simplex/src/services/TokenSender.ts
@@ -2,6 +2,8 @@ import { ERC20_ABI } from "@/config/abis/ERC20"
 import { ERC4626_ABI } from "@/config/abis/Erc4626"
 import type { VaultToml } from "@/config/filler-toml"
 import type { ChainClientManager } from "@/services/ChainClientManager"
+import type { FillerConfigService } from "@/services/FillerConfigService"
+import { paymasterReserveForToken } from "@/services/paymaster"
 import type { UserOpSender } from "@/services/UserOpSender"
 import { type Logger , moduleLogger} from "@/services/Logger"
 import { encodeERC7821ExecuteBatch, type ERC7821Call, type HexString } from "@hyperbridge/sdk"
@@ -43,6 +45,8 @@ export class TokenSender {
 		/** Live view of the configured vaults so runtime vault edits are honored. */
 		private readonly getVaults: () => VaultToml[],
 		private readonly userOpSender?: UserOpSender,
+		/** Only needed to size the paymaster's gas reserve; without it a send reserves nothing. */
+		private readonly configService?: FillerConfigService,
 	) {
 		this.logger = moduleLogger(clientManager.loggers, "token-sender")
 	}
@@ -87,17 +91,32 @@ export class TokenSender {
 					data: encodeFunctionData({ abi: ERC4626_ABI, functionName: "redeem", args: [units, to, this.solver] }),
 				})
 			} else {
-				// Withdrawing exactly `units - balance` leaves the wallet at zero, so
-				// anything that spends from it between building this batch and
-				// executing it makes the transfer revert. The sponsored path does
-				// exactly that: the paymaster debits its gas from this same token
-				// during validation, before the batch runs. Asking for the vault's
-				// configured wallet floor on top leaves that headroom.
-				if (balance < units) {
-					const withdrawal = await this.vaultWithdrawalCall(chain, token as HexString, decimals, units - balance)
-					if (!withdrawal) throw new Error(`Insufficient token balance: have ${balance}, need ${units}`)
-					redeemed = true
-					calls.push(withdrawal)
+				// Sizing the transfer to the last unit is what makes a send revert on
+				// the sponsored path: the paymaster charges gas in this same token and
+				// pulls it during validation, before the batch runs, so a wallet left
+				// at exactly `units` is always short by that pull. Reserve for it, and
+				// for the vault's own wallet floor, whichever is larger.
+				const reserve =
+					this.userOpSender?.canSponsor(chain) && this.configService
+						? paymasterReserveForToken(chain, tokenLower, this.configService)
+						: 0n
+				if (balance < units + reserve) {
+					const withdrawal = await this.vaultWithdrawalCall(
+						chain,
+						token as HexString,
+						decimals,
+						units - balance,
+						reserve,
+					)
+					// A vault can only decline to top up the headroom; the transfer
+					// itself still has to be funded.
+					if (!withdrawal && balance < units) {
+						throw new Error(`Insufficient token balance: have ${balance}, need ${units}`)
+					}
+					if (withdrawal) {
+						redeemed = true
+						calls.push(withdrawal)
+					}
 				}
 				calls.push({
 					target: token as HexString,
@@ -119,20 +138,22 @@ export class TokenSender {
 	 */
 	/**
 	 * A withdrawal that funds the transfer and, where the vault can afford it,
-	 * leaves the wallet at its floor rather than at zero.
+	 * leaves headroom in the wallet rather than nothing.
 	 *
-	 * `shortfall` is what the transfer cannot do without. The vault's
-	 * `minBalance` is what the sweep leaves in the wallet, so it is the
-	 * operator's own statement of the working balance this token keeps, and a
-	 * send that is already going to the vault takes it along. A vault that can
-	 * only cover the shortfall still funds the send: the floor is a preference,
-	 * not a reason to refuse a transfer the operator asked for.
+	 * `shortfall` is what the transfer cannot do without, and is zero or negative
+	 * when the wallet already covers it. The headroom is the larger of the
+	 * paymaster's gas `reserve` and the vault's `minBalance` — the first is what
+	 * validation will pull out of this wallet, the second is the operator's own
+	 * statement of the working balance this token keeps. A vault that can only
+	 * cover the shortfall still funds the send: headroom is a preference, not a
+	 * reason to refuse a transfer the operator asked for.
 	 */
 	private async vaultWithdrawalCall(
 		chain: string,
 		token: HexString,
 		decimals: number,
 		shortfall: bigint,
+		reserve: bigint,
 	): Promise<ERC7821Call | null> {
 		const publicClient = this.clientManager.getPublicClient(chain)
 		for (const vault of this.getVaults()) {
@@ -149,12 +170,14 @@ export class TokenSender {
 				functionName: "maxWithdraw",
 				args: [this.solver],
 			})) as bigint
-			if (available < shortfall) continue
-			// Withdraw-only vaults declare no floor, and there a send behaves as it
-			// always did.
+			const required = shortfall > 0n ? shortfall : 0n
+			if (available < required) continue
+			// Withdraw-only vaults declare no floor of their own, and fall back to
+			// the paymaster reserve.
 			const floor = vault.minBalance === undefined ? 0n : parseUnits(vault.minBalance, decimals)
-			const wanted = shortfall + floor
-			const amount = available >= wanted ? wanted : shortfall
+			const headroom = reserve > floor ? reserve : floor
+			const wanted = shortfall + headroom
+			const amount = available >= wanted ? wanted : required
 			if (amount <= 0n) return null
 			return {
 				target: vault.vault,

--- a/sdk/packages/simplex/src/services/TokenSender.ts
+++ b/sdk/packages/simplex/src/services/TokenSender.ts
@@ -87,8 +87,14 @@ export class TokenSender {
 					data: encodeFunctionData({ abi: ERC4626_ABI, functionName: "redeem", args: [units, to, this.solver] }),
 				})
 			} else {
+				// Withdrawing exactly `units - balance` leaves the wallet at zero, so
+				// anything that spends from it between building this batch and
+				// executing it makes the transfer revert. The sponsored path does
+				// exactly that: the paymaster debits its gas from this same token
+				// during validation, before the batch runs. Asking for the vault's
+				// configured wallet floor on top leaves that headroom.
 				if (balance < units) {
-					const withdrawal = await this.vaultWithdrawalCall(chain, token as HexString, units - balance)
+					const withdrawal = await this.vaultWithdrawalCall(chain, token as HexString, decimals, units - balance)
 					if (!withdrawal) throw new Error(`Insufficient token balance: have ${balance}, need ${units}`)
 					redeemed = true
 					calls.push(withdrawal)
@@ -111,7 +117,23 @@ export class TokenSender {
 	 * this chain whose underlying is the token being sent and that can cover the
 	 * shortfall, or null when no vault can.
 	 */
-	private async vaultWithdrawalCall(chain: string, token: HexString, shortfall: bigint): Promise<ERC7821Call | null> {
+	/**
+	 * A withdrawal that funds the transfer and, where the vault can afford it,
+	 * leaves the wallet at its floor rather than at zero.
+	 *
+	 * `shortfall` is what the transfer cannot do without. The vault's
+	 * `minBalance` is what the sweep leaves in the wallet, so it is the
+	 * operator's own statement of the working balance this token keeps, and a
+	 * send that is already going to the vault takes it along. A vault that can
+	 * only cover the shortfall still funds the send: the floor is a preference,
+	 * not a reason to refuse a transfer the operator asked for.
+	 */
+	private async vaultWithdrawalCall(
+		chain: string,
+		token: HexString,
+		decimals: number,
+		shortfall: bigint,
+	): Promise<ERC7821Call | null> {
 		const publicClient = this.clientManager.getPublicClient(chain)
 		for (const vault of this.getVaults()) {
 			if (vault.chain !== chain) continue
@@ -128,13 +150,19 @@ export class TokenSender {
 				args: [this.solver],
 			})) as bigint
 			if (available < shortfall) continue
+			// Withdraw-only vaults declare no floor, and there a send behaves as it
+			// always did.
+			const floor = vault.minBalance === undefined ? 0n : parseUnits(vault.minBalance, decimals)
+			const wanted = shortfall + floor
+			const amount = available >= wanted ? wanted : shortfall
+			if (amount <= 0n) return null
 			return {
 				target: vault.vault,
 				value: 0n,
 				data: encodeFunctionData({
 					abi: ERC4626_ABI,
 					functionName: "withdraw",
-					args: [shortfall, this.solver, this.solver],
+					args: [amount, this.solver, this.solver],
 				}),
 			}
 		}

--- a/sdk/packages/simplex/src/tests/token-sender.test.ts
+++ b/sdk/packages/simplex/src/tests/token-sender.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest"
-import { decodeFunctionData } from "viem"
+import { decodeAbiParameters, decodeFunctionData, parseAbi } from "viem"
+
+const ERC7821_EXECUTE_ABI = parseAbi(["function execute(bytes32 mode, bytes executionData)"])
 import { ERC20_ABI } from "@/config/abis/ERC20"
 import { ERC4626_ABI } from "@/config/abis/Erc4626"
 import { TokenSender } from "@/services/TokenSender"
@@ -9,6 +11,54 @@ const SOLVER = "0x5b2c3e25243634732eE94525Ae98aEc404c82506" as const
 const RECIPIENT = "0x1111111111111111111111111111111111111111" as const
 const TOKEN = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" as const
 const VAULT = "0xC768c589647798a6EE01A91FdE98EF2ed046DBD6" as const
+
+/** A sender whose wallet is short and whose vault holds the rest, as a real filler's does. */
+function makeVaultSender(opts: {
+	walletBalance: bigint
+	maxWithdraw: bigint
+	minBalance?: string
+	vaultAsset?: `0x${string}`
+}) {
+	const sendTransaction = vi.fn().mockResolvedValue("0xhash")
+	const publicClient = {
+		getBalance: vi.fn().mockResolvedValue(10n ** 18n),
+		readContract: vi.fn(async ({ functionName }: { functionName: string }): Promise<unknown> => {
+			if (functionName === "decimals") return 6
+			if (functionName === "balanceOf") return opts.walletBalance
+			if (functionName === "asset") return opts.vaultAsset ?? TOKEN
+			if (functionName === "maxWithdraw") return opts.maxWithdraw
+			throw new Error(`unexpected read: ${functionName}`)
+		}),
+		waitForTransactionReceipt: vi.fn().mockResolvedValue({ status: "success" }),
+	}
+	const clientManager = {
+		getPublicClient: () => publicClient,
+		getWalletClient: () => ({ sendTransaction, chain: undefined }),
+	} as unknown as ChainClientManager
+	const vaults = [{ chain: "EVM-8453", vault: VAULT, ...(opts.minBalance ? { minBalance: opts.minBalance } : {}) }]
+	const sender = new TokenSender(clientManager, SOLVER, () => vaults.map((v) => ({ ...v })))
+	return { sender, sendTransaction }
+}
+
+/** The two calls of a batched send, decoded. */
+function batchOf(sendTransaction: ReturnType<typeof vi.fn>) {
+	const tx = sendTransaction.mock.calls[0][0]
+	const outer = decodeFunctionData({ abi: ERC7821_EXECUTE_ABI, data: tx.data })
+	const [calls] = decodeAbiParameters(
+		[
+			{
+				type: "tuple[]",
+				components: [
+					{ name: "target", type: "address" },
+					{ name: "value", type: "uint256" },
+					{ name: "data", type: "bytes" },
+				],
+			},
+		],
+		outer.args[1] as `0x${string}`,
+	)
+	return calls as Array<{ target: string; value: bigint; data: `0x${string}` }>
+}
 
 function makeSender(vaults: Array<{ chain: string; vault: `0x${string}` }> = []) {
 	const sendTransaction = vi.fn().mockResolvedValue("0xhash")
@@ -69,6 +119,67 @@ describe("TokenSender", () => {
 		expect(tx.to).toBe(RECIPIENT)
 		expect(tx.value).toBe(5n * 10n ** 17n)
 		expect(tx.data).toBe("0x")
+	})
+
+	it("leaves the wallet at the vault's floor instead of at zero", async () => {
+		// The numbers from the send that reverted on Base at block 51039630: the
+		// wallet held 9.989773 USDC, the operator sent 4000, and the withdrawal was
+		// sized to make up exactly the difference. The paymaster then debited its
+		// gas from the same USDC during validation, so the transfer was short by
+		// that much and the whole batch reverted.
+		const { sender, sendTransaction } = makeVaultSender({
+			walletBalance: 9_989_773n,
+			maxWithdraw: 481_970_486_507n,
+			minBalance: "3000",
+		})
+		const result = await sender.send({ chain: "EVM-8453", token: TOKEN, amount: "4000", to: RECIPIENT })
+		expect(result.redeemed).toBe(true)
+
+		const calls = batchOf(sendTransaction)
+		expect(calls).toHaveLength(2)
+		const withdrawal = decodeFunctionData({ abi: ERC4626_ABI, data: calls[0].data })
+		expect(withdrawal.functionName).toBe("withdraw")
+		// The shortfall plus the floor, not the shortfall alone.
+		expect(withdrawal.args?.[0]).toBe(4_000_000_000n - 9_989_773n + 3_000_000_000n)
+		const transfer = decodeFunctionData({ abi: ERC20_ABI, data: calls[1].data })
+		expect(transfer.args).toEqual([RECIPIENT, 4_000_000_000n])
+	})
+
+	it("withdraws only the shortfall when the vault declares no floor", async () => {
+		// Withdraw-only vaults omit minBalance; nothing changes for them.
+		const { sender, sendTransaction } = makeVaultSender({
+			walletBalance: 9_989_773n,
+			maxWithdraw: 481_970_486_507n,
+		})
+		await sender.send({ chain: "EVM-8453", token: TOKEN, amount: "4000", to: RECIPIENT })
+		const withdrawal = decodeFunctionData({ abi: ERC4626_ABI, data: batchOf(sendTransaction)[0].data })
+		expect(withdrawal.args?.[0]).toBe(4_000_000_000n - 9_989_773n)
+	})
+
+	it("falls back to the bare shortfall when the vault cannot cover the floor as well", async () => {
+		// A floor is a preference. Refusing a transfer the operator asked for
+		// because the vault is nearly empty would be worse than sending it.
+		const { sender, sendTransaction } = makeVaultSender({
+			walletBalance: 9_989_773n,
+			maxWithdraw: 4_000_000_000n,
+			minBalance: "3000",
+		})
+		const result = await sender.send({ chain: "EVM-8453", token: TOKEN, amount: "4000", to: RECIPIENT })
+		expect(result.redeemed).toBe(true)
+		const withdrawal = decodeFunctionData({ abi: ERC4626_ABI, data: batchOf(sendTransaction)[0].data })
+		expect(withdrawal.args?.[0]).toBe(4_000_000_000n - 9_989_773n)
+	})
+
+	it("still refuses when no vault holds the asset at all", async () => {
+		const { sender } = makeVaultSender({
+			walletBalance: 9_989_773n,
+			maxWithdraw: 481_970_486_507n,
+			minBalance: "3000",
+			vaultAsset: "0x2222222222222222222222222222222222222222",
+		})
+		await expect(sender.send({ chain: "EVM-8453", token: TOKEN, amount: "4000", to: RECIPIENT })).rejects.toThrow(
+			/Insufficient token balance/,
+		)
 	})
 
 	it("rejects bad inputs before submitting anything", async () => {

--- a/sdk/packages/simplex/src/tests/token-sender.test.ts
+++ b/sdk/packages/simplex/src/tests/token-sender.test.ts
@@ -18,6 +18,8 @@ function makeVaultSender(opts: {
 	maxWithdraw: bigint
 	minBalance?: string
 	vaultAsset?: `0x${string}`
+	/** Reserve the paymaster would pull, in token units; implies the sponsored path. */
+	reserve?: bigint
 }) {
 	const sendTransaction = vi.fn().mockResolvedValue("0xhash")
 	const publicClient = {
@@ -36,7 +38,25 @@ function makeVaultSender(opts: {
 		getWalletClient: () => ({ sendTransaction, chain: undefined }),
 	} as unknown as ChainClientManager
 	const vaults = [{ chain: "EVM-8453", vault: VAULT, ...(opts.minBalance ? { minBalance: opts.minBalance } : {}) }]
-	const sender = new TokenSender(clientManager, SOLVER, () => vaults.map((v) => ({ ...v })))
+	// canSponsor decides whether a reserve applies at all; the amount comes from
+	// the config service, which is where paymasterReserveForToken reads it.
+	const userOpSender =
+		opts.reserve === undefined
+			? undefined
+			: ({ canSponsor: () => true, trySendSponsored: async () => null } as never)
+	const configService =
+		opts.reserve === undefined
+			? undefined
+			: ({
+					getPaymasterAddress: () => "0x15b3B03C870c7ef252029c35A12d3b339F5c8d7f",
+					getSimplexPaymasterAddress: () => "0x15b3B03C870c7ef252029c35A12d3b339F5c8d7f",
+					getCirclePaymasterAddress: () => undefined,
+					getUsdcAsset: () => TOKEN,
+					getUsdcDecimals: () => 6,
+					getUsdtAsset: () => "0x",
+					getUsdtDecimals: () => 6,
+				} as never)
+	const sender = new TokenSender(clientManager, SOLVER, () => vaults.map((v) => ({ ...v })), userOpSender, configService)
 	return { sender, sendTransaction }
 }
 
@@ -168,6 +188,36 @@ describe("TokenSender", () => {
 		expect(result.redeemed).toBe(true)
 		const withdrawal = decodeFunctionData({ abi: ERC4626_ABI, data: batchOf(sendTransaction)[0].data })
 		expect(withdrawal.args?.[0]).toBe(4_000_000_000n - 9_989_773n)
+	})
+
+	it("reserves the paymaster's gas when it is larger than the vault floor", async () => {
+		// The floor only helps if it is set and big enough. The reserve is what the
+		// paymaster will actually pull out of this wallet during validation, and it
+		// applies even to a withdraw-only vault with no floor of its own.
+		const { sender, sendTransaction } = makeVaultSender({
+			walletBalance: 9_989_773n,
+			maxWithdraw: 481_970_486_507n,
+			reserve: 2_000_000n,
+		})
+		await sender.send({ chain: "EVM-8453", token: TOKEN, amount: "4000", to: RECIPIENT })
+		const withdrawal = decodeFunctionData({ abi: ERC4626_ABI, data: batchOf(sendTransaction)[0].data })
+		expect(withdrawal.args?.[0]).toBe(4_000_000_000n - 9_989_773n + 2_000_000n)
+	})
+
+	it("tops the wallet up when it covers the transfer but not the paymaster's pull", async () => {
+		// The case a floor alone never reaches: the wallet covers the amount, so the
+		// old code built a lone transfer and left nothing for validation to take.
+		const { sender, sendTransaction } = makeVaultSender({
+			walletBalance: 4_000_000_000n,
+			maxWithdraw: 481_970_486_507n,
+			reserve: 2_000_000n,
+		})
+		const result = await sender.send({ chain: "EVM-8453", token: TOKEN, amount: "4000", to: RECIPIENT })
+		expect(result.redeemed).toBe(true)
+		const calls = batchOf(sendTransaction)
+		expect(calls).toHaveLength(2)
+		const withdrawal = decodeFunctionData({ abi: ERC4626_ABI, data: calls[0].data })
+		expect(withdrawal.args?.[0]).toBe(2_000_000n)
 	})
 
 	it("still refuses when no vault holds the asset at all", async () => {


### PR DESCRIPTION
An operator send on Base failed: [`0x737bdede…`](https://basescan.org/tx/0x737bdedea92db30baa5e17a1d01899e0b1dcfb63ce7e85e24f48e2e26a225f3e), block 51039630. Basescan shows it green because that is the bundler's wrapper; the send inside it reverted with `ERC20: transfer amount exceeds balance`.

## What happened

The wallet held 9.989773 USDC and the operator sent 4000, so simplex withdrew the difference from the vault in the same batch:

```
[0] 0xC768c589…  withdraw(3990.010227 USDC)   ← Aave stataUSDC vault
[1] 0x833589fC…  transfer(0xb5E45BAF…, 4000 USDC)
```

9.989773 + 3990.010227 = 4000.000000. Exactly the amount being sent, with nothing spare.

Gas on that transaction is also paid in USDC, and the paymaster takes it during validation — before the batch runs. The log order shows it: the permit `Approval`, then a `Transfer` of 0.031564 from the solver to the paymaster, and only then EntryPoint's `BeforeExecution`. The transfer ran against 3999.968436 and was short by exactly that pull.

Nothing moved. The withdrawal was rolled back with the transfer, so the vault's share balance is identical either side of the block. The paymaster still kept ~0.0097 net after its postOp refund.

## Evidence

Simulated at block 51039629 with `eth_call`, replaying the decoded batch from the solver's account:

| Run | Result |
|---|---|
| unmodified | success |
| control — USDC balance slot overridden to its true value | success |
| balance slot minus 31,564 and nothing else | revert, identical string |

Aave rounding is not the cause: with the wallet forced to zero, `transfer(3_990_010_227)` succeeds and one unit more reverts, so the vault credited exactly the assets asked for. Vault capacity was never binding either — `maxWithdraw` was 481,970 against a 3,990 need.

This is not a max-size edge case. For a token the paymaster charges in, a vault-topped send always leaves the wallet holding exactly the amount about to be transferred, so the pull always takes it below.

## The fix

`vaultWithdrawalCall` now withdraws more than the shortfall, leaving headroom in the wallet. The headroom is the larger of:

- the matched vault's `minBalance`, the floor the sweep already keeps
- `paymasterReserveForToken`, which exists for exactly this and whose own comment says the paymaster "pulls it from the same wallet during `validatePaymasterUserOp` — before the UserOp's callData runs"

That helper is already used twice in the fill path. `TokenSender` never imported it.

Two deliberate limits. Headroom is a preference, not a gate: a vault that can cover the shortfall but not the headroom still funds the send, because refusing a transfer the operator asked for would be worse than the bug. And the reserve only applies when `canSponsor(chain)` is true, so unsponsored chains and the native-tx fallback are untouched.

It also covers a case the vault floor alone cannot reach. Sending exactly what is in the wallet skips the vault branch entirely, builds a lone transfer, and fails the same way. That is now topped up.

## Tests

11 in `token-sender.test.ts`, 6 new. The first replays the numbers above. The others cover a withdraw-only vault, the fallback when the vault cannot afford the headroom, no matching vault, the reserve exceeding the floor, and the top-up case.

## Not in this PR

Three places with the same assumption, left alone deliberately:

- `VaultFundingPlanner` deposits `walletBalance - minBalance` in a sponsored op, and `filler-toml` accepts a `minBalance` of `0.001` — below the pull seen here.
- `BalanceProvider.available` and the send dialog show wallet-plus-vault with no gas allowance, so the "max" an operator is offered is still optimistic.
- `vaultWithdrawalCall` reads `maxWithdraw` from the vault rather than `VaultLiquidityState.remaining()`, so an operator send can withdraw liquidity a live bid has reserved.
