### PR TITLE
[simplex]: move operator state into bids.db and retire runtime-state.json

### DIFF
--- a/docs/content/developers/sdk/api/simplex.mdx
+++ b/docs/content/developers/sdk/api/simplex.mdx
@@ -668,9 +668,16 @@ else, so an implementation may prune, sample or cap history freely.
 ```typescript lineNumbers
 get(): Promise<RuntimeState>
 set(state: RuntimeState): Promise<void>
+patch?(patch: Partial<RuntimeState>): Promise<RuntimeState>
 ```
 
-`RuntimeState` is `{ paused?: boolean }`.
+`RuntimeState` is `{ paused?: boolean, phantomBids?: Record<string, string> }`.
+
+`set` replaces the whole record. `patch` is optional and merges, leaving keys it does not name
+untouched — implement it if your backend can do that atomically. The fallback when you do not is a
+read, a merge and a write back, which loses a key another writer set in between. That race is real
+on a running filler: `paused` is written by the operator and `phantomBids` by the bid batch, from
+different places at unrelated times.
 
 ### Implementations
 
@@ -679,8 +686,10 @@ set(state: RuntimeState): Promise<void>
 | `MemoryDataStore` | `@hyperbridge/simplex` | Default. Process-local, row-capped, lost on exit |
 | `SqliteDataStore` | `@hyperbridge/simplex/sqlite` | Durable. Built on `node:sqlite`, so nothing to install |
 
-`SqliteDataStore(dataDir)` keeps `bids.db`, `activity.db` and `runtime-state.json` in the given
-directory, so a data directory written by the binary is picked up unchanged. It is built on Node's
+`SqliteDataStore(dataDir)` keeps `bids.db` and `activity.db` in the given directory, so a data
+directory written by the binary is picked up unchanged. Operator state rides in `bids.db` beside
+the bids, and implements `patch`; a `runtime-state.json` from an earlier version is imported once
+and then removed. It is built on Node's
 built-in `node:sqlite`, so there is no native module to install or compile — which is why the
 package requires Node 22.16 or newer.
 

--- a/sdk/packages/simplex/docs/ai/changelog/2026-09-10-operator-state-moved-into-bids-db-runtime-state-json-retired.md
+++ b/sdk/packages/simplex/docs/ai/changelog/2026-09-10-operator-state-moved-into-bids-db-runtime-state-json-retired.md
@@ -1,0 +1,34 @@
+# Operator state moved into `bids.db`; `runtime-state.json` retired
+
+`FileStateStore` is now `SqliteStateStore`, backed by a `runtime_state` table in `bids.db` — the
+database `SqliteBidStore` already holds open — with one row per `RuntimeState` key and the value
+JSON-encoded. `SqliteDataStore` passes it the bids connection and the data directory.
+
+Two bugs go with the file. Its `writeFileSync` truncated before writing, so a crash mid-write left
+JSON that would not parse and `get()` fell back to `{}`, silently resuming a paused filler and
+stranding the phantom deposit the file existed to reclaim. And every writer went through
+`patchRuntimeState`'s read-merge-write, so the phantom batch and an operator pause could drop one
+another's key. `StateStore` gained an optional `patch`, which the SQLite store implements as an
+upsert of only the named keys inside one transaction; `patchRuntimeState` uses it when present and
+otherwise keeps the old get-then-set, which is what `MemoryDataStore` gets. A key set to
+`undefined` deletes its row. `node:sqlite` has no transaction helper, so `write` brackets its
+statements with `BEGIN`/`COMMIT` and rolls back on a throw.
+
+Existing data directories are migrated on open: if `runtime_state` is empty the store reads
+`runtime-state.json` from the data directory, then from `.filler-data/` relative to cwd, writes
+what it finds, and unlinks both copies. Guarding on an empty table means it can never overwrite
+state the database already holds; deleting both copies means an empty database cannot resurrect a
+pause the operator has since lifted.
+
+Writes still swallow their errors (logged now, which the file store could not do) so a pause that
+cannot be persisted still pauses the filler; reads no longer do, so an unreadable database fails
+`bootFiller` instead of starting a filler that was paused.
+
+No version bump here. The `FileStateStore` export from `@hyperbridge/simplex/sqlite` is gone and
+the on-disk format changed, so whichever release picks this up owes at least a minor.
+
+Files: `src/data/sqlite/state.ts`, `src/data/sqlite/index.ts`, `src/data/state.ts`,
+`src/data/types.ts`, `src/tests/data/state-store.test.ts`,
+`docs/ai/flows/operator-state-on-disk.md`,
+`docs/ai/flows/opening-an-operator-data-directory.md`,
+`docs/ai/flows/phantom-bid-deposits-across-restarts.md`.

--- a/sdk/packages/simplex/docs/ai/changelog/2026-09-10-operator-state-moved-into-bids-db-runtime-state-json-retired.md
+++ b/sdk/packages/simplex/docs/ai/changelog/2026-09-10-operator-state-moved-into-bids-db-runtime-state-json-retired.md
@@ -16,9 +16,17 @@ statements with `BEGIN`/`COMMIT` and rolls back on a throw.
 
 Existing data directories are migrated on open: if `runtime_state` is empty the store reads
 `runtime-state.json` from the data directory, then from `.filler-data/` relative to cwd, writes
-what it finds, and unlinks both copies. Guarding on an empty table means it can never overwrite
-state the database already holds; deleting both copies means an empty database cannot resurrect a
-pause the operator has since lifted.
+what it finds, and unlinks the copies it read. Guarding on an empty table means it can never
+overwrite state the database already holds; deleting every readable copy — not just the imported
+one — means an empty database cannot resurrect a pause the operator has since lifted.
+
+Only files that were read back are deleted, which the first draft got wrong: it unlinked both paths
+whether or not the read succeeded, so a `runtime-state.json` that existed but could not be read
+(no permission, an I/O error, malformed JSON) was destroyed and its pause and phantom bids lost —
+the exact state the import exists to rescue. Found in review by @royvardhan, who reproduced it with
+a mode-000 file holding a real pause. A missing file is still silent, since that is the normal
+case; every other read failure logs and leaves the file where it is. A parsed value that is not a
+plain object counts as a failed read for the same reason.
 
 Writes still swallow their errors (logged now, which the file store could not do) so a pause that
 cannot be persisted still pauses the filler; reads no longer do, so an unreadable database fails

--- a/sdk/packages/simplex/docs/ai/changelog/2026-09-10-review-fix-the-state-store-s-rollback-is-guarded-like-attachorder-s.md
+++ b/sdk/packages/simplex/docs/ai/changelog/2026-09-10-review-fix-the-state-store-s-rollback-is-guarded-like-attachorder-s.md
@@ -1,0 +1,26 @@
+# 2026-09-10 — Review fix: the state store's ROLLBACK is guarded like `attachOrder`'s
+
+`SqliteStateStore.write` brackets its statements with `BEGIN`/`COMMIT` by hand, because
+`node:sqlite` has no transaction helper — but it rolled back unconditionally, which is the shape
+`2026-09-09-attachorder-s-transaction-is-explicit-begin-commit-rollback.md` rejected. SQLite rolls
+a failed COMMIT back on its own, so `ROLLBACK` from the catch block throws
+`cannot rollback - no transaction is active` before `throw err` is reached, and the real cause is
+discarded.
+
+That cost more here than it would have at the other call site. Through `set` and `patch` the error
+only ever reaches `persist`, which logs it: an operator whose pause will not survive a restart read
+`Could not persist operator state: cannot rollback - no transaction is active` instead of the
+`SQLITE_FULL` or `SQLITE_IOERR` that named the actual problem. Through `importRetiredStateFile` the
+`write` is deliberately outside `persist` and `openDataStore` no longer wraps store construction,
+so a COMMIT that failed during the one-time migration aborted boot reporting the rollback rather
+than the import.
+
+Now the same guarded form as `SqliteActivityStore.attachOrder`: `isTransaction !== false` — the
+comparison, not truthiness, because the Node 23 line never got the property and `engines` is
+advisory — with the ROLLBACK in its own catch for the runtime that cannot answer the question.
+
+One test, failing against the previous behaviour: a `DatabaseSync` proxy whose COMMIT rolls back
+and then throws, as SQLite does, asserting the logged record carries the real error and not the
+rollback one.
+
+Files: `src/data/sqlite/state.ts`, `src/tests/data/state-store.test.ts`.

