### PR TITLE
[simplex]: add --no-open and --log-format json to the CLI

### DIFF
--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -141,6 +141,11 @@ jobs:
             - name: Run simplex data-store tests
               run: pnpm --filter="@hyperbridge/simplex" test:data
 
+            # test:filler covers the network-backed suites; the CLI and logger units
+            # were gated by nothing until 2026-09-10, so a broken flag stayed green.
+            - name: Run simplex test - cli and logger units
+              run: pnpm --filter="@hyperbridge/simplex" test:unit
+
             - name: Run simplex test
               run: pnpm --filter="@hyperbridge/simplex" test:filler
 

--- a/sdk/packages/simplex/README.md
+++ b/sdk/packages/simplex/README.md
@@ -92,7 +92,9 @@ simplex run --log-format json                # NDJSON on stdout instead of colou
 
 `--no-open` and `--log-format json` are for running the solver under a supervisor. The wizard still
 starts and still reports its URL under `--no-open`; only the browser launch is skipped. `json` makes
-every line of stdout one JSON object, with no ANSI escapes, which is what a captured log file needs.
+every line simplex writes to stdout one JSON object, with no ANSI escapes, which is what a captured log
+file needs. (One caveat: `@polkadot/api` prints a plain-text line to stdout if the Hyperbridge runtime
+upgrades while the solver is running, so parse defensively.)
 
 The curve-update API:
 

--- a/sdk/packages/simplex/README.md
+++ b/sdk/packages/simplex/README.md
@@ -86,7 +86,13 @@ Flags:
 simplex run -c filler-config.toml            # UI on 127.0.0.1:8686
 simplex run -c filler-config.toml --ui 9000  # custom port
 simplex run -c filler-config.toml --no-ui    # headless
+simplex run --no-open                        # start the wizard, don't launch a browser
+simplex run --log-format json                # NDJSON on stdout instead of colourised lines
 ```
+
+`--no-open` and `--log-format json` are for running the solver under a supervisor. The wizard still
+starts and still reports its URL under `--no-open`; only the browser launch is skipped. `json` makes
+every line of stdout one JSON object, with no ANSI escapes, which is what a captured log file needs.
 
 The curve-update API:
 

--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -333,8 +333,14 @@ byte-identical to a default run and launched no browser (checked with a stub `xd
 `--log-format pretty` was identical to passing nothing. A separate check ran two `LoggerContext`s into
 one shared `process.stdout` for 4000 records and found no interleaved or partial lines.
 
