### PR TITLE
[tesseract]: Deliver modules named in the module filter alongside the incentivized ones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28396,7 +28396,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tesseract"
-version = "2.4.10"
+version = "2.4.11"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/tesseract/messaging/messaging/src/events.rs
+++ b/tesseract/messaging/messaging/src/events.rs
@@ -12,10 +12,7 @@ use ismp::{
 	router::{GetResponse, PostRequest, Request},
 };
 use sp_core::{H160, U256};
-use std::{
-	collections::{BTreeSet, HashMap},
-	sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 use tesseract_primitives::{config::RelayerConfig, Cost, Hasher, IsmpProvider, Query};
 use tokio_stream::StreamExt;
 
@@ -79,12 +76,6 @@ impl From<IsmpEvent> for Event {
 /// misestimate or fail the success check. Callers that don't submit a
 /// consensus message alongside (inbound pipeline) pass `None`.
 ///
-/// `incentivized` is the on-chain reward allowlist snapshot for this cycle. It
-/// is unioned with the operator's `module_filter` when deciding which modules
-/// to relay, so a relayer that scopes itself to a handful of modules still
-/// delivers everything it can earn a reward on. Callers with no snapshot to
-/// hand (the inbound pipeline) pass `None`.
-///
 /// Returns a tuple where the first item are messages to be submitted to the sink
 /// and the second tuple are currently unprofitable messages.
 pub async fn translate_events_to_messages(
@@ -93,7 +84,6 @@ pub async fn translate_events_to_messages(
 	events: Vec<IsmpEvent>,
 	state_machine_height: StateMachineHeight,
 	config: RelayerConfig,
-	incentivized: Option<Arc<BTreeSet<Vec<u8>>>>,
 	coprocessor: StateMachine,
 	client_map: &HashMap<StateMachine, Arc<dyn IsmpProvider>>,
 	consensus_prelude: Option<Message>,
@@ -116,7 +106,6 @@ pub async fn translate_events_to_messages(
 				let event = event.clone();
 				let sink = sink.clone();
 				let config = config.clone();
-				let incentivized = incentivized.clone();
 				async move {
 					match event {
 						IsmpEvent::PostRequest(post) => {
@@ -132,7 +121,7 @@ pub async fn translate_events_to_messages(
 								return Ok::<_, anyhow::Error>(None);
 							}
 
-							if !is_allowed_module(&config, incentivized.as_deref(), &post.from) {
+							if !is_allowed_module(&config, &post.from) {
 								tracing::trace!(
 									target: crate::LOG_TARGET, "Request from module {}, filtered by module filter",
 									hex::encode(&post.from),
@@ -268,15 +257,9 @@ pub async fn translate_events_to_messages(
 	// we gate each one for profitability and then batch the survivors into
 	// chunked `handleGetResponses` calls the same way post requests are batched.
 	if source.state_machine_id().state_id == coprocessor {
-		let (response_messages, response_queries, responses) = build_get_response_candidates(
-			&source,
-			&sink,
-			&events,
-			&config,
-			incentivized.as_deref(),
-			state_machine_height,
-		)
-		.await?;
+		let (response_messages, response_queries, responses) =
+			build_get_response_candidates(&source, &sink, &events, &config, state_machine_height)
+				.await?;
 
 		if !response_messages.is_empty() {
 			let profitability = return_successful_queries(
@@ -338,7 +321,6 @@ async fn build_get_response_candidates(
 	sink: &Arc<dyn IsmpProvider>,
 	events: &[IsmpEvent],
 	config: &RelayerConfig,
-	incentivized: Option<&BTreeSet<Vec<u8>>>,
 	state_machine_height: StateMachineHeight,
 ) -> Result<(Vec<Message>, Vec<Query>, Vec<GetResponse>), anyhow::Error> {
 	let sink_state_machine = sink.state_machine_id().state_id;
@@ -359,7 +341,7 @@ async fn build_get_response_candidates(
 			// regardless of the request's timeout for the same reason. A response that
 			// exists is always deliverable.
 
-			if !is_allowed_module(config, incentivized, &res.get.from) {
+			if !is_allowed_module(config, &res.get.from) {
 				tracing::trace!(
 					target: crate::LOG_TARGET, "Get response for module {}, filtered by module filter",
 					hex::encode(&res.get.from),
@@ -424,18 +406,15 @@ async fn build_get_response_candidates(
 ///
 /// Events are gated by `module_filter` via `is_allowed_module`, so operators
 /// can scope which modules they deliver. With no `module_filter` configured,
-/// `is_allowed_module` permits every module. `incentivized` is the on-chain
-/// reward allowlist (`pallet_ismp_relayer::OutboundRequestDeliveryReward`)
-/// snapshot, which widens a configured `module_filter` rather than narrowing
-/// it: modules the relayer earns a reward on are always allowed through.
-/// Callers with no snapshot pass `None`.
+/// `is_allowed_module` permits every module. The on-chain reward allowlist
+/// (`pallet_ismp_relayer::OutboundRequestDeliveryReward`) is applied
+/// separately by the outbound task.
 ///
 /// When the counterparty is the coprocessor, every post request flows through
 /// regardless of its final destination or the module filter — the coprocessor
 /// needs to ingest all requests so it can process and forward them.
 pub fn filter_events(
 	config: &RelayerConfig,
-	incentivized: Option<&BTreeSet<Vec<u8>>>,
 	counterparty: StateMachine,
 	coprocessor: StateMachine,
 	ev: &IsmpEvent,
@@ -445,12 +424,12 @@ pub fn filter_events(
 			if counterparty == coprocessor {
 				return true;
 			}
-			post.dest == counterparty && is_allowed_module(config, incentivized, &post.from)
+			post.dest == counterparty && is_allowed_module(config, &post.from)
 		},
 		// GetResponses only originate on the coprocessor and are delivered back to the
 		// chain that made the request, so `get.source` is their destination.
 		IsmpEvent::GetResponse(res) =>
-			res.get.source == counterparty && is_allowed_module(config, incentivized, &res.get.from),
+			res.get.source == counterparty && is_allowed_module(config, &res.get.from),
 		_ => false,
 	}
 }
@@ -596,26 +575,11 @@ pub async fn return_successful_queries(
 	Ok(ProfitabilityResult { queries: queries_to_be_relayed, retriable_messages })
 }
 
-/// Whether the relayer will deliver requests dispatched by `module`.
-///
-/// The operator's `module_filter` and the on-chain reward allowlist are
-/// additive: a module passes if it appears in either. An absent or empty
-/// `module_filter` places no restriction at all, so every module passes and
-/// the snapshot is irrelevant.
-///
-/// The union is what makes a scoped relayer usable. `module_filter` on its own
-/// is a hard allowlist, so an operator who adds one module to unblock it would
-/// otherwise stop relaying every module they were being paid for.
-fn is_allowed_module(
-	config: &RelayerConfig,
-	incentivized: Option<&BTreeSet<Vec<u8>>>,
-	module: &[u8],
-) -> bool {
+fn is_allowed_module(config: &RelayerConfig, module: &[u8]) -> bool {
 	match config.module_filter {
 		Some(ref filters) =>
 			if !filters.is_empty() {
-				return is_explicitly_filtered(config, module) ||
-					incentivized.map_or(false, |set| set.contains(module));
+				return is_explicitly_filtered(config, module);
 			},
 		// if no filter is provided, allow all modules
 		_ => {},
@@ -626,11 +590,9 @@ fn is_allowed_module(
 
 /// Whether `module` was explicitly named in the operator's `module_filter`.
 ///
-/// Distinct from [`is_allowed_module`]: an absent or empty filter means the
-/// operator listed nothing, so this returns false, where `is_allowed_module`
-/// would permit everything. Callers that need "the operator asked for this
-/// module by name" — such as the outbound reward-allowlist filter — want this
-/// one.
+/// Distinct from [`is_allowed_module`], where an absent or empty filter permits
+/// every module. Here it names none, which is what callers that need "the
+/// operator asked for this module by name" want.
 pub fn is_explicitly_filtered(config: &RelayerConfig, module: &[u8]) -> bool {
 	config.module_filter.as_ref().map_or(false, |filters| {
 		filters.iter().any(|filter| {
@@ -638,87 +600,4 @@ pub fn is_explicitly_filtered(config: &RelayerConfig, module: &[u8]) -> bool {
 				module
 		})
 	})
-}
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-
-	/// `pallet-hyper-fungible-token`'s module id. It has no delivery reward
-	/// registered on hyperbridge, so it only ever passes because an operator
-	/// named it explicitly.
-	const HFT_MODULE: &[u8] = b"pall_hft";
-	const REWARDED_MODULE: &[u8] = b"pall_hst";
-	const UNKNOWN_MODULE: &[u8] = b"pall_xyz";
-
-	fn config_filtering(modules: &[&[u8]]) -> RelayerConfig {
-		RelayerConfig {
-			module_filter: Some(modules.iter().map(|m| hex::encode(m)).collect()),
-			..Default::default()
-		}
-	}
-
-	fn rewards(modules: &[&[u8]]) -> BTreeSet<Vec<u8>> {
-		modules.iter().map(|m| m.to_vec()).collect()
-	}
-
-	#[test]
-	fn no_module_filter_permits_everything() {
-		let config = RelayerConfig::default();
-		let incentivized = rewards(&[REWARDED_MODULE]);
-		// An empty filter is "no restriction", so the reward snapshot is
-		// irrelevant and even an unknown module passes.
-		assert!(is_allowed_module(&config, Some(&incentivized), UNKNOWN_MODULE));
-		assert!(is_allowed_module(&config, None, UNKNOWN_MODULE));
-	}
-
-	#[test]
-	fn empty_module_filter_permits_everything() {
-		let config = RelayerConfig { module_filter: Some(vec![]), ..Default::default() };
-		assert!(is_allowed_module(&config, None, UNKNOWN_MODULE));
-	}
-
-	#[test]
-	fn module_filter_and_rewards_are_additive() {
-		// The operator listed only HFT. Without the union that would silence
-		// every module they were being paid for; with it, both pass.
-		let config = config_filtering(&[HFT_MODULE]);
-		let incentivized = rewards(&[REWARDED_MODULE]);
-
-		assert!(is_allowed_module(&config, Some(&incentivized), HFT_MODULE));
-		assert!(is_allowed_module(&config, Some(&incentivized), REWARDED_MODULE));
-		assert!(!is_allowed_module(&config, Some(&incentivized), UNKNOWN_MODULE));
-	}
-
-	#[test]
-	fn module_filter_without_snapshot_stays_exclusive() {
-		// Snapshot fetch failed this cycle: fall back to the operator's list
-		// alone rather than widening to everything.
-		let config = config_filtering(&[HFT_MODULE]);
-		assert!(is_allowed_module(&config, None, HFT_MODULE));
-		assert!(!is_allowed_module(&config, None, REWARDED_MODULE));
-	}
-
-	#[test]
-	fn module_filter_accepts_hex_with_or_without_prefix() {
-		let prefixed = RelayerConfig {
-			module_filter: Some(vec![format!("0x{}", hex::encode(HFT_MODULE))]),
-			..Default::default()
-		};
-		assert!(is_allowed_module(&prefixed, None, HFT_MODULE));
-		assert!(is_explicitly_filtered(&prefixed, HFT_MODULE));
-	}
-
-	#[test]
-	fn explicitly_filtered_is_false_when_nothing_is_listed() {
-		// The distinction `retain_incentivized_requests` relies on: an empty
-		// filter permits everything in `is_allowed_module`, but names nothing.
-		assert!(!is_explicitly_filtered(&RelayerConfig::default(), HFT_MODULE));
-		assert!(!is_explicitly_filtered(
-			&RelayerConfig { module_filter: Some(vec![]), ..Default::default() },
-			HFT_MODULE
-		));
-		assert!(is_explicitly_filtered(&config_filtering(&[HFT_MODULE]), HFT_MODULE));
-		assert!(!is_explicitly_filtered(&config_filtering(&[HFT_MODULE]), REWARDED_MODULE));
-	}
 }

--- a/tesseract/messaging/messaging/src/events.rs
+++ b/tesseract/messaging/messaging/src/events.rs
@@ -12,7 +12,10 @@ use ismp::{
 	router::{GetResponse, PostRequest, Request},
 };
 use sp_core::{H160, U256};
-use std::{collections::HashMap, sync::Arc};
+use std::{
+	collections::{BTreeSet, HashMap},
+	sync::Arc,
+};
 use tesseract_primitives::{config::RelayerConfig, Cost, Hasher, IsmpProvider, Query};
 use tokio_stream::StreamExt;
 
@@ -76,6 +79,12 @@ impl From<IsmpEvent> for Event {
 /// misestimate or fail the success check. Callers that don't submit a
 /// consensus message alongside (inbound pipeline) pass `None`.
 ///
+/// `incentivized` is the on-chain reward allowlist snapshot for this cycle. It
+/// is unioned with the operator's `module_filter` when deciding which modules
+/// to relay, so a relayer that scopes itself to a handful of modules still
+/// delivers everything it can earn a reward on. Callers with no snapshot to
+/// hand (the inbound pipeline) pass `None`.
+///
 /// Returns a tuple where the first item are messages to be submitted to the sink
 /// and the second tuple are currently unprofitable messages.
 pub async fn translate_events_to_messages(
@@ -84,6 +93,7 @@ pub async fn translate_events_to_messages(
 	events: Vec<IsmpEvent>,
 	state_machine_height: StateMachineHeight,
 	config: RelayerConfig,
+	incentivized: Option<Arc<BTreeSet<Vec<u8>>>>,
 	coprocessor: StateMachine,
 	client_map: &HashMap<StateMachine, Arc<dyn IsmpProvider>>,
 	consensus_prelude: Option<Message>,
@@ -106,6 +116,7 @@ pub async fn translate_events_to_messages(
 				let event = event.clone();
 				let sink = sink.clone();
 				let config = config.clone();
+				let incentivized = incentivized.clone();
 				async move {
 					match event {
 						IsmpEvent::PostRequest(post) => {
@@ -121,7 +132,7 @@ pub async fn translate_events_to_messages(
 								return Ok::<_, anyhow::Error>(None);
 							}
 
-							if !is_allowed_module(&config, &post.from) {
+							if !is_allowed_module(&config, incentivized.as_deref(), &post.from) {
 								tracing::trace!(
 									target: crate::LOG_TARGET, "Request from module {}, filtered by module filter",
 									hex::encode(&post.from),
@@ -262,6 +273,7 @@ pub async fn translate_events_to_messages(
 			&sink,
 			&events,
 			&config,
+			incentivized.as_deref(),
 			state_machine_height,
 		)
 		.await?;
@@ -326,6 +338,7 @@ async fn build_get_response_candidates(
 	sink: &Arc<dyn IsmpProvider>,
 	events: &[IsmpEvent],
 	config: &RelayerConfig,
+	incentivized: Option<&BTreeSet<Vec<u8>>>,
 	state_machine_height: StateMachineHeight,
 ) -> Result<(Vec<Message>, Vec<Query>, Vec<GetResponse>), anyhow::Error> {
 	let sink_state_machine = sink.state_machine_id().state_id;
@@ -346,7 +359,7 @@ async fn build_get_response_candidates(
 			// regardless of the request's timeout for the same reason. A response that
 			// exists is always deliverable.
 
-			if !is_allowed_module(config, &res.get.from) {
+			if !is_allowed_module(config, incentivized, &res.get.from) {
 				tracing::trace!(
 					target: crate::LOG_TARGET, "Get response for module {}, filtered by module filter",
 					hex::encode(&res.get.from),
@@ -411,15 +424,18 @@ async fn build_get_response_candidates(
 ///
 /// Events are gated by `module_filter` via `is_allowed_module`, so operators
 /// can scope which modules they deliver. With no `module_filter` configured,
-/// `is_allowed_module` permits every module. The on-chain reward allowlist
-/// (`pallet_ismp_relayer::OutboundRequestDeliveryReward`) is applied
-/// separately by the outbound task.
+/// `is_allowed_module` permits every module. `incentivized` is the on-chain
+/// reward allowlist (`pallet_ismp_relayer::OutboundRequestDeliveryReward`)
+/// snapshot, which widens a configured `module_filter` rather than narrowing
+/// it: modules the relayer earns a reward on are always allowed through.
+/// Callers with no snapshot pass `None`.
 ///
 /// When the counterparty is the coprocessor, every post request flows through
 /// regardless of its final destination or the module filter — the coprocessor
 /// needs to ingest all requests so it can process and forward them.
 pub fn filter_events(
 	config: &RelayerConfig,
+	incentivized: Option<&BTreeSet<Vec<u8>>>,
 	counterparty: StateMachine,
 	coprocessor: StateMachine,
 	ev: &IsmpEvent,
@@ -429,12 +445,12 @@ pub fn filter_events(
 			if counterparty == coprocessor {
 				return true;
 			}
-			post.dest == counterparty && is_allowed_module(config, &post.from)
+			post.dest == counterparty && is_allowed_module(config, incentivized, &post.from)
 		},
 		// GetResponses only originate on the coprocessor and are delivered back to the
 		// chain that made the request, so `get.source` is their destination.
 		IsmpEvent::GetResponse(res) =>
-			res.get.source == counterparty && is_allowed_module(config, &res.get.from),
+			res.get.source == counterparty && is_allowed_module(config, incentivized, &res.get.from),
 		_ => false,
 	}
 }
@@ -580,22 +596,129 @@ pub async fn return_successful_queries(
 	Ok(ProfitabilityResult { queries: queries_to_be_relayed, retriable_messages })
 }
 
-fn is_allowed_module(config: &RelayerConfig, module: &[u8]) -> bool {
+/// Whether the relayer will deliver requests dispatched by `module`.
+///
+/// The operator's `module_filter` and the on-chain reward allowlist are
+/// additive: a module passes if it appears in either. An absent or empty
+/// `module_filter` places no restriction at all, so every module passes and
+/// the snapshot is irrelevant.
+///
+/// The union is what makes a scoped relayer usable. `module_filter` on its own
+/// is a hard allowlist, so an operator who adds one module to unblock it would
+/// otherwise stop relaying every module they were being paid for.
+fn is_allowed_module(
+	config: &RelayerConfig,
+	incentivized: Option<&BTreeSet<Vec<u8>>>,
+	module: &[u8],
+) -> bool {
 	match config.module_filter {
 		Some(ref filters) =>
 			if !filters.is_empty() {
-				return filters
-					.iter()
-					.find(|filter| {
-						hex::decode(filter.replace("0x", ""))
-							.expect("Module identifier should be valid hex") ==
-							module
-					})
-					.is_some();
+				return is_explicitly_filtered(config, module) ||
+					incentivized.map_or(false, |set| set.contains(module));
 			},
 		// if no filter is provided, allow all modules
 		_ => {},
 	};
 
 	true
+}
+
+/// Whether `module` was explicitly named in the operator's `module_filter`.
+///
+/// Distinct from [`is_allowed_module`]: an absent or empty filter means the
+/// operator listed nothing, so this returns false, where `is_allowed_module`
+/// would permit everything. Callers that need "the operator asked for this
+/// module by name" — such as the outbound reward-allowlist filter — want this
+/// one.
+pub fn is_explicitly_filtered(config: &RelayerConfig, module: &[u8]) -> bool {
+	config.module_filter.as_ref().map_or(false, |filters| {
+		filters.iter().any(|filter| {
+			hex::decode(filter.replace("0x", "")).expect("Module identifier should be valid hex") ==
+				module
+		})
+	})
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// `pallet-hyper-fungible-token`'s module id. It has no delivery reward
+	/// registered on hyperbridge, so it only ever passes because an operator
+	/// named it explicitly.
+	const HFT_MODULE: &[u8] = b"pall_hft";
+	const REWARDED_MODULE: &[u8] = b"pall_hst";
+	const UNKNOWN_MODULE: &[u8] = b"pall_xyz";
+
+	fn config_filtering(modules: &[&[u8]]) -> RelayerConfig {
+		RelayerConfig {
+			module_filter: Some(modules.iter().map(|m| hex::encode(m)).collect()),
+			..Default::default()
+		}
+	}
+
+	fn rewards(modules: &[&[u8]]) -> BTreeSet<Vec<u8>> {
+		modules.iter().map(|m| m.to_vec()).collect()
+	}
+
+	#[test]
+	fn no_module_filter_permits_everything() {
+		let config = RelayerConfig::default();
+		let incentivized = rewards(&[REWARDED_MODULE]);
+		// An empty filter is "no restriction", so the reward snapshot is
+		// irrelevant and even an unknown module passes.
+		assert!(is_allowed_module(&config, Some(&incentivized), UNKNOWN_MODULE));
+		assert!(is_allowed_module(&config, None, UNKNOWN_MODULE));
+	}
+
+	#[test]
+	fn empty_module_filter_permits_everything() {
+		let config = RelayerConfig { module_filter: Some(vec![]), ..Default::default() };
+		assert!(is_allowed_module(&config, None, UNKNOWN_MODULE));
+	}
+
+	#[test]
+	fn module_filter_and_rewards_are_additive() {
+		// The operator listed only HFT. Without the union that would silence
+		// every module they were being paid for; with it, both pass.
+		let config = config_filtering(&[HFT_MODULE]);
+		let incentivized = rewards(&[REWARDED_MODULE]);
+
+		assert!(is_allowed_module(&config, Some(&incentivized), HFT_MODULE));
+		assert!(is_allowed_module(&config, Some(&incentivized), REWARDED_MODULE));
+		assert!(!is_allowed_module(&config, Some(&incentivized), UNKNOWN_MODULE));
+	}
+
+	#[test]
+	fn module_filter_without_snapshot_stays_exclusive() {
+		// Snapshot fetch failed this cycle: fall back to the operator's list
+		// alone rather than widening to everything.
+		let config = config_filtering(&[HFT_MODULE]);
+		assert!(is_allowed_module(&config, None, HFT_MODULE));
+		assert!(!is_allowed_module(&config, None, REWARDED_MODULE));
+	}
+
+	#[test]
+	fn module_filter_accepts_hex_with_or_without_prefix() {
+		let prefixed = RelayerConfig {
+			module_filter: Some(vec![format!("0x{}", hex::encode(HFT_MODULE))]),
+			..Default::default()
+		};
+		assert!(is_allowed_module(&prefixed, None, HFT_MODULE));
+		assert!(is_explicitly_filtered(&prefixed, HFT_MODULE));
+	}
+
+	#[test]
+	fn explicitly_filtered_is_false_when_nothing_is_listed() {
+		// The distinction `retain_incentivized_requests` relies on: an empty
+		// filter permits everything in `is_allowed_module`, but names nothing.
+		assert!(!is_explicitly_filtered(&RelayerConfig::default(), HFT_MODULE));
+		assert!(!is_explicitly_filtered(
+			&RelayerConfig { module_filter: Some(vec![]), ..Default::default() },
+			HFT_MODULE
+		));
+		assert!(is_explicitly_filtered(&config_filtering(&[HFT_MODULE]), HFT_MODULE));
+		assert!(!is_explicitly_filtered(&config_filtering(&[HFT_MODULE]), REWARDED_MODULE));
+	}
 }

--- a/tesseract/messaging/messaging/src/lib.rs
+++ b/tesseract/messaging/messaging/src/lib.rs
@@ -308,7 +308,15 @@ async fn handle_update(
 			events
 				.into_iter()
 				.filter(|ev| {
-					filter_events(&config, chain_a.state_machine_id().state_id, coprocessor, ev)
+					// The inbound pipeline has no reward-allowlist snapshot to
+					// widen the module filter with; the outbound task owns that.
+					filter_events(
+						&config,
+						None,
+						chain_a.state_machine_id().state_id,
+						coprocessor,
+						ev,
+					)
 				})
 				.collect::<Vec<_>>()
 		},
@@ -363,6 +371,7 @@ async fn handle_update(
 		events,
 		state_machine_height.clone(),
 		config.clone(),
+		None,
 		coprocessor,
 		&client_map,
 		// Inbound pipeline doesn't batch a consensus message alongside — the

--- a/tesseract/messaging/messaging/src/lib.rs
+++ b/tesseract/messaging/messaging/src/lib.rs
@@ -308,15 +308,7 @@ async fn handle_update(
 			events
 				.into_iter()
 				.filter(|ev| {
-					// The inbound pipeline has no reward-allowlist snapshot to
-					// widen the module filter with; the outbound task owns that.
-					filter_events(
-						&config,
-						None,
-						chain_a.state_machine_id().state_id,
-						coprocessor,
-						ev,
-					)
+					filter_events(&config, chain_a.state_machine_id().state_id, coprocessor, ev)
 				})
 				.collect::<Vec<_>>()
 		},
@@ -371,7 +363,6 @@ async fn handle_update(
 		events,
 		state_machine_height.clone(),
 		config.clone(),
-		None,
 		coprocessor,
 		&client_map,
 		// Inbound pipeline doesn't batch a consensus message alongside — the

--- a/tesseract/messaging/messaging/src/outbound.rs
+++ b/tesseract/messaging/messaging/src/outbound.rs
@@ -347,15 +347,7 @@ async fn submit_for_dest(
 	// so the filter keeps every event routed to this destination.
 	let mut events = events
 		.into_iter()
-		.filter(|ev| {
-			filter_events(
-				&relayer_config,
-				incentivized.as_deref(),
-				dest_state_machine,
-				coprocessor,
-				ev,
-			)
-		})
+		.filter(|ev| filter_events(&relayer_config, dest_state_machine, coprocessor, ev))
 		.collect::<Vec<_>>();
 
 	retain_incentivized_requests(
@@ -407,7 +399,6 @@ async fn submit_for_dest(
 			events,
 			state_machine_height,
 			relayer_config,
-			incentivized.clone(),
 			coprocessor,
 			&client_map,
 			// Pass the consensus update as the gas-estimation prelude so EVM
@@ -472,7 +463,6 @@ async fn submit_for_dest(
 		coprocessor,
 		&batch_requests,
 		&result.receipts,
-		incentivized.as_deref(),
 		&claim_tx_payment,
 	)
 	.await;
@@ -549,16 +539,16 @@ async fn submit_for_dest(
 }
 
 /// Drop hyperbridge-originated requests whose `source_module` is neither on the
-/// on-chain reward allowlist nor explicitly named in the operator's
-/// `module_filter`. User-originated requests and non-request events pass
-/// through. `None` means the snapshot fetch failed this cycle; deliver
-/// everything as a no-op fallback.
+/// on-chain reward allowlist nor named in the operator's `module_filter`.
+/// User-originated requests and non-request events pass through. `None` means
+/// the snapshot fetch failed this cycle; deliver everything as a no-op
+/// fallback.
 ///
-/// The reward allowlist decides what the relayer gets *paid* for; the
-/// `module_filter` decides what the operator is *willing* to deliver. A module
-/// on neither list is dropped, which is what kept hyperbridge-originated
-/// transfers from `pallet-hyper-fungible-token` from being relayed at all
-/// while no reward was configured for it.
+/// The reward allowlist decides what the relayer is paid for, the
+/// `module_filter` decides what the operator is willing to deliver, and a
+/// module on either list is delivered. Modules with no reward configured, such
+/// as `pallet-hyper-fungible-token`, are otherwise dropped here before a batch
+/// is ever built.
 fn retain_incentivized_requests(
 	events: &mut Vec<Event>,
 	config: &RelayerConfig,
@@ -614,15 +604,13 @@ async fn forward_request_delivery_claims(
 	coprocessor: StateMachine,
 	batch_requests: &[PostRequest],
 	receipts: &[TxReceipt],
-	incentivized: Option<&BTreeSet<Vec<u8>>>,
 	claim_tx_payment: &Option<Arc<TransactionPayment>>,
 ) {
 	let Some(tx_payment) = claim_tx_payment else {
 		return;
 	};
 
-	let claims =
-		collect_hyperbridge_request_claims(coprocessor, batch_requests, receipts, incentivized);
+	let claims = collect_hyperbridge_request_claims(coprocessor, batch_requests, receipts);
 	if claims.is_empty() {
 		return;
 	}
@@ -648,18 +636,10 @@ async fn forward_request_delivery_claims(
 /// Filters receipts to those originating from the hyperbridge coprocessor and
 /// pairs each one with its source request. Returns an empty vec when nothing
 /// in the batch is hyperbridge-originated.
-///
-/// Requests from a module that isn't on the reward allowlist are skipped:
-/// they can only be here because the operator named the module in their
-/// `module_filter`, and `process_outbound_request_delivery_claim` would reject
-/// the claim with `OutboundRequestNoRewardConfigured`. `None` means the
-/// snapshot fetch failed this cycle, so every hyperbridge-originated receipt is
-/// kept and the claim task sorts it out.
 fn collect_hyperbridge_request_claims(
 	coprocessor: StateMachine,
 	batch_requests: &[PostRequest],
 	receipts: &[TxReceipt],
-	incentivized: Option<&BTreeSet<Vec<u8>>>,
 ) -> Vec<PendingRequestDeliveryClaim> {
 	// Index every PostRequest in the batch by its commitment so receipts
 	// can be paired back to their source request. BTreeMap keeps iteration
@@ -675,7 +655,6 @@ fn collect_hyperbridge_request_claims(
 			(query.source_chain == coprocessor)
 				.then(|| by_commitment.get(&query.commitment).cloned())
 				.flatten()
-				.filter(|request| incentivized.map_or(true, |set| set.contains(&request.from)))
 				.map(|request| PendingRequestDeliveryClaim { request, delivery_height: *height })
 		})
 		.collect()
@@ -1200,7 +1179,7 @@ mod tests {
 			request_receipt_for(&hb_req_b, 102),
 		];
 
-		let claims = collect_hyperbridge_request_claims(HB, &batch_requests, &receipts, None);
+		let claims = collect_hyperbridge_request_claims(HB, &batch_requests, &receipts);
 
 		assert_eq!(claims.len(), 2, "only hyperbridge-originated requests forwarded");
 		assert!(claims.iter().all(|c| c.request.source == HB));
@@ -1212,7 +1191,7 @@ mod tests {
 	#[test]
 	fn collect_claims_empty_receipts_is_empty() {
 		let hb_req = build_post(HB, 0x11);
-		let claims = collect_hyperbridge_request_claims(HB, &[hb_req], &[], None);
+		let claims = collect_hyperbridge_request_claims(HB, &[hb_req], &[]);
 		assert!(claims.is_empty());
 	}
 
@@ -1220,7 +1199,7 @@ mod tests {
 	fn collect_claims_no_hyperbridge_requests_is_empty() {
 		let user_req = build_post(DEST_B, 0x11);
 		let receipts = vec![request_receipt_for(&user_req, 100)];
-		let claims = collect_hyperbridge_request_claims(HB, &[user_req], &receipts, None);
+		let claims = collect_hyperbridge_request_claims(HB, &[user_req], &receipts);
 		assert!(claims.is_empty());
 	}
 
@@ -1256,6 +1235,43 @@ mod tests {
 	}
 
 	#[test]
+	fn retain_incentivized_keeps_modules_named_in_the_module_filter() {
+		// `pallet-hyper-fungible-token` has no reward registered, so it only
+		// survives because the operator named it in `module_filter`.
+		let hft_module = b"pall_hft".to_vec();
+		let rewarded_module = vec![0xAA, 0xBB];
+		let allowlist: BTreeSet<Vec<u8>> = [rewarded_module.clone()].into_iter().collect();
+		let config = RelayerConfig {
+			module_filter: Some(vec![hex::encode(&hft_module)]),
+			..Default::default()
+		};
+
+		let mut rewarded = post_req(HB, DEST_A, 1);
+		rewarded.from = rewarded_module;
+		let mut hft = post_req(HB, DEST_A, 2);
+		hft.from = hft_module;
+		let mut unlisted = post_req(HB, DEST_A, 3);
+		unlisted.from = vec![0xCC, 0xDD];
+
+		let mut events = vec![
+			Event::PostRequest(rewarded),
+			Event::PostRequest(hft),
+			Event::PostRequest(unlisted),
+		];
+
+		retain_incentivized_requests(&mut events, &config, HB, Some(&allowlist));
+
+		let nonces: Vec<u64> = events
+			.iter()
+			.filter_map(|ev| match ev {
+				Event::PostRequest(p) => Some(p.nonce),
+				_ => None,
+			})
+			.collect();
+		assert_eq!(nonces, vec![1, 2], "reward allowlist and module_filter are additive");
+	}
+
+	#[test]
 	fn retain_incentivized_none_is_noop() {
 		let mut events = vec![
 			Event::PostRequest(post_req(HB, DEST_A, 1)),
@@ -1278,72 +1294,6 @@ mod tests {
 		assert_eq!(events.len(), 1);
 	}
 
-	/// `pallet-hyper-fungible-token`'s module id, the real case this filter
-	/// was widened for: HFT dispatches with `ModuleId::Pallet(PalletId(*b"pall_hft"))`
-	/// and has no delivery reward registered, so the reward allowlist alone
-	/// dropped every BRIDGE transfer out of hyperbridge.
-	const HFT_MODULE: &[u8] = b"pall_hft";
-
-	fn config_filtering(modules: &[&[u8]]) -> RelayerConfig {
-		RelayerConfig {
-			module_filter: Some(modules.iter().map(|m| hex::encode(m)).collect()),
-			..Default::default()
-		}
-	}
-
-	#[test]
-	fn retain_incentivized_keeps_modules_named_in_the_module_filter() {
-		// The reward allowlist pays for `rewarded`; the operator additionally
-		// asked for HFT by name. Both survive, an unlisted third module doesn't.
-		let rewarded = vec![0xAA, 0xBB];
-		let allowlist: BTreeSet<Vec<u8>> = [rewarded.clone()].into_iter().collect();
-		let config = config_filtering(&[HFT_MODULE]);
-
-		let mut incentivized_req = post_req(HB, DEST_A, 1);
-		incentivized_req.from = rewarded;
-		let mut hft_req = post_req(HB, DEST_A, 2);
-		hft_req.from = HFT_MODULE.to_vec();
-		let mut unlisted = post_req(HB, DEST_A, 3);
-		unlisted.from = vec![0xCC, 0xDD];
-
-		let mut events = vec![
-			Event::PostRequest(incentivized_req),
-			Event::PostRequest(hft_req),
-			Event::PostRequest(unlisted),
-		];
-
-		retain_incentivized_requests(&mut events, &config, HB, Some(&allowlist));
-
-		let nonces: Vec<u64> = events
-			.iter()
-			.filter_map(|ev| match ev {
-				Event::PostRequest(p) => Some(p.nonce),
-				_ => None,
-			})
-			.collect();
-		assert_eq!(nonces, vec![1, 2], "reward allowlist and module_filter are additive");
-	}
-
-	#[test]
-	fn collect_claims_skips_modules_with_no_reward() {
-		// An HFT delivery only reached the wire because the operator named it
-		// in `module_filter`. Claiming for it would be rejected on chain with
-		// `OutboundRequestNoRewardConfigured`, so no row is persisted.
-		let rewarded_module = vec![0x77; 8];
-		let allowlist: BTreeSet<Vec<u8>> = [rewarded_module].into_iter().collect();
-
-		let rewarded = build_post(HB, 0x11);
-		let mut hft = build_post(HB, 0x22);
-		hft.from = HFT_MODULE.to_vec();
-		let batch = vec![rewarded.clone(), hft.clone()];
-		let receipts = vec![request_receipt_for(&rewarded, 100), request_receipt_for(&hft, 101)];
-
-		let claims = collect_hyperbridge_request_claims(HB, &batch, &receipts, Some(&allowlist));
-
-		assert_eq!(claims.len(), 1, "only the rewarded module is claimable");
-		assert_eq!(claims[0].delivery_height, 100);
-	}
-
 	#[test]
 	fn collect_claims_drops_receipts_with_no_matching_batch_request() {
 		// A receipt whose commitment is HB-sourced but whose request wasn't in
@@ -1351,7 +1301,7 @@ mod tests {
 		let orphan = build_post(HB, 0x11);
 		let receipts = vec![request_receipt_for(&orphan, 100)];
 		// orphan is NOT in batch_requests.
-		let claims = collect_hyperbridge_request_claims(HB, &[], &receipts, None);
+		let claims = collect_hyperbridge_request_claims(HB, &[], &receipts);
 		assert!(claims.is_empty());
 	}
 }

--- a/tesseract/messaging/messaging/src/outbound.rs
+++ b/tesseract/messaging/messaging/src/outbound.rs
@@ -39,7 +39,7 @@ use tokio::sync::mpsc::Sender;
 use tracing::Instrument;
 use transaction_fees::TransactionPayment;
 
-use crate::events::{filter_events, translate_events_to_messages};
+use crate::events::{filter_events, is_explicitly_filtered, translate_events_to_messages};
 
 /// Log/tracing target for the outbound pipeline.
 const LOG_TARGET: &str = concat!("messaging", "-outbound");
@@ -347,10 +347,23 @@ async fn submit_for_dest(
 	// so the filter keeps every event routed to this destination.
 	let mut events = events
 		.into_iter()
-		.filter(|ev| filter_events(&relayer_config, dest_state_machine, coprocessor, ev))
+		.filter(|ev| {
+			filter_events(
+				&relayer_config,
+				incentivized.as_deref(),
+				dest_state_machine,
+				coprocessor,
+				ev,
+			)
+		})
 		.collect::<Vec<_>>();
 
-	retain_incentivized_requests(&mut events, coprocessor, incentivized.as_deref());
+	retain_incentivized_requests(
+		&mut events,
+		&relayer_config,
+		coprocessor,
+		incentivized.as_deref(),
+	);
 	let has_events_for_dest = events.iter().any(|ev| match ev {
 		Event::PostRequest(req) => req.dest == dest_state_machine,
 		// GetResponses are delivered back to the chain that made the request.
@@ -394,6 +407,7 @@ async fn submit_for_dest(
 			events,
 			state_machine_height,
 			relayer_config,
+			incentivized.clone(),
 			coprocessor,
 			&client_map,
 			// Pass the consensus update as the gas-estimation prelude so EVM
@@ -458,6 +472,7 @@ async fn submit_for_dest(
 		coprocessor,
 		&batch_requests,
 		&result.receipts,
+		incentivized.as_deref(),
 		&claim_tx_payment,
 	)
 	.await;
@@ -533,18 +548,29 @@ async fn submit_for_dest(
 	Ok(())
 }
 
-/// Drop hyperbridge-originated requests whose `source_module` is not on
-/// the on-chain reward allowlist. User-originated requests and non-request
-/// events pass through. `None` means the snapshot fetch failed this cycle;
-/// deliver everything as a no-op fallback.
+/// Drop hyperbridge-originated requests whose `source_module` is neither on the
+/// on-chain reward allowlist nor explicitly named in the operator's
+/// `module_filter`. User-originated requests and non-request events pass
+/// through. `None` means the snapshot fetch failed this cycle; deliver
+/// everything as a no-op fallback.
+///
+/// The reward allowlist decides what the relayer gets *paid* for; the
+/// `module_filter` decides what the operator is *willing* to deliver. A module
+/// on neither list is dropped, which is what kept hyperbridge-originated
+/// transfers from `pallet-hyper-fungible-token` from being relayed at all
+/// while no reward was configured for it.
 fn retain_incentivized_requests(
 	events: &mut Vec<Event>,
+	config: &RelayerConfig,
 	coprocessor: StateMachine,
 	incentivized: Option<&BTreeSet<Vec<u8>>>,
 ) {
 	let Some(incentivized) = incentivized else { return };
 	events.retain(|ev| match ev {
-		Event::PostRequest(post) => post.source != coprocessor || incentivized.contains(&post.from),
+		Event::PostRequest(post) =>
+			post.source != coprocessor ||
+				incentivized.contains(&post.from) ||
+				is_explicitly_filtered(config, &post.from),
 		_ => true,
 	});
 }
@@ -588,13 +614,15 @@ async fn forward_request_delivery_claims(
 	coprocessor: StateMachine,
 	batch_requests: &[PostRequest],
 	receipts: &[TxReceipt],
+	incentivized: Option<&BTreeSet<Vec<u8>>>,
 	claim_tx_payment: &Option<Arc<TransactionPayment>>,
 ) {
 	let Some(tx_payment) = claim_tx_payment else {
 		return;
 	};
 
-	let claims = collect_hyperbridge_request_claims(coprocessor, batch_requests, receipts);
+	let claims =
+		collect_hyperbridge_request_claims(coprocessor, batch_requests, receipts, incentivized);
 	if claims.is_empty() {
 		return;
 	}
@@ -620,10 +648,18 @@ async fn forward_request_delivery_claims(
 /// Filters receipts to those originating from the hyperbridge coprocessor and
 /// pairs each one with its source request. Returns an empty vec when nothing
 /// in the batch is hyperbridge-originated.
+///
+/// Requests from a module that isn't on the reward allowlist are skipped:
+/// they can only be here because the operator named the module in their
+/// `module_filter`, and `process_outbound_request_delivery_claim` would reject
+/// the claim with `OutboundRequestNoRewardConfigured`. `None` means the
+/// snapshot fetch failed this cycle, so every hyperbridge-originated receipt is
+/// kept and the claim task sorts it out.
 fn collect_hyperbridge_request_claims(
 	coprocessor: StateMachine,
 	batch_requests: &[PostRequest],
 	receipts: &[TxReceipt],
+	incentivized: Option<&BTreeSet<Vec<u8>>>,
 ) -> Vec<PendingRequestDeliveryClaim> {
 	// Index every PostRequest in the batch by its commitment so receipts
 	// can be paired back to their source request. BTreeMap keeps iteration
@@ -639,6 +675,7 @@ fn collect_hyperbridge_request_claims(
 			(query.source_chain == coprocessor)
 				.then(|| by_commitment.get(&query.commitment).cloned())
 				.flatten()
+				.filter(|request| incentivized.map_or(true, |set| set.contains(&request.from)))
 				.map(|request| PendingRequestDeliveryClaim { request, delivery_height: *height })
 		})
 		.collect()
@@ -1163,7 +1200,7 @@ mod tests {
 			request_receipt_for(&hb_req_b, 102),
 		];
 
-		let claims = collect_hyperbridge_request_claims(HB, &batch_requests, &receipts);
+		let claims = collect_hyperbridge_request_claims(HB, &batch_requests, &receipts, None);
 
 		assert_eq!(claims.len(), 2, "only hyperbridge-originated requests forwarded");
 		assert!(claims.iter().all(|c| c.request.source == HB));
@@ -1175,7 +1212,7 @@ mod tests {
 	#[test]
 	fn collect_claims_empty_receipts_is_empty() {
 		let hb_req = build_post(HB, 0x11);
-		let claims = collect_hyperbridge_request_claims(HB, &[hb_req], &[]);
+		let claims = collect_hyperbridge_request_claims(HB, &[hb_req], &[], None);
 		assert!(claims.is_empty());
 	}
 
@@ -1183,7 +1220,7 @@ mod tests {
 	fn collect_claims_no_hyperbridge_requests_is_empty() {
 		let user_req = build_post(DEST_B, 0x11);
 		let receipts = vec![request_receipt_for(&user_req, 100)];
-		let claims = collect_hyperbridge_request_claims(HB, &[user_req], &receipts);
+		let claims = collect_hyperbridge_request_claims(HB, &[user_req], &receipts, None);
 		assert!(claims.is_empty());
 	}
 
@@ -1206,7 +1243,7 @@ mod tests {
 			Event::PostRequest(user_originated.clone()),
 		];
 
-		retain_incentivized_requests(&mut events, HB, Some(&allowlist));
+		retain_incentivized_requests(&mut events, &RelayerConfig::default(), HB, Some(&allowlist));
 
 		let nonces: Vec<u64> = events
 			.iter()
@@ -1224,7 +1261,7 @@ mod tests {
 			Event::PostRequest(post_req(HB, DEST_A, 1)),
 			Event::PostRequest(post_req(HB, DEST_A, 2)),
 		];
-		retain_incentivized_requests(&mut events, HB, None);
+		retain_incentivized_requests(&mut events, &RelayerConfig::default(), HB, None);
 		assert_eq!(events.len(), 2);
 	}
 
@@ -1237,8 +1274,74 @@ mod tests {
 			state_machine_id: hb_id(),
 			latest_height: 1,
 		})];
-		retain_incentivized_requests(&mut events, HB, Some(&allowlist));
+		retain_incentivized_requests(&mut events, &RelayerConfig::default(), HB, Some(&allowlist));
 		assert_eq!(events.len(), 1);
+	}
+
+	/// `pallet-hyper-fungible-token`'s module id, the real case this filter
+	/// was widened for: HFT dispatches with `ModuleId::Pallet(PalletId(*b"pall_hft"))`
+	/// and has no delivery reward registered, so the reward allowlist alone
+	/// dropped every BRIDGE transfer out of hyperbridge.
+	const HFT_MODULE: &[u8] = b"pall_hft";
+
+	fn config_filtering(modules: &[&[u8]]) -> RelayerConfig {
+		RelayerConfig {
+			module_filter: Some(modules.iter().map(|m| hex::encode(m)).collect()),
+			..Default::default()
+		}
+	}
+
+	#[test]
+	fn retain_incentivized_keeps_modules_named_in_the_module_filter() {
+		// The reward allowlist pays for `rewarded`; the operator additionally
+		// asked for HFT by name. Both survive, an unlisted third module doesn't.
+		let rewarded = vec![0xAA, 0xBB];
+		let allowlist: BTreeSet<Vec<u8>> = [rewarded.clone()].into_iter().collect();
+		let config = config_filtering(&[HFT_MODULE]);
+
+		let mut incentivized_req = post_req(HB, DEST_A, 1);
+		incentivized_req.from = rewarded;
+		let mut hft_req = post_req(HB, DEST_A, 2);
+		hft_req.from = HFT_MODULE.to_vec();
+		let mut unlisted = post_req(HB, DEST_A, 3);
+		unlisted.from = vec![0xCC, 0xDD];
+
+		let mut events = vec![
+			Event::PostRequest(incentivized_req),
+			Event::PostRequest(hft_req),
+			Event::PostRequest(unlisted),
+		];
+
+		retain_incentivized_requests(&mut events, &config, HB, Some(&allowlist));
+
+		let nonces: Vec<u64> = events
+			.iter()
+			.filter_map(|ev| match ev {
+				Event::PostRequest(p) => Some(p.nonce),
+				_ => None,
+			})
+			.collect();
+		assert_eq!(nonces, vec![1, 2], "reward allowlist and module_filter are additive");
+	}
+
+	#[test]
+	fn collect_claims_skips_modules_with_no_reward() {
+		// An HFT delivery only reached the wire because the operator named it
+		// in `module_filter`. Claiming for it would be rejected on chain with
+		// `OutboundRequestNoRewardConfigured`, so no row is persisted.
+		let rewarded_module = vec![0x77; 8];
+		let allowlist: BTreeSet<Vec<u8>> = [rewarded_module].into_iter().collect();
+
+		let rewarded = build_post(HB, 0x11);
+		let mut hft = build_post(HB, 0x22);
+		hft.from = HFT_MODULE.to_vec();
+		let batch = vec![rewarded.clone(), hft.clone()];
+		let receipts = vec![request_receipt_for(&rewarded, 100), request_receipt_for(&hft, 101)];
+
+		let claims = collect_hyperbridge_request_claims(HB, &batch, &receipts, Some(&allowlist));
+
+		assert_eq!(claims.len(), 1, "only the rewarded module is claimable");
+		assert_eq!(claims[0].delivery_height, 100);
 	}
 
 	#[test]
@@ -1248,7 +1351,7 @@ mod tests {
 		let orphan = build_post(HB, 0x11);
 		let receipts = vec![request_receipt_for(&orphan, 100)];
 		// orphan is NOT in batch_requests.
-		let claims = collect_hyperbridge_request_claims(HB, &[], &receipts);
+		let claims = collect_hyperbridge_request_claims(HB, &[], &receipts, None);
 		assert!(claims.is_empty());
 	}
 }

--- a/tesseract/messaging/messaging/src/outbound.rs
+++ b/tesseract/messaging/messaging/src/outbound.rs
@@ -463,6 +463,7 @@ async fn submit_for_dest(
 		coprocessor,
 		&batch_requests,
 		&result.receipts,
+		incentivized.as_deref(),
 		&claim_tx_payment,
 	)
 	.await;
@@ -604,13 +605,15 @@ async fn forward_request_delivery_claims(
 	coprocessor: StateMachine,
 	batch_requests: &[PostRequest],
 	receipts: &[TxReceipt],
+	incentivized: Option<&BTreeSet<Vec<u8>>>,
 	claim_tx_payment: &Option<Arc<TransactionPayment>>,
 ) {
 	let Some(tx_payment) = claim_tx_payment else {
 		return;
 	};
 
-	let claims = collect_hyperbridge_request_claims(coprocessor, batch_requests, receipts);
+	let claims =
+		collect_hyperbridge_request_claims(coprocessor, batch_requests, receipts, incentivized);
 	if claims.is_empty() {
 		return;
 	}
@@ -636,10 +639,20 @@ async fn forward_request_delivery_claims(
 /// Filters receipts to those originating from the hyperbridge coprocessor and
 /// pairs each one with its source request. Returns an empty vec when nothing
 /// in the batch is hyperbridge-originated.
+///
+/// Requests from a module that is not on the reward allowlist are skipped:
+/// they can only be here because the operator named the module in their
+/// `module_filter`, and `process_outbound_request_delivery_claim` would reject
+/// the claim with `OutboundRequestNoRewardConfigured`. A row persisted for one
+/// is never deleted, since the claim task only removes rows on success, so it
+/// would be retried on every claim cycle for good. `None` means the snapshot
+/// fetch failed this cycle, so every hyperbridge-originated receipt is kept and
+/// the claim task sorts it out.
 fn collect_hyperbridge_request_claims(
 	coprocessor: StateMachine,
 	batch_requests: &[PostRequest],
 	receipts: &[TxReceipt],
+	incentivized: Option<&BTreeSet<Vec<u8>>>,
 ) -> Vec<PendingRequestDeliveryClaim> {
 	// Index every PostRequest in the batch by its commitment so receipts
 	// can be paired back to their source request. BTreeMap keeps iteration
@@ -655,6 +668,7 @@ fn collect_hyperbridge_request_claims(
 			(query.source_chain == coprocessor)
 				.then(|| by_commitment.get(&query.commitment).cloned())
 				.flatten()
+				.filter(|request| incentivized.map_or(true, |set| set.contains(&request.from)))
 				.map(|request| PendingRequestDeliveryClaim { request, delivery_height: *height })
 		})
 		.collect()
@@ -1179,7 +1193,7 @@ mod tests {
 			request_receipt_for(&hb_req_b, 102),
 		];
 
-		let claims = collect_hyperbridge_request_claims(HB, &batch_requests, &receipts);
+		let claims = collect_hyperbridge_request_claims(HB, &batch_requests, &receipts, None);
 
 		assert_eq!(claims.len(), 2, "only hyperbridge-originated requests forwarded");
 		assert!(claims.iter().all(|c| c.request.source == HB));
@@ -1191,7 +1205,7 @@ mod tests {
 	#[test]
 	fn collect_claims_empty_receipts_is_empty() {
 		let hb_req = build_post(HB, 0x11);
-		let claims = collect_hyperbridge_request_claims(HB, &[hb_req], &[]);
+		let claims = collect_hyperbridge_request_claims(HB, &[hb_req], &[], None);
 		assert!(claims.is_empty());
 	}
 
@@ -1199,7 +1213,7 @@ mod tests {
 	fn collect_claims_no_hyperbridge_requests_is_empty() {
 		let user_req = build_post(DEST_B, 0x11);
 		let receipts = vec![request_receipt_for(&user_req, 100)];
-		let claims = collect_hyperbridge_request_claims(HB, &[user_req], &receipts);
+		let claims = collect_hyperbridge_request_claims(HB, &[user_req], &receipts, None);
 		assert!(claims.is_empty());
 	}
 
@@ -1295,13 +1309,34 @@ mod tests {
 	}
 
 	#[test]
+	fn collect_claims_skips_modules_with_no_reward() {
+		// An HFT delivery only reached the wire because the operator named it
+		// in `module_filter`. Claiming for it would be rejected on chain with
+		// `OutboundRequestNoRewardConfigured` and the row retried forever, so
+		// no row is persisted.
+		let rewarded_module = vec![0x77; 8];
+		let allowlist: BTreeSet<Vec<u8>> = [rewarded_module].into_iter().collect();
+
+		let rewarded = build_post(HB, 0x11);
+		let mut hft = build_post(HB, 0x22);
+		hft.from = b"pall_hft".to_vec();
+		let batch = vec![rewarded.clone(), hft.clone()];
+		let receipts = vec![request_receipt_for(&rewarded, 100), request_receipt_for(&hft, 101)];
+
+		let claims = collect_hyperbridge_request_claims(HB, &batch, &receipts, Some(&allowlist));
+
+		assert_eq!(claims.len(), 1, "only the rewarded module is claimable");
+		assert_eq!(claims[0].delivery_height, 100);
+	}
+
+	#[test]
 	fn collect_claims_drops_receipts_with_no_matching_batch_request() {
 		// A receipt whose commitment is HB-sourced but whose request wasn't in
 		// the batch produces no claim (shouldn't happen in practice).
 		let orphan = build_post(HB, 0x11);
 		let receipts = vec![request_receipt_for(&orphan, 100)];
 		// orphan is NOT in batch_requests.
-		let claims = collect_hyperbridge_request_claims(HB, &[], &receipts);
+		let claims = collect_hyperbridge_request_claims(HB, &[], &receipts, None);
 		assert!(claims.is_empty());
 	}
 }

--- a/tesseract/relayer/Cargo.toml
+++ b/tesseract/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tesseract"
-version = "2.4.10"
+version = "2.4.11"
 edition = "2021"
 description = "Consolidated Hyperbridge relayer — inbound and outbound consensus + messaging"
 authors = ["Polytope Labs <hello@polytope.technology>"]


### PR DESCRIPTION
The outbound task drops hyperbridge-originated requests whose source module has no `OutboundRequestDeliveryReward` registered, so a module with no reward configured is never delivered at all. `pallet-hyper-fungible-token` sits in that position, which leaves its transfers out of hyperbridge undeliverable.

`module_filter` could not be used to unblock it either, since a non empty filter is exclusive and naming one module there silences every other module the relayer was being paid for.

The two lists are now additive: a request is delivered when its source module appears in the reward allowlist or in the operator's `module_filter`, and an empty filter keeps the current behaviour. Claims are still only filed for modules on the reward allowlist, since the pallet rejects the rest with `OutboundRequestNoRewardConfigured`.