### PR TITLE
[simplex]: Make the SSH tunnel's publickey guard fail closed

### DIFF
--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -12,6 +12,29 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-09-09 — Make the SSH tunnel's publickey guard fail closed
+
+The embedded SSH server treated a publickey request as an unsigned probe whenever *either*
+`ctx.signature` or `ctx.blob` was missing (`||`), and answered it with `ctx.accept()`. That is not
+neutral: ssh2's `PKAuthContext.accept()` sends PK_OK only when there is no signature, and
+authenticates outright when there is one. So a request carrying a signature but no blob would have
+been authenticated having never reached `key.verify()`.
+
+Not exploitable against the pinned `ssh2@1.17.0`: its USERAUTH_REQUEST parser builds `methodData`
+with `signature` and `blob` together or not at all, and a signed request whose signature fails to
+parse is a fatal protocol error that never raises an `authentication` event. The guard was therefore
+resting entirely on an undocumented internal invariant of a dependency — the same kind of assumption
+that produced the bypass fixed earlier the same day, where the trusted invariant was the return type
+of `verify()`. The probe branch now requires *both* halves absent, and a half-populated request is
+refused as malformed.
+
+Adds a regression test that drives the handler with each shape (signature only, blob only, neither)
+and asserts the first two are rejected while an honest probe still gets its PK_OK; it fails against
+the old `||` guard with `accepted: true`.
+
+Files: src/services/tunnel/EmbeddedSshServer.ts, src/tests/tunnel.test.ts, package.json (0.16.1).
+
+
 ## 2026-09-09 — Fix SSH tunnel auth bypass: strict signature verification + key-algorithm check
 
 The embedded SSH server's public-key auth accepted a forged signature. ssh2's `key.verify()` returns

--- a/sdk/packages/simplex/docs/ai/Decisions.md
+++ b/sdk/packages/simplex/docs/ai/Decisions.md
@@ -4,6 +4,30 @@ AI-maintained record of non-obvious choices made in `sdk/packages/simplex`: what
 
 Entry format: heading with the decision, then alternatives considered and the reasoning. Newest first.
 
+## 2026-09-09 — The publickey probe branch requires both halves absent, not either
+
+Decided: `ctx.signature === undefined && ctx.blob === undefined` selects the unsigned-probe path;
+anything with exactly one of the two is refused as malformed. Previously the test was `||`, so a
+half-populated request reached `ctx.accept()` — which authenticates rather than sending PK_OK once a
+signature is present.
+
+Why change something not currently reachable: `ssh2@1.17.0` always populates both fields together,
+so no wire input produces the dangerous shape today. But the safety of the guard came entirely from
+that internal parser detail, not from anything in this file, and the version is a floating `^1.17.0`.
+The bypass fixed earlier the same day had the identical shape — correct-looking code whose safety
+depended on an undocumented ssh2 behaviour (`verify()` returning a boolean) that turned out not to
+hold. Making the fallback refusal costs nothing and removes the dependency on that invariant.
+
+Rejected: asserting the invariant instead (e.g. throwing if ssh2 ever hands over one without the
+other). It is the same branch either way, and refusing an unverifiable request is the behaviour we
+actually want; a thrown error inside the authentication handler would be a less predictable path
+through ssh2 than a plain rejection.
+
+Rejected: pinning ssh2 to an exact version to preserve the invariant. Version pinning is worth doing
+on its own merits, but it protects this guard only until the next deliberate upgrade, and it does
+not make the authentication path correct in isolation.
+
+
 ## 2026-09-09 — SSH tunnel auth: strict verify + declared-algorithm must match the key
 
 Decided: in the embedded SSH server, reject a login unless `key.verify(...) === true` (strict) AND the

--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/simplex",
-	"version": "0.16.0",
+	"version": "0.16.1",
 	"license": "Apache-2.0",
 	"description": "Automated intent filler for the Hyperbridge IntentGateway — run it as a binary or embed it as a library",
 	"main": "dist/index.js",

--- a/sdk/packages/simplex/src/services/tunnel/EmbeddedSshServer.ts
+++ b/sdk/packages/simplex/src/services/tunnel/EmbeddedSshServer.ts
@@ -321,9 +321,18 @@ export class EmbeddedSshServer {
 			}
 			const fingerprint = fingerprintOf(ctx.key.data)
 			if (!this.opts.isAuthorized(fingerprint)) return fail(`unknown device key ${fingerprint}`)
