### PR TITLE
[simplex]: fix SSH tunnel auth bypass

### DIFF
--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -12,6 +12,29 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-09-09 — Fix SSH tunnel auth bypass: strict signature verification + key-algorithm check
+
+The embedded SSH server's public-key auth accepted a forged signature. ssh2's `key.verify()` returns
+`true` on success but an `Error` object (not `false`) on a critical failure such as an unsupported digest
+for the key; the handler used `if (!key.verify(...))`, and `!errorObject` is `false`, so the rejection was
+skipped and the client was authenticated. The Error path is reachable without any private key via
+key-algorithm confusion: an attacker who knows a paired device's public key (public by design) offers that
+ed25519 key blob tagged as an RSA signature algorithm — it parses as ed25519 so its fingerprint matches an
+authorized device, while ssh2 drives `verify()` with a SHA-2 digest ed25519 cannot compute, which throws.
+A tunnelled session has full operator privileges (`/api/send`, `/api/vault/*`), so this was a fund-drain
+path over the public relay port. Reproduced end-to-end with a real ssh2 client holding no private key.
+
+Two-part fix in the `authentication` handler: (1) require the parsed key type to equal the declared
+signature algorithm (`key.type === ctx.key.algo`; ssh2 already normalises rsa-sha2-256/512 to `ssh-rsa`),
+rejecting the confusion up front and never rejecting an honest client; (2) require a strict boolean
+`key.verify(...) !== true`, which closes the Error-return bypass for any key type. Added a regression test
+that drives the exact forged-key exploit and asserts rejection — it fails against the old code and passes
+against the fix. Also gave `FakeRelay`'s forwarded pipe `error` listeners so a rejected handshake's EPIPE
+no longer surfaces as an unhandled error attributed to a later test.
+
+Files: src/services/tunnel/EmbeddedSshServer.ts, src/tests/tunnel.test.ts.
+
+
 ## 2026-09-09 — Prefer funded, Permit2-approved fee tokens before bootstrap (#1223)
 
 Fee-token selection now scans USDC then USDT for both a balance of at least one whole

--- a/sdk/packages/simplex/docs/ai/Decisions.md
+++ b/sdk/packages/simplex/docs/ai/Decisions.md
@@ -4,6 +4,29 @@ AI-maintained record of non-obvious choices made in `sdk/packages/simplex`: what
 
 Entry format: heading with the decision, then alternatives considered and the reasoning. Newest first.
 
+## 2026-09-09 — SSH tunnel auth: strict verify + declared-algorithm must match the key
+
+Decided: in the embedded SSH server, reject a login unless `key.verify(...) === true` (strict) AND the
+parsed key type equals the client-declared signature algorithm (`ctx.key.algo`). This fixes an auth bypass
+(see ChangeLog 2026-09-09).
+
+Why the strict `!== true` and not just fixing the confusion vector: ssh2 documents `verify()` as returning
+`false` OR an `Error` on failure, and its own examples use `!== true`. Treating only the confusion case
+would leave any other Error-returning failure (future ssh2 versions, other digest edge cases) as a bypass.
+The strict check is the load-bearing fix; it alone closes the demonstrated exploit.
+
+Why also the key-type/algorithm match, given the strict check already covers it: defence in depth and a
+clear rejection reason, and it stops the confused request before `verify()` is even attempted. It is safe
+for every legitimate key type — ssh2 normalises rsa-sha2-256 and rsa-sha2-512 to `ssh-rsa`, so an honest
+RSA client's `ctx.key.algo` (`ssh-rsa`) still equals its parsed `key.type` (`ssh-rsa`), and an ed25519
+client matches trivially.
+
+Rejected: pinning device keys to ed25519 only. It would also close the specific exploit, but the pairing
+flow (`addDevice`) accepts any OpenSSH public key an operator pastes, so pinning would lock out a device
+legitimately paired with an RSA or ECDSA key — a functional regression for a weaker reason than the two
+checks above, which are correct for all key types.
+
+
 ## 2026-09-09 — Fee-token readiness takes priority over bootstrap (#1223)
 
 Chosen: scan configured fee tokens in USDC-then-USDT order and select the first with both

