### PR TITLE
[simplex]: Add a Unix domain socket listen mode to UiServer

### DIFF
--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -153,6 +153,65 @@ src/tests/data/sqlite-compat.test.ts (new), src/tests/data/fixtures/legacy-v0/ (
 src/tests/data/bid-store.test.ts, scripts/build.sh, package.json, ../../pnpm-lock.yaml,
 ../../pnpm-workspace.yaml, docs/content/developers/sdk/simplex.mdx,
 docs/content/developers/sdk/api/simplex.mdx.
+## 2026-09-09 — Security audit fixes for the Unix socket listen mode (#1245)
+
+A multi-agent security audit of the socket listen mode (8 independent lenses, findings deduped and put
+through 3-lens adversarial refutation) produced two surviving findings and one ordering bug; all three
+are fixed here, each pinned by a test that fails when the fix is reverted.
+
+**The socket is now created `0600` instead of being chmod'ed to `0600` after binding.** Binding first
+and narrowing after left the file at `0777 & ~umask` — 0775 under the common `umask 002` — for roughly
+a millisecond. That is not a theoretical window: Linux checks the mode at connect(2) and *never
+re-checks*, so a local user who connects inside it keeps a fully privileged, unauthenticated session
+for the life of the daemon — tightening the mode afterwards does not revoke an established connection.
+The audit won that race in 7 of 8 attempts with a connect loop. `listenPrivate` now sets `umask 0177`
+around the synchronous `listen` call, which makes libuv create the socket `0600` with no window at all;
+verified directly (mode is `600` at bind, `775` without the guard). Because `process.umask` is
+process-wide, it wraps only the synchronous call — libuv binds inside it, so no other JavaScript in the
+process can run in between.
+
+The old code's comment asserted this window "cannot be closed from Node". That was wrong, and it is
+corrected rather than merely superseded, since the claim is what would have kept the bug unfixed.
+
+`assertSocketIsPrivate` now **asserts** the mode rather than chmod-ing it. A repair there would restore
+the mode only after the socket had been reachable at the wrong one — reintroducing the window it is
+supposed to prove absent, and hiding the regression from the test. It also fails closed: the previous
+version logged a warning and kept serving the fund-moving API on a group-writable socket.
+
+**`clearStaleSocket` no longer deletes whatever sits at the socket path.** The stated invariant —
+"ECONNREFUSED means the file outlived its listener" — is false: connect(2) answers ECONNREFUSED for a
+regular file, a FIFO and a directory too, so `--ui-socket ~/filler-config.toml` silently deleted it
+(reproduced against a file holding a signer key). The type is now checked with `lstat` before any probe
+or unlink, and only a socket is ever a removal candidate. `lstat` rather than `existsSync` also fixes a
+DoS: `existsSync` follows symlinks, so a dangling one read as absent, nothing was cleaned up, and the
+bind then failed with a bare `EADDRINUSE` naming no cause.
+
+**`listenProvenance` and `boundLoopback` are assigned inside the `listen` callback, not before the
+bind.** Setting them first meant a rejected socket start on an already-listening server left a live TCP
+listener with every connection tagged `unix` — and so exempt from the Host-header check, re-opening DNS
+rebinding against `/api/send`. Reproduced against the real class. Not reachable from the CLI, which
+picks exactly one transport, but `UiServer` is exported and the desktop app this feature exists for is
+an embedder. `listenOnSocket` also refuses outright when the server is already listening.
+
+Smaller items from the same audit: the over-long-path error no longer suggests `$TMPDIR` (on Linux that
+is `/tmp`, mode 1777, and this path is the daemon's address) and points at `$XDG_RUNTIME_DIR` instead;
+`--ui-socket ""` is rejected rather than falling through to the TCP port the operator was avoiding;
+`isWindowsPipe` is gated on the platform, so a `\\.\pipe\` string on Linux is treated as the ordinary
+file it is; and the `--ui-socket` help text no longer claims owner-only access unconditionally, which
+this change's own Windows research contradicts.
+
+Audit findings deliberately not acted on: path squatting (`--ui-socket` has no default, so there is no
+well-known path to camp on, and the daemon is fail-closed on a live socket); chmod-through-symlink (the
+lstat gate closes it, and the sticky bit forbids the precondition anyway); and TCP-to-socket bridging
+(an operator who builds one has already converted a 0600 boundary back into an open port). Pre-existing
+issues recorded, not fixed here: the server has no authentication in any mode, `serveStatic`'s traversal
+guard uses a bare `startsWith`, and the stale `once("error")` handler swallows the first post-listen
+server error.
+
+Files: src/services/server/UiServer.ts, src/bin/simplex.ts, src/tests/ui-server-socket.test.ts,
+docs/ai/{ChangeLog,Decisions,Flow}.md.
+
+
 ## 2026-09-09 — UiServer can listen on a Unix domain socket (#1237)
 
 `UiServer.start()` now takes a listen target — `{ host, port }` as before, or `{ socketPath }` — and
@@ -163,16 +222,18 @@ be embedded by a desktop app with no TCP port open at all. The CLI's default is 
 or `--no-ui` rather than silently winning. Verified at the parser level against the real commander
 build: for every pre-existing argv, the parse result is identical with and without the new option.
 
-That check also turned up a pre-existing bug left untouched here: `--ui`'s declared flags,
-`[<[host:]port>]`, contain a `<`, and commander computes `required` as `flags.includes("<")`, so a
-valueless `--ui` is rejected with "argument missing" and the optional-argument form has never worked.
-Fixing it would change existing `--ui` behaviour, which this change had to leave alone.
+That check also turned up a pre-existing bug: `--ui`'s declared flags, `[<[host:]port>]`, contain a
+`<`, and commander computes `required` as `flags.includes("<")`, so a valueless `--ui` was rejected
+with "argument missing" and the optional-argument form had never worked. It was left out of this
+change to keep `--ui` untouched, and fixed separately in #1249, which also moved the `run` flags into
+`src/cli/run-options.ts`. `--ui-socket` is declared there with the rest of them.
 
-The socket is chmod'ed to `0600` after bind. This is the point of the mode, and Node does not do it:
-`listen(path)` creates the file `0777 & ~umask`, which is 0775 under the common `umask 002` — measured,
-not assumed — so without the chmod every member of the operator's group could connect and drive
-`/api/send`, which is an unauthenticated token transfer. Linux and macOS both check write permission on
-the socket file at connect(2), so the mode is enforced.
+The socket is created `0600`. This is the point of the mode, and Node does not do it: `listen(path)`
+creates the file `0777 & ~umask`, which is 0775 under the common `umask 002` — measured, not assumed —
+so otherwise every member of the operator's group could connect and drive `/api/send`, an
+unauthenticated token transfer. Linux and macOS both check write permission on the socket file at
+connect(2), so the mode is enforced. (The first version of this change chmod'ed after binding; see the
+security-audit entry below for why that was not sufficient.)
 
 Stale sockets are recovered rather than fatal. A `SIGKILL`ed run leaves the file behind and the next
 bind fails `EADDRINUSE` (both verified against a real killed process), so the path is connect-tested

--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -153,6 +153,53 @@ src/tests/data/sqlite-compat.test.ts (new), src/tests/data/fixtures/legacy-v0/ (
 src/tests/data/bid-store.test.ts, scripts/build.sh, package.json, ../../pnpm-lock.yaml,
 ../../pnpm-workspace.yaml, docs/content/developers/sdk/simplex.mdx,
 docs/content/developers/sdk/api/simplex.mdx.
+## 2026-09-09 — UiServer can listen on a Unix domain socket (#1237)
+
+`UiServer.start()` now takes a listen target — `{ host, port }` as before, or `{ socketPath }` — and
+`simplex --ui-socket <path>` selects the second from the CLI. Node's `listen(path)` speaks HTTP over a
+Unix socket natively, so the route table, the handlers and the SSE stream are untouched; the daemon can
+be embedded by a desktop app with no TCP port open at all. The CLI's default is unchanged: `--ui` and
+`--no-ui` behave exactly as before, and `--ui-socket` conflicts with either an explicit `--ui <addr>`
+or `--no-ui` rather than silently winning. Verified at the parser level against the real commander
+build: for every pre-existing argv, the parse result is identical with and without the new option.
+
+That check also turned up a pre-existing bug left untouched here: `--ui`'s declared flags,
+`[<[host:]port>]`, contain a `<`, and commander computes `required` as `flags.includes("<")`, so a
+valueless `--ui` is rejected with "argument missing" and the optional-argument form has never worked.
+Fixing it would change existing `--ui` behaviour, which this change had to leave alone.
+
+The socket is chmod'ed to `0600` after bind. This is the point of the mode, and Node does not do it:
+`listen(path)` creates the file `0777 & ~umask`, which is 0775 under the common `umask 002` — measured,
+not assumed — so without the chmod every member of the operator's group could connect and drive
+`/api/send`, which is an unauthenticated token transfer. Linux and macOS both check write permission on
+the socket file at connect(2), so the mode is enforced.
+
+Stale sockets are recovered rather than fatal. A `SIGKILL`ed run leaves the file behind and the next
+bind fails `EADDRINUSE` (both verified against a real killed process), so the path is connect-tested
+first: `ECONNREFUSED` means the file outlived its listener and is unlinked; anything that answers is a
+running instance and is refused, which doubles as the single-instance lock. The path is also unlinked
+on clean shutdown. Over-long paths are rejected up front with the limit and a suggested fallback —
+without the guard they fail at bind with `listen EINVAL: invalid argument`, naming neither cause nor
+limit.
+
+`http-util`'s `VIA_TUNNEL` marker is generalised into a `PROVENANCE` symbol carrying `tcp` / `unix` /
+`tunnel`, stamped on sockets this process owns and therefore unforgeable in the same way. The
+host-header (DNS-rebinding) check is now skipped for socket-arrived connections — there is no name to
+rebind onto a socket and no browser that can open one — and is byte-for-byte unchanged for TCP.
+`isTunnelled()` keeps its signature and meaning.
+
+Also reworded `EmbeddedSshServer`'s "No UI to serve behind the tunnel" warning, which fires whenever
+the server declines a channel and therefore misreports a UI that exists but is not listening.
+
+New `src/tests/ui-server-socket.test.ts` (8 tests) covers the API, mutating routes, CSRF and SSE over a
+socket; the host-header skip alongside proof that TCP still rejects the same Hosts; the 0600 mode and
+unlink-on-stop; stale recovery and live refusal; the path-length error; and — the trap the issue calls
+out — that a socket-only server still serves tunnelled connections, which arrive injected rather than
+listened for. Each fix was mutation-checked: reverting it fails its test.
+
+Files: src/services/server/UiServer.ts, src/services/server/http-util.ts,
+src/services/tunnel/EmbeddedSshServer.ts, src/bin/simplex.ts, src/tests/ui-server-socket.test.ts,
+docs/ai/{ChangeLog,Decisions,Flow}.md.
 
 
 ## 2026-09-09 — Make the SSH tunnel's publickey guard fail closed

--- a/sdk/packages/simplex/docs/ai/Decisions.md
+++ b/sdk/packages/simplex/docs/ai/Decisions.md
@@ -202,6 +202,136 @@ database in the test.
 Rejected: skipping the fixture and trusting that SQLite's file format is driver-independent. It is
 — but the migrations, the WAL header on `activity.db`, and the row values are the parts that
 actually break, and none of them are guaranteed by the format.
+## 2026-09-09 — Connection provenance is tagged on the socket, not inferred from the listener
+
+Decided: every socket carries a `PROVENANCE` symbol holding `tcp`, `unix` or `tunnel`. The listener
+stamps what it accepted (prepended to `connection`, so the stamp lands before http attaches a parser),
+`accept()` stamps what the tunnel injected, and `markProvenance` keeps the first stamp so an injected
+channel is never relabelled by the listener's blanket one. `handle` reads `provenanceOf(req.socket)`.
+
+This generalises `VIA_TUNNEL`, which answered one boolean question. A Unix socket makes it three, and
+the request rules genuinely differ per provenance: a socket reaches only the owning user, a tunnel
+connection is an authenticated device with *fewer* rights than a local caller (it cannot manage remote
+access), and a TCP port reaches every local user and every web page on the machine.
+
+Why a symbol set on our own socket, rather than a header or a flag: it is unforgeable by construction.
+The value is set on an object this process created, and nothing a client can put on the wire reaches
+it. That was already the reason `VIA_TUNNEL` was a symbol; widening the value does not weaken it.
+
+Rejected: branching on what the server is listening on (`this.listenProvenance` read at request time,
+with no per-socket tag). It is one field instead of a stamp, and it is right today because each server
+listens one way. But tunnel connections are *injected* and never listened for, so the listening mode is
+already not the truth for them — the tunnel would have to keep its own marker anyway, leaving two
+mechanisms answering the same question. Tagging also makes `provenanceOf` total, so a socket arriving
+by some future path with no stamp is a visible bug rather than one that silently inherits whatever the
+listener happens to be.
+
+Rejected: keeping `VIA_TUNNEL` alongside a new socket flag. Two symbols, two call sites to keep in
+step, and the pair can disagree; `isTunnelled()` is now one line over the single tag and keeps its
+signature, so no caller changed.
+
+
+## 2026-09-09 — The host-header check is skipped for socket connections, not relaxed
+
+Decided: `hostHeaderAllowed` is not consulted at all when `provenanceOf(req.socket) === "unix"`. Its
+signature and its logic are untouched, and the TCP path through it is byte-for-byte what it was — it is
+still the DNS-rebinding defense, and the existing rebinding test still passes unchanged.
+
+Why skip rather than widen the allowed set: the check exists because an attacker page can resolve its
+own domain to a loopback address and become same-origin with the dashboard. Nothing about that applies
+to a Unix socket. A browser cannot open a socket file at all, so there is no origin to rebind and
+nothing for the check to defend; and an HTTP client over a socket puts whatever it likes in `Host`,
+since there is no authority to derive one from. Measured on Node 24: `node:http` with `socketPath`
+sends `Host: localhost`, which the existing rule happens to accept — so the breakage is not universal,
+but it is arbitrary. A client built on any other base URL (`http://simplex/`, `http://unix/`) is a 403
+for a reason that protects nothing, and that is a trap for the embedding app rather than a defense.
+
+Rejected: adding `unix` to the accepted host set, or accepting any Host when the server is
+socket-bound. Both leave a rule running that cannot fail usefully and can still fail wrongly — the
+next client with an unusual base URL hits it again. If a check defends nothing on a transport, not
+running it is clearer than tuning it forever.
+
+Rejected: keying the skip off `this.boundLoopback` or the listen mode instead of the socket's
+provenance. A tunnelled connection arriving at a socket-only server would then also skip the check,
+which is a change to the tunnel's rules made by accident. `boundLoopback` stays `true` in socket mode
+precisely so tunnelled connections keep the behaviour they had.
+
+
+## 2026-09-09 — Windows named pipes are NOT equivalent to a 0600 socket (verified)
+
+Finding, verified rather than assumed, because the security argument for this listen mode rests on it.
+
+`libuv/src/win/pipe.c` `pipe_alloc_accept` makes the pipe with
+`CreateNamedPipeW(..., PIPE_UNLIMITED_INSTANCES, 65536, 65536, 0, NULL)` — the final
+`lpSecurityAttributes` is `NULL`, and there is no libuv or Node API to supply one. Microsoft documents
+what `NULL` means, verbatim: "the named pipe gets a default security descriptor ... The ACLs in the
+default security descriptor for a named pipe grant full control to the LocalSystem account,
+administrators, and the creator owner. They also grant read access to members of the Everyone group and
+the anonymous account."
+
+So the pipe is **not owner-only**. Everyone and anonymous get read access, and Administrators get full
+control, in a machine-global namespace (`\\.\pipe\`) rather than a directory the owner controls.
+
+Practically, driving the HTTP API needs write access to send a request, which Everyone does not get, so
+a non-administrator local user cannot reach `/api/send` over the pipe. Administrators can — but an
+administrator already reads `filler-config.toml` and takes the signing key without touching any API, so
+that is not a boundary this could have held. libuv also passes `FILE_FLAG_FIRST_PIPE_INSTANCE`, so a
+hostile process cannot pre-create the name and impersonate the daemon; our bind fails loudly instead.
+
+The gap cannot be closed from Node. The only pipe-ACL control Node surfaces is `listen({ readableAll,
+writableAll })`, which reaches `uv_pipe_chmod`; that sets an ACE for the Everyone SID and Node invokes
+it only when one of those flags is set, so the single knob available *widens* access and none narrows
+it. `restrictSocketToOwner` therefore returns early on win32 rather than pretending.
+
+Stated plainly so it is not papered over: on Unix the kernel is the access control; on Windows the
+claim is weaker — read-open by any local user, full control for administrators — and an embedder that
+needs owner-only on Windows must supply the pipe from native code, not from Node.
+
+
+## 2026-09-09 — A stale socket is detected by connecting, and an over-long path is an error
+
+Decided: before binding a socket path that exists, dial it. `ECONNREFUSED` means the file outlived its
+listener, so unlink and rebind. Anything that answers is a live instance and the start fails. `ENOENT`
+means it vanished under us; proceed. Any other error (`EACCES` on somebody else's socket) fails with a
+message saying we could not tell, because deleting it would be guessing.
+
+Why not an existence test: a live socket has a file too, so existence cannot distinguish the two and
+the check would either be useless or would steal a running instance's path. Verified against a real
+`SIGKILL`ed process: the file survives, connecting to it gives `ECONNREFUSED`, and binding over it
+gives `EADDRINUSE` — which `start()`'s `once("error", reject)` turns into a rejected start.
+
+Refusing a live socket is deliberate and not merely defensive: the socket file is also the desktop
+app's discovery mechanism and single-instance lock, so "someone is already serving here" is the answer
+it needs, not something to overwrite.
+
+Decided: a socket path over `sun_path` (103 bytes on macOS, 107 on Linux, NUL included) is a clear
+error naming the size, the limit and `$TMPDIR` as a fallback.
+
+Rejected: silently relocating to a short path under `$TMPDIR`. The caller uses this path to find the
+daemon again — it is the discovery mechanism — so moving it trades a legible startup error for a
+daemon nothing can attach to, which is strictly worse. The caller can implement that fallback itself;
+it cannot recover from a socket at an address it was never told about. Without the guard the failure is
+`listen EINVAL: invalid argument <path>`, which names neither the limit nor the reason.
+
+
+## 2026-09-09 — `accept()` keeps its `listening` guard; the coupling is pinned by a test instead
+
+Decided: `accept()` still returns false when `!this.server.listening`, unchanged. A test asserts a
+socket-only server serves tunnelled connections, and that `accept()` refuses them when nothing is bound.
+
+Tunnel connections are dialled outbound to the relay and injected with `server.emit("connection")`;
+nothing listens for them, so the guard tests a condition the path does not logically need. It is
+satisfied by a Unix listener today, so socket-only remote access works and there is no bug to fix —
+which is exactly why it is worth a test: the trap springs later, when someone removes a listener that
+appears unused and silently takes remote access with it.
+
+Rejected: dropping the guard now. It is not dead — it is what stops a channel being handed to a server
+that has been stopped, and `stop()` clears `_handle` synchronously so the check is meaningful. Removing
+it as part of this change would trade a pinned, harmless coupling for an untested behaviour change in
+the tunnel's hot path.
+
+`EmbeddedSshServer`'s log line was reworded, though: it said "No UI to serve behind the tunnel" for
+every refusal, which misdescribes the case where the UI exists and is merely unbound.
 
 
 ## 2026-09-09 — The publickey probe branch requires both halves absent, not either

--- a/sdk/packages/simplex/docs/ai/Decisions.md
+++ b/sdk/packages/simplex/docs/ai/Decisions.md
@@ -202,6 +202,82 @@ database in the test.
 Rejected: skipping the fixture and trusting that SQLite's file format is driver-independent. It is
 — but the migrations, the WAL header on `activity.db`, and the row values are the parts that
 actually break, and none of them are guaranteed by the format.
+## 2026-09-09 — The socket is created 0600 by umask, not chmod'ed to 0600 after binding
+
+Decided: `listenPrivate` sets `umask 0177` around the synchronous `listen` call so libuv creates the
+socket file `0600`. The mode is never briefly wider.
+
+Why not bind then chmod, which is the obvious shape and what this change originally did: AF_UNIX
+permissions are checked at connect(2) and never re-checked, so the window is not "a moment of exposure"
+— a connection opened inside it is served for the life of the daemon, and tightening the mode does not
+revoke it. Measured at roughly a millisecond, and won 7 times out of 8 by a connect loop. On an
+unauthenticated API where `/api/send` moves funds and init mode holds private keys, that is a real
+local privilege boundary, not a hardening nicety.
+
+Rejected: documenting the window and telling embedders to use a private parent directory. That was the
+original decision here and it was wrong on the facts — it rested on the claim that the window "cannot be
+closed from Node", which is simply false. A private parent directory is still good advice, but it is
+defence in depth, not the fix, and stating it as the fix is what kept the bug in place.
+
+Rejected: bind to a temporary name in the same directory, chmod it, then rename over the real path.
+Also race-free and it avoids touching a process-wide setting. But libuv records the bound name and
+unlinks *that* on close, so after a rename the real socket file would survive every clean shutdown —
+trading a security bug for a litter bug that the stale-socket path would then have to clean up.
+
+On `process.umask` being process-wide: it wraps only the synchronous `listen` call. libuv binds inside
+that call, so no other JavaScript in this process can run between the set and the restore. It throws on
+a worker thread, hence the guard; the UI server runs on the main thread.
+
+Consequence for `assertSocketIsPrivate`: it asserts the resulting mode and does NOT chmod. A repair
+there would restore the mode only after the socket had been reachable at the wrong one — recreating the
+exact window, while also hiding the regression from the test that is supposed to catch it. A wrong mode
+now refuses to serve (a default ACL on the containing directory is the likely cause, and the error says
+so). Failing closed is the same rule applied to a chmod failure, which an earlier version downgraded to
+a warning while continuing to serve.
+
+
+## 2026-09-09 — A socket path is type-checked with lstat before anything is probed or removed
+
+Decided: `clearStaleSocket` calls `lstatSync` first and refuses anything that is not a socket. Only a
+socket is ever a candidate for the connect probe or for `unlink`.
+
+Why the probe cannot come first: the invariant the previous version rested on — "ECONNREFUSED means the
+file outlived its listener and is a corpse" — is false. connect(2) answers ECONNREFUSED for a regular
+file, a FIFO and a directory exactly as it does for an orphaned socket. So a probe-only test classified
+an operator's file as stale and deleted it; `--ui-socket ~/filler-config.toml` destroyed the config,
+reproduced against a file holding a signer key. Only a live socket is distinguishable by probing, which
+is the one thing `lstat` cannot tell us — so each check does the part the other cannot.
+
+Why `lstat` and not `existsSync`/`stat`: `existsSync` follows symlinks, so a dangling one read as
+absent, nothing was cleaned up, and the bind then failed with a bare `EADDRINUSE` naming no cause — a
+permanent, unrecoverable start failure that the stale-socket recovery was specifically meant to prevent.
+Not following the link also means a symlink planted at the path can never redirect a later operation.
+
+Rejected: unlinking a non-socket after warning. The path is operator-supplied and typo-prone, and the
+value of what might be there (a config with a signing key) is far higher than the convenience of
+auto-clearing it. Refusing costs one manual `rm` in the rare legitimate case.
+
+
+## 2026-09-09 — Listen state is assigned after the bind succeeds, never before
+
+Decided: `boundLoopback` and `listenProvenance` are set inside the `listen` callback in both
+`listenOnPort` and `listenOnSocket`, and `listenOnSocket` refuses outright when the server is already
+listening.
+
+Why: `listenProvenance` decides whether the DNS-rebinding Host check runs at all. Assigned before a
+fallible bind, a rejected socket start on an already-listening server left a live TCP listener with
+every connection tagged `unix`, and therefore exempt from that check — full DNS rebinding re-opened
+against `/api/send`, with `start()` having reported failure. Reproduced against the real class.
+
+Not reachable from the shipped CLI, which selects exactly one transport and constructs one server per
+address — but `UiServer` is an exported class and the desktop app this listen mode exists for is
+precisely an embedder that might retry or attach-or-spawn. A security toggle that is fail-open by
+statement ordering is worth fixing on reachability grounds alone, and the fix is to move two lines.
+
+The callback runs before the event loop can deliver a connection, so there is no interval in which a
+request is served under stale values.
+
+
 ## 2026-09-09 — Connection provenance is tagged on the socket, not inferred from the listener
 
 Decided: every socket carries a `PROVENANCE` symbol holding `tcp`, `unix` or `tunnel`. The listener
@@ -305,7 +381,11 @@ app's discovery mechanism and single-instance lock, so "someone is already servi
 it needs, not something to overwrite.
 
 Decided: a socket path over `sun_path` (103 bytes on macOS, 107 on Linux, NUL included) is a clear
-error naming the size, the limit and `$TMPDIR` as a fallback.
+error naming the size and the limit.
+
+Superseded 2026-09-09 (same day): that error originally suggested `$TMPDIR` as the fallback. On Linux
+`os.tmpdir()` is `/tmp`, mode 1777 — anything on the machine can create names there, and this path is
+the daemon's address. It now points at `$XDG_RUNTIME_DIR` and says to avoid a shared directory.
 
 Rejected: silently relocating to a short path under `$TMPDIR`. The caller uses this path to find the
 daemon again — it is the discovery mechanism — so moving it trades a legible startup error for a

--- a/sdk/packages/simplex/docs/ai/Flow.md
+++ b/sdk/packages/simplex/docs/ai/Flow.md
@@ -660,3 +660,41 @@ configured vaults, share metadata from the cached ERC-20 reads) and updates the 
 ask as the token0 → token1 rate and the first bid as `reverse_rate` (both token1 per token0, the
 app's unit), or, for a bid-only market, sells token1 → token0 at the reciprocal bid; `buildSolverLink`
 writes the app's `/swap?wl=1&wlv=1&…` query. Copy goes through `navigator.clipboard` with a toast.
+
+## UI server: choosing a listen mode, and how a request reaches a handler
+
+Read from the source and exercised by `src/tests/ui-server-socket.test.ts`; the Node behaviours noted
+below were measured on Node 24 rather than inferred.
+
+1. `bin/simplex.ts` resolves one listen target before anything binds. `--no-ui` skips the server
+   entirely; `--ui [<[host:]port>]` fills `uiBind` (default `127.0.0.1:8686`); `--ui-socket <path>`
+   selects socket mode. `--ui-socket` with either `--no-ui` or an explicit `--ui <addr>` throws before
+   the filler starts, rather than one silently winning. Note that commander rejects a valueless `--ui`
+   before any of this runs — the declared flags `[<[host:]port>]` contain a `<`, and commander computes
+   `required` as `flags.includes("<")`, so the optional-argument form never took effect. That predates
+   this change and is deliberately not fixed here, since `--ui` had to stay exactly as it was.
+2. `UiServer.start()` dispatches on the argument's shape: `start(port, host)` and `start({host, port})`
+   both reach `listenOnPort`, `start({socketPath})` reaches `listenOnSocket`. The TCP path is
+   unchanged — the init-mode loopback refusal, the operator-mode warning, `boundLoopback`, and the
+   resolved bound port all behave as before, and the ephemeral-port retry in the wizard path still
+   works by passing port 0.
+3. `listenOnSocket` resolves the path (unless it is a `\\.\pipe\` name), checks it against
+   `sun_path` (103 bytes on macOS, 107 on Linux) and connect-tests any file already there:
+   `ECONNREFUSED` means stale, so it is unlinked; anything answering fails the start. It then binds,
+   chmods the file to `0600` — Node creates it `0777 & ~umask`, i.e. 0775 under `umask 002` — and
+   resolves 0, since there is no port to report.
+4. `listenProvenance` is set by whichever of the two ran (`tcp` / `unix`). A listener prepended to the
+   server's `connection` event stamps that value onto every accepted socket, ahead of http's own
+   connection listener, so the tag is in place before any parser exists.
+5. Tunnel connections skip steps 1–4 entirely. `TunnelService` dials the relay outbound; a device's
+   channel is built by `EmbeddedSshServer`, stamped `tunnel` there, and handed to
+   `deliver: (socket) => uiServer?.accept(socket) ?? false`. `accept()` refuses when the server is not
+   listening, stamps `tunnel` itself (first stamp wins, so the two agree), and emits `connection`. No
+   port is involved, which is why a socket-only server serves remote devices exactly as a TCP one does.
+6. `handle` reads `provenanceOf(req.socket)` once, then applies the rules in order: the host-header
+   (DNS-rebinding) check for everything except `unix`; the `X-Simplex-UI` CSRF header on every
+   mutating method regardless of transport; and the refusal to let a `tunnel` connection change remote
+   access. Only the first of the three varies by provenance.
+7. `stop()` ends every SSE client, closes the server and unlinks the socket path. `server.close()`
+   also unlinks after it drains, so the explicit call is what frees the path immediately and covers a
+   close that never completes.

--- a/sdk/packages/simplex/docs/ai/Flow.md
+++ b/sdk/packages/simplex/docs/ai/Flow.md
@@ -666,13 +666,12 @@ writes the app's `/swap?wl=1&wlv=1&…` query. Copy goes through `navigator.clip
 Read from the source and exercised by `src/tests/ui-server-socket.test.ts`; the Node behaviours noted
 below were measured on Node 24 rather than inferred.
 
-1. `bin/simplex.ts` resolves one listen target before anything binds. `--no-ui` skips the server
-   entirely; `--ui [<[host:]port>]` fills `uiBind` (default `127.0.0.1:8686`); `--ui-socket <path>`
-   selects socket mode. `--ui-socket` with either `--no-ui` or an explicit `--ui <addr>` throws before
-   the filler starts, rather than one silently winning. Note that commander rejects a valueless `--ui`
-   before any of this runs — the declared flags `[<[host:]port>]` contain a `<`, and commander computes
-   `required` as `flags.includes("<")`, so the optional-argument form never took effect. That predates
-   this change and is deliberately not fixed here, since `--ui` had to stay exactly as it was.
+1. `bin/simplex.ts` resolves one listen target before anything binds. The flags themselves are
+   declared in `src/cli/run-options.ts` (`addRunOptions`), so they can be parsed in tests without
+   importing the bin. `--no-ui` skips the server entirely; `--ui [host:port]` fills `uiBind` (default
+   `127.0.0.1:8686`); `--ui-socket <path>` selects socket mode. `--ui-socket` with either `--no-ui` or
+   an explicit `--ui <addr>` throws before the filler starts, rather than one silently winning. A bare
+   `--ui` is not a conflict: it names no address, it only turns the UI on.
 2. `UiServer.start()` dispatches on the argument's shape: `start(port, host)` and `start({host, port})`
    both reach `listenOnPort`, `start({socketPath})` reaches `listenOnSocket`. The TCP path is
    unchanged — the init-mode loopback refusal, the operator-mode warning, `boundLoopback`, and the
@@ -680,10 +679,15 @@ below were measured on Node 24 rather than inferred.
    works by passing port 0.
 3. `listenOnSocket` resolves the path (unless it is a `\\.\pipe\` name), checks it against
    `sun_path` (103 bytes on macOS, 107 on Linux) and connect-tests any file already there:
-   `ECONNREFUSED` means stale, so it is unlinked; anything answering fails the start. It then binds,
-   chmods the file to `0600` — Node creates it `0777 & ~umask`, i.e. 0775 under `umask 002` — and
-   resolves 0, since there is no port to report.
-4. `listenProvenance` is set by whichever of the two ran (`tcp` / `unix`). A listener prepended to the
+   `ECONNREFUSED` means stale, so it is unlinked; anything answering fails the start. Anything at the
+   path that is not a socket is refused outright rather than removed, and the check is `lstat`, so a
+   dangling symlink is seen rather than read as absent. It then binds through `listenPrivate`, which
+   sets `umask 0177` around the synchronous `listen` so libuv creates the file `0600` — Node would
+   otherwise create it `0777 & ~umask`, i.e. 0775 under `umask 002`. `assertSocketIsPrivate` then
+   asserts the mode (it does not repair it), and resolves 0, since there is no port to report.
+4. `listenProvenance` is set by whichever of the two ran (`tcp` / `unix`), inside the `listen` callback
+   rather than before the bind, so a rejected start never leaves a live listener described by the
+   other mode's rules. A listener prepended to the
    server's `connection` event stamps that value onto every accepted socket, ahead of http's own
    connection listener, so the tag is in place before any parser exists.
 5. Tunnel connections skip steps 1–4 entirely. `TunnelService` dials the relay outbound; a device's

--- a/sdk/packages/simplex/src/bin/simplex.ts
+++ b/sdk/packages/simplex/src/bin/simplex.ts
@@ -240,6 +240,11 @@ addRunOptions(program.command("run", { isDefault: true }))
 
 			const uiEnabled = options.ui !== false
 			const uiSocket = options.uiSocket
+			// An empty value would be falsy at every use below, so the UI would quietly
+			// come up on the TCP port the operator was trying to avoid.
+			if (uiSocket !== undefined && uiSocket.trim() === "") {
+				throw new Error("--ui-socket needs a path; it was given an empty value")
+			}
 			// Two listen addresses, or an address and an off switch, are a mistake worth
 			// naming: silently picking one leaves the operator watching a port nothing
 			// is on. Only an explicit `--ui <addr>` conflicts — a bare `--ui` just turns

--- a/sdk/packages/simplex/src/bin/simplex.ts
+++ b/sdk/packages/simplex/src/bin/simplex.ts
@@ -239,6 +239,19 @@ addRunOptions(program.command("run", { isDefault: true }))
 
 
 			const uiEnabled = options.ui !== false
+			const uiSocket = options.uiSocket
+			// Two listen addresses, or an address and an off switch, are a mistake worth
+			// naming: silently picking one leaves the operator watching a port nothing
+			// is on. Only an explicit `--ui <addr>` conflicts — a bare `--ui` just turns
+			// the UI on and names no address, so it pairs with a socket fine.
+			if (uiSocket && !uiEnabled) {
+				throw new Error("--ui-socket and --no-ui contradict each other: one serves the UI, the other turns it off")
+			}
+			if (uiSocket && typeof options.ui === "string") {
+				throw new Error(
+					`--ui and --ui-socket name two different listen addresses; pass one (got --ui ${options.ui} and --ui-socket ${uiSocket})`,
+				)
+			}
 			let uiBind = { host: "127.0.0.1", port: DEFAULT_UI_PORT }
 			if (typeof options.ui === "string") {
 				const parsed = parseBind(options.ui, "127.0.0.1")
@@ -356,12 +369,17 @@ addRunOptions(program.command("run", { isDefault: true }))
 						operator: await operatorContextFrom(simplex!, () => shutdown("UI"), tunnel),
 					})
 					try {
-						uiBoundPort = await uiServer.start(uiBind.port, uiBind.host)
+						// A socket has no port, so `uiBoundPort` keeps its default — which is
+						// only the address paired devices dial through the tunnel's forward.
+						// Nothing listens there in socket mode and nothing needs to: channels
+						// are injected via `deliver` above, never connected to.
+						if (uiSocket) await uiServer.start({ socketPath: uiSocket })
+						else uiBoundPort = await uiServer.start(uiBind.port, uiBind.host)
 						startTunnel()
 					} catch (err) {
 						// The filler is the primary workload; a bind failure (e.g. port in use)
 						// costs the UI, not the process.
-						logger.error({ err, bind: `${uiBind.host}:${uiBind.port}` }, "UI server failed to start")
+						logger.error({ err, bind: uiSocket ?? `${uiBind.host}:${uiBind.port}` }, "UI server failed to start")
 						uiServer = undefined
 						await tunnel?.stop()
 						tunnel = undefined
@@ -397,6 +415,16 @@ addRunOptions(program.command("run", { isDefault: true }))
 				},
 			})
 			uiServer = server
+
+			if (uiSocket) {
+				// No URL to print and no browser that could open a socket: an embedding
+				// application renders the wizard itself over this socket. A bind failure
+				// here is fatal — there is no other way in.
+				await server.start({ socketPath: uiSocket })
+				console.log(`\n  No config found — the setup wizard is serving on ${uiSocket}\n`)
+				// The server keeps the event loop alive until the wizard completes.
+				return
+			}
 
 			let boundPort: number
 			try {

--- a/sdk/packages/simplex/src/cli/run-options.ts
+++ b/sdk/packages/simplex/src/cli/run-options.ts
@@ -37,7 +37,7 @@ export function addRunOptions(command: Command): Command {
 		)
 		.option(
 			"--ui-socket <path>",
-			"Serve the web UI on a Unix domain socket at <path> (a named pipe on Windows) instead of a TCP port. Only the user running simplex can connect, and no web page can reach it — for embedding simplex in a desktop application",
+			"Serve the web UI on a Unix domain socket at <path> instead of a TCP port. The socket is created 0600, so no other local user and no web page can reach it. On Windows this is a named pipe, whose default ACL is weaker (see docs/ai/Decisions.md). For embedding simplex in a desktop application",
 		)
 		.option("--no-ui", "Disable the local web UI")
 }

--- a/sdk/packages/simplex/src/cli/run-options.ts
+++ b/sdk/packages/simplex/src/cli/run-options.ts
@@ -14,6 +14,8 @@ export interface RunOptions {
 	 * `--no-ui`, and absent when neither flag is passed.
 	 */
 	ui?: string | boolean
+	/** A socket path from `--ui-socket <path>`; absent when the flag is not passed. */
+	uiSocket?: string
 }
 
 /**
@@ -32,6 +34,10 @@ export function addRunOptions(command: Command): Command {
 		.option(
 			"--ui [host:port]",
 			`Bind address for the local web UI (status, pause/resume, price curves); a bare port keeps the host at 127.0.0.1. Unauthenticated; default 127.0.0.1:${DEFAULT_UI_PORT}`,
+		)
+		.option(
+			"--ui-socket <path>",
+			"Serve the web UI on a Unix domain socket at <path> (a named pipe on Windows) instead of a TCP port. Only the user running simplex can connect, and no web page can reach it — for embedding simplex in a desktop application",
 		)
 		.option("--no-ui", "Disable the local web UI")
 }

--- a/sdk/packages/simplex/src/services/server/UiServer.ts
+++ b/sdk/packages/simplex/src/services/server/UiServer.ts
@@ -1,4 +1,8 @@
+import { chmodSync, existsSync, unlinkSync } from "node:fs"
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http"
+import { connect } from "node:net"
+import { tmpdir } from "node:os"
+import { resolve as resolvePath } from "node:path"
 import type { Duplex } from "node:stream"
 import { Decimal } from "decimal.js"
 import { FillerPricePolicy, formatChainKey, parseChainKey, type PriceCurvePoint } from "@/config/interpolated-curve"
@@ -18,7 +22,17 @@ import type { ActivityEvent, BidStore, OrderLeg } from "@/data/types"
 import type { BalanceProvider } from "../BalanceProvider"
 import { getLogger, type LogLevel } from "../Logger"
 import { DEFAULT_TUNNEL_RELAY, parseRelayAddress, relayKey, type TunnelControls } from "../tunnel/TunnelService"
-import { readBody, sendJson, isLoopbackHost, isContainerized, hostHeaderAllowed, isTunnelled } from "./http-util"
+import {
+	readBody,
+	sendJson,
+	isLoopbackHost,
+	isContainerized,
+	hostHeaderAllowed,
+	isTunnelled,
+	markProvenance,
+	provenanceOf,
+	type Provenance,
+} from "./http-util"
 import { serveStatic } from "./static"
 import {
 	handleSetupRequest,
@@ -94,6 +108,19 @@ export interface AdminStrategy {
 }
 
 export type UiMode = "init" | "operator"
+
+/**
+ * Where the UI server listens.
+ *
+ * A TCP port is the CLI's mode and reaches every local user, so it carries the
+ * host-header defense and the loopback rules below. A `socketPath` binds a Unix
+ * domain socket instead (a named pipe on Windows) — the filesystem decides who
+ * may connect, and no web page can open one at all, which is what lets an
+ * embedding application (the desktop app) expose the API without a port.
+ *
+ * The two are alternatives, not layers: a server listens on one or the other.
+ */
+export type ListenTarget = { host?: string; port: number } | { socketPath: string }
 
 /** Narrow view of the IntentFiller, so tests can stub it. */
 export interface PauseControl {
@@ -210,6 +237,43 @@ Run <code>pnpm ui:build</code> (or a full <code>pnpm build</code>) and restart.<
 <p>The JSON API under <code>/api</code> is unaffected.</p></body>`
 
 /**
+ * `sun_path` in `sockaddr_un` is a fixed-size field: 108 bytes on Linux, 104 on
+ * macOS and the BSDs, terminating NUL included. Past it bind(2) fails with a
+ * message naming neither the limit nor the offending path.
+ *
+ * It bites in practice rather than in theory: a desktop application's natural
+ * home for such a file is its user-data directory, which on macOS is already
+ * `~/Library/Application Support/<app>/` before a filename is added.
+ */
+const SUN_PATH_MAX_BYTES = process.platform === "darwin" ? 103 : 107
+
+/** Windows names a pipe `\\.\pipe\name`, which is not a filesystem path. */
+function isWindowsPipe(path: string): boolean {
+	return /^\\\\[.?]\\pipe\\/i.test(path)
+}
+
+/**
+ * Refuses an over-long socket path up front, with the limit and a way out,
+ * rather than letting bind(2) produce an opaque failure.
+ *
+ * Refusing beats silently relocating to a shorter path: the caller uses this
+ * path to find the daemon again, so moving it would trade a clear error at
+ * startup for a daemon nothing can attach to.
+ */
+function assertSocketPathFits(path: string): void {
+	// A Windows pipe is not a sockaddr_un; its own cap is the 256-character pipe
+	// name, which no plausible path approaches.
+	if (process.platform === "win32") return
+	// Bytes, not characters: a non-ASCII path spends more of the field than it looks.
+	const bytes = Buffer.byteLength(path)
+	if (bytes <= SUN_PATH_MAX_BYTES) return
+	throw new Error(
+		`UI socket path is ${bytes} bytes, over this platform's ${SUN_PATH_MAX_BYTES}-byte limit for a Unix socket: ${path}. ` +
+			`Use a shorter path — a directory under ${tmpdir()} is the usual fallback when the natural location is too long.`,
+	)
+}
+
+/**
  * Loopback HTTP server embedded in the simplex process. Serves the bundled SPA
  * and a JSON API in one of two modes: `init` (setup wizard endpoints, before a
  * config exists) or `operator` (status/pause/balances plus inflight price curve
@@ -228,6 +292,10 @@ export class UiServer {
 	private sseClients = new Set<ServerResponse>()
 	private activityListener?: (event: ActivityEvent) => void
 	private boundLoopback = true
+	/** How connections this server accepted arrived; stamped onto each socket. */
+	private listenProvenance: Provenance = "tcp"
+	/** Set while a Unix socket is bound, so shutdown can take the path back down with it. */
+	private socketPath?: string
 	private deps: Required<SetupDeps>
 	/**
 	 * Chain ids aligned with `config.chains` rows. The TOML records no chain id
@@ -260,6 +328,13 @@ export class UiServer {
 				}
 			})
 		})
+		// Prepended so the stamp lands before http's own connection listener attaches
+		// a parser, which makes `provenanceOf(req.socket)` total by the time `handle`
+		// runs. `accept()` stamps its channels first and `markProvenance` keeps the
+		// first stamp, so an injected connection is never relabelled as a listened-for
+		// one. Tagging the socket, rather than reading what the server happens to be
+		// listening on, is what keeps the rules right for a server serving both.
+		this.server.prependListener("connection", (socket) => markProvenance(socket, this.listenProvenance))
 	}
 
 	/**
@@ -269,12 +344,124 @@ export class UiServer {
 	 */
 	accept(socket: Duplex): boolean {
 		if (!this.server.listening) return false
+		// The tunnel is the only caller, and this is the one place that holds
+		// regardless of how the channel was built — so the tunnel provenance is
+		// settled here, ahead of the listener stamp the emit below would otherwise
+		// apply.
+		markProvenance(socket, "tunnel")
 		this.server.emit("connection", socket)
 		return true
 	}
 
 	/** Resolves with the bound port once listening (pass port 0 for an ephemeral port). */
-	start(port: number, host = "127.0.0.1"): Promise<number> {
+	start(port: number, host?: string): Promise<number>
+	/** Resolves once listening; the bound port for a TCP target, 0 for a Unix socket. */
+	start(target: ListenTarget): Promise<number>
+	async start(target: number | ListenTarget, host = "127.0.0.1"): Promise<number> {
+		if (typeof target === "number") return this.listenOnPort(target, host)
+		if ("socketPath" in target) return this.listenOnSocket(target.socketPath)
+		return this.listenOnPort(target.port, target.host ?? host)
+	}
+
+	/**
+	 * Binds a Unix domain socket (a named pipe on Windows) rather than a port.
+	 * Node's `listen(path)` speaks HTTP over one natively, so the route table,
+	 * the handlers and the SSE stream are the same code either way.
+	 *
+	 * Resolves 0: there is no port to report. A listening TCP server never reports
+	 * 0 either, so the two are not confusable.
+	 */
+	private async listenOnSocket(socketPath: string): Promise<number> {
+		// A named pipe name is not a filesystem path; resolving one would mangle it.
+		const path = isWindowsPipe(socketPath) ? socketPath : resolvePath(socketPath)
+		assertSocketPathFits(path)
+		await this.clearStaleSocket(path)
+		// A socket file is reachable by strictly fewer callers than loopback is, so the
+		// loopback branch of the host rule is the right default for anything that does
+		// consult it — though `handle` skips the check outright for these connections.
+		this.boundLoopback = true
+		this.listenProvenance = "unix"
+		await new Promise<void>((resolve, reject) => {
+			this.server.once("error", reject)
+			this.server.listen(path, () => resolve())
+		})
+		this.socketPath = path
+		this.restrictSocketToOwner(path)
+		this.logger.info({ bind: path }, `Simplex UI available on the socket at ${path}`)
+		return 0
+	}
+
+	/**
+	 * Narrows the socket file to `0600`, which is the access control this listen
+	 * mode exists for. Node binds it `0777 & ~umask` — 0775 under the common
+	 * `umask 002`, letting every member of the operator's group connect and drive
+	 * `/api/send`. Linux and macOS both check write permission on the socket file
+	 * at connect(2), so the mode is enforced rather than advisory.
+	 *
+	 * A window exists between bind and chmod in which the umask mode stands. It
+	 * cannot be closed from Node — libuv takes no mode at bind, and changing the
+	 * process umask would race every other write this process makes — so an
+	 * embedder that cares should place the socket in a directory only it can
+	 * traverse, which closes it from the outside.
+	 */
+	private restrictSocketToOwner(path: string): void {
+		// Windows named pipes are not files and carry no mode. Their DACL is not
+		// owner-only and Node cannot narrow it; see docs/ai/Decisions.md.
+		if (process.platform === "win32") return
+		try {
+			chmodSync(path, 0o600)
+		} catch (err) {
+			this.logger.warn(
+				{ err, path },
+				"Could not restrict the UI socket to this user — other local users may be able to connect",
+			)
+		}
+	}
+
+	/**
+	 * Clears a socket file left behind by a run that was killed before it could
+	 * remove its own; without this a `SIGKILL`ed predecessor makes every later
+	 * start fail with EADDRINUSE.
+	 *
+	 * Existence proves nothing — a live socket has a file too — so the test is to
+	 * dial it. `ECONNREFUSED` means the file outlived its listener and is a corpse.
+	 * Anything that answers belongs to a running instance, and taking its path
+	 * would silently steal its clients, so that is an error instead. That doubles
+	 * as the single-instance lock an embedding application wants.
+	 *
+	 * Windows needs none of it: a named pipe is refcounted by its handles and
+	 * vanishes with the process that made it, so nothing stale can exist and the
+	 * existence check below returns first.
+	 */
+	private async clearStaleSocket(path: string): Promise<void> {
+		if (!existsSync(path)) return
+		const code = await new Promise<string | undefined>((resolve) => {
+			const probe = connect(path)
+			const settle = (result: string | undefined) => {
+				probe.destroy()
+				resolve(result)
+			}
+			probe.once("connect", () => settle(undefined))
+			probe.once("error", (err) => settle((err as NodeJS.ErrnoException).code ?? "UNKNOWN"))
+		})
+		// Vanished between the check and the dial: nothing to clear.
+		if (code === "ENOENT") return
+		if (code === undefined) {
+			throw new Error(`Another simplex is already serving its UI on ${path}`)
+		}
+		if (code !== "ECONNREFUSED") {
+			// EACCES on somebody else's socket, say. Not ours to delete.
+			throw new Error(`Cannot tell whether ${path} is in use (${code}); remove it by hand if no simplex is running`)
+		}
+		try {
+			unlinkSync(path)
+			this.logger.warn({ path }, "Removed a stale UI socket left behind by a previous run")
+		} catch (err) {
+			if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err
+		}
+	}
+
+	private listenOnPort(port: number, host: string): Promise<number> {
 		if (this.mode === "init" && !isLoopbackHost(host)) {
 			// Outside a container the host's interfaces are the real ones, and the wizard
 			// collects private keys — the bind is refused. Inside one, see isContainerized().
@@ -295,6 +482,7 @@ export class UiServer {
 			)
 		}
 		this.boundLoopback = isLoopbackHost(host)
+		this.listenProvenance = "tcp"
 		return new Promise((resolve, reject) => {
 			this.server.once("error", reject)
 			this.server.listen(port, host, () => {
@@ -314,6 +502,27 @@ export class UiServer {
 		for (const client of this.sseClients) client.end()
 		this.sseClients.clear()
 		this.server.close()
+		this.unlinkSocket()
+	}
+
+	/**
+	 * Removes the socket file on the way out, so the next run has nothing to
+	 * recover. `server.close()` unlinks too, but only once it has drained every
+	 * connection; doing it here frees the path the moment we stop serving and
+	 * covers a close that never completes.
+	 */
+	private unlinkSocket(): void {
+		const path = this.socketPath
+		if (!path) return
+		this.socketPath = undefined
+		if (isWindowsPipe(path)) return
+		try {
+			unlinkSync(path)
+		} catch (err) {
+			if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+				this.logger.debug({ err, path }, "Could not remove the UI socket")
+			}
+		}
 	}
 
 	/** Flips a live init-mode server into operator mode; the listener keeps running. */
@@ -356,11 +565,19 @@ export class UiServer {
 		const path = (req.url ?? "/").split("?")[0]
 		const method = req.method ?? "GET"
 
+		const provenance = provenanceOf(req.socket)
+
 		// DNS-rebinding defense: an attacker page resolving its own domain to
 		// this address becomes same-origin and could drive every endpoint,
 		// including /api/send. A rebound origin always carries its DNS name in
 		// Host, so only IP-literal/localhost Hosts are served.
-		if (!hostHeaderAllowed(req.headers.host, this.boundLoopback)) {
+		//
+		// Skipped, not relaxed, for a connection that arrived on a Unix socket:
+		// there is no name to rebind onto one and no browser that can open one, so
+		// the check defends nothing there — while an HTTP client over a socket puts
+		// whatever it likes in Host (node:http sends "localhost", others send the
+		// URL's authority), which would make an arbitrary base URL a 403.
+		if (provenance !== "unix" && !hostHeaderAllowed(req.headers.host, this.boundLoopback)) {
 			return sendJson(res, 403, { error: "Host header is not allowed" })
 		}
 

--- a/sdk/packages/simplex/src/services/server/UiServer.ts
+++ b/sdk/packages/simplex/src/services/server/UiServer.ts
@@ -1,4 +1,4 @@
-import { chmodSync, existsSync, unlinkSync } from "node:fs"
+import { lstatSync, unlinkSync, type Stats } from "node:fs"
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http"
 import { connect } from "node:net"
 import { tmpdir } from "node:os"
@@ -247,9 +247,24 @@ Run <code>pnpm ui:build</code> (or a full <code>pnpm build</code>) and restart.<
  */
 const SUN_PATH_MAX_BYTES = process.platform === "darwin" ? 103 : 107
 
-/** Windows names a pipe `\\.\pipe\name`, which is not a filesystem path. */
+/**
+ * Windows names a pipe `\\.\pipe\name`, which is not a filesystem path.
+ *
+ * Gated on the platform as well as the shape: on Linux such a string is just an
+ * oddly-named file, and treating it as a pipe there would skip the path
+ * resolution and the cleanup that every other path gets.
+ */
 function isWindowsPipe(path: string): boolean {
-	return /^\\\\[.?]\\pipe\\/i.test(path)
+	return process.platform === "win32" && /^\\\\[.?]\\pipe\\/i.test(path)
+}
+
+/** Names what is sitting at a socket path, for an error the operator can act on. */
+function describeEntry(entry: Stats): string {
+	if (entry.isSymbolicLink()) return "a symbolic link"
+	if (entry.isDirectory()) return "a directory"
+	if (entry.isFIFO()) return "a FIFO"
+	if (entry.isFile()) return "a regular file"
+	return "not a socket"
 }
 
 /**
@@ -269,7 +284,9 @@ function assertSocketPathFits(path: string): void {
 	if (bytes <= SUN_PATH_MAX_BYTES) return
 	throw new Error(
 		`UI socket path is ${bytes} bytes, over this platform's ${SUN_PATH_MAX_BYTES}-byte limit for a Unix socket: ${path}. ` +
-			`Use a shorter path — a directory under ${tmpdir()} is the usual fallback when the natural location is too long.`,
+			`Use a shorter path in a directory only this user can write — on Linux $XDG_RUNTIME_DIR ` +
+				`(${process.env.XDG_RUNTIME_DIR ?? "/run/user/<uid>"}) is both short and already private. ` +
+				`Avoid a shared directory such as ${tmpdir()}: anything that can create names there can take this address first.`,
 	)
 }
 
@@ -375,45 +392,104 @@ export class UiServer {
 		// A named pipe name is not a filesystem path; resolving one would mangle it.
 		const path = isWindowsPipe(socketPath) ? socketPath : resolvePath(socketPath)
 		assertSocketPathFits(path)
+		// Refused rather than attempted: `listen` throws ERR_SERVER_ALREADY_LISTEN here,
+		// and the provenance set below decides whether the DNS-rebinding check runs.
+		// Setting it for a bind that cannot happen would relabel a live TCP listener's
+		// connections as socket-arrived and switch that check off for them.
+		if (this.server.listening) {
+			throw new Error("This UI server is already listening; build a second UiServer for a second address")
+		}
 		await this.clearStaleSocket(path)
-		// A socket file is reachable by strictly fewer callers than loopback is, so the
-		// loopback branch of the host rule is the right default for anything that does
-		// consult it — though `handle` skips the check outright for these connections.
-		this.boundLoopback = true
-		this.listenProvenance = "unix"
 		await new Promise<void>((resolve, reject) => {
 			this.server.once("error", reject)
-			this.server.listen(path, () => resolve())
+			this.listenPrivate(path, () => {
+				// Assigned here, not before the bind: these describe how requests on this
+				// server are judged, so they must describe a listener that came up. The
+				// callback runs before the loop can deliver a connection, so nothing is
+				// ever served under the previous values.
+				//
+				// A socket file is reachable by strictly fewer callers than loopback is, so
+				// the loopback branch of the host rule is the right default for anything
+				// that consults it — though `handle` skips that check outright here.
+				this.boundLoopback = true
+				this.listenProvenance = "unix"
+				resolve()
+			})
 		})
 		this.socketPath = path
-		this.restrictSocketToOwner(path)
+		try {
+			this.assertSocketIsPrivate(path)
+		} catch (err) {
+			// Never keep serving a fund-moving API on a socket we cannot prove is
+			// owner-only. The bind succeeded, so it has to be taken back down.
+			this.server.close()
+			this.unlinkSocket()
+			throw err
+		}
 		this.logger.info({ bind: path }, `Simplex UI available on the socket at ${path}`)
 		return 0
 	}
 
 	/**
-	 * Narrows the socket file to `0600`, which is the access control this listen
-	 * mode exists for. Node binds it `0777 & ~umask` — 0775 under the common
-	 * `umask 002`, letting every member of the operator's group connect and drive
-	 * `/api/send`. Linux and macOS both check write permission on the socket file
-	 * at connect(2), so the mode is enforced rather than advisory.
+	 * Binds the socket with a umask that makes it `0600` at creation.
 	 *
-	 * A window exists between bind and chmod in which the umask mode stands. It
-	 * cannot be closed from Node — libuv takes no mode at bind, and changing the
-	 * process umask would race every other write this process makes — so an
-	 * embedder that cares should place the socket in a directory only it can
-	 * traverse, which closes it from the outside.
+	 * It cannot be narrowed after the fact instead. libuv creates the file with
+	 * `0777 & ~umask` — 0775 under the common `umask 002` — and Linux checks that
+	 * mode at connect(2) and never again, so a local user who connects in the gap
+	 * before a follow-up chmod keeps a fully privileged, unauthenticated session for
+	 * the life of the daemon: tightening the mode does not revoke a connection that
+	 * already exists. The gap is around a millisecond, which a connect loop wins
+	 * reliably. The mode has to be right before the socket is reachable at all.
+	 *
+	 * `process.umask` is process-wide, which is why this wraps only the synchronous
+	 * `listen` call: libuv binds inside it, and no other JavaScript in this process
+	 * can run in between. It throws on a worker thread, hence the guard.
 	 */
-	private restrictSocketToOwner(path: string): void {
-		// Windows named pipes are not files and carry no mode. Their DACL is not
-		// owner-only and Node cannot narrow it; see docs/ai/Decisions.md.
-		if (process.platform === "win32") return
+	private listenPrivate(path: string, onListening: () => void): void {
+		if (process.platform === "win32" || isWindowsPipe(path)) {
+			// A named pipe carries no file mode; see docs/ai/Decisions.md.
+			this.server.listen(path, onListening)
+			return
+		}
+		let previous: number | undefined
 		try {
-			chmodSync(path, 0o600)
-		} catch (err) {
-			this.logger.warn(
-				{ err, path },
-				"Could not restrict the UI socket to this user — other local users may be able to connect",
+			previous = process.umask(0o177)
+		} catch {
+			previous = undefined
+		}
+		try {
+			this.server.listen(path, onListening)
+		} finally {
+			if (previous !== undefined) process.umask(previous)
+		}
+	}
+
+	/**
+	 * Proves the socket is owner-only, and refuses to serve when it is not.
+	 *
+	 * `listenPrivate` has already made it `0600`; this is purely the post-condition.
+	 * It asserts rather than repairs on purpose: a chmod here would "fix" the mode
+	 * only after the socket had been reachable at the wrong one, which is precisely
+	 * the window `listenPrivate` exists to close — so a repair would hide the very
+	 * regression this checks for, while leaving the vulnerability in place.
+	 *
+	 * `lstat`, not `stat`, so a symlink swapped in at the path is rejected rather
+	 * than followed.
+	 *
+	 * Fails closed deliberately. This mode is the entire access control for the
+	 * socket listen mode, and an earlier version logged a warning and kept serving.
+	 */
+	private assertSocketIsPrivate(path: string): void {
+		if (process.platform === "win32" || isWindowsPipe(path)) return
+		const entry = lstatSync(path)
+		if (!entry.isSocket()) {
+			throw new Error(`${path} is ${describeEntry(entry)}, not the socket just bound — refusing to serve`)
+		}
+		const mode = entry.mode & 0o777
+		if (mode !== 0o600) {
+			throw new Error(
+				`${path} was created mode 0${mode.toString(8)} rather than 0600, so other users could reach the UI. ` +
+					"A default ACL on the containing directory is the usual cause; use a directory without one.",
 			)
 		}
 	}
@@ -434,7 +510,17 @@ export class UiServer {
 	 * existence check below returns first.
 	 */
 	private async clearStaleSocket(path: string): Promise<void> {
-		if (!existsSync(path)) return
+		// `lstat`, not `existsSync`: existsSync follows symlinks, so a dangling one
+		// reads as absent, nothing is cleaned up, and the bind then fails EADDRINUSE.
+		const entry = lstatSync(path, { throwIfNoEntry: false })
+		if (!entry) return
+		// The type test comes before the probe, not after: connect(2) answers
+		// ECONNREFUSED for a regular file, a FIFO and a directory exactly as it does
+		// for an orphaned socket, so probing alone would read an operator's file as a
+		// corpse and delete it. Only a socket is ever a candidate for removal.
+		if (!entry.isSocket()) {
+			throw new Error(`${path} already exists and is ${describeEntry(entry)}; refusing to remove it`)
+		}
 		const code = await new Promise<string | undefined>((resolve) => {
 			const probe = connect(path)
 			const settle = (result: string | undefined) => {
@@ -481,11 +567,13 @@ export class UiServer {
 				"UI server binding a non-loopback address — it is unauthenticated, make sure the network is trusted",
 			)
 		}
-		this.boundLoopback = isLoopbackHost(host)
-		this.listenProvenance = "tcp"
 		return new Promise((resolve, reject) => {
 			this.server.once("error", reject)
 			this.server.listen(port, host, () => {
+				// Set once the listener is actually up: these say how this server judges
+				// requests, so they must never describe a bind that did not happen.
+				this.boundLoopback = isLoopbackHost(host)
+				this.listenProvenance = "tcp"
 				const address = this.server.address()
 				const boundPort = typeof address === "object" && address !== null ? address.port : port
 				this.logger.info({ bind: `${host}:${boundPort}` }, `Simplex UI available at http://${host}:${boundPort}/`)

--- a/sdk/packages/simplex/src/services/server/http-util.ts
+++ b/sdk/packages/simplex/src/services/server/http-util.ts
@@ -28,15 +28,48 @@ export function sendJson(res: ServerResponse, status: number, payload: unknown):
 }
 
 /**
- * Marks a connection handed to the UI server by the remote-access tunnel,
- * rather than one dialled from the local network. A symbol, and set on a socket
- * this process created, so nothing a device sends can forge it.
+ * How a connection reached the UI server. The three differ in who can open one,
+ * which is what the request rules key off:
+ *
+ * - `tcp` — a listening port. Every local user can reach it, and a browser can
+ *   be pointed at it, so it needs the host-header check below.
+ * - `unix` — a Unix domain socket file, narrowed to the owning user. No browser
+ *   can open one at all, so the host-header check is meaningless there.
+ * - `tunnel` — a channel injected by the remote-access tunnel, already
+ *   authenticated against a paired device key, and holding fewer privileges
+ *   than a local caller (it cannot manage remote access).
  */
-export const VIA_TUNNEL = Symbol.for("simplex.tunnel.connection")
+export type Provenance = "tcp" | "unix" | "tunnel"
+
+/**
+ * Symbol key carrying a socket's {@link Provenance}. A symbol, and only ever set
+ * on sockets this process owns — the listener stamps what it accepted, the
+ * tunnel stamps what it injected — so nothing a client sends can forge it.
+ *
+ * Generalises the older `VIA_TUNNEL` marker, which answered one question
+ * (tunnelled or not) that a Unix socket made into three.
+ */
+export const PROVENANCE = Symbol.for("simplex.connection.provenance")
+
+/**
+ * Records how a socket arrived. The first stamp wins: the tunnel marks a channel
+ * as it builds it, and the listener's blanket stamp must not overwrite that when
+ * the channel is handed to the server.
+ */
+export function markProvenance(socket: object, provenance: Provenance): void {
+	if (provenanceOf(socket) !== undefined) return
+	Object.defineProperty(socket, PROVENANCE, { value: provenance, configurable: true })
+}
+
+/** How this request arrived, or undefined for a socket nothing stamped. */
+export function provenanceOf(socket: unknown): Provenance | undefined {
+	const tag = (socket as Record<symbol, unknown> | null | undefined)?.[PROVENANCE]
+	return tag === "tcp" || tag === "unix" || tag === "tunnel" ? tag : undefined
+}
 
 /** Whether this request arrived through the remote-access tunnel. */
 export function isTunnelled(socket: unknown): boolean {
-	return (socket as Record<symbol, unknown> | null | undefined)?.[VIA_TUNNEL] === true
+	return provenanceOf(socket) === "tunnel"
 }
 
 export function isLoopbackHost(host: string): boolean {

--- a/sdk/packages/simplex/src/services/tunnel/EmbeddedSshServer.ts
+++ b/sdk/packages/simplex/src/services/tunnel/EmbeddedSshServer.ts
@@ -2,7 +2,7 @@ import type { Socket } from "node:net"
 import type { Duplex } from "node:stream"
 import ssh2, { type Connection, type Server as SshServerType } from "ssh2"
 import { getLogger } from "../Logger"
-import { isLoopbackHost, VIA_TUNNEL } from "../server/http-util"
+import { isLoopbackHost, markProvenance } from "../server/http-util"
 import { fingerprintOf } from "./keys"
 
 // ssh2 is CommonJS: named imports resolve under vitest's transform but not in
@@ -381,8 +381,10 @@ export class EmbeddedSshServer {
 					remoteAddress: { value: originIp, configurable: true },
 					remotePort: { value: originPort, configurable: true },
 					remoteFamily: { value: originIp.includes(":") ? "IPv6" : "IPv4", configurable: true },
-					[VIA_TUNNEL]: { value: true, configurable: true },
 				})
+				// Stamped on a channel this process built, so a device cannot forge its
+				// way out of the tunnel's reduced privileges.
+				markProvenance(channel, "tunnel")
 				Object.assign(channel, {
 					setTimeout: () => channel,
 					setNoDelay: () => channel,
@@ -393,7 +395,9 @@ export class EmbeddedSshServer {
 				})
 				channel.on("error", (err: Error) => this.logger.debug({ origin, err: err.message }, "Tunnel channel error"))
 				if (!this.opts.deliver(channel, { ip: originIp, port: originPort })) {
-					this.logger.warn({ origin }, "No UI to serve behind the tunnel")
+					// Not necessarily "no UI": the server also refuses a channel while it is
+					// not listening, which says nothing about whether the dashboard exists.
+					this.logger.warn({ origin }, "UI server would not accept the tunnelled connection")
 					channel.destroy()
 				}
 			})

--- a/sdk/packages/simplex/src/tests/cli/run-options.test.ts
+++ b/sdk/packages/simplex/src/tests/cli/run-options.test.ts
@@ -37,6 +37,24 @@ describe("simplex run flags", () => {
 		expect(parseRun([]).ui).toBeUndefined()
 	})
 
+	it("takes a socket path from --ui-socket, independently of --ui", () => {
+		expect(parseRun(["--ui-socket", "/run/user/1000/simplex.sock"]).uiSocket).toBe("/run/user/1000/simplex.sock")
+		expect(parseRun([]).uiSocket).toBeUndefined()
+		// The two are separate flags. The handler rejects the combinations that name
+		// two listen addresses (`--ui <addr>` with a socket, or `--no-ui` with one);
+		// parsing keeps both so it can tell them apart and say which was meant.
+		expect(parseRun(["--ui", "9000", "--ui-socket", "/tmp/s.sock"])).toMatchObject({
+			ui: "9000",
+			uiSocket: "/tmp/s.sock",
+		})
+		expect(parseRun(["--no-ui", "--ui-socket", "/tmp/s.sock"])).toMatchObject({
+			ui: false,
+			uiSocket: "/tmp/s.sock",
+		})
+		// A bare --ui names no address, so it is not a competing target.
+		expect(parseRun(["--ui", "--ui-socket", "/tmp/s.sock"])).toMatchObject({ ui: true, uiSocket: "/tmp/s.sock" })
+	})
+
 	it("carries the other run flags", () => {
 		const options = parseRun(["-c", "filler-config.toml", "-d", "/data", "--watch-only"])
 		expect(options).toMatchObject({ config: "filler-config.toml", dataDir: "/data", watchOnly: true })

--- a/sdk/packages/simplex/src/tests/ui-server-socket.test.ts
+++ b/sdk/packages/simplex/src/tests/ui-server-socket.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, vi } from "vitest"
-import { existsSync, linkSync, mkdtempSync, statSync } from "node:fs"
+import { existsSync, linkSync, mkdtempSync, readFileSync, statSync, symlinkSync, writeFileSync } from "node:fs"
 import { request as httpRequest } from "node:http"
 import { createServer as createNetServer, connect as netConnect, createConnection, type Socket } from "node:net"
 import { tmpdir } from "node:os"
@@ -251,6 +251,65 @@ describe("UiServer Unix socket listen mode", () => {
 
 		server.stop()
 		expect(existsSync(socketPath)).toBe(false)
+	})
+
+	it("creates the socket 0600 even under a permissive umask", async () => {
+		// The mode IS the access control here, and it has to be right at creation, not
+		// shortly after: libuv makes the file 0777 & ~umask, and Linux checks that mode
+		// at connect(2) and never again — so a connection won before a later chmod is
+		// served for the life of the daemon. Under `umask 0` the old bind-then-chmod
+		// order left the socket briefly 0777 to every local user.
+		if (process.platform === "win32") return
+		const socketPath = join(tmpDir(), "ui.sock")
+		const { server } = newServer()
+		const previousUmask = process.umask(0o000)
+		try {
+			await server.start({ socketPath })
+			expect((statSync(socketPath).mode & 0o777).toString(8)).toBe("600")
+		} finally {
+			process.umask(previousUmask)
+		}
+		// The process-wide umask is borrowed only for the bind, and handed back.
+		expect(process.umask()).toBe(previousUmask)
+	})
+
+	it("refuses a non-socket at the socket path instead of deleting it", async () => {
+		// connect(2) answers ECONNREFUSED for a regular file exactly as it does for an
+		// orphaned socket, so a probe-only staleness test reads an operator's file as a
+		// corpse and unlinks it. `--ui-socket ~/filler-config.toml` must not eat it.
+		if (process.platform === "win32") return
+		const socketPath = join(tmpDir(), "not-a-socket.toml")
+		writeFileSync(socketPath, "[simplex.signer]\nkey = \"0xdeadbeef\"\n")
+		const { server } = newServer()
+		await expect(server.start({ socketPath })).rejects.toThrow(/exists and is a regular file; refusing to remove it/)
+		expect(readFileSync(socketPath, "utf8")).toContain("0xdeadbeef")
+	})
+
+	it("refuses a dangling symlink at the socket path with an actionable error", async () => {
+		// existsSync follows symlinks, so a broken one reads as absent: nothing gets
+		// cleaned up and the bind then fails with a bare EADDRINUSE naming no cause.
+		if (process.platform === "win32") return
+		const dir = tmpDir()
+		const socketPath = join(dir, "ui.sock")
+		symlinkSync(join(dir, "nowhere"), socketPath)
+		expect(existsSync(socketPath)).toBe(false)
+		const { server } = newServer()
+		await expect(server.start({ socketPath })).rejects.toThrow(/exists and is a symbolic link; refusing to remove it/)
+	})
+
+	it("does not relabel a live TCP listener's connections when a socket start fails", async () => {
+		// `listenProvenance` decides whether the DNS-rebinding check runs. Setting it
+		// before the bind meant a rejected socket start on an already-listening server
+		// left every TCP connection tagged 'unix' — and so exempt from the Host check.
+		const { server } = newServer()
+		const port = await server.start(0)
+		expect(await tcpRequest(port, "/api/status", "evil.example.com")).toContain("403")
+
+		await expect(server.start({ socketPath: join(tmpDir(), "ui.sock") })).rejects.toThrow(/already listening/)
+
+		// Still a TCP listener, so still defended.
+		expect(await tcpRequest(port, "/api/status", "evil.example.com")).toContain("403")
+		expect(await tcpRequest(port, "/api/status", `127.0.0.1:${port}`)).toContain("200")
 	})
 
 	it("recovers a socket file left behind by a killed run", async () => {

--- a/sdk/packages/simplex/src/tests/ui-server-socket.test.ts
+++ b/sdk/packages/simplex/src/tests/ui-server-socket.test.ts
@@ -1,0 +1,335 @@
+import { describe, it, expect, afterEach, vi } from "vitest"
+import { existsSync, linkSync, mkdtempSync, statSync } from "node:fs"
+import { request as httpRequest } from "node:http"
+import { createServer as createNetServer, connect as netConnect, createConnection, type Socket } from "node:net"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { UiServer, type OperatorContext } from "@/services/server/UiServer"
+import { ActivityRecorder } from "@/data/recorder"
+import { MemoryDataStore } from "@/data/memory"
+import { SignerType } from "@/services/wallet"
+import type { FillerConfigFile } from "@/config/filler-toml"
+import type { ActivityEvent } from "@/data/types"
+
+// Covers the Unix-socket listen mode: an embedding application (the desktop app)
+// attaches to the daemon over a `0600` socket file rather than a TCP port, so no
+// other local user can reach `/api/send` and no web page can reach it at all.
+//
+// The socket path doubles as that application's discovery mechanism and its
+// single-instance lock, which is why a leftover file must be recovered rather
+// than fatal, and a live one must be refused rather than stolen.
+
+const CSRF = { "X-Simplex-UI": "1", "Content-Type": "application/json" }
+
+function tmpDir(): string {
+	return mkdtempSync(join(tmpdir(), "simplex-uds-"))
+}
+
+/** One HTTP request over a Unix socket, with the Host header under our control. */
+function socketRequest(
+	socketPath: string,
+	path: string,
+	opts: { method?: string; headers?: Record<string, string>; body?: string } = {},
+): Promise<{ status: number; body: string }> {
+	return new Promise((resolve, reject) => {
+		const req = httpRequest({ socketPath, path, method: opts.method ?? "GET", headers: opts.headers }, (res) => {
+			let body = ""
+			res.setEncoding("utf8")
+			res.on("data", (chunk: string) => {
+				body += chunk
+			})
+			res.on("end", () => resolve({ status: res.statusCode ?? 0, body }))
+		})
+		req.on("error", reject)
+		req.end(opts.body)
+	})
+}
+
+/** A raw GET over TCP, so the Host header is exactly what the test says it is. */
+function tcpRequest(port: number, path: string, host: string): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const socket = createConnection(port, "127.0.0.1", () => {
+			socket.write(`GET ${path} HTTP/1.1\r\nHost: ${host}\r\nConnection: close\r\n\r\n`)
+		})
+		let data = ""
+		socket.on("data", (chunk) => {
+			data += chunk.toString()
+		})
+		socket.on("end", () => resolve(data))
+		socket.on("error", reject)
+	})
+}
+
+/** Opens the SSE stream over a socket and hands back the frames as they arrive. */
+function openSse(socketPath: string): Promise<{
+	status: number
+	contentType?: string
+	next: () => Promise<string>
+	close: () => void
+}> {
+	return new Promise((resolve, reject) => {
+		const req = httpRequest({ socketPath, path: "/api/events", method: "GET" }, (res) => {
+			const pending: string[] = []
+			let waiter: ((frame: string) => void) | undefined
+			res.setEncoding("utf8")
+			res.on("data", (chunk: string) => {
+				if (waiter) {
+					waiter(chunk)
+					waiter = undefined
+				} else pending.push(chunk)
+			})
+			resolve({
+				status: res.statusCode ?? 0,
+				contentType: res.headers["content-type"],
+				next: () =>
+					pending.length > 0
+						? Promise.resolve(pending.shift() as string)
+						: new Promise<string>((r) => {
+								waiter = r
+							}),
+				close: () => req.destroy(),
+			})
+		})
+		req.on("error", reject)
+		req.end()
+	})
+}
+
+/**
+ * Hands the server a live socket it never listened for — the shape of every
+ * tunnel connection, which arrives as an SSH channel dialled outbound to the
+ * relay and injected with `accept()`. A real TCP pair rather than a stub duplex,
+ * so the HTTP server gets a socket with every method it actually calls.
+ */
+async function injectConnection(server: UiServer): Promise<{ client: Socket; delivered: boolean }> {
+	const pairer = createNetServer()
+	await new Promise<void>((resolve) => pairer.listen(0, "127.0.0.1", () => resolve()))
+	const { port } = pairer.address() as { port: number }
+	const accepted = new Promise<Socket>((resolve) => pairer.once("connection", resolve))
+	const client = netConnect(port, "127.0.0.1")
+	await new Promise<void>((resolve, reject) => {
+		client.once("connect", () => resolve())
+		client.once("error", reject)
+	})
+	const serverSide = await accepted
+	pairer.close()
+	return { client, delivered: server.accept(serverSide) }
+}
+
+function readAll(socket: Socket): Promise<string> {
+	return new Promise((resolve, reject) => {
+		let data = ""
+		socket.on("data", (chunk) => {
+			data += chunk.toString()
+		})
+		socket.on("end", () => resolve(data))
+		socket.on("close", () => resolve(data))
+		socket.on("error", reject)
+	})
+}
+
+function operatorContext(): OperatorContext & { configPath: string } {
+	const data = new MemoryDataStore()
+	const config: FillerConfigFile = {
+		simplex: {
+			signer: { type: SignerType.PrivateKey, key: "0xab" },
+			substratePrivateKey: "seed",
+			hyperbridgeWsUrl: "wss://example",
+		},
+		pairs: [],
+		chains: [],
+	}
+	let paused = false
+	return {
+		strategies: [],
+		filler: {
+			pause() {
+				paused = true
+			},
+			resume() {
+				paused = false
+			},
+			isPaused: () => paused,
+			getWatchOnly: () => ({}),
+		},
+		balances: { getSnapshot: () => ({ updatedAt: null, status: "loading", chains: [], issues: [] }) },
+		haltControls: [],
+		config,
+		stop: vi.fn().mockResolvedValue(undefined),
+		activity: new ActivityRecorder(data.activity),
+		bids: data.bids,
+		setPaused: vi.fn(),
+		setLogLevel: vi.fn(),
+		applyAllowlist: vi.fn(),
+		applyRebalancing: vi.fn(),
+		version: "0.0.0-test",
+		startedAt: Date.now(),
+		configPath: join(tmpDir(), "filler-config.toml"),
+		chains: [],
+		strategyTypes: [],
+	}
+}
+
+describe("UiServer Unix socket listen mode", () => {
+	const servers: UiServer[] = []
+
+	function newServer(): { server: UiServer; operator: OperatorContext } {
+		const operator = operatorContext()
+		const server = new UiServer({ mode: "operator", operator })
+		servers.push(server)
+		return { server, operator }
+	}
+
+	afterEach(() => {
+		while (servers.length > 0) servers.pop()?.stop()
+	})
+
+	it("serves the JSON API, mutating routes and SSE over a socket", async () => {
+		const socketPath = join(tmpDir(), "ui.sock")
+		const { server, operator } = newServer()
+		expect(await server.start({ socketPath })).toBe(0)
+
+		const health = await socketRequest(socketPath, "/health")
+		expect(health.status).toBe(200)
+		expect(JSON.parse(health.body)).toEqual({ status: "ok", mode: "operator" })
+
+		const status = await socketRequest(socketPath, "/api/status")
+		expect(status.status).toBe(200)
+		expect(JSON.parse(status.body).mode).toBe("operator")
+
+		// Mutating routes work, and the CSRF header rule is untouched by the transport.
+		const unguarded = await socketRequest(socketPath, "/api/pause", { method: "POST" })
+		expect(unguarded.status).toBe(403)
+		const paused = await socketRequest(socketPath, "/api/pause", { method: "POST", headers: CSRF })
+		expect(paused.status).toBe(200)
+		expect(JSON.parse(paused.body)).toEqual({ paused: true })
+
+		// SSE is the endpoint the desktop app has to bridge, so it gets its own check.
+		const sse = await openSse(socketPath)
+		expect(sse.status).toBe(200)
+		expect(sse.contentType).toBe("text/event-stream")
+		expect(await sse.next()).toBe(":ok\n\n")
+		const event = { id: 1, ts: 42, type: "detected" } as unknown as ActivityEvent
+		operator.activity.emit("event", event)
+		expect(await sse.next()).toBe(`data: ${JSON.stringify(event)}\n\n`)
+		sse.close()
+	})
+
+	it("skips the host-header check on a socket while TCP still enforces it", async () => {
+		const socketPath = join(tmpDir(), "ui.sock")
+		const { server } = newServer()
+		await server.start({ socketPath })
+
+		// An HTTP client over a socket puts whatever it likes in Host — node:http
+		// sends "localhost", others send the URL's authority. There is no name to
+		// rebind onto a socket and no browser that can open one, so the check is
+		// skipped rather than relaxed, and a Host that TCP must refuse is served.
+		for (const host of ["evil.example.com", "simplex.internal", "unix", "127.0.0.1.evil.example.com"]) {
+			const res = await socketRequest(socketPath, "/api/status", { headers: { host } })
+			expect({ host, status: res.status }).toEqual({ host, status: 200 })
+		}
+
+		// The DNS-rebinding defense is unchanged for a listening port.
+		const { server: overTcp } = newServer()
+		const port = await overTcp.start(0)
+		expect(await tcpRequest(port, "/api/status", "evil.example.com")).toContain("403")
+		expect(await tcpRequest(port, "/api/status", "127.0.0.1.evil.example.com")).toContain("403")
+		expect(await tcpRequest(port, "/api/status", `127.0.0.1:${port}`)).toContain("200")
+	})
+
+	it("narrows the socket to the owning user and removes it on stop", async () => {
+		// Windows named pipes carry no file mode; see docs/ai/Decisions.md.
+		if (process.platform === "win32") return
+		const socketPath = join(tmpDir(), "ui.sock")
+		const { server } = newServer()
+		await server.start({ socketPath })
+
+		// Node binds it 0777 & ~umask — 0775 under the common `umask 002`, which
+		// lets the operator's whole group drive /api/send. The chmod is the access
+		// control this listen mode exists for, not decoration.
+		expect((statSync(socketPath).mode & 0o777).toString(8)).toBe("600")
+
+		server.stop()
+		expect(existsSync(socketPath)).toBe(false)
+	})
+
+	it("recovers a socket file left behind by a killed run", async () => {
+		const dir = tmpDir()
+		const bound = join(dir, "bound.sock")
+		const orphan = join(dir, "orphan.sock")
+
+		// A genuine orphaned socket inode. Binding one and hard-linking a second
+		// name to it, then closing the server, leaves the link behind: close()
+		// unlinks only the name it bound. That is exactly the on-disk state a
+		// SIGKILLed run leaves, and it is why an existence test will not do — a
+		// live socket has a file too.
+		const previous = createNetServer()
+		await new Promise<void>((resolve) => previous.listen(bound, () => resolve()))
+		linkSync(bound, orphan)
+		await new Promise<void>((resolve) => previous.close(() => resolve()))
+		expect(existsSync(orphan)).toBe(true)
+		expect(statSync(orphan).isSocket()).toBe(true)
+
+		const { server } = newServer()
+		await expect(server.start({ socketPath: orphan })).resolves.toBe(0)
+		expect((await socketRequest(orphan, "/health")).status).toBe(200)
+	})
+
+	it("refuses to take over a socket another instance is serving", async () => {
+		const socketPath = join(tmpDir(), "ui.sock")
+		const { server: first } = newServer()
+		await first.start({ socketPath })
+
+		// Stealing the path would silently take the running instance's clients.
+		// Refusing is also the single-instance lock the desktop app attaches with.
+		const { server: second } = newServer()
+		await expect(second.start({ socketPath })).rejects.toThrow(/already serving/i)
+
+		// The incumbent is untouched.
+		expect((await socketRequest(socketPath, "/health")).status).toBe(200)
+	})
+
+	it("rejects a socket path longer than sun_path with an actionable error", async () => {
+		// Otherwise this surfaces at bind time naming neither the limit nor the path.
+		if (process.platform === "win32") return
+		const socketPath = join(tmpDir(), `${"a".repeat(120)}.sock`)
+		const { server } = newServer()
+		await expect(server.start({ socketPath })).rejects.toThrow(/over this platform's \d+-byte limit/)
+		expect(existsSync(socketPath)).toBe(false)
+	})
+
+	// The trap this pins: `accept()` returns false unless the server is listening,
+	// which couples remote access to a listener it does not logically need. Tunnel
+	// connections are dialled outbound to the relay and injected — nothing listens
+	// for them — so a socket-only server must serve remote devices exactly as a TCP
+	// one does. A Unix listener satisfies the guard today; a later change that drops
+	// the listener entirely would break remote access, and this is what would catch it.
+	it("serves tunnelled connections against a socket-only server", async () => {
+		const socketPath = join(tmpDir(), "ui.sock")
+		const { server } = newServer()
+		await server.start({ socketPath })
+
+		const { client, delivered } = await injectConnection(server)
+		expect(delivered).toBe(true)
+		client.write("GET /api/status HTTP/1.1\r\nHost: 127.0.0.1:8686\r\nConnection: close\r\n\r\n")
+		const response = await readAll(client)
+		expect(response).toContain("200 OK")
+		expect(response).toContain('"mode":"operator"')
+	})
+
+	it("turns a tunnelled connection away when nothing is listening", async () => {
+		// Not a silent failure, but the log it produces used to say "No UI to serve
+		// behind the tunnel" — misleading, since the UI exists and is merely unbound.
+		const { server } = newServer()
+		const { client, delivered } = await injectConnection(server)
+		expect(delivered).toBe(false)
+		client.destroy()
+
+		const socketPath = join(tmpDir(), "ui.sock")
+		await server.start({ socketPath })
+		server.stop()
+		const afterStop = await injectConnection(server)
+		expect(afterStop.delivered).toBe(false)
+		afterStop.client.destroy()
+	})
+})


### PR DESCRIPTION
Lets the solver serve its web UI over a Unix socket instead of a TCP port, so a desktop app can embed the daemon without opening a port at all.

Part of #1237. Daemon-side only — no Electron code here.

## Why

The UI server has no authentication of any kind. `/api/send` transfers tokens.

Right now it listens on `127.0.0.1:8686`. Every local user on the machine can reach that port.

A socket file is different. The kernel decides who may connect, and a web page cannot open one at all.

**The CLI is unchanged.** It still binds `127.0.0.1:8686` exactly as before. This is purely additive.

## What you get

```bash
simplex --ui-socket /run/user/1000/simplex.sock
```

That serves the full API and the SSE stream over the socket. No port is opened.

| Who | Listens on |
| --- | --- |
| CLI (`simplex`) | TCP `127.0.0.1:8686`, unchanged |
| Desktop app | a Unix socket, and nothing else |

## How it works

`UiServer.start()` now takes either `{ host, port }` or `{ socketPath }`. Node speaks HTTP over a socket natively, so the routes, the handlers and the SSE code are untouched.

`--ui-socket` is declared in `src/cli/run-options.ts` alongside the other `run` flags, and covered by the tests there.

Every connection is tagged with how it arrived: `tcp`, `unix` or `tunnel`. The tag is a symbol set on a socket this process owns, so nothing a client sends can forge it.

One rule reads that tag. The Host-header check is our DNS-rebinding defence, and it is skipped for socket connections. There is no DNS name to rebind onto a socket, and no browser can open one, so the check defends nothing there. It is unchanged for TCP.

## Security

The socket is created mode `0600`.

The ordering matters more than it looks, and I got it wrong in the first version of this PR:

- Binding first and running `chmod` after leaves the file at `0775` for about a millisecond, under the usual `umask 002`.
- Unix socket permissions are checked when a client connects, and never again.
- So a connection made during that gap keeps working for the life of the daemon. The later `chmod` does not close it.

Fixed by setting `umask 0177` around the bind, so the socket is `0600` from the instant it exists.

An audit of the first version found that plus two more. All three are fixed:

- **Stale-socket cleanup deleted any file at the socket path.** `--ui-socket ~/filler-config.toml` would have deleted your config. It turns out `connect()` reports `ECONNREFUSED` for ordinary files too, not just for dead sockets.
- **A failed socket start on an already-listening server tagged TCP connections as `unix`**, which switched off the Host check for them.

The reasoning behind each fix is in `docs/ai/Decisions.md`.

## Testing

12 tests in `src/tests/ui-server-socket.test.ts`. Every fix has a test that fails if you revert that fix.

They cover the API, SSE and CSRF over a socket, the `0600` mode, recovering a socket left behind by a killed process, and that remote access over the tunnel still works when nothing is listening on a port.

## Known gaps, not addressed here

- **The UI server still has no authentication, in any mode.** The Host check stops browsers, not `curl`. This PR narrows who can reach the server. It does not add auth.
- On Windows this is a named pipe, and its default permissions are weaker than `0600`. Node cannot tighten them. Written up in `docs/ai/Decisions.md`.
- `serveStatic`'s path guard uses a bare `startsWith`. Pre-existing.

Docs under `docs/ai/` are updated. No version bump — `package.json` is untouched.