-Files: src/bin/simplex.ts, src/cli/log-format.ts (new), src/tests/cli/log-format.test.ts (new),
-README.md.
+Rebased onto #1249, which split `run`'s option declarations into `addRunOptions`
+(`src/cli/run-options.ts`). Both flags moved there, and `open` joined its `RunOptions` interface;
+`logFormat` deliberately did not. The test now parses the real builder instead of a hand-copied mirror,
+which is what makes the `--ui`-swallows-the-next-flag case (fixed by #1249) testable here at all — the
+suite went from 15 to 22 tests, including the first coverage `--no-open` has had.
+
+Files: src/bin/simplex.ts, src/cli/run-options.ts, src/cli/log-format.ts (new),
+src/tests/cli/log-format.test.ts (new), README.md.
 
 No version bump. Four simplex branches were open against #1237 at once and a bump in each would have
 collided on the same field for nothing — publishing is tag-driven, so the version can be set once on

--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -261,6 +261,37 @@ listened for. Each fix was mutation-checked: reverting it fails its test.
 Files: src/services/server/UiServer.ts, src/services/server/http-util.ts,
 src/services/tunnel/EmbeddedSshServer.ts, src/bin/simplex.ts, src/tests/ui-server-socket.test.ts,
 docs/ai/{ChangeLog,Decisions,Flow}.md.
+## 2026-09-09 — `--no-open` and `--log-format json`, for running the solver under a supervisor (#1237)
+
+The desktop app spawns `simplex` as a detached child and captures its stdout to a log file. Two things
+the CLI did unconditionally get in the way of that, so each now has a flag on `run`.
+
+`--no-open` suppresses the `openBrowser()` call on the setup-wizard path. The app renders the wizard in
+its own window, so a system browser opening alongside it is wrong. Nothing else about that path changes:
+the server still binds and the URL is still reported. This is not `--no-ui`, which turns the UI server
+off entirely.
+
+`--log-format <pretty|json>` chooses how this process's logs reach stdout, and defaults to `pretty`, so
+a terminal user sees what they saw before. In `json` mode `consoleSink()` returns `process.stdout`
+itself and pino's NDJSON goes out untouched — no pino-pretty, so no ANSI escapes in the captured file.
+The ASCII banner and the wizard's plain-text URL line are the only other writers to stdout: in json mode
+the banner is dropped and the URL becomes a `cli` record carrying a `url` field. Every line of stdout is
+then one JSON object.
+
+The format is read from raw argv by `logFormatFromArgv`, because the process-wide sink is registered
+while `bin/simplex.ts` is still evaluating, before commander has parsed anything. Commander declares the
+flag too, so `--help` lists it and an unknown value is rejected with the allowed choices.
+`src/tests/cli/log-format.test.ts` pins the scan and checks it agrees with commander across the
+invocations that reach the flag.
+
+Verified against the built bundle in a directory with no config. `--no-open` produced stdout
+byte-identical to a default run and launched no browser (checked with a stub `xdg-open` on `PATH`).
+`--log-format json` produced two records, both parsing as JSON, with zero ANSI escapes and no banner.
+`--log-format pretty` was identical to passing nothing. A separate check ran two `LoggerContext`s into
+one shared `process.stdout` for 4000 records and found no interleaved or partial lines.
+
+Files: src/bin/simplex.ts, src/cli/log-format.ts (new), src/tests/cli/log-format.test.ts (new),
+README.md, package.json (0.17.0).
 
 
 ## 2026-09-09 — Make the SSH tunnel's publickey guard fail closed

--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -12,6 +12,28 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-09-10 — Guard the socket-mode wizard announcement for json output (#1237)
+
+Rebasing #1237 onto #1245 (Unix domain socket listen mode) landed the exact collision the audit of
+this branch predicted. #1245 added an unguarded
+
+    console.log(`\n  No config found — the setup wizard is serving on ${uiSocket}\n`)
+
+on the socket wizard path. Git merged it without complaint — it sits about twenty lines from the
+guarded TCP announcement, so the resolver got no signal — and `--ui-socket <path> --log-format json`
+would then emit one plain-text line into a stream a supervisor is parsing as NDJSON. That is the exact
+promise `--log-format json` exists to make.
+
+Guarded it the same way as its TCP sibling: a `cli` record carrying a `socket` field in json mode,
+the prose line otherwise.
+
+Worth noting for the next merge: this is now the second announcement on the wizard path, and both are
+easy to add a third alongside without noticing the rule. A `console.log` reaching stdout anywhere in
+`run` breaks json mode, and nothing in the suite catches it.
+
+Files: src/bin/simplex.ts.
+
+
 ## 2026-09-10 — `simplex --ui` with no value stopped erroring
 
 `run` declared the UI bind as `--ui [<[host:]port>]`. The `[...]` was meant to make the value

--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -295,7 +295,13 @@ the process: `@polkadot/util`'s logger routes `log` to `console.log`, and `bin/q
 `console.warn`, so a Hyperbridge runtime upgrade mid-run would print one plain-text line. The claims
 are now scoped to what simplex itself writes.
 
-Files: src/bin/simplex.ts, docs/ai/Decisions.md, docs/ai/Flow.md, README.md.
+CI ran none of this. `.github/workflows/test-sdk.yml` gated simplex on `test:filler`, which pins four
+network-backed files; `src/tests/cli` and `src/tests/logger.test.ts` were gated by nothing, so the
+flags' own 15 tests never ran on a PR. Added a `test:unit` script over those two paths and a CI step
+ahead of `test:filler`. It is network-free and takes ~20s.
+
+Files: src/bin/simplex.ts, package.json (test:unit), .github/workflows/test-sdk.yml,
+docs/ai/Decisions.md, docs/ai/Flow.md, README.md.
 
 
 ## 2026-09-09 — `--no-open` and `--log-format json`, for running the solver under a supervisor (#1237)

--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -261,6 +261,43 @@ listened for. Each fix was mutation-checked: reverting it fails its test.
 Files: src/services/server/UiServer.ts, src/services/server/http-util.ts,
 src/services/tunnel/EmbeddedSshServer.ts, src/bin/simplex.ts, src/tests/ui-server-socket.test.ts,
 docs/ai/{ChangeLog,Decisions,Flow}.md.
+## 2026-09-10 — json mode needs its own stdout `error` listener, or a broken pipe kills the filler (#1237)
+
+Found by auditing the branch that added `--log-format json`, and fixed on it before merge.
+
+`consoleSink()` returns a bare `process.stdout` in json mode. What that also removed, without anyone
+noticing, was error handling: pino-pretty's `build()` ends in `pump(source, stream, destination)`, and
+pump attaches `error` listeners to the destination — `process.stdout.listenerCount("error")` goes from
+0 to 2 the moment `prettyStream({destination: process.stdout})` is constructed. A stream with no
+listener turns a failed write into an unhandled `error` event, which Node turns into an uncaught
+exception.
+
+The failure lands precisely on the case the flag was added for. Spawning the built CLI detached with
+`stdio: ["ignore","pipe","pipe"]` and then destroying the read end — the desktop app quitting while
+the filler it spawned keeps running — killed it with exit 1 and `Unhandled 'error' event`, 3/3 runs.
+The same invocation without `--log-format json` survived, 3/3. `simplex run --log-format json | head`
+is the same failure at a terminal.
+
+Fix: `if (logFormat === "json") process.stdout.on("error", () => {})`, once at module scope beside the
+`logFormat` constant, because `consoleSink()` is called per writer. Swallowing matches the pretty path,
+where such an error tears down pump's chain and logging goes quiet while the filler keeps filling —
+`LoggerContext` already treats a broken sink as the host's problem rather than a reason to fail a fill.
+Re-verified after the fix: json survives 3/3, and all five acceptance criteria still hold (`--no-open`
+and `--log-format pretty` stdout byte-identical to a default run; json 2/2 valid lines, 0 ANSI bytes).
+
+The audit also corrected three inaccurate claims in the previous entry's docs. `init` and
+`validateConfig` were named as consumers of the process-wide sink; neither resolves a logger, and the
+real wizard-path consumers are `UiServer`'s `getLogger("ui")` and `setup-api`'s `getLogger("setup")`.
+The Flow.md walk placed the filler's second sink before the config branch, when `startFiller` is only
+*defined* there and called inside `if (configPath)`, and it omitted the `--no-ui` + no-config exit.
+And "every line of stdout is one JSON object" is true of every writer this package controls but not of
+the process: `@polkadot/util`'s logger routes `log` to `console.log`, and `bin/quiet.ts` patches only
+`console.warn`, so a Hyperbridge runtime upgrade mid-run would print one plain-text line. The claims
+are now scoped to what simplex itself writes.
+
+Files: src/bin/simplex.ts, docs/ai/Decisions.md, docs/ai/Flow.md, README.md.
+
+
 ## 2026-09-09 — `--no-open` and `--log-format json`, for running the solver under a supervisor (#1237)
 
 The desktop app spawns `simplex` as a detached child and captures its stdout to a log file. Two things

--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -334,7 +334,11 @@ byte-identical to a default run and launched no browser (checked with a stub `xd
 one shared `process.stdout` for 4000 records and found no interleaved or partial lines.
 
 Files: src/bin/simplex.ts, src/cli/log-format.ts (new), src/tests/cli/log-format.test.ts (new),
-README.md, package.json (0.17.0).
+README.md.
+
+No version bump. Four simplex branches were open against #1237 at once and a bump in each would have
+collided on the same field for nothing — publishing is tag-driven, so the version can be set once on
+whatever lands. This is the exception to the usual "bump inside the feature PR" rule, not a change to it.
 
 
 ## 2026-09-09 — Make the SSH tunnel's publickey guard fail closed

--- a/sdk/packages/simplex/docs/ai/Decisions.md
+++ b/sdk/packages/simplex/docs/ai/Decisions.md
@@ -412,6 +412,66 @@ the tunnel's hot path.
 
 `EmbeddedSshServer`'s log line was reworded, though: it said "No UI to serve behind the tunnel" for
 every refusal, which misdescribes the case where the UI exists and is merely unbound.
+## 2026-09-09 — `--log-format` is read from raw argv, and json mode writes straight to stdout (#1237)
+
+Decided: `bin/simplex.ts` calls `logFormatFromArgv(process.argv)` at module scope and builds its
+console sink from the result. Commander declares `--log-format <pretty|json>` on `run` as well, but
+only so that `--help` lists it and a bad value is rejected; the action never reads the parsed value.
+
+Why the scan rather than the parsed option: `addLogSink(consoleSink(...))` runs while the module is
+still evaluating, so that records emitted during parsing and command setup have somewhere to go.
+Commander has not run at that point. The sink has to exist before the parse, so its format has to be
+known before the parse.
+
+Why the action ignores `options.logFormat` even though it is available by then: the sink is already
+writing, and a command line the two readers disagree about (`simplex run -c --log-format json`, where
+commander binds `--log-format` to `-c`) would then put an ASCII banner in the middle of a stream a
+supervisor is parsing as NDJSON. One reader, one answer.
+
+Rejected: moving the `addLogSink` call into each command's action, after the parse. It would remove
+the double read, but the process-wide sink covers `init`, config validation and the keeper command as
+well as `run`, and anything logged during parsing would be lost. That is a real cost paid for a
+cosmetic gain.
+
+Decided: in json mode `consoleSink()` returns `process.stdout` itself. pino hands a destination one
+finished NDJSON record per write, newline included, so there is nothing left to format.
+
+Why not pino-pretty with `colorize: false`: pino-pretty would still reformat, drop fields and reorder
+them. The point of json mode is that a parser downstream sees exactly what pino produced.
+
+This also removes the interleaving hazard that forces one pino-pretty transform per writer on the
+pretty path. Two pino instances sharing one pino-pretty transform interleave their chunks, and it
+echoes the unparseable remainder as raw NDJSON. With no transform in between there is nothing
+reassembling anything, so the process context and a running filler can share one `process.stdout`
+safely. Checked by running two `LoggerContext`s into a shared stdout for 4000 records with 4 KB
+payloads: no partial or interleaved lines.
+
+Decided: in json mode the ASCII banner is not printed and the wizard's URL line becomes a log record
+with a `url` field. Those two are the only writers to stdout outside the logger, and either one would
+break the promise that every line is a JSON object. The URL is more useful as a field than as prose a
+parser would have to scrape.
+
+Rejected: deciding the format by whether stdout is a TTY, the way many tools do. It is the more
+convenient default, but it silently changes what an existing user gets the moment they pipe simplex
+into a file — and `colorize: true` is currently explicit, so today they get colour there on purpose.
+An explicit flag keeps "no flags" meaning exactly what it meant before.
+
+
+## 2026-09-09 — `--no-open` and `--log-format` are flags only, with no env-var equivalent (#1237)
+
+Decided: neither flag has a `SIMPLEX_*` counterpart. The consumer in #1237 is Electron's `spawn`,
+which builds argv directly, so there is nothing to make easier. Docker is the other supervisor, and it
+already passes CLI arguments through `CMD` — the image's default command carries `--ui` for the same
+reason.
+
+Rejected: adding `SIMPLEX_NO_OPEN` / `SIMPLEX_LOG_FORMAT` alongside. Two ways to say one thing needs a
+precedence rule, and that rule needs a test and a place in the docs, all for a caller that does not
+exist yet. `SIMPLEX_HOME` is the package's one env var and it earns its place: config discovery has to
+work before any argument is parsed. These do not have that problem — `--log-format` is read early, but
+it is read from argv, which is available just as early.
+
+If a supervisor that cannot construct argv does turn up, adding an env fallback inside
+`logFormatFromArgv` is a couple of lines and breaks nothing.
 
 
 ## 2026-09-09 — The publickey probe branch requires both halves absent, not either

--- a/sdk/packages/simplex/docs/ai/Decisions.md
+++ b/sdk/packages/simplex/docs/ai/Decisions.md
@@ -412,6 +412,39 @@ the tunnel's hot path.
 
 `EmbeddedSshServer`'s log line was reworded, though: it said "No UI to serve behind the tunnel" for
 every refusal, which misdescribes the case where the UI exists and is merely unbound.
+## 2026-09-10 — json mode installs its own `error` listener on stdout, and swallows (#1237)
+
+Decided: when the format is `json`, `bin/simplex.ts` registers `process.stdout.on("error", () => {})`
+once at module scope, next to where `logFormat` is resolved.
+
+Why it is needed at all: the thing pino-pretty was providing was not only formatting. Its `build()`
+ends in `pump(source, stream, destination)`, and pump attaches error handling to the destination —
+measurably, `process.stdout.listenerCount("error")` goes from 0 to 2 the moment
+`prettyStream({destination: process.stdout})` is constructed. json mode returns the bare stream, so it
+dropped those listeners along with the transform. A stream with no `error` listener turns the first
+failed write into an unhandled `error` event, and Node turns that into an uncaught exception.
+
+That is not theoretical, and it lands exactly on the case the flag exists for. Spawned the built CLI
+detached with `stdio: ["ignore", "pipe", "pipe"]`, let it bind, then destroyed the read end — the
+parent going away while the filler keeps running, which is the whole point of the detached child in
+[#1237]. `--log-format json` died with exit 1 and `Unhandled 'error' event`, 3/3. The same run without
+the flag survived, 3/3. `simplex run --log-format json | head` is the same failure in a terminal.
+
+Why swallow rather than re-throw non-EPIPE errors: parity with the path this replaces. On the pretty
+path an stdout error tears down pump's chain and logging simply goes quiet; the filler keeps filling.
+`LoggerContext`'s destination already states the principle — "A broken sink is the host's problem, not
+a reason to fail a fill". Re-throwing anything other than EPIPE would make json mode strictly more
+fragile than pretty, which inverts the point of the flag.
+
+Rejected: registering the listener inside `consoleSink()`. It is called once per writer — the
+process-wide sink and again per filler — so that adds a duplicate listener per Simplex and drifts
+toward Node's max-listeners warning. The format is a module-level constant; the listener belongs with it.
+
+Rejected: `process.stdout.on("error")` unconditionally, for both formats. On the pretty path pino-pretty
+already installs its own, and adding a second changes existing behaviour for every current user — which
+the "default behaviour is completely unchanged" requirement rules out.
+
+
 ## 2026-09-09 — `--log-format` is read from raw argv, and json mode writes straight to stdout (#1237)
 
 Decided: `bin/simplex.ts` calls `logFormatFromArgv(process.argv)` at module scope and builds its
@@ -419,9 +452,8 @@ console sink from the result. Commander declares `--log-format <pretty|json>` on
 only so that `--help` lists it and a bad value is rejected; the action never reads the parsed value.
 
 Why the scan rather than the parsed option: `addLogSink(consoleSink(...))` runs while the module is
-still evaluating, so that records emitted during parsing and command setup have somewhere to go.
-Commander has not run at that point. The sink has to exist before the parse, so its format has to be
-known before the parse.
+still evaluating, so the sink exists before anything can log. Commander has not run at that point. The
+sink has to exist before the parse, so its format has to be known before the parse.
 
 Why the action ignores `options.logFormat` even though it is available by then: the sink is already
 writing, and a command line the two readers disagree about (`simplex run -c --log-format json`, where
@@ -429,9 +461,11 @@ commander binds `--log-format` to `-c`) would then put an ASCII banner in the mi
 supervisor is parsing as NDJSON. One reader, one answer.
 
 Rejected: moving the `addLogSink` call into each command's action, after the parse. It would remove
-the double read, but the process-wide sink covers `init`, config validation and the keeper command as
-well as `run`, and anything logged during parsing would be lost. That is a real cost paid for a
-cosmetic gain.
+the double read, but the process-wide sink is what the setup wizard logs to — `UiServer`'s
+`getLogger("ui")` and `setup-api`'s `getLogger("setup")`, which produce the first record of a wizard
+run — as well as the keeper command, so each would need its own copy of the wiring. That is a real
+cost paid for a cosmetic gain. (`init` is not in that list: nothing under `src/cli/init/**` resolves a
+logger, and it spawns `simplex run` as a child rather than sharing the process.)
 
 Decided: in json mode `consoleSink()` returns `process.stdout` itself. pino hands a destination one
 finished NDJSON record per write, newline included, so there is nothing left to format.
@@ -447,9 +481,16 @@ safely. Checked by running two `LoggerContext`s into a shared stdout for 4000 re
 payloads: no partial or interleaved lines.
 
 Decided: in json mode the ASCII banner is not printed and the wizard's URL line becomes a log record
-with a `url` field. Those two are the only writers to stdout outside the logger, and either one would
-break the promise that every line is a JSON object. The URL is more useful as a field than as prose a
-parser would have to scrape.
+with a `url` field. Those two are the only writers to stdout outside the logger *in this package*, and
+either one would break the promise that every line is a JSON object. The URL is more useful as a field
+than as prose a parser would have to scrape.
+
+The promise is therefore about what simplex itself writes, not about the process. `@polkadot/util`'s
+logger routes `log` to `console.log`, and `@polkadot/api`'s `Init.js` uses it to announce "Runtime
+version updated to spec=…"; `bin/quiet.ts` patches only `console.warn`, so that one line would reach
+stdout as plain text on a genuine Hyperbridge runtime upgrade. Rejected for now: widening `quiet.ts` to
+redirect that logger's `console.log` to stderr. It is the right fix if json mode ever needs to be
+absolute, but it changes behaviour on the pretty path too, and this change was scoped to two flags.
 
 Rejected: deciding the format by whether stdout is a TTY, the way many tools do. It is the more
 convenient default, but it silently changes what an existing user gets the moment they pipe simplex

--- a/sdk/packages/simplex/docs/ai/Decisions.md
+++ b/sdk/packages/simplex/docs/ai/Decisions.md
@@ -458,7 +458,12 @@ sink has to exist before the parse, so its format has to be known before the par
 Why the action ignores `options.logFormat` even though it is available by then: the sink is already
 writing, and a command line the two readers disagree about (`simplex run -c --log-format json`, where
 commander binds `--log-format` to `-c`) would then put an ASCII banner in the middle of a stream a
-supervisor is parsing as NDJSON. One reader, one answer.
+supervisor is parsing as NDJSON. One reader, one answer. `RunOptions` in `src/cli/run-options.ts`
+therefore omits `logFormat`, with the reason recorded on the field it would have occupied.
+
+Both flags live in `addRunOptions` (`src/cli/run-options.ts`) with the rest of `run`'s options, after
+#1249 split that builder out of the bin. That is also what lets the tests parse the *real* declarations
+rather than a hand-copied mirror that could drift.
 
 Rejected: moving the `addLogSink` call into each command's action, after the parse. It would remove
 the double read, but the process-wide sink is what the setup wizard logs to — `UiServer`'s

--- a/sdk/packages/simplex/docs/ai/Flow.md
+++ b/sdk/packages/simplex/docs/ai/Flow.md
@@ -9,30 +9,47 @@ Read from `bin/simplex.ts` and exercised against the built `dist/bin/simplex.js`
 1. Module evaluation, before commander sees anything. `logFormatFromArgv(process.argv)` scans raw argv
    for `--log-format` (both `--log-format json` and `--log-format=json`, last occurrence wins, stopping
    at `--`) and falls back to `pretty`. `addLogSink(consoleSink(logFormat))` then registers the sink on
-   the process-wide `LoggerContext`, which is what `init`, config validation, the keeper command and
-   anything logged during parsing write to.
-2. `consoleSink(format)` returns `process.stdout` for `json` and a `pino-pretty` transform for
+   the process-wide `LoggerContext`. On the `run` path its real consumers are the `cli` logger and,
+   in wizard mode, `UiServer`'s `getLogger("ui")` and `setup-api`'s `getLogger("setup")` — the first
+   record of a wizard run is `[ui]`, not `[cli]`. The keeper command uses it too. `init` does not:
+   nothing under `src/cli/init/**` resolves a logger, and it spawns `simplex run` as a child anyway.
+2. In json mode only, an `error` listener goes on `process.stdout`. pino-pretty's `pump()` chain
+   installs one on whatever destination it is given (0 listeners before `prettyStream(...)`, 2 after);
+   a bare stream has none, and without it the first write after a reader disappears is an unhandled
+   `error` event that kills the process.
+3. `consoleSink(format)` returns `process.stdout` for `json` and a `pino-pretty` transform for
    `pretty`. The transform is built with `destination: process.stdout`, not `.pipe()` — piped, it
    echoes each record's raw NDJSON next to the formatted line.
-3. `program.parse(process.argv)` runs. `--log-format` is declared on `run` with `.choices()`, so an
+4. `program.parse(process.argv)` runs. `--log-format` is declared on `run` with `.choices()`, so an
    unknown value exits here with the allowed values and the action never runs. `--no-open` is a
    commander negated boolean: `options.open` is `true` unless the flag is present.
-4. The `run` action writes `ASCII_HEADER` to stdout only when `logFormat === "pretty"`.
-5. `startFiller` passes `consoleSink(logFormat)` as `SimplexOptions.logger`, so the filler's own
-   `LoggerContext` gets a second sink. On the pretty path that is a second pino-pretty transform, which
-   is deliberate: two pino instances sharing one transform interleave their chunks. On the json path
-   both sinks are the same `process.stdout`, which is safe because nothing is reassembling anything.
-6. With a config present the flow ends there — the filler and, if enabled, the UI and tunnel start, and
-   everything that follows is logged through those sinks.
-7. With no config, the wizard binds (falling back to an ephemeral port if the preferred one is taken)
-   and the URL is reported: `console.log` with the surrounding blank lines in pretty mode, or
+5. The `run` action writes `ASCII_HEADER` to stdout only when `logFormat === "pretty"`.
+6. The config branch. With a config present, `startFiller` is called and passes `consoleSink(logFormat)`
+   as `SimplexOptions.logger`, so the filler's own `LoggerContext` gets a second sink. On the pretty
+   path that is a second pino-pretty transform, which is deliberate: two pino instances sharing one
+   transform interleave their chunks. On the json path both sinks are the same `process.stdout`, which
+   is safe because nothing is reassembling anything. The flow ends there — the filler and, if enabled,
+   the UI and tunnel start, and everything after is logged through those sinks. (`startFiller` is
+   *defined* earlier in the action, but only called here or from the wizard's `onSaveAndStart`, so on
+   the no-config path there is no second sink until the operator saves.)
+7. With no config and `--no-ui`, the CLI writes "No config found (looked for ./filler-config.toml…)"
+   to stderr and exits 1. No wizard, no URL, no browser — and in pretty mode a banner already on
+   stdout with nothing after it.
+8. Otherwise the wizard binds (falling back to an ephemeral port if the preferred one is taken) and the
+   URL is reported: `console.log` with the surrounding blank lines in pretty mode, or
    `logger.info({ url }, ...)` on the `cli` module in json mode.
-8. `openBrowser(url)` runs unless `--no-open` was passed. It is best-effort in any case — a failed
+9. `openBrowser(url)` runs unless `--no-open` was passed. It is best-effort in any case — a failed
    spawn logs "Could not open a browser" and the printed URL is the fallback.
 
 So stdout in pretty mode is: banner, then colourised single-line records, then the wizard URL block. In
-json mode it is NDJSON and nothing else, one JSON object per line, with the wizard URL among the
-records.
+json mode every line simplex itself writes is one JSON object, with the wizard URL among the records.
+
+The one writer outside simplex's control is `@polkadot/util`'s logger, which routes `log` to
+`console.log`; `@polkadot/api`'s `Init.js` uses it to announce "Runtime version updated to spec=…".
+`bin/quiet.ts` patches only `console.warn`, so that line would land on stdout as plain text. It fires
+only on a genuine Hyperbridge runtime upgrade mid-run, and never on the wizard path, which builds no
+`ApiPromise` — but a json-mode consumer should tolerate a non-JSON line rather than assume none exists.
+
 ## Opening an operator data directory
 
 Read from the source and exercised by `src/tests/data/sqlite-compat.test.ts` against real

--- a/sdk/packages/simplex/docs/ai/Flow.md
+++ b/sdk/packages/simplex/docs/ai/Flow.md
@@ -20,9 +20,10 @@ Read from `bin/simplex.ts` and exercised against the built `dist/bin/simplex.js`
 3. `consoleSink(format)` returns `process.stdout` for `json` and a `pino-pretty` transform for
    `pretty`. The transform is built with `destination: process.stdout`, not `.pipe()` — piped, it
    echoes each record's raw NDJSON next to the formatted line.
-4. `program.parse(process.argv)` runs. `--log-format` is declared on `run` with `.choices()`, so an
-   unknown value exits here with the allowed values and the action never runs. `--no-open` is a
-   commander negated boolean: `options.open` is `true` unless the flag is present.
+4. `program.parse(process.argv)` runs. Both flags are declared in `addRunOptions` (`src/cli/run-options.ts`),
+   alongside the rest of `run`'s options. `--log-format` uses `.choices()`, so an unknown value exits
+   here with the allowed values and the action never runs. `--no-open` is a commander negated boolean:
+   `options.open` is `true` unless the flag is present.
 5. The `run` action writes `ASCII_HEADER` to stdout only when `logFormat === "pretty"`.
 6. The config branch. With a config present, `startFiller` is called and passes `consoleSink(logFormat)`
    as `SimplexOptions.logger`, so the filler's own `LoggerContext` gets a second sink. On the pretty

--- a/sdk/packages/simplex/docs/ai/Flow.md
+++ b/sdk/packages/simplex/docs/ai/Flow.md
@@ -2,6 +2,37 @@
 
 AI-maintained map of how code paths in `sdk/packages/simplex` actually execute, so that when something breaks you can tell whether the fault is upstream or downstream of where the symptom appears. Only flows that have been read and verified are documented; coverage grows as areas of the package are touched.
 
+## CLI stdout: the banner, the log sinks, and the wizard URL
+
+Read from `bin/simplex.ts` and exercised against the built `dist/bin/simplex.js` on 2026-09-09.
+
+1. Module evaluation, before commander sees anything. `logFormatFromArgv(process.argv)` scans raw argv
+   for `--log-format` (both `--log-format json` and `--log-format=json`, last occurrence wins, stopping
+   at `--`) and falls back to `pretty`. `addLogSink(consoleSink(logFormat))` then registers the sink on
+   the process-wide `LoggerContext`, which is what `init`, config validation, the keeper command and
+   anything logged during parsing write to.
+2. `consoleSink(format)` returns `process.stdout` for `json` and a `pino-pretty` transform for
+   `pretty`. The transform is built with `destination: process.stdout`, not `.pipe()` — piped, it
+   echoes each record's raw NDJSON next to the formatted line.
+3. `program.parse(process.argv)` runs. `--log-format` is declared on `run` with `.choices()`, so an
+   unknown value exits here with the allowed values and the action never runs. `--no-open` is a
+   commander negated boolean: `options.open` is `true` unless the flag is present.
+4. The `run` action writes `ASCII_HEADER` to stdout only when `logFormat === "pretty"`.
+5. `startFiller` passes `consoleSink(logFormat)` as `SimplexOptions.logger`, so the filler's own
+   `LoggerContext` gets a second sink. On the pretty path that is a second pino-pretty transform, which
+   is deliberate: two pino instances sharing one transform interleave their chunks. On the json path
+   both sinks are the same `process.stdout`, which is safe because nothing is reassembling anything.
+6. With a config present the flow ends there — the filler and, if enabled, the UI and tunnel start, and
+   everything that follows is logged through those sinks.
+7. With no config, the wizard binds (falling back to an ephemeral port if the preferred one is taken)
+   and the URL is reported: `console.log` with the surrounding blank lines in pretty mode, or
+   `logger.info({ url }, ...)` on the `cli` module in json mode.
+8. `openBrowser(url)` runs unless `--no-open` was passed. It is best-effort in any case — a failed
+   spawn logs "Could not open a browser" and the printed URL is the fallback.
+
+So stdout in pretty mode is: banner, then colourised single-line records, then the wizard URL block. In
+json mode it is NDJSON and nothing else, one JSON object per line, with the wizard URL among the
+records.
 ## Opening an operator data directory
 
 Read from the source and exercised by `src/tests/data/sqlite-compat.test.ts` against real

--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/simplex",
-	"version": "0.16.1",
+	"version": "0.17.0",
 	"license": "Apache-2.0",
 	"description": "Automated intent filler for the Hyperbridge IntentGateway — run it as a binary or embed it as a library",
 	"main": "dist/index.js",

--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/simplex",
-	"version": "0.17.0",
+	"version": "0.16.1",
 	"license": "Apache-2.0",
 	"description": "Automated intent filler for the Hyperbridge IntentGateway — run it as a binary or embed it as a library",
 	"main": "dist/index.js",

--- a/sdk/packages/simplex/package.json
+++ b/sdk/packages/simplex/package.json
@@ -41,6 +41,7 @@
 		"prepublishOnly": "npm run build",
 		"test": "pnpm run codegen && vitest --watch=false --maxConcurrency=1",
 		"test:data": "pnpm run codegen && vitest --watch=false --maxConcurrency=1 src/tests/data",
+		"test:unit": "pnpm run codegen && vitest --watch=false --maxConcurrency=1 src/tests/cli src/tests/logger.test.ts",
 		"test:filler": "pnpm run codegen && vitest --watch=false --maxConcurrency=1 --testTimeout=1000000 src/tests/pairs.test.ts src/tests/strategies/fx.curve-payout.test.ts src/tests/strategies/fx.testnet.test.ts src/tests/quorum-public-client.test.ts",
 		"test:basic:testnet": "pnpm run codegen && vitest --watch=false --maxConcurrency=1 --testTimeout=1000000 src/tests/strategies/basic.testnet.test.ts",
 		"test:fx": "pnpm run codegen && vitest --watch=false --maxConcurrency=1 --testTimeout=1000000 src/tests/strategies/fx.mainnet.test.ts",

--- a/sdk/packages/simplex/src/bin/simplex.ts
+++ b/sdk/packages/simplex/src/bin/simplex.ts
@@ -450,7 +450,10 @@ addRunOptions(program.command("run", { isDefault: true }))
 				// application renders the wizard itself over this socket. A bind failure
 				// here is fatal — there is no other way in.
 				await server.start({ socketPath: uiSocket })
-				console.log(`\n  No config found — the setup wizard is serving on ${uiSocket}\n`)
+				// Same rule as the TCP announcement below: in json mode this is a record,
+				// not prose, or it is the one non-JSON line in a stream someone is parsing.
+				if (logFormat === "json") logger.info({ socket: uiSocket }, "No config found, starting the setup wizard")
+				else console.log(`\n  No config found — the setup wizard is serving on ${uiSocket}\n`)
 				// The server keeps the event loop alive until the wizard completes.
 				return
 			}

--- a/sdk/packages/simplex/src/bin/simplex.ts
+++ b/sdk/packages/simplex/src/bin/simplex.ts
@@ -80,6 +80,17 @@ function consoleSink(format: LogFormat): LogSink {
 // this module is still evaluating, and commander has not run yet.
 const logFormat = logFormatFromArgv(process.argv)
 
+// pino-pretty's pump() chain attaches an `error` listener to whatever destination
+// it is handed; a bare `process.stdout` has none. Without one, the first write
+// after something closes the read end — the desktop app quitting while the filler
+// it spawned keeps running, or a plain `simplex ... | head` — raises an unhandled
+// `error` event and kills the process, which is the opposite of what json mode is
+// for. Swallowing matches the pretty path, where the same error tears the
+// transform chain down and logging simply goes quiet; LoggerContext already treats
+// a broken sink as the host's problem rather than a reason to stop filling.
+// Registered here, once, because consoleSink() is called per writer.
+if (logFormat === "json") process.stdout.on("error", () => {})
+
 // The process-wide context covers everything outside a filler: the setup wizard,
 // config validation, the keeper command. A running filler logs to its own
 // context and gets a sink of its own below — on the pretty path that means one

--- a/sdk/packages/simplex/src/bin/simplex.ts
+++ b/sdk/packages/simplex/src/bin/simplex.ts
@@ -20,6 +20,7 @@ import { SqliteDataStore } from "@/data/sqlite"
 import { discoverConfigPath, DEFAULT_CONFIG_FILENAME } from "@/cli/discover-config"
 import { addRunOptions, DEFAULT_UI_PORT, type RunOptions } from "@/cli/run-options"
 import { openBrowser } from "@/cli/open-browser"
+import { logFormatFromArgv, type LogFormat } from "@/cli/log-format"
 import { addLogSink, getLogger, configureLogger, type LogLevel, type LogSink } from "@/services/Logger"
 import prettyStream from "pino-pretty"
 import {
@@ -52,14 +53,18 @@ const packageJsonPath = resolve(__dirname, "../../package.json")
 const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"))
 
 /**
- * Sends the library's log records to this process's stdout, pretty-printed.
+ * Sends the library's log records to this process's stdout.
  *
  * The library logs nowhere until something registers a sink — correct for an
  * embedded filler, and the CLI *is* the application, so opting in here is the
  * whole point. Formatting happens in-process rather than through pino's
  * worker-thread transport, which keeps startup off the thread-stream path.
  */
-function consoleSink(): LogSink {
+function consoleSink(format: LogFormat): LogSink {
+	// Nothing to format: pino hands the destination one finished NDJSON record per
+	// write, newline included, so json mode is the *absence* of a transform rather
+	// than a different one — no pino-pretty, and therefore none of its parsing.
+	if (format === "json") return process.stdout
 	// `destination`, not `.pipe(process.stdout)`: piped, pino-pretty echoes each
 	// record's raw NDJSON alongside the formatted line, so every log appears twice.
 	return prettyStream({
@@ -71,12 +76,19 @@ function consoleSink(): LogSink {
 	})
 }
 
+// Read from raw argv, not the parsed options: the sink below is registered while
+// this module is still evaluating, and commander has not run yet.
+const logFormat = logFormatFromArgv(process.argv)
+
 // The process-wide context covers everything outside a filler: the setup wizard,
 // config validation, the keeper command. A running filler logs to its own
-// context and gets a stream of its own below — one transform per writer, because
-// two pino instances writing into a single pino-pretty transform interleave
-// their chunks and it echoes the unparseable remainder as raw NDJSON.
-addLogSink(consoleSink())
+// context and gets a sink of its own below — on the pretty path that means one
+// transform per writer, because two pino instances writing into a single
+// pino-pretty transform interleave their chunks and it echoes the unparseable
+// remainder as raw NDJSON. Sharing stdout in json mode is safe for the same
+// reason it is a hazard here: there is no transform in between reassembling
+// anything, and pino writes each record whole.
+addLogSink(consoleSink(logFormat))
 
 /**
  * Opens the CLI's persistent store.
@@ -232,8 +244,9 @@ addRunOptions(program.command("run", { isDefault: true }))
 	.description("Run the intent filler; without a config it starts the browser setup wizard")
 	.action(async (options: RunOptions) => {
 		try {
-			// Display ASCII art header
-			process.stdout.write(ASCII_HEADER)
+			// Decoration for a terminal. In json mode stdout is a log file someone
+			// else is parsing, and a banner is not a record.
+			if (logFormat === "pretty") process.stdout.write(ASCII_HEADER)
 
 			const logger = getLogger("cli")
 
@@ -285,7 +298,7 @@ addRunOptions(program.command("run", { isDefault: true }))
 					config,
 					signer,
 					configPath: path,
-					logger: consoleSink(),
+					logger: consoleSink(logFormat),
 					data: dataStore,
 					watchOnly: options.watchOnly,
 				})
@@ -443,8 +456,14 @@ addRunOptions(program.command("run", { isDefault: true }))
 			// outright. The operator reaches it on localhost, via whatever they published.
 			const browsableHost = uiBind.host === "0.0.0.0" || uiBind.host === "::" ? "localhost" : uiBind.host
 			const url = `http://${browsableHost}:${boundPort}/`
-			console.log(`\n  No config found — starting the setup wizard.\n\n  ${url}\n`)
-			openBrowser(url)
+			// The URL is the one thing the operator must see. In json mode it is also
+			// the one thing a supervisor must see, so it goes out as a record with a
+			// `url` field rather than as prose no parser will look at.
+			if (logFormat === "json") logger.info({ url }, "No config found, starting the setup wizard")
+			else console.log(`\n  No config found — starting the setup wizard.\n\n  ${url}\n`)
+			// --no-open: the caller renders the wizard itself (the desktop app puts it
+			// in its own window), so a system browser opening alongside is wrong.
+			if (options.open !== false) openBrowser(url)
 			// The server keeps the event loop alive until the wizard completes.
 		} catch (error) {
 			// Use console.error for initial startup errors since logger might not be configured yet

--- a/sdk/packages/simplex/src/cli/log-format.ts
+++ b/sdk/packages/simplex/src/cli/log-format.ts
@@ -1,0 +1,40 @@
+/** How the CLI renders its own log records to stdout. */
+export const LOG_FORMATS = ["pretty", "json"] as const
+
+export type LogFormat = (typeof LOG_FORMATS)[number]
+
+/** What a terminal user has always got, so no flag must ever change it. */
+export const DEFAULT_LOG_FORMAT: LogFormat = "pretty"
+
+const FLAG = "--log-format"
+
+function isLogFormat(value: string | undefined): value is LogFormat {
+	return value !== undefined && (LOG_FORMATS as readonly string[]).includes(value)
+}
+
+/**
+ * Reads `--log-format` straight out of raw argv.
+ *
+ * The console sink is registered while `bin/simplex.ts` is still evaluating —
+ * before commander has parsed anything — because records emitted during parsing
+ * and command setup need somewhere to go. So the format cannot come from the
+ * parsed options, and this reads argv itself.
+ *
+ * Commander still declares the flag: it owns `--help` and rejects an unknown
+ * value. This only has to agree with it on the values that are accepted, so
+ * anything else falls back to the default rather than throwing here, before
+ * commander can print its own message.
+ */
+export function logFormatFromArgv(argv: readonly string[]): LogFormat {
+	let found: LogFormat = DEFAULT_LOG_FORMAT
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i]
+		// Commander stops parsing options at `--`; a scan that did not would read a
+		// filler's own operands as flags.
+		if (arg === "--") break
+		const value = arg === FLAG ? argv[i + 1] : arg.startsWith(`${FLAG}=`) ? arg.slice(FLAG.length + 1) : undefined
+		// Last wins, as it does in commander when an option is repeated.
+		if (isLogFormat(value)) found = value
+	}
+	return found
+}

--- a/sdk/packages/simplex/src/cli/run-options.ts
+++ b/sdk/packages/simplex/src/cli/run-options.ts
@@ -1,5 +1,6 @@
-import type { Command } from "commander"
+import { Option, type Command } from "commander"
 import { DEFAULT_CONFIG_FILENAME } from "@/cli/discover-config"
+import { DEFAULT_LOG_FORMAT, LOG_FORMATS } from "@/cli/log-format"
 
 /** Port the local web UI binds when `--ui` names no other one. */
 export const DEFAULT_UI_PORT = 8686
@@ -16,6 +17,17 @@ export interface RunOptions {
 	ui?: string | boolean
 	/** A socket path from `--ui-socket <path>`; absent when the flag is not passed. */
 	uiSocket?: string
+	/** `false` from `--no-open`, otherwise `true`. Only the wizard path reads it. */
+	open?: boolean
+	/**
+	 * `--log-format` is deliberately absent. It is read straight from argv by
+	 * `logFormatFromArgv`, because the console sink is built while `bin/simplex.ts`
+	 * is still evaluating — before commander runs. The sink is already writing by
+	 * the time an action is called, so reading the parsed value too would let the
+	 * two disagree over a malformed command line and put a banner in the middle of
+	 * the NDJSON. It is declared below only so `--help` lists it and a bad value is
+	 * rejected.
+	 */
 }
 
 /**
@@ -40,4 +52,10 @@ export function addRunOptions(command: Command): Command {
 			"Serve the web UI on a Unix domain socket at <path> instead of a TCP port. The socket is created 0600, so no other local user and no web page can reach it. On Windows this is a named pipe, whose default ACL is weaker (see docs/ai/Decisions.md). For embedding simplex in a desktop application",
 		)
 		.option("--no-ui", "Disable the local web UI")
+		.option("--no-open", "Don't launch a browser for the setup wizard; it still starts and reports its URL")
+		.addOption(
+			new Option("--log-format <format>", "How to render this process's logs on stdout")
+				.choices([...LOG_FORMATS])
+				.default(DEFAULT_LOG_FORMAT),
+		)
 }

--- a/sdk/packages/simplex/src/tests/cli/log-format.test.ts
+++ b/sdk/packages/simplex/src/tests/cli/log-format.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest"
+import { Command } from "commander"
+import { DEFAULT_LOG_FORMAT, logFormatFromArgv } from "@/cli/log-format"
+import { addRunOptions, type RunOptions } from "@/cli/run-options"
+
+describe("logFormatFromArgv", () => {
+	it("defaults to pretty, which is what a terminal has always got", () => {
+		expect(logFormatFromArgv(["node", "simplex"])).toBe("pretty")
+		expect(logFormatFromArgv(["node", "simplex", "run", "--no-ui"])).toBe("pretty")
+		expect(DEFAULT_LOG_FORMAT).toBe("pretty")
+	})
+
+	it("reads both spellings, before or after the subcommand", () => {
+		expect(logFormatFromArgv(["node", "simplex", "--log-format", "json"])).toBe("json")
+		expect(logFormatFromArgv(["node", "simplex", "--log-format=json"])).toBe("json")
+		expect(logFormatFromArgv(["node", "simplex", "run", "--log-format", "json"])).toBe("json")
+		expect(logFormatFromArgv(["node", "simplex", "run", "--log-format=json", "--no-ui"])).toBe("json")
+	})
+
+	it("falls back to the default on an unknown value, leaving the complaint to commander", () => {
+		expect(logFormatFromArgv(["node", "simplex", "--log-format", "ndjson"])).toBe("pretty")
+		expect(logFormatFromArgv(["node", "simplex", "--log-format"])).toBe("pretty")
+	})
+
+	it("takes the last of a repeated flag, as commander does", () => {
+		expect(logFormatFromArgv(["node", "simplex", "--log-format", "json", "--log-format", "pretty"])).toBe("pretty")
+		expect(logFormatFromArgv(["node", "simplex", "--log-format", "pretty", "--log-format", "json"])).toBe("json")
+	})
+
+	it("stops at --, where commander stops parsing options", () => {
+		expect(logFormatFromArgv(["node", "simplex", "run", "--", "--log-format", "json"])).toBe("pretty")
+	})
+})
+
+/**
+ * Parses `args` with the real `run` declarations — `addRunOptions` is the same
+ * builder `bin/simplex.ts` calls, so this cannot drift from the shipped CLI the
+ * way a hand-copied mirror would.
+ */
+function runOptionsFor(args: string[]): (RunOptions & { logFormat?: string }) | undefined {
+	let seen: (RunOptions & { logFormat?: string }) | undefined
+	const program = new Command()
+	program
+		.name("simplex")
+		.exitOverride()
+		.configureOutput({ writeErr: () => {} })
+	program.command("init").action(() => {})
+	addRunOptions(program.command("run", { isDefault: true })).action((opts) => {
+		seen = opts
+	})
+	program.parse(["node", "simplex", ...args])
+	return seen
+}
+
+/**
+ * The flag is read twice: once from raw argv, because the console sink is built
+ * before commander runs, and once by commander itself. Nothing forces the two to
+ * agree, so pin it — a disagreement puts pretty-printed output in a stream a
+ * supervisor is parsing as NDJSON.
+ */
+function commanderLogFormat(args: string[]): string | undefined {
+	return runOptionsFor(args)?.logFormat
+}
+
+describe("the argv scan and commander agree", () => {
+	const invocations = [
+		[],
+		["run"],
+		["--log-format", "json"],
+		["--log-format=json"],
+		["run", "--log-format", "json"],
+		["run", "--log-format=pretty"],
+		["--log-format", "json", "--log-format", "pretty"],
+		["--no-ui", "--no-open", "--log-format", "json"],
+		["run", "-c", "filler-config.toml", "--log-format", "json"],
+		// `--ui` takes an optional value, so it is the declaration most able to
+		// swallow a following flag. It did, until #1249 dropped the angle brackets.
+		["run", "--ui", "--log-format", "json"],
+		["run", "--ui", "9000", "--log-format", "json"],
+		["run", "--watch-only", "--log-format", "json"],
+	]
+
+	it.each(invocations)("simplex %s", (...args: string[]) => {
+		expect(commanderLogFormat(args)).toBe(logFormatFromArgv(["node", "simplex", ...args]))
+	})
+
+	it("rejects an unknown format rather than guessing, so nothing is logged in the wrong one", () => {
+		expect(() => commanderLogFormat(["--log-format", "ndjson"])).toThrow(/Allowed choices are pretty, json/)
+	})
+})
+
+describe("--no-open", () => {
+	it("is absent unless passed, so a plain run still opens a browser", () => {
+		expect(runOptionsFor(["run"])?.open).toBe(true)
+		expect(runOptionsFor([])?.open).toBe(true)
+	})
+
+	it("turns off only the browser launch", () => {
+		expect(runOptionsFor(["run", "--no-open"])?.open).toBe(false)
+		expect(runOptionsFor(["--no-open"])?.open).toBe(false)
+		// --no-ui is a different switch and must not be implied either way.
+		expect(runOptionsFor(["run", "--no-open"])?.ui).toBeUndefined()
+	})
+
+	it("survives a bare --ui in front of it", () => {
+		// `--ui [<[host:]port>]` used to be required *and* optional, so commander
+		// shifted the next token into it and `--no-open` was silently dropped (#1249).
+		const opts = runOptionsFor(["run", "--ui", "--no-open"])
+		expect(opts?.open).toBe(false)
+		expect(opts?.ui).toBe(true)
+	})
+
+	it("is unaffected by a --ui that does take a value", () => {
+		expect(runOptionsFor(["run", "--ui", "9000", "--no-open"])?.open).toBe(false)
+		expect(runOptionsFor(["run", "--no-open", "--ui", "9000"])?.ui).toBe("9000")
+	})
+})


### PR DESCRIPTION
Part of #1237.

The desktop app will run `simplex` as a background process and save its output to a log file. Two
things the CLI always did got in the way. Each now has a flag on `run`.

Just the two flags. No Electron code, no changes to the server transport.

## The flags

**`--no-open`** — start the setup wizard, but don't launch a browser.

The app shows the wizard in its own window, so a second browser opening is wrong. Everything else is
the same: the wizard still starts, and still prints its URL.

Not to be confused with `--no-ui`, which switches the web UI off entirely.

**`--log-format json`** — print logs as one JSON object per line.

Colour codes are unreadable in a log file. `json` gives you plain NDJSON instead. It defaults to
`pretty`, so nothing changes for anyone running simplex in a terminal.

```bash
simplex run --no-open          # wizard starts, no browser
simplex run --log-format json  # {"level":30,"time":...,"msg":"..."}
```

## Nothing changes if you don't pass them

This was the main thing to get right, so it was checked by running the built binary and diffing the
output byte for byte.

| Command | What comes out on stdout | Browser opens? |
|---|---|---|
| `simplex run` | banner, colourised logs, wizard URL | yes |
| `simplex run --log-format pretty` | identical to the above | yes |
| `simplex run --no-open` | identical to the above | **no** |
| `simplex run --no-open --log-format json` | 2 lines, both valid JSON, no colour codes | no |

A bad value is rejected up front: `--log-format ndjson` exits 1 and says
`Allowed choices are pretty, json`.

## A bug was found in review, and fixed

The first version of `--log-format json` **crashed the solver** when whatever was reading its output
went away — which is the exact thing the flag was added for.

The short version: pino-pretty was quietly handling stream errors for us. Passing `process.stdout`
straight through removed pino-pretty, and took that error handling with it. A broken pipe then killed
the process instead of being ignored.

Reproduced by starting the solver in the background and closing the pipe, 3 runs each way:

| | before the fix | after |
|---|---|---|
| `--log-format json` | **died, exit 1** | keeps running |
| no flags | keeps running | keeps running |

Fixed in 93900ca6. The reasoning is written up in `docs/ai/Decisions.md`.

## CI wasn't running the new tests

CI ran simplex's `test:filler` script, which only covers four network-backed files. The 15 tests added
here were never run on a PR — you could delete the feature and CI would still go green.

e0b86680 adds a `test:unit` script and a CI step for it. Takes about 20 seconds, makes no network calls.

## Rebased onto #1249

#1249 moved `run`'s option declarations out of the bin into `addRunOptions`
(`src/cli/run-options.ts`). Both flags moved there with them, and `open` joined its `RunOptions`
interface. `logFormat` deliberately did not — see the implementation notes.

That turned out to be a real improvement, not just a merge. The tests can now parse the **actual**
declarations instead of a hand-copied mirror that could silently drift. Which in turn made this
testable:

```
simplex run --ui --no-open
```

That used to swallow `--no-open` and open a browser anyway, because the old `--ui [<[host:]port>]`
placeholder made commander treat the option as required. #1249 fixed it; there is now a regression
test pinning it. The test file went from 15 tests to 22, including the first coverage `--no-open` has
had.

## Known and not fixed here

- `--log-format` works on `run` but not on `paymaster-keeper`, which is also a long-running daemon.
- Whoever merges `simplex-ui-socket-listen-mode`: it adds an unguarded `console.log` on the same
  wizard path, which will break the "every line is JSON" promise. The two branches merge cleanly, so
  nothing will warn you.

## Commits

| | |
|---|---|
| 7070bca5 | the two flags |
| c5f4dbfc | the crash fix |
| 165271b4 | the CI gate |
| e6c1d8cf | drop the version bump |
| 8e8231b5 | docs, after the #1249 rebase |

Also included: the `docs/ai/` entries the package convention asks for, and a README note.

**No version bump.** Four simplex branches are open against #1237 at once, and a bump in each would
collide on the same field for nothing. Publishing is tag-driven, so the version can be set once on
whatever lands.

<details>
<summary>Implementation notes, if you're reviewing the code</summary>

**Why the flag is parsed twice.** The log sink has to exist before commander runs — it's registered
while `bin/simplex.ts` is still being evaluated. So `logFormatFromArgv` in `src/cli/log-format.ts`
scans raw argv for `--log-format`, and commander declares it separately for `--help` and validation.

The action deliberately ignores commander's parsed value. One reader, one answer. Otherwise a
command line the two could read differently — `simplex run -c --log-format json`, where commander
binds `--log-format` to `-c` — could put the ASCII banner in the middle of the NDJSON.

**Two existing properties that had to survive.** Both are documented in comments around
`consoleSink()`, and both still hold:

1. Formatting happens in-process, not through pino's worker-thread transport. json mode removes a
   transform rather than adding one.
2. Each writer gets its own pino-pretty transform, because two pino instances sharing one interleave
   their output. In json mode both writers share `process.stdout` instead, which is safe for the
   opposite reason: there's no transform in the middle reassembling anything. Checked by driving
   4000 records of 4 KB through a shared stdout — no partial or interleaved lines.

**Where stdout writes come from.** The ASCII banner and the wizard's URL line were the only two
non-logger writers. In json mode the banner is skipped and the URL becomes a log record with a `url`
field, which is more useful to a supervisor than prose it would have to scrape.

One caveat found in review: that covers every writer simplex controls, but not the whole process.
`@polkadot/api` prints a plain-text line to stdout if the Hyperbridge runtime upgrades mid-run. Rare,
and impossible on the wizard path, but json consumers should parse defensively. The docs say so now.

**Local test state.** The full suite doesn't pass cleanly in my worktree, and didn't before this
change either — 15 files fail on environment gaps (stale `@uniswap/sdk-core`, missing
`BINANCE_API_KEY` and RPC URLs, network-dependent simnode suites). I ran it on the pristine tree and
again with the change: the failing-file set is identical. `tsc --noEmit` is unchanged apart from a
pre-existing error shifting line number.

</details>