--- a/sdk/packages/simplex/src/services/tunnel/EmbeddedSshServer.ts
+++ b/sdk/packages/simplex/src/services/tunnel/EmbeddedSshServer.ts
@@ -306,12 +306,30 @@ export class EmbeddedSshServer {
 			if (ctx.method !== "publickey") return fail(`unsupported authentication method ${ctx.method}`)
 			const key = utils.parseKey(ctx.key.data)
 			if (key instanceof Error) return fail("unreadable key")
+			// The signature algorithm the client declared (`ctx.key.algo`, ssh2's
+			// already-normalised form: both rsa-sha2-256 and rsa-sha2-512 arrive as
+			// `ssh-rsa`) must match the key it actually presented. A mismatch is
+			// key-algorithm confusion: offering an ed25519 key blob tagged as an RSA
+			// signature algorithm parses as ed25519 here — so its fingerprint can
+			// match an authorized device — while ssh2 drives verify() with a SHA-2
+			// digest that key cannot compute. verify() then *throws*, which the
+			// strict `!== true` below already rejects; this check refuses it earlier
+			// and with a clear reason, and never rejects an honest client, whose
+			// declared algorithm always matches its own key type.
+			if (key.type !== ctx.key.algo) {
+				return fail(`key type ${key.type} does not match offered algorithm ${ctx.key.algo}`)
+			}
 			const fingerprint = fingerprintOf(ctx.key.data)
 			if (!this.opts.isAuthorized(fingerprint)) return fail(`unknown device key ${fingerprint}`)
 			// No signature yet: the client is asking whether this key would be
 			// accepted. Saying yes only tells it to sign.
 			if (ctx.signature === undefined || ctx.blob === undefined) return ctx.accept()
-			if (!key.verify(ctx.blob, ctx.signature, ctx.hashAlgo)) return fail("bad signature")
+			// ssh2's key.verify() returns `true` on success and `false` on a normal
+			// bad signature, but an *Error object* on a "more critical failure"
+			// (e.g. an unsupported digest for the key). A loose `!key.verify(...)`
+			// treats that Error as falsy and so lets it through — an auth bypass.
+			// Require a strict boolean `true`.
+			if (key.verify(ctx.blob, ctx.signature, ctx.hashAlgo) !== true) return fail("bad signature")
 			authenticated = true
 			if (guard) guard.authenticated = true
 			deviceFingerprint = fingerprint

--- a/sdk/packages/simplex/src/tests/tunnel.test.ts
+++ b/sdk/packages/simplex/src/tests/tunnel.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach, beforeAll, vi } from "vitest"
 import { createServer as createHttpServer, type Server as HttpServer } from "node:http"
 import { createServer as createTcpServer, type Server as TcpServer } from "node:net"
+import { randomBytes } from "node:crypto"
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
 import { Duplex, PassThrough } from "node:stream"
 import { tmpdir } from "node:os"
