### PR TITLE
[simplex]: deny framing of the operator UI

### DIFF
--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -367,6 +367,25 @@ src/tests/cli/log-format.test.ts (new), README.md.
 No version bump. Four simplex branches were open against #1237 at once and a bump in each would have
 collided on the same field for nothing — publishing is tag-driven, so the version can be set once on
 whatever lands. This is the exception to the usual "bump inside the feature PR" rule, not a change to it.
+## 2026-09-09 — Deny framing of the operator UI (clickjacking)
+
+The UI server sent no `X-Frame-Options` and no `frame-ancestors` CSP, so any page could put the operator
+UI in an invisible iframe — including a page in a phone's browser while the remote-access tunnel's local
+forward is up on `127.0.0.1:8686`. The existing defences do not cover this and were never meant to: a
+framing page can neither read nor script the cross-origin document, so the `X-Simplex-UI` preflight
+requirement and the Host-header rebinding check both still hold, but an overlay can make the operator
+click the real UI's own buttons, and those clicks are same-origin and carry the header. One click each
+reaches `/api/pause`, `/api/reset-halt`, `/api/vault/sweep` and `/api/vault/redeem`. `/api/stop` sits
+behind a `window.confirm`, which browsers suppress in cross-origin frames, and `/api/send` needs typed
+input.
+
+`handle()` now sets `Content-Security-Policy: frame-ancestors 'none'` and `X-Frame-Options: DENY` on
+every response, before any route can return, so rejections carry them too. Setting them with `setHeader`
+rather than at each `writeHead` means the four existing header-writing sites (JSON, SSE, static, the
+UI-not-built page) merge them in and a future route cannot forget them. Added a test asserting both
+headers on HTML, on JSON, and on a 403.
+
+Files: src/services/server/UiServer.ts, src/tests/ui-server.test.ts.
 
 
 ## 2026-09-09 — Make the SSH tunnel's publickey guard fail closed

--- a/sdk/packages/simplex/docs/ai/Decisions.md
+++ b/sdk/packages/simplex/docs/ai/Decisions.md
@@ -518,6 +518,25 @@ it is read from argv, which is available just as early.
 
 If a supervisor that cannot construct argv does turn up, adding an env fallback inside
 `logFormatFromArgv` is a couple of lines and breaks nothing.
+## 2026-09-09 — Framing headers are set once in `handle()`, not per response
+
+Decided: set `Content-Security-Policy: frame-ancestors 'none'` and `X-Frame-Options: DENY` with
+`setHeader` at the top of `UiServer.handle()`, before the Host and CSRF checks run.
+
+Why there rather than at each `writeHead`: the server writes headers from four places (`sendJson`, the
+SSE stream, `serveStatic`, the UI-not-built fallback), and Node merges `setHeader` values into a later
+`writeHead`, so one assignment covers all four and every route added later. Setting them ahead of the
+Host and `X-Simplex-UI` checks also means the 403s carry them — a rejected response is still a document
+a page can frame.
+
+Why both headers: `frame-ancestors` is the specified control and what current browsers honour;
+`X-Frame-Options: DENY` costs one line and still covers older WebViews that ignore CSP, which is a
+plausible way for an operator to open this UI from a phone.
+
+Rejected: a full CSP (`default-src`, `script-src`, …). Stronger, but the SPA is a Vite bundle with
+inline styles and an SSE connection, so a usable policy has to be derived from the build output and
+checked against the running UI. That is worth doing on its own terms rather than as a side effect of
+closing the framing hole, which is the one gap the existing defences left open.
 
 
 ## 2026-09-09 — The publickey probe branch requires both halves absent, not either