--- a/sdk/packages/simplex/docs/ai/changelog/2026-09-10-review-fixes-patch-rejects-duplicate-paths-and-stale-api-docs.md
+++ b/sdk/packages/simplex/docs/ai/changelog/2026-09-10-review-fixes-patch-rejects-duplicate-paths-and-stale-api-docs.md
@@ -1,0 +1,33 @@
+# Review fixes: `patch` rejecting, duplicate candidate paths, stale API docs
+
+Three findings from @Wizdave97 on #1234, all confirmed in the code before being acted on.
+
+`SqliteStateStore.patch` guarded its write with `persist` but then called `read()` outside the
+guard, so an unreadable `bids.db` still rejected. That is the only path production takes —
+`Simplex.pause/resume`, the CLI's `setPaused` and the phantom batch all reach the store through
+`patchRuntimeState`, and nothing outside tests calls `set`. `UiServer` pauses the filler at
+`/api/pause` and *then* awaits `setPaused`, so the rejection returned a 500 while the filler was in
+fact paused — exactly what `persist` promises will not happen. The write and the read-back now run
+inside one guard, and a failure returns the requested patch: with the database unreadable that is
+the most that can honestly be said, the failure is already logged, and no caller reads the value.
+`persist` is generic over its return type to allow this. The existing test missed it because it
+exercised `set`, which never reads.
+
+The two candidate paths for the retired JSON file were not de-duplicated. `--data-dir .filler-data`
+makes `join(dataDir, …)` and `resolve(cwd, ".filler-data", …)` the same file under a relative and
+an absolute string, so it was imported twice and unlinked twice — the second failing with ENOENT
+and logging that a stale file had survived when it had not. Both paths are now `resolve`d and
+passed through a `Set`.
+
+`docs/content/developers/sdk/api/simplex.mdx` still described `SqliteDataStore` as keeping
+`runtime-state.json`, and its `StateStore` snippet omitted the new optional `patch`. Since the
+stated reason for making `patch` optional is third-party implementers, and that page is what they
+read, leaving it out would have shipped them the read-merge-write race. `RuntimeState` was also
+still documented as `{ paused?: boolean }`, from before `phantomBids` existed.
+
+Two tests, each failing against the previous behaviour: `patch` on a closed database resolves
+rather than rejecting, and a data directory that *is* the legacy directory imports once with no
+"could not delete" warning. The second reads the store's log through a `LoggerContext` sink.
+
+Files: `src/data/sqlite/state.ts`, `src/tests/data/state-store.test.ts`,
+`docs/content/developers/sdk/api/simplex.mdx`, `docs/ai/flows/operator-state-on-disk.md`.

--- a/sdk/packages/simplex/docs/ai/decisions/2026-09-10-operator-state-lives-in-bids-db-and-the-json-file-is-deleted.md
+++ b/sdk/packages/simplex/docs/ai/decisions/2026-09-10-operator-state-lives-in-bids-db-and-the-json-file-is-deleted.md
@@ -1,0 +1,25 @@
+# Operator state lives in `bids.db`, and `runtime-state.json` is deleted on sight
+
+Chosen: `SqliteStateStore` keeps `RuntimeState` as one row per key in `bids.db`, the database the
+bid store already owns. The JSON file it replaces is imported once, from the data directory and
+from the older `.filler-data/`, and then unlinked from both.
+
+The file was never a decision — it arrived with pause/resume in July, before `SimplexDataStore`
+existed, and survived the library extraction unexamined. It had two defects. `writeFileSync` opens
+with truncate, so a crash mid-write left a file that would not parse, and the reader's fallback
+returned `{}`: a paused filler resumed and a live phantom bid was forgotten, which are the only two
+things the file carried. And `patchRuntimeState` read, merged and wrote back, so the phantom batch
+and an operator pause could drop one another's key — the merge helper narrowed that window but
+could not close it. Both are free in SQLite, which the process already has open on this exact file.
+
+Alternatives rejected: a temp-file-plus-rename would have made the write atomic but left the
+read-modify-write race and a third storage format in a directory that already has two databases. A
+separate `state.db` would add a file and a handle to carry one boolean. Keeping the JSON file
+around after importing it was rejected too — an empty database reads it again, so a copy left
+behind resurrects a pause the operator has since lifted. The cost is that a downgrade past this finds no
+state and starts unpaused; the version that reads the file is the one that deletes it, so this is a
+one-way door by construction.
+
+`StateStore.patch` is optional rather than required, because the interface is public and a consumer
+backing it with Postgres or an HTTP API should not have to implement two writers to keep compiling.
+`patchRuntimeState` prefers it and falls back to get-then-set, which is what `MemoryDataStore` uses.

--- a/sdk/packages/simplex/docs/ai/decisions/2026-09-10-operator-state-lives-in-bids-db-and-the-json-file-is-deleted.md
+++ b/sdk/packages/simplex/docs/ai/decisions/2026-09-10-operator-state-lives-in-bids-db-and-the-json-file-is-deleted.md
@@ -16,7 +16,9 @@ Alternatives rejected: a temp-file-plus-rename would have made the write atomic 
 read-modify-write race and a third storage format in a directory that already has two databases. A
 separate `state.db` would add a file and a handle to carry one boolean. Keeping the JSON file
 around after importing it was rejected too — an empty database reads it again, so a copy left
-behind resurrects a pause the operator has since lifted. The cost is that a downgrade past this finds no
+behind resurrects a pause the operator has since lifted. Deletion is limited to files that were
+actually read back: a file that exists but cannot be read may still hold the pause, and unlinking
+it destroys the state the import exists to rescue. The cost is that a downgrade past this finds no
 state and starts unpaused; the version that reads the file is the one that deletes it, so this is a
 one-way door by construction.
 