@@ -87,6 +88,13 @@ class FakeRelay {
 					(err, channel) => {
 						if (err) return sock.destroy()
 						sock.pipe(channel).pipe(sock)
+						// A rejected handshake (e.g. the kex test) tears one side down
+						// while the other is still writing; the resulting EPIPE has no
+						// listener and would surface as an unhandled error attributed to
+						// whichever test happens to be running. A real relay never crashes
+						// on a client hang-up either.
+						channel.on("error", () => {})
+						sock.on("error", () => {})
 						channel.on("close", () => sock.destroy())
 						sock.on("close", () => channel.destroy())
 					},
@@ -660,6 +668,65 @@ describe("TunnelService", { timeout: 30_000 }, () => {
 		} as never)
 		await waitFor(() => (serverSide as unknown as { destroyed: boolean }).destroyed, 8000)
 		await waitFor(() => embedded.connections === 0, 8000)
+		clientSide.destroy()
+		embedded.close()
+	})
+
+	it("rejects a forged signature from an authorized key blob (algorithm confusion)", async () => {
+		// The whole point of public-key auth is that knowing the public half buys
+		// nothing. This is the regression test for the bypass where it did: ssh2's
+		// key.verify() returns an Error (not false) on a critical failure, so a
+		// loose `!key.verify(...)` accepted it. An attacker who knows a paired
+		// device's *public* key offers that ed25519 blob tagged as an RSA signature
+		// algorithm and a garbage signature — no private key. It must fail.
+		const dir = mkdtempSync(join(tmpdir(), "simplex-forge-"))
+		const keys = new TunnelKeyStore(dir)
+		const victim = generateKeyPair()
+		const victimBlob = utils.parseKey(victim.public).getPublicSSH()
+		const victimFingerprint = fingerprintOf(victimBlob)
+		const embedded = new EmbeddedSshServer({
+			hostKey: keys.hostKey().privateKey,
+			isAuthorized: (fp) => fp === victimFingerprint,
+			target: () => ({ host: "127.0.0.1", port: ui.port }),
+			deliver: () => true,
+			// Let the client exhaust its one forged method and end its own
+			// connection, rather than the server force-destroying the stream
+			// mid-protocol — the latter races a late disconnect write into a dead
+			// pipe (EPIPE) that would surface as an unhandled error in a later test.
+			authTimeoutMs: 60_000,
+		})
+		const { clientSide, serverSide } = pipePair()
+		embedded.inject(serverSide, { ip: "203.0.113.9", port: 40002 })
+
+		// A "parsed key" whose type is ssh-rsa (so ssh2 signs with rsa-sha2-256,
+		// hashAlgo sha256) but whose public blob is the victim's ed25519 key and
+		// whose sign() returns garbage — exactly the exploit shape, no private key.
+		const donor = utils.parseKey(utils.generateKeyPairSync("rsa", { bits: 2048 }).private)
+		const forged = Object.create(Object.getPrototypeOf(donor))
+		for (const sym of Object.getOwnPropertySymbols(donor)) forged[sym] = (donor as never)[sym]
+		Object.assign(forged, {
+			type: "ssh-rsa",
+			getPublicSSH: () => victimBlob,
+			getPublicPEM: () => donor.getPublicPEM(),
+			sign: () => randomBytes(256),
+			isPrivateKey: () => true,
+		})
+
+		const client = new SshClient()
+		const authenticated = await new Promise<boolean>((resolve) => {
+			client.on("ready", () => resolve(true))
+			client.on("error", () => resolve(false))
+			client.on("close", () => resolve(false))
+			client.connect({
+				sock: clientSide,
+				username: "simplex",
+				authHandler: () => ({ type: "publickey", username: "simplex", key: forged }),
+				hostVerifier: () => true,
+			} as never)
+		})
+		expect(authenticated).toBe(false)
+		expect(embedded.connections).toBe(0)
+		client.end()
 		clientSide.destroy()
 		embedded.close()
 	})


### PR DESCRIPTION
The embedded SSH server's public-key auth accepted a forged signature. ssh2's key.verify() returns true on success but an Error object (not false) on a critical failure such as an unsupported digest for the key. The handler used `if (!key.verify(...))`, and `!errorObject` is false, so the rejection was skipped and the client authenticated.

The Error path is reachable with no private key via key-algorithm confusion: an attacker who knows a paired device's public key (public by design) offers that ed25519 key blob tagged as an RSA signature algorithm. It parses as ed25519 so its fingerprint matches an authorized device, while ssh2 drives verify() with a SHA-2 digest ed25519 cannot compute, which throws. A tunnelled session has full operator privileges (/api/send, /api/vault/*), so this was a fund-drain path over the public relay port. Reproduced end-to-end with a real ssh2 client holding no private key.

Fix, in the authentication handler:
- require the parsed key type to equal the declared signature algorithm (key.type === ctx.key.algo; ssh2 normalises rsa-sha2-256/512 to ssh-rsa), rejecting the confusion up front without rejecting any honest client;
- require a strict boolean key.verify(...) !== true, closing the Error-return bypass for every key type.

Adds a regression test driving the exact forged-key exploit and asserting rejection (fails against the old code, passes against the fix), and gives FakeRelay's forwarded pipe error listeners so a rejected handshake's EPIPE no longer surfaces as an unhandled error.