--- a/sdk/packages/simplex/src/services/server/UiServer.ts
+++ b/sdk/packages/simplex/src/services/server/UiServer.ts
@@ -653,6 +653,18 @@ export class UiServer {
 		const path = (req.url ?? "/").split("?")[0]
 		const method = req.method ?? "GET"
 
+		// Framing defense: the API is unauthenticated by design — the bind is the
+		// boundary — so a page that frames this UI never needs to read or script
+		// it. It only needs the operator to tap through an invisible overlay: the
+		// click lands in the real UI, same-origin, with its own X-Simplex-UI header.
+		// That reaches pause, reset-halt and vault sweep/redeem, which are one
+		// click each. `frame-ancestors` is the directive browsers honour today;
+		// X-Frame-Options is the fallback for older WebViews that ignore CSP.
+		// Set here, before anything can return, so 403s carry it too — and via
+		// setHeader so every writeHead downstream merges rather than drops it.
+		res.setHeader("Content-Security-Policy", "frame-ancestors 'none'")
+		res.setHeader("X-Frame-Options", "DENY")
+
 		const provenance = provenanceOf(req.socket)
 
 		// DNS-rebinding defense: an attacker page resolving its own domain to

--- a/sdk/packages/simplex/src/tests/ui-server.test.ts
+++ b/sdk/packages/simplex/src/tests/ui-server.test.ts
@@ -287,6 +287,26 @@ describe("UiServer (operator mode)", () => {
 		expect(await rawRequest(port, "/api/status", "localhost")).toContain("200")
 	})
 
+	it("forbids framing on every response, including rejections", async () => {
+		const { base } = await startServer()
+		// A framing page cannot read or script this origin, but it does not need
+		// to: an invisible overlay makes the operator click the real UI's own
+		// buttons. Pause, reset-halt and vault redeem are one click each.
+		const expectFramingDenied = async (path: string, init?: Parameters<typeof fetch>[1]) => {
+			const res = await fetch(`${base}${path}`, init)
+			await res.arrayBuffer()
+			expect(res.headers.get("content-security-policy")).toBe("frame-ancestors 'none'")
+			expect(res.headers.get("x-frame-options")).toBe("DENY")
+			return res
+		}
+		// The HTML an operator's browser loads, and the JSON API behind it.
+		await expectFramingDenied("/")
+		await expectFramingDenied("/api/status")
+		// Rejections carry it too: the headers are set before any route can
+		// return, so every writeHead downstream merges rather than drops them.
+		expect((await expectFramingDenied("/api/pause", { method: "POST" })).status).toBe(403)
+	})
+
 	it("lists strategies with their curves", async () => {
 		const { base } = await startServer()
 		const res = await fetch(`${base}/api/strategies`)


### PR DESCRIPTION
## The problem

Nothing stopped another website from putting the Simplex operator UI inside an invisible iframe.

That page can't read the UI or run code inside it. Browser rules already prevent that, and this PR doesn't change them. But it doesn't need to read anything. It can float the invisible UI under its own "tap to continue" button and let you click the real thing yourself.

Your click lands in the real UI, from the real origin. So it goes through.

Four actions are one click each, with no confirmation:

- `/api/pause`
- `/api/reset-halt`
- `/api/vault/sweep`
- `/api/vault/redeem`

Two others were already out of reach. `/api/stop` asks you to confirm, and browsers suppress confirm dialogs inside a cross-origin frame. `/api/send` needs an address and an amount typed in.

This matters most on a phone or tablet. You reach the UI there over the remote-access tunnel, on `127.0.0.1:8686`, and that address is open to anything on the device — including the browser.

## The fix

Two headers on every response, telling the browser to refuse framing:

```
Content-Security-Policy: frame-ancestors 'none'
X-Frame-Options: DENY
```

Three things about how they're set.

They go in once, at the top of `handle()`. The server writes headers from four different places, and Node merges anything set with `setHeader` into a later `writeHead`. So one line covers all four, and a route added later can't forget it.

They're set before the Host and CSRF checks run. Those checks return 403s, and a 403 is still a page someone can frame.

Both headers, not just the CSP. `frame-ancestors` is the real control. `X-Frame-Options` costs one extra line and still covers older WebViews that ignore CSP, which is a plausible way to open this UI from a phone.

## What I left out

A full CSP — `default-src`, `script-src`, and the rest. It would be stronger, but the UI is a Vite bundle with inline styles and a live SSE connection, so the policy has to be worked out from the build output and checked against the running app. That's worth its own PR. Framing was the specific hole here.

## Testing

A new test checks both headers on three kinds of response: HTML, JSON, and a 403.

Rebased onto main, most recently over #1245 and #1248, then re-ran:

- 109 tests pass across `ui-server`, `ui-server-tunnel`, `setup-api` and `tunnel`
- biome clean