--- a/sdk/packages/simplex/docs/ai/decisions/2026-09-10-the-second-hand-rolled-transaction-is-copied-not-extracted.md
+++ b/sdk/packages/simplex/docs/ai/decisions/2026-09-10-the-second-hand-rolled-transaction-is-copied-not-extracted.md
@@ -1,0 +1,30 @@
+# 2026-09-10 — The second hand-rolled transaction is copied, not extracted into a helper
+
+Decided: `SqliteStateStore.write` repeats the `BEGIN`/`COMMIT`/guarded-`ROLLBACK` block from
+`SqliteActivityStore.attachOrder` verbatim rather than either simplifying it or factoring the two
+into a shared `transaction(fn)`.
+
+`2026-09-09-attachorder-s-transaction-is-explicit-begin-commit-rollback.md` rejected a helper
+partly because "there is one call site". That is no longer true — this is the second — so the
+question was worth asking again, and the answer is still no. A helper would have to decide what to
+do about nesting, which `node:sqlite` rejects, and about savepoints; neither call site nests, so it
+would be designing for a case that does not exist. Two call sites is also exactly where a helper is
+least valuable and most likely to be built for the wrong shape.
+
+What is *not* optional is the guard. Both halves of it are load-bearing and neither is obvious
+from reading the block:
+
+- `isTransaction !== false`, not `if (isTransaction)`. SQLite rolls a failed COMMIT back itself, so
+  an unconditional ROLLBACK throws `cannot rollback - no transaction is active` over the real
+  cause. But the property landed after the `engines.node` floor and the Node 23 line never got it,
+  and `engines` is advisory in npm and pnpm — so truthiness would skip the ROLLBACK on a runtime
+  that is admitted, wedging the connection mid-transaction.
+- The inner `catch {}` covers only that runtime: where `isTransaction` cannot answer, the ROLLBACK
+  is attempted anyway and its own failure must not displace `err` either.
+
+Copying it whole is what keeps those two properties together. Simplifying either of them at this
+call site would have reintroduced a defect the other call site already paid for in review.
+
+Rejected: leaving `write` unwrapped and letting `persist` swallow whatever arrives. `persist` does
+swallow it, but it logs it first, and the log is the only thing an operator has when a pause does
+not survive a restart. `importRetiredStateFile` does not go through `persist` at all.

--- a/sdk/packages/simplex/docs/ai/flows/opening-an-operator-data-directory.md
+++ b/sdk/packages/simplex/docs/ai/flows/opening-an-operator-data-directory.md
@@ -23,8 +23,10 @@ better-sqlite3-written databases on 2026-09-09.
    absent, then add `order_json TEXT` to `events` and `token_in`/`amount_in TEXT` to
    `wallet_txs` when `columnNames` says they are missing. Rows written before those columns
    existed therefore read back with `order: null` and `tokenIn`/`amountIn: null`.
-5. `FileStateStore` takes the same directory for `runtime-state.json`. It is plain JSON on
-   disk, not SQLite, and is unaffected by any of the above.
+5. `SqliteStateStore` takes the `bids.db` connection and the data directory. It creates
+   `runtime_state` the same additive way, then — only when that table is empty — imports the
+   `runtime-state.json` earlier versions kept here, and deletes every copy it could read. See
+   [operator state on disk](./operator-state-on-disk.md).
 6. Who closes it depends on who opened it. `Simplex.start` sets `ownsData: !options.data`, and
    `core/boot.ts` closes the store on shutdown only `if (options.ownsData)` — so a store the
    caller handed in is the caller's to close, since it may be shared with another solver. The