-			// No signature yet: the client is asking whether this key would be
-			// accepted. Saying yes only tells it to sign.
-			if (ctx.signature === undefined || ctx.blob === undefined) return ctx.accept()
+			// A probe carries neither half: the client is asking whether this key
+			// would be accepted, and saying yes only tells it to sign.
+			if (ctx.signature === undefined && ctx.blob === undefined) return ctx.accept()
+			// Anything else must reach the verification below. `ctx.accept()` is not
+			// neutral: ssh2's PKAuthContext.accept() sends PK_OK only when there is no
+			// signature and authenticates outright when there is one, so treating a
+			// half-populated request as a probe would authenticate it unverified. ssh2
+			// populates both fields together, which is the only reason the previous
+			// `||` was not a bypass; refuse rather than keep resting on that.
+			if (ctx.signature === undefined || ctx.blob === undefined) {
+				return fail("malformed publickey request: a signature without the blob it signs, or the reverse")
+			}
 			// ssh2's key.verify() returns `true` on success and `false` on a normal
 			// bad signature, but an *Error object* on a "more critical failure"
 			// (e.g. an unsupported digest for the key). A loose `!key.verify(...)`

--- a/sdk/packages/simplex/src/tests/tunnel.test.ts
+++ b/sdk/packages/simplex/src/tests/tunnel.test.ts
@@ -731,6 +731,68 @@ describe("TunnelService", { timeout: 30_000 }, () => {
 		embedded.close()
 	})
 
+	it("refuses a publickey request that carries only half of a signed attempt", async () => {
+		// ssh2 fills ctx.signature and ctx.blob together, so this shape cannot be
+		// produced over the wire against the pinned version — it is asserted
+		// directly because that invariant is the only thing that made the old `||`
+		// safe. ctx.accept() is not neutral: PKAuthContext.accept() sends PK_OK
+		// only when there is no signature and authenticates outright when there is
+		// one, so a half-populated request routed to it would be authenticated
+		// having never been verified.
+		const dir = mkdtempSync(join(tmpdir(), "simplex-halfsig-"))
+		const keys = new TunnelKeyStore(dir)
+		const device = generateKeyPair()
+		const parsedDevice = utils.parseKey(device.public)
+		if (parsedDevice instanceof Error) throw parsedDevice
+		const deviceBlob = parsedDevice.getPublicSSH()
+		const embedded = new EmbeddedSshServer({
+			hostKey: keys.hostKey().privateKey,
+			isAuthorized: (fp) => fp === fingerprintOf(deviceBlob),
+			target: () => ({ host: "127.0.0.1", port: ui.port }),
+			deliver: () => true,
+			authTimeoutMs: 60_000,
+		})
+
+		// The handler under test is registered on the real ssh2 Connection, which is
+		// raised only once a peer completes an identification line.
+		let conn: Connection | undefined
+		;(embedded as unknown as { server: SshServerType }).server.on("connection", (c: Connection) => {
+			conn = c
+		})
+		const { clientSide, serverSide } = pipePair()
+		embedded.inject(serverSide, { ip: "203.0.113.11", port: 40003 })
+		clientSide.write("SSH-2.0-halfsig\r\n")
+		await waitFor(() => conn !== undefined)
+
+		const attempt = (signature: Buffer | undefined, blob: Buffer | undefined) => {
+			const seen = { accepted: false, rejected: false }
+			conn!.emit("authentication", {
+				method: "publickey",
+				key: { algo: "ssh-ed25519", data: deviceBlob },
+				signature,
+				blob,
+				hashAlgo: undefined,
+				accept: () => {
+					seen.accepted = true
+				},
+				reject: () => {
+					seen.rejected = true
+				},
+			} as never)
+			return seen
+		}
+
+		// A signature with nothing to verify it against cannot have been verified.
+		expect(attempt(randomBytes(64), undefined)).toEqual({ accepted: false, rejected: true })
+		// The mirror image is just as malformed.
+		expect(attempt(undefined, randomBytes(32))).toEqual({ accepted: false, rejected: true })
+		// An honest probe still gets its PK_OK.
+		expect(attempt(undefined, undefined)).toEqual({ accepted: true, rejected: false })
+
+		clientSide.destroy()
+		embedded.close()
+	})
+
 	it("reaps a peer that never finishes the SSH identification line", async () => {
 		const dir = mkdtempSync(join(tmpdir(), "simplex-ident-"))
 		const keys = new TunnelKeyStore(dir)


### PR DESCRIPTION
The embedded SSH server treated a publickey request as an unsigned probe whenever *either* ctx.signature or ctx.blob was missing, and answered it with ctx.accept(). That is not neutral: ssh2's PKAuthContext.accept() sends PK_OK only when there is no signature, and authenticates outright when there is one. So a request carrying a signature but no blob would have been authenticated having never reached key.verify().

This is not exploitable against the pinned ssh2@1.17.0. Its USERAUTH_REQUEST parser builds methodData with signature and blob together or not at all, and a signed request whose signature fails to parse is a fatal protocol error that never raises an authentication event. The guard's safety therefore rested entirely on an undocumented internal invariant of a dependency carried on a caret range, which is the same shape as the bypass fixed in #1225, where the trusted invariant was the return type of verify().

The probe branch now requires both halves absent, and a half-populated request is refused as malformed. Adds a regression test driving the handler with each shape (signature only, blob only, neither): the first two must be rejected and an honest probe must still get its PK_OK. It fails against the old guard with accepted: true.