--- a/sdk/packages/simplex/docs/ai/flows/operator-state-on-disk.md
+++ b/sdk/packages/simplex/docs/ai/flows/operator-state-on-disk.md
@@ -11,7 +11,9 @@ both `SqliteBidStore` and `SqliteStateStore`. The state store keeps one `runtime
 
 `node:sqlite` has no transaction helper, so `write` brackets its statements with `BEGIN`/`COMMIT`
 by hand and rolls back on a throw. Without it a `set` could be observed with the old rows deleted
-and the new ones not yet written.
+and the new ones not yet written. The rollback is guarded on `isTransaction !== false`, the same
+shape as `SqliteActivityStore.attachOrder`: SQLite rolls a failed COMMIT back itself, and rolling
+back again throws `cannot rollback - no transaction is active` over the error worth reading.
 
 On construction the store imports the `runtime-state.json` earlier versions wrote — first from the
 data directory, then from `.filler-data/` relative to the process's cwd — but only when

--- a/sdk/packages/simplex/docs/ai/flows/operator-state-on-disk.md
+++ b/sdk/packages/simplex/docs/ai/flows/operator-state-on-disk.md
@@ -15,9 +15,14 @@ and the new ones not yet written.
 
 On construction the store imports the `runtime-state.json` earlier versions wrote — first from the
 data directory, then from `.filler-data/` relative to the process's cwd — but only when
-`runtime_state` is empty, so it can never overwrite state the database already holds. Both copies
-are then deleted: one left behind is read again by the next empty database, resurrecting a pause
-the operator has since lifted.
+`runtime_state` is empty, so it can never overwrite state the database already holds. Every copy it
+managed to read is then deleted, not just the one it imported: a copy left behind is read again by
+the next empty database, resurrecting a pause the operator has since lifted.
+
+A file it could not read is left alone. A missing file is silent, since that is the normal case;
+any other failure — no permission, an I/O error, malformed JSON, or a parsed value that is not a
+plain object — logs at warn and keeps the file, because it may still hold the pause and deleting it
+would destroy the state the import exists to rescue.
 
 Writes are wrapped so a failure logs instead of throwing: a pause that cannot be persisted still
 pauses the filler. Reads are not, so a database that cannot be read fails `bootFiller` rather than

--- a/sdk/packages/simplex/docs/ai/flows/operator-state-on-disk.md
+++ b/sdk/packages/simplex/docs/ai/flows/operator-state-on-disk.md
@@ -25,5 +25,12 @@ plain object — logs at warn and keeps the file, because it may still hold the 
 would destroy the state the import exists to rescue.
 
 Writes are wrapped so a failure logs instead of throwing: a pause that cannot be persisted still
-pauses the filler. Reads are not, so a database that cannot be read fails `bootFiller` rather than
+pauses the filler. `patch` wraps its read-back too, returning the requested patch if the database
+cannot be read — production reaches the store only through `patch`, and `UiServer` pauses the
+filler before awaiting it, so a throw would report failure for a pause that had already happened.
+`get` is deliberately unwrapped, so a database that cannot be read fails `bootFiller` rather than
 starting a filler the operator had paused.
+
+The two candidate paths are resolved to absolute and de-duplicated before any of this: with
+`--data-dir .filler-data` they name the same file, and importing and unlinking it twice logged a
+failure to delete a file that was already gone.

--- a/sdk/packages/simplex/docs/ai/flows/operator-state-on-disk.md
+++ b/sdk/packages/simplex/docs/ai/flows/operator-state-on-disk.md
@@ -1,0 +1,24 @@
+# Operator state on disk
+
+`SqliteDataStore` opens `bids.db` and `activity.db` in the data directory and hands `bids.db` to
+both `SqliteBidStore` and `SqliteStateStore`. The state store keeps one `runtime_state` row per
+`RuntimeState` key (`paused`, `phantomBids`), value JSON-encoded.
+
+- `set` replaces every row inside one transaction.
+- `patch` upserts only the keys it was given, and a key set to `undefined` deletes its row.
+- `patchRuntimeState` calls `patch` when the store has one, and otherwise reads and writes the
+  whole record back, which is what `MemoryDataStore` gets.
+
+`node:sqlite` has no transaction helper, so `write` brackets its statements with `BEGIN`/`COMMIT`
+by hand and rolls back on a throw. Without it a `set` could be observed with the old rows deleted
+and the new ones not yet written.
+
+On construction the store imports the `runtime-state.json` earlier versions wrote — first from the
+data directory, then from `.filler-data/` relative to the process's cwd — but only when
+`runtime_state` is empty, so it can never overwrite state the database already holds. Both copies
+are then deleted: one left behind is read again by the next empty database, resurrecting a pause
+the operator has since lifted.
+
+Writes are wrapped so a failure logs instead of throwing: a pause that cannot be persisted still
+pauses the filler. Reads are not, so a database that cannot be read fails `bootFiller` rather than
+starting a filler the operator had paused.

--- a/sdk/packages/simplex/docs/ai/flows/phantom-bid-deposits-across-restarts.md
+++ b/sdk/packages/simplex/docs/ai/flows/phantom-bid-deposits-across-restarts.md
@@ -4,7 +4,9 @@
 chain's `placeBid` and, when `lastPhantomCommitmentByChain` has a previous bid for the chain, its
 `retractBid` (refunding the 0.01 BRIDGE storage deposit). `rememberPhantomBid` updates that map on a
 landed or pooled bid and persists it as `RuntimeState.phantomBids` through `patchRuntimeState`
-(read-modify-write; `Simplex.pause/resume` and the CLI's `setPaused` use the same helper so they
-never drop the key). `bootFiller` reads the state before starting and calls
+(`Simplex.pause/resume` and the CLI's `setPaused` use the same helper, and the SQLite store's
+`patch` writes only the key it is given, so neither drops the other's — see
+[operator state on disk](./operator-state-on-disk.md)). `bootFiller` reads the state before
+starting and calls
 `restorePhantomBids`, so the first batch of a new process retracts the bid the previous process
 left live. A chain already remembered by the running process is not overwritten by the restore.

--- a/sdk/packages/simplex/src/data/sqlite/index.ts
+++ b/sdk/packages/simplex/src/data/sqlite/index.ts
@@ -5,11 +5,11 @@ import { defaultLoggerContext, type Logger, type LoggerContext } from "@/service
 import type { ActivityStore, BidStore, SimplexDataStore, StateStore } from "@/data/types"
 import { SqliteActivityStore } from "./activity"
 import { SqliteBidStore } from "./bids"
-import { FileStateStore } from "./state"
+import { SqliteStateStore } from "./state"
 
 export { SqliteActivityStore } from "./activity"
 export { SqliteBidStore } from "./bids"
-export { FileStateStore } from "./state"
+export { SqliteStateStore } from "./state"
 
 /**
  * How long a write waits for another connection's lock before giving up.
@@ -31,7 +31,8 @@ const BUSY_TIMEOUT_MS = 5_000
  *
  * Keeps bids and activity in separate database files (`bids.db`,
  * `activity.db`) so an existing data directory written by an earlier version is
- * picked up unchanged, plus `runtime-state.json` for operator state.
+ * picked up unchanged. Operator state rides in `bids.db` beside the bids; a
+ * `runtime-state.json` from before that is imported once and deleted.
  *
  * Built on `node:sqlite`, so there is nothing to install and nothing to
  * compile — the engine ships inside the Node runtime. That is why the package
@@ -59,7 +60,7 @@ export class SqliteDataStore implements SimplexDataStore {
 		this.databases = [bidsDb, activityDb]
 		this.bids = new SqliteBidStore(bidsDb, loggers)
 		this.activity = new SqliteActivityStore(activityDb, loggers)
-		this.state = new FileStateStore(dataDir)
+		this.state = new SqliteStateStore(bidsDb, dataDir, loggers)
 
 		this.logger.info({ dataDir }, "SQLite data store opened")
 	}

--- a/sdk/packages/simplex/src/data/sqlite/state.ts
+++ b/sdk/packages/simplex/src/data/sqlite/state.ts
@@ -1,5 +1,5 @@
 import { readFileSync, unlinkSync } from "node:fs"
-import { join, resolve } from "node:path"
+import { resolve } from "node:path"
 import type { DatabaseSync } from "node:sqlite"
 import { defaultLoggerContext, type Logger, type LoggerContext } from "@/services/Logger"
 import type { RuntimeState, StateStore } from "@/data/types"
@@ -59,7 +59,16 @@ export class SqliteStateStore implements StateStore {
 		}
 		if (rows > 0) return
 
-		const paths = [join(dataDir, RETIRED_STATE_FILE), resolve(process.cwd(), RETIRED_STATE_DIR, RETIRED_STATE_FILE)]
+		// Resolved and de-duplicated: `--data-dir .filler-data` makes both entries
+		// the same file under different strings, which would import it twice and
+		// then unlink it twice — the second failing, and logging that a stale file
+		// survived when it did not.
+		const paths = [
+			...new Set([
+				resolve(dataDir, RETIRED_STATE_FILE),
+				resolve(process.cwd(), RETIRED_STATE_DIR, RETIRED_STATE_FILE),
+			]),
+		]
 		const recovered: { path: string; state: RuntimeState }[] = []
 
 		for (const path of paths) {
@@ -151,22 +160,35 @@ export class SqliteStateStore implements StateStore {
 	 * Merges `patch` in one transaction, leaving every other key untouched. The
 	 * generic {@link StateStore} fallback reads and writes back the whole record,
 	 * which loses a concurrent writer's key; this cannot.
+	 *
+	 * The read-back is inside the guard with the write. Every production caller
+	 * reaches this store through here — `Simplex.pause/resume`, the CLI's
+	 * `setPaused`, the phantom batch — so a throw is a pause that reports failure
+	 * while the filler is actually paused, which is the one thing {@link persist}
+	 * exists to prevent. With the database unreadable the requested patch is the
+	 * most that can honestly be said about the state; the failure is in the log,
+	 * and no caller reads this value.
 	 */
 	async patch(patch: Partial<RuntimeState>): Promise<RuntimeState> {
-		this.persist(() => this.write(patch, false))
-		return this.read()
+		return (
+			this.persist(() => {
+				this.write(patch, false)
+				return this.read()
+			}) ?? patch
+		)
 	}
 
 	/**
-	 * Runs a write, logging rather than throwing if it fails. A pause that cannot
-	 * be persisted must still pause the filler; only its survival across a
-	 * restart is lost.
+	 * Runs a write, logging rather than throwing if it fails, and returning
+	 * `undefined` in that case. A pause that cannot be persisted must still pause
+	 * the filler; only its survival across a restart is lost.
 	 */
-	private persist(write: () => void): void {
+	private persist<T>(work: () => T): T | undefined {
 		try {
-			write()
+			return work()
 		} catch (err) {
 			this.logger.warn({ err }, "Could not persist operator state")
+			return undefined
 		}
 	}
 }

--- a/sdk/packages/simplex/src/data/sqlite/state.ts
+++ b/sdk/packages/simplex/src/data/sqlite/state.ts
@@ -50,8 +50,8 @@ export class SqliteStateStore implements StateStore {
 
 	/**
 	 * Moves state out of the JSON file a previous version wrote, then removes
-	 * every copy of it. Runs only against an empty table, so it can never
-	 * overwrite state this database already holds.
+	 * the copies it managed to read. Runs only against an empty table, so it can
+	 * never overwrite state this database already holds.
 	 */
 	private importRetiredStateFile(dataDir: string): void {
 		const { rows } = this.db.prepare("SELECT COUNT(*) as rows FROM runtime_state").get() as unknown as {
@@ -60,25 +60,44 @@ export class SqliteStateStore implements StateStore {
 		if (rows > 0) return
 
 		const paths = [join(dataDir, RETIRED_STATE_FILE), resolve(process.cwd(), RETIRED_STATE_DIR, RETIRED_STATE_FILE)]
+		const recovered: { path: string; state: RuntimeState }[] = []
+
 		for (const path of paths) {
-			let state: RuntimeState
 			try {
-				state = JSON.parse(readFileSync(path, "utf-8")) as RuntimeState
-			} catch {
-				continue
+				const parsed = JSON.parse(readFileSync(path, "utf-8")) as unknown
+				if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+					throw new Error(`expected a JSON object, got ${Array.isArray(parsed) ? "an array" : typeof parsed}`)
+				}
+				recovered.push({ path, state: parsed as RuntimeState })
+			} catch (err) {
+				// An absent file is the normal case and says nothing. Anything else —
+				// no read permission, an I/O error, malformed JSON — may still hold the
+				// operator's pause, so the file stays put for them to recover. Deleting
+				// it would destroy the state this import exists to rescue.
+				if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+					this.logger.warn({ err, path }, "Could not read the retired state file; leaving it in place")
+				}
 			}
-			this.write(state, true)
-			this.logger.info({ path, keys: Object.keys(state) }, "Imported operator state from its retired JSON file")
-			break
 		}
 
-		// Delete every copy, imported or not: one left behind would be read again
-		// by the next empty database, resurrecting a pause the operator has since
-		// lifted. Best-effort — a read-only directory just keeps a dead file.
-		for (const path of paths) {
+		const [first] = recovered
+		if (first) {
+			this.write(first.state, true)
+			this.logger.info(
+				{ path: first.path, keys: Object.keys(first.state) },
+				"Imported operator state from its retired JSON file",
+			)
+		}
+
+		// Delete only what was read back. A copy left behind is read again by the
+		// next empty database, resurrecting a pause the operator has since lifted,
+		// so every readable copy goes — not just the one that was imported.
+		for (const { path } of recovered) {
 			try {
 				unlinkSync(path)
-			} catch {}
+			} catch (err) {
+				this.logger.warn({ err, path }, "Could not delete the retired state file")
+			}
 		}
 	}
 

--- a/sdk/packages/simplex/src/data/sqlite/state.ts
+++ b/sdk/packages/simplex/src/data/sqlite/state.ts
@@ -143,7 +143,21 @@ export class SqliteStateStore implements StateStore {
 			}
 			this.db.exec("COMMIT")
 		} catch (err) {
-			this.db.exec("ROLLBACK")
+			// Same shape as `SqliteActivityStore.attachOrder`, for the same reason: a
+			// COMMIT that fails has already rolled back, so an unconditional ROLLBACK
+			// throws `cannot rollback - no transaction is active` over the real cause
+			// — and the real cause is the one worth reading, here more than there,
+			// since `persist` only logs it and the migration's write fails a boot.
+			// Compared against `false`, not truthiness: the Node 23 line never got
+			// the property, and treating `undefined` as "no transaction" would skip
+			// the ROLLBACK and wedge the connection mid-transaction for good.
+			if (this.db.isTransaction !== false) {
+				try {
+					this.db.exec("ROLLBACK")
+				} catch {
+					// Nothing to roll back, or the connection is already gone.
+				}
+			}
 			throw err
 		}
 	}

--- a/sdk/packages/simplex/src/data/sqlite/state.ts
+++ b/sdk/packages/simplex/src/data/sqlite/state.ts
@@ -1,53 +1,153 @@
-import { readFileSync, writeFileSync } from "node:fs"
+import { readFileSync, unlinkSync } from "node:fs"
 import { join, resolve } from "node:path"
+import type { DatabaseSync } from "node:sqlite"
+import { defaultLoggerContext, type Logger, type LoggerContext } from "@/services/Logger"
 import type { RuntimeState, StateStore } from "@/data/types"
 
-const STATE_FILE = "runtime-state.json"
-
 /**
- * Where operator state lived before it moved into the data directory. Read once
- * as a fallback so an upgrade does not silently resume a paused filler.
+ * Where operator state lived before it moved into the database, newest first:
+ * beside the databases, then the pre-data-directory location. Imported once and
+ * deleted — a paused filler that silently resumed on upgrade would start
+ * committing capital the operator had stopped.
  */
-const LEGACY_DIR = ".filler-data"
+const RETIRED_STATE_FILE = "runtime-state.json"
+const RETIRED_STATE_DIR = ".filler-data"
 
 /**
- * Operator state in a small JSON file beside the SQLite databases.
+ * SQLite-backed {@link StateStore}, sharing `bids.db` with the bid store.
  *
- * Best-effort by design: both reads and writes swallow their errors. A
- * read-only data directory should degrade to "pause does not survive restart",
- * never to a filler that refuses to pause.
+ * `node:sqlite` is synchronous, so every method resolves immediately — the
+ * promises satisfy the interface, they do not defer work.
+ *
+ * One row per {@link RuntimeState} key, JSON-encoded, so a write touches only
+ * the keys it names. That is what the JSON file this replaces could not do: it
+ * was rewritten whole and non-atomically, so a crash mid-write truncated it and
+ * lost both the operator's pause and the live phantom bids — precisely the two
+ * things it existed to carry across a restart — while two overlapping
+ * read-modify-writes could drop one another's key.
  */
-export class FileStateStore implements StateStore {
-	private path: string
+export class SqliteStateStore implements StateStore {
+	private logger: Logger
 
-	constructor(dataDir: string) {
-		this.path = join(dataDir, STATE_FILE)
+	constructor(
+		private db: DatabaseSync,
+		dataDir: string,
+		loggers: LoggerContext = defaultLoggerContext(),
+	) {
+		this.logger = loggers.get("state-storage")
+		this.initializeSchema()
+		this.importRetiredStateFile(dataDir)
 	}
 
-	async get(): Promise<RuntimeState> {
-		try {
-			return JSON.parse(readFileSync(this.path, "utf-8")) as RuntimeState
-		} catch {
-			// Fall back to the pre-move location, and rewrite it forward so the
-			// migration happens once. A paused filler that silently resumed on
-			// upgrade would start committing capital the operator had stopped.
+	private initializeSchema(): void {
+		this.db.exec(`
+			CREATE TABLE IF NOT EXISTS runtime_state (
+				key TEXT PRIMARY KEY,
+				value TEXT NOT NULL
+			);
+		`)
+	}
+
+	/**
+	 * Moves state out of the JSON file a previous version wrote, then removes
+	 * every copy of it. Runs only against an empty table, so it can never
+	 * overwrite state this database already holds.
+	 */
+	private importRetiredStateFile(dataDir: string): void {
+		const { rows } = this.db.prepare("SELECT COUNT(*) as rows FROM runtime_state").get() as unknown as {
+			rows: number
+		}
+		if (rows > 0) return
+
+		const paths = [join(dataDir, RETIRED_STATE_FILE), resolve(process.cwd(), RETIRED_STATE_DIR, RETIRED_STATE_FILE)]
+		for (const path of paths) {
+			let state: RuntimeState
 			try {
-				const legacy = JSON.parse(
-					readFileSync(resolve(process.cwd(), LEGACY_DIR, STATE_FILE), "utf-8"),
-				) as RuntimeState
-				await this.set(legacy)
-				return legacy
+				state = JSON.parse(readFileSync(path, "utf-8")) as RuntimeState
 			} catch {
-				return {}
+				continue
 			}
+			this.write(state, true)
+			this.logger.info({ path, keys: Object.keys(state) }, "Imported operator state from its retired JSON file")
+			break
+		}
+
+		// Delete every copy, imported or not: one left behind would be read again
+		// by the next empty database, resurrecting a pause the operator has since
+		// lifted. Best-effort — a read-only directory just keeps a dead file.
+		for (const path of paths) {
+			try {
+				unlinkSync(path)
+			} catch {}
 		}
 	}
 
-	async set(state: RuntimeState): Promise<void> {
+	private read(): RuntimeState {
+		const rows = this.db.prepare("SELECT key, value FROM runtime_state").all() as unknown as {
+			key: string
+			value: string
+		}[]
+		const state: Record<string, unknown> = {}
+		for (const row of rows) state[row.key] = JSON.parse(row.value)
+		return state as RuntimeState
+	}
+
+	/**
+	 * Writes the keys `state` names. With `replace`, keys it does not name are
+	 * dropped — the whole-record semantics {@link StateStore.set} promises.
+	 */
+	private write(state: Partial<RuntimeState>, replace: boolean): void {
+		const upsert = this.db.prepare(`
+			INSERT INTO runtime_state (key, value) VALUES (?, ?)
+			ON CONFLICT(key) DO UPDATE SET value = excluded.value
+		`)
+		const remove = this.db.prepare("DELETE FROM runtime_state WHERE key = ?")
+
+		// `node:sqlite` has no transaction helper of its own, so the statements are
+		// bracketed by hand. Without this a `set` could be observed with the old
+		// rows deleted and the new ones not yet written.
+		this.db.exec("BEGIN")
 		try {
-			writeFileSync(this.path, JSON.stringify(state))
-		} catch {
-			// best-effort: a read-only data dir must not break pause/resume
+			if (replace) this.db.exec("DELETE FROM runtime_state")
+			for (const [key, value] of Object.entries(state)) {
+				if (value === undefined) remove.run(key)
+				else upsert.run(key, JSON.stringify(value))
+			}
+			this.db.exec("COMMIT")
+		} catch (err) {
+			this.db.exec("ROLLBACK")
+			throw err
+		}
+	}
+
+	async get(): Promise<RuntimeState> {
+		return this.read()
+	}
+
+	async set(state: RuntimeState): Promise<void> {
+		this.persist(() => this.write(state, true))
+	}
+
+	/**
+	 * Merges `patch` in one transaction, leaving every other key untouched. The
+	 * generic {@link StateStore} fallback reads and writes back the whole record,
+	 * which loses a concurrent writer's key; this cannot.
+	 */
+	async patch(patch: Partial<RuntimeState>): Promise<RuntimeState> {
+		this.persist(() => this.write(patch, false))
+		return this.read()
+	}
+
+	/**
+	 * Runs a write, logging rather than throwing if it fails. A pause that cannot
+	 * be persisted must still pause the filler; only its survival across a
+	 * restart is lost.
+	 */
+	private persist(write: () => void): void {
+		try {
+			write()
+		} catch (err) {
+			this.logger.warn({ err }, "Could not persist operator state")
 		}
 	}
 }

--- a/sdk/packages/simplex/src/data/state.ts
+++ b/sdk/packages/simplex/src/data/state.ts
@@ -1,11 +1,15 @@
 import type { RuntimeState, StateStore } from "./types"
 
 /**
- * Merges `patch` into the stored runtime state. `StateStore.set` replaces the
- * whole record, so every writer must go through here or it wipes the other
- * writers' keys (a pause would otherwise forget the live phantom bids).
+ * Merges `patch` into the stored runtime state.
+ *
+ * Uses the store's own atomic merge when it has one. Otherwise `StateStore.set`
+ * replaces the whole record, so every writer must come through here or it wipes
+ * the other writers' keys (a pause would otherwise forget the live phantom
+ * bids) — and even then two overlapping calls can lose one another's write.
  */
 export async function patchRuntimeState(store: StateStore, patch: Partial<RuntimeState>): Promise<RuntimeState> {
+	if (store.patch) return store.patch(patch)
 	const next = { ...(await store.get()), ...patch }
 	await store.set(next)
 	return next

--- a/sdk/packages/simplex/src/data/types.ts
+++ b/sdk/packages/simplex/src/data/types.ts
@@ -268,5 +268,13 @@ export interface RuntimeState {
 
 export interface StateStore {
 	get(): Promise<RuntimeState>
+	/** Replaces the whole record. Keys absent from `state` are dropped. */
 	set(state: RuntimeState): Promise<void>
+	/**
+	 * Merges `patch` into the stored record atomically, leaving keys it does not
+	 * name untouched. Optional: `patchRuntimeState` falls back to a read and a
+	 * `set` for stores that cannot do better, which loses a key written
+	 * concurrently. The bundled SQLite store implements it.
+	 */
+	patch?(patch: Partial<RuntimeState>): Promise<RuntimeState>
 }

--- a/sdk/packages/simplex/src/tests/data/state-store.test.ts
+++ b/sdk/packages/simplex/src/tests/data/state-store.test.ts
@@ -1,29 +1,116 @@
 import { describe, expect, it } from "vitest"
-import { mkdtempSync } from "fs"
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "fs"
 import { tmpdir } from "os"
 import { join } from "path"
 import { MemoryDataStore } from "@/data/memory"
-import { FileStateStore } from "@/data/sqlite/state"
+import { patchRuntimeState } from "@/data/state"
+import { SqliteDataStore } from "@/data/sqlite"
 
-describe("FileStateStore", () => {
+const dataDir = () => mkdtempSync(join(tmpdir(), "simplex-state-"))
+
+/** A store on a fresh data directory, plus the directory it was opened on. */
+function openStore(dir = dataDir()) {
+	const store = new SqliteDataStore(dir)
+	return { dir, state: store.state, close: () => store.close() }
+}
+
+describe("SqliteStateStore", () => {
 	it("round-trips operator state", async () => {
-		const store = new FileStateStore(mkdtempSync(join(tmpdir(), "simplex-state-")))
+		const { state } = openStore()
 
-		expect(await store.get()).toEqual({})
-		await store.set({ paused: true })
-		expect(await store.get()).toEqual({ paused: true })
-		await store.set({ paused: false })
-		expect(await store.get()).toEqual({ paused: false })
+		expect(await state.get()).toEqual({})
+		await state.set({ paused: true })
+		expect(await state.get()).toEqual({ paused: true })
+		await state.set({ paused: false })
+		expect(await state.get()).toEqual({ paused: false })
 	})
 
-	it("reads empty state from a directory that does not exist", async () => {
-		expect(await new FileStateStore("/nonexistent/simplex-test-dir").get()).toEqual({})
+	it("survives a reopen of the same data directory", async () => {
+		const first = openStore()
+		await first.state.set({ paused: true, phantomBids: { "EVM-8453": "0xabc" } })
+		await first.close()
+
+		const second = openStore(first.dir)
+		expect(await second.state.get()).toEqual({ paused: true, phantomBids: { "EVM-8453": "0xabc" } })
 	})
 
-	it("swallows write failures so an unwritable data dir cannot break pause", async () => {
+	it("patches one key without reading or rewriting the others", async () => {
+		const { state } = openStore()
+		await state.set({ paused: true, phantomBids: { "EVM-8453": "0xabc" } })
+
+		// The whole point of the atomic merge: a pause and a phantom bid landing
+		// concurrently must not drop one another.
+		await Promise.all([
+			patchRuntimeState(state, { paused: false }),
+			patchRuntimeState(state, { phantomBids: { "EVM-1": "0xdef" } }),
+		])
+
+		expect(await state.get()).toEqual({ paused: false, phantomBids: { "EVM-1": "0xdef" } })
+	})
+
+	it("drops a key set to undefined", async () => {
+		const { state } = openStore()
+		await state.set({ paused: true, phantomBids: { "EVM-8453": "0xabc" } })
+		await patchRuntimeState(state, { phantomBids: undefined })
+		expect(await state.get()).toEqual({ paused: true })
+	})
+
+	it("replaces the whole record on set", async () => {
+		const { state } = openStore()
+		await state.set({ paused: true, phantomBids: { "EVM-8453": "0xabc" } })
+		await state.set({ paused: false })
+		expect(await state.get()).toEqual({ paused: false })
+	})
+
+	it("swallows write failures so an unwritable store cannot break pause", async () => {
 		// A pause that cannot be persisted must still pause the filler; only its
 		// survival across a restart is lost.
-		await expect(new FileStateStore("/nonexistent/simplex-test-dir").set({ paused: true })).resolves.toBeUndefined()
+		const store = openStore()
+		await store.close()
+		await expect(store.state.set({ paused: true })).resolves.toBeUndefined()
+	})
+})
+
+describe("retired runtime-state.json", () => {
+	it("is imported on first open and then deleted", async () => {
+		const dir = dataDir()
+		const file = join(dir, "runtime-state.json")
+		writeFileSync(file, JSON.stringify({ paused: true, phantomBids: { "EVM-8453": "0xabc" } }))
+
+		const { state } = openStore(dir)
+
+		expect(await state.get()).toEqual({ paused: true, phantomBids: { "EVM-8453": "0xabc" } })
+		expect(existsSync(file)).toBe(false)
+	})
+
+	it("is imported from the pre-data-directory location too", async () => {
+		const cwd = process.cwd()
+		const home = dataDir()
+		mkdirSync(join(home, ".filler-data"))
+		writeFileSync(join(home, ".filler-data", "runtime-state.json"), JSON.stringify({ paused: true }))
+
+		try {
+			process.chdir(home)
+			const { state } = openStore()
+			expect(await state.get()).toEqual({ paused: true })
+			expect(existsSync(join(home, ".filler-data", "runtime-state.json"))).toBe(false)
+		} finally {
+			process.chdir(cwd)
+		}
+	})
+
+	it("never overwrites state the database already holds", async () => {
+		const first = openStore()
+		await first.state.set({ paused: false })
+		await first.close()
+		writeFileSync(join(first.dir, "runtime-state.json"), JSON.stringify({ paused: true }))
+
+		const second = openStore(first.dir)
+		expect(await second.state.get()).toEqual({ paused: false })
+	})
+
+	it("reads an empty record when there is nothing to import", async () => {
+		expect(await openStore().state.get()).toEqual({})
 	})
 })
 
@@ -33,5 +120,12 @@ describe("MemoryDataStore state", () => {
 		expect(await store.state.get()).toEqual({})
 		await store.state.set({ paused: true })
 		expect(await store.state.get()).toEqual({ paused: true })
+	})
+
+	it("merges through the get-then-set fallback", async () => {
+		const store = new MemoryDataStore()
+		await store.state.set({ paused: true })
+		await patchRuntimeState(store.state, { phantomBids: { "EVM-1": "0xdef" } })
+		expect(await store.state.get()).toEqual({ paused: true, phantomBids: { "EVM-1": "0xdef" } })
 	})
 })

--- a/sdk/packages/simplex/src/tests/data/state-store.test.ts
+++ b/sdk/packages/simplex/src/tests/data/state-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "fs"
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, writeFileSync } from "fs"
 import { tmpdir } from "os"
 import { join } from "path"
 import { MemoryDataStore } from "@/data/memory"
@@ -111,6 +111,69 @@ describe("retired runtime-state.json", () => {
 
 	it("reads an empty record when there is nothing to import", async () => {
 		expect(await openStore().state.get()).toEqual({})
+	})
+
+	it("keeps a file it could not parse instead of deleting it", async () => {
+		const dir = dataDir()
+		const file = join(dir, "runtime-state.json")
+		writeFileSync(file, '{"paused": tru')
+
+		const { state } = openStore(dir)
+
+		// Deleting a file we could not read destroys the very state this import
+		// exists to rescue. It stays put for the operator to recover.
+		expect(await state.get()).toEqual({})
+		expect(existsSync(file)).toBe(true)
+	})
+
+	it("keeps a file holding something other than an object", async () => {
+		const dir = dataDir()
+		const file = join(dir, "runtime-state.json")
+		writeFileSync(file, "null")
+
+		const { state } = openStore(dir)
+
+		expect(await state.get()).toEqual({})
+		expect(existsSync(file)).toBe(true)
+	})
+
+	// Root reads a mode-000 file regardless, which is how some CI containers run.
+	it.skipIf(process.getuid?.() === 0)("keeps a file it could not read instead of deleting it", async () => {
+		const dir = dataDir()
+		const file = join(dir, "runtime-state.json")
+		writeFileSync(file, JSON.stringify({ paused: true, phantomBids: { "EVM-8453": "0xabc" } }))
+		chmodSync(file, 0o000)
+
+		try {
+			const { state } = openStore(dir)
+			expect(await state.get()).toEqual({})
+			expect(existsSync(file)).toBe(true)
+		} finally {
+			chmodSync(file, 0o600)
+		}
+	})
+
+	it("deletes every readable copy, not just the one it imported", async () => {
+		const cwd = process.cwd()
+		const home = dataDir()
+		const dir = join(home, "data")
+		mkdirSync(dir)
+		mkdirSync(join(home, ".filler-data"))
+		writeFileSync(join(dir, "runtime-state.json"), JSON.stringify({ paused: true }))
+		writeFileSync(join(home, ".filler-data", "runtime-state.json"), JSON.stringify({ paused: false }))
+
+		try {
+			process.chdir(home)
+			const { state } = openStore(dir)
+
+			// The data directory wins, and the older copy goes too — left behind, it
+			// would be re-imported by the next empty database.
+			expect(await state.get()).toEqual({ paused: true })
+			expect(existsSync(join(dir, "runtime-state.json"))).toBe(false)
+			expect(existsSync(join(home, ".filler-data", "runtime-state.json"))).toBe(false)
+		} finally {
+			process.chdir(cwd)
+		}
 	})
 })
 

--- a/sdk/packages/simplex/src/tests/data/state-store.test.ts
+++ b/sdk/packages/simplex/src/tests/data/state-store.test.ts
@@ -2,16 +2,24 @@ import { describe, expect, it } from "vitest"
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, writeFileSync } from "fs"
 import { tmpdir } from "os"
 import { join } from "path"
+import { LoggerContext, type LogSink } from "@/services/Logger"
 import { MemoryDataStore } from "@/data/memory"
 import { patchRuntimeState } from "@/data/state"
 import { SqliteDataStore } from "@/data/sqlite"
 
 const dataDir = () => mkdtempSync(join(tmpdir(), "simplex-state-"))
 
+/** Captures every log line the store emits, so a test can assert on warnings. */
+function collector(): LogSink & { lines: string[] } {
+	const lines: string[] = []
+	return { lines, write: (line) => void lines.push(line) }
+}
+
 /** A store on a fresh data directory, plus the directory it was opened on. */
 function openStore(dir = dataDir()) {
-	const store = new SqliteDataStore(dir)
-	return { dir, state: store.state, close: () => store.close() }
+	const logs = collector()
+	const store = new SqliteDataStore(dir, new LoggerContext({ level: "warn", sink: logs }))
+	return { dir, logs, state: store.state, close: () => store.close() }
 }
 
 describe("SqliteStateStore", () => {
@@ -69,6 +77,16 @@ describe("SqliteStateStore", () => {
 		await store.close()
 		await expect(store.state.set({ paused: true })).resolves.toBeUndefined()
 	})
+
+	it("does not reject from patch on an unwritable store either", async () => {
+		// `patch` is the only path production takes — `Simplex.pause`, the CLI's
+		// `setPaused` and the phantom batch all route through `patchRuntimeState`.
+		// A rejection here tells the operator the pause failed while the filler is
+		// in fact paused, and returns a 500 from POST /api/pause.
+		const store = openStore()
+		await store.close()
+		await expect(store.state.patch!({ paused: true })).resolves.toEqual({ paused: true })
+	})
 })
 
 describe("retired runtime-state.json", () => {
@@ -107,6 +125,27 @@ describe("retired runtime-state.json", () => {
 
 		const second = openStore(first.dir)
 		expect(await second.state.get()).toEqual({ paused: false })
+	})
+
+	it("imports once when the data directory is the legacy directory", async () => {
+		// `--data-dir .filler-data` makes both candidate paths the same file under
+		// different strings. Unlinking it twice used to log that a stale copy had
+		// survived when it had not.
+		const cwd = process.cwd()
+		const home = dataDir()
+		mkdirSync(join(home, ".filler-data"))
+		writeFileSync(join(home, ".filler-data", "runtime-state.json"), JSON.stringify({ paused: true }))
+
+		try {
+			process.chdir(home)
+			const store = openStore(".filler-data")
+
+			expect(await store.state.get()).toEqual({ paused: true })
+			expect(existsSync(join(home, ".filler-data", "runtime-state.json"))).toBe(false)
+			expect(store.logs.lines.filter((line) => line.includes("Could not delete"))).toEqual([])
+		} finally {
+			process.chdir(cwd)
+		}
 	})
 
 	it("reads an empty record when there is nothing to import", async () => {

--- a/sdk/packages/simplex/src/tests/data/state-store.test.ts
+++ b/sdk/packages/simplex/src/tests/data/state-store.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest"
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, writeFileSync } from "fs"
 import { tmpdir } from "os"
 import { join } from "path"
+import { DatabaseSync } from "node:sqlite"
 import { LoggerContext, type LogSink } from "@/services/Logger"
 import { MemoryDataStore } from "@/data/memory"
 import { patchRuntimeState } from "@/data/state"
 import { SqliteDataStore } from "@/data/sqlite"
+import { SqliteStateStore } from "@/data/sqlite/state"
 
 const dataDir = () => mkdtempSync(join(tmpdir(), "simplex-state-"))
 
@@ -13,6 +15,27 @@ const dataDir = () => mkdtempSync(join(tmpdir(), "simplex-state-"))
 function collector(): LogSink & { lines: string[] } {
 	const lines: string[] = []
 	return { lines, write: (line) => void lines.push(line) }
+}
+
+/**
+ * A connection whose COMMIT fails the way SQLite fails one: the transaction is
+ * already rolled back by the time the error reaches the caller, so `ROLLBACK`
+ * from the catch block would throw over it.
+ */
+function commitFailsWith(db: DatabaseSync, failure: Error): DatabaseSync {
+	return new Proxy(db, {
+		get(target, prop) {
+			if (prop === "exec") {
+				return (sql: string) => {
+					if (sql.trim().toUpperCase() !== "COMMIT") return target.exec(sql)
+					target.exec("ROLLBACK")
+					throw failure
+				}
+			}
+			const value = Reflect.get(target, prop, target)
+			return typeof value === "function" ? value.bind(target) : value
+		},
+	})
 }
 
 /** A store on a fresh data directory, plus the directory it was opened on. */
@@ -86,6 +109,28 @@ describe("SqliteStateStore", () => {
 		const store = openStore()
 		await store.close()
 		await expect(store.state.patch!({ paused: true })).resolves.toEqual({ paused: true })
+	})
+
+	it("reports why a write failed, not that it could not roll back afterwards", async () => {
+		// SQLite rolls a failed COMMIT back on its own, so an unconditional ROLLBACK
+		// throws `cannot rollback - no transaction is active` over the real cause —
+		// and the real cause is the only one that says anything. Here it reaches the
+		// log; on the migration path `write` is outside `persist` and it fails a boot.
+		const dir = dataDir()
+		const db = new DatabaseSync(join(dir, "bids.db"))
+		const logs = collector()
+		const state = new SqliteStateStore(
+			commitFailsWith(db, new Error("disk I/O error")),
+			dir,
+			new LoggerContext({ level: "warn", sink: logs }),
+		)
+
+		await state.set({ paused: true })
+		db.close()
+
+		const logged = logs.lines.join("")
+		expect(logged).toContain("disk I/O error")
+		expect(logged).not.toContain("cannot rollback")
 	})
 })
 


### PR DESCRIPTION
Simplex keeps two pieces of operator state across restarts:

- `paused` — whether the operator has stopped the filler
- `phantomBids` — the live phantom bid on each chain, so the next run can retract it and get the 0.01 BRIDGE deposit back

Both lived in a `runtime-state.json` file next to `bids.db` and `activity.db`. This PR moves them into `bids.db` and deletes the file.

## Why

The file was never a deliberate choice. It arrived with pause/resume back in July, before the `SimplexDataStore` interface existed, and nobody revisited it when simplex became a library.

It had two bugs.

**A crash mid-write lost everything.** `writeFileSync` truncates the file before writing it. If the process died in between, the file no longer parsed, and the reader fell back to an empty record. A paused filler came back up unpaused, and the phantom deposit was stranded — the two failures the file existed to prevent, in the exact situation it was meant to cover.

**Two writers could overwrite each other.** Saving one key meant reading the whole record, merging, and writing it all back. The phantom batch and an operator pause could interleave and drop one another's key.

SQLite gives us both properties for free, and the process already has `bids.db` open.

## What changed

- `SqliteStateStore` keeps one row per key in `bids.db`, values JSON-encoded. Adding a key later needs no schema change.
- `StateStore` gains an optional `patch`. The SQLite store implements it as an upsert of just the named keys, in a single transaction.
- `patchRuntimeState` uses `patch` when the store has one, and keeps the old read-merge-write for stores that don't — which is what `MemoryDataStore` uses.

`patch` is optional because `StateStore` is public API. Someone backing it with Postgres or an HTTP service shouldn't have to implement two writers just to keep compiling.

Error handling keeps its old intent. Writes log instead of throwing, so a pause that can't be saved still pauses the filler. Reads now throw, so an unreadable database fails boot rather than quietly starting a filler the operator had paused.

## Upgrading

The first time a filler starts on this version, the store looks for the old file — first in the data directory, then in `.filler-data/` — imports whatever it finds, and deletes both copies.

It only does this when the table is empty, so it can't overwrite state the database already holds. Deleting both copies matters too: otherwise a fresh database would re-import a stale file and re-apply a pause the operator had already lifted.

One consequence worth knowing: **downgrading to 0.16.x loses the state and starts unpaused.** The version that reads the file is the one that deletes it.

## Breaking

`FileStateStore` is no longer exported from `@hyperbridge/simplex/sqlite`, and the on-disk state format changed. No version bump in this PR, so whichever release picks it up owes at least a minor.

## Testing

New tests cover the round trip, reopening a data directory, two concurrent patches, deleting a key, whole-record `set`, writing to a closed database, and all three migration cases.

The concurrent-patch test is a real regression test — it fails if you disable `patch` and let the old read-merge-write run.

CI is green. The first run hit an unrelated failure in `fx.testnet.test.ts`, where a Hyperbridge extrinsic couldn't replace an identical one already in the pool. It passed on re-run with no code change.
