### PR TITLE
[simplex]: accept `simplex --ui` with no value

### DIFF
--- a/docs/content/developers/evm/simplex/dashboard.mdx
+++ b/docs/content/developers/evm/simplex/dashboard.mdx
@@ -32,7 +32,7 @@ The bind address is set on `simplex run`, which is the default command (`simplex
 
 | Flag | Default | What it does |
 |---|---|---|
-| `--ui <[host:]port>` | `127.0.0.1:8686` | Where the dashboard listens. A bare number keeps the host at `127.0.0.1`, so `--ui 9000` means `127.0.0.1:9000`. |
+| `--ui [host:port]` | `127.0.0.1:8686` | Where the dashboard listens. A bare number keeps the host at `127.0.0.1`, so `--ui 9000` means `127.0.0.1:9000`. The value is optional — a bare `--ui` is the default bind, spelled out. |
 | `--no-ui` | off | Runs the filler headless — no dashboard, no port. |
 | `-c, --config <path>` | `./filler-config.toml`, then `$SIMPLEX_HOME/config.toml` | The TOML config. When neither exists, `run` starts the browser setup wizard instead of the filler. |
 | `-d, --data-dir <path>` | `./.simplex-data` | Bid database, runtime state, and the tunnel's keys under `tunnel/`. |

--- a/sdk/packages/simplex/docs/ai/ChangeLog.md
+++ b/sdk/packages/simplex/docs/ai/ChangeLog.md
@@ -12,6 +12,38 @@ Files: list of files touched.
 
 Newest entries first.
 
+## 2026-09-10 — `simplex --ui` with no value stopped erroring
+
+`run` declared the UI bind as `--ui [<[host:]port>]`. The `[...]` was meant to make the value
+optional, but commander derives the two properties independently from the flags string:
+`this.required = flags.includes("<")` and `this.optional = flags.includes("[")`. The placeholder
+`<[host:]port>` contains a `<`, so the option came out both required and optional, and required
+wins. `simplex --ui` and `simplex run --ui` each died with `error: option '--ui [<[host:]port>]'
+argument missing`, even though the flag was declared and documented as taking an optional value.
+
+The placeholder is now `[host:port]`, which has no angle brackets. Nothing else about the option
+changes — `--ui 9000`, `--ui 192.168.1.50:8686`, `--ui 0.0.0.0:8686`, `--no-ui` and passing nothing
+at all parse exactly as they did, verified against the pinned commander 12.1.0 through the real
+default-subcommand route. A valueless `--ui` now yields `true`, which the existing handler already
+reads correctly: `uiEnabled = options.ui !== false` turns the UI on, and `typeof options.ui ===
+"string"` is false, so the bind stays at the default `127.0.0.1:8686`. `simplex --ui` therefore
+means the same as `simplex`, said out loud, and reads as the counterpart of `--no-ui`. The
+description gained one clause — "a bare port keeps the host at 127.0.0.1" — because the placeholder
+no longer carries that nuance.
+
+The `run` flags moved into `src/cli/run-options.ts` so a test can parse the real declarations:
+`src/bin/simplex.ts` calls `program.parse(process.argv)` at module load, so a test cannot import it.
+`DEFAULT_UI_PORT` moved with them, and the action handler's inline options type — a hand-maintained
+duplicate of the flags — is now `RunOptions`, declared beside the flags that produce it. The new
+test fails against the old placeholder with `required: true`.
+
+Found while adding `--ui-socket` (#1237), which deliberately left `--ui` alone: its acceptance
+criteria required the CLI's existing TCP behaviour to be unchanged.
+
+Files: src/cli/run-options.ts (new), src/bin/simplex.ts, src/tests/cli/run-options.test.ts (new),
+and the flag table in the repo's docs/content/developers/evm/simplex/dashboard.mdx.
+
+
 ## 2026-09-09 — Make the SSH tunnel's publickey guard fail closed
 
 The embedded SSH server treated a publickey request as an unsigned probe whenever *either*

--- a/sdk/packages/simplex/docs/ai/Decisions.md
+++ b/sdk/packages/simplex/docs/ai/Decisions.md
@@ -4,6 +4,37 @@ AI-maintained record of non-obvious choices made in `sdk/packages/simplex`: what
 
 Entry format: heading with the decision, then alternatives considered and the reasoning. Newest first.
 
+## 2026-09-10 — `run`'s flags live in src/cli/run-options.ts, not in the bin
+
+Decided: the option declarations for `simplex run` sit in their own module, and `src/bin/simplex.ts`
+applies them with `addRunOptions(program.command("run", { isDefault: true }))`.
+
+Why: the bin parses `process.argv` at module load, so importing it from a test runs the CLI. Testing
+the flags meant either copying the flag strings into the test — where they would have kept passing
+after someone edited the real declaration back — or putting them somewhere importable. The `--ui`
+bug this now guards survived precisely because nothing ever parsed the CLI's own flags.
+
+Rejected: extracting the whole program into a `buildProgram()`. It reindents ~280 lines of action
+handlers for a fix that changes one string, and those handler bodies are the part a unit test cannot
+exercise anyway.
+
+Rejected: leaving the declarations in the bin and asserting on a `new Option("--ui [host:port]")`
+built inside the test. That tests commander, not simplex, and stays green when the bin regresses.
+
+
+## 2026-09-10 — The `--ui` placeholder is `[host:port]`, not `[addr]`
+
+Decided: spell the optional value `[host:port]`.
+
+Why not `[addr]`: the placeholder is what `--help` shows, and the flag takes either a bare port
+(`--ui 9000`) or `host:port`. `[host:port]` keeps that shape visible; `[addr]` hides it.
+
+Why not keep the old `[host:]port` nuance, where the *host* half is the optional one: any angle
+bracket anywhere in the flags string sets commander's `required`, which is the bug being fixed, and
+commander has no notation for "optional value whose host half is also optional". The description
+carries that instead.
+
+
 ## 2026-09-09 — The publickey probe branch requires both halves absent, not either
 
 Decided: `ctx.signature === undefined && ctx.blob === undefined` selects the unsigned-probe path;

--- a/sdk/packages/simplex/src/bin/simplex.ts
+++ b/sdk/packages/simplex/src/bin/simplex.ts
@@ -17,6 +17,7 @@ import type { PairConfig } from "@/config/pairs"
 import type { FillerRuntime } from "@/core/boot"
 import { Simplex } from "@/simplex"
 import { discoverConfigPath, DEFAULT_CONFIG_FILENAME } from "@/cli/discover-config"
+import { addRunOptions, DEFAULT_UI_PORT, type RunOptions } from "@/cli/run-options"
 import { openBrowser } from "@/cli/open-browser"
 import { addLogSink, getLogger, configureLogger, type LogLevel, type LogSink } from "@/services/Logger"
 import prettyStream from "pino-pretty"
@@ -48,8 +49,6 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 const packageJsonPath = resolve(__dirname, "../../package.json")
 const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"))
-
-const DEFAULT_UI_PORT = 8686
 
 /**
  * Sends the library's log records to this process's stdout, pretty-printed.
@@ -237,18 +236,9 @@ program
 		}
 	})
 
-program
-	.command("run", { isDefault: true })
+addRunOptions(program.command("run", { isDefault: true }))
 	.description("Run the intent filler; without a config it starts the browser setup wizard")
-	.option("-c, --config <path>", `Path to TOML configuration file (default: ./${DEFAULT_CONFIG_FILENAME})`)
-	.option("-d, --data-dir <path>", "Directory for persistent data storage (bids database, etc.)")
-	.option("--watch-only", "Watch-only mode: monitor orders without executing fills", false)
-	.option(
-		"--ui [<[host:]port>]",
-		`Bind address for the local web UI (status, pause/resume, price curves). Unauthenticated; default ${`127.0.0.1:${DEFAULT_UI_PORT}`}`,
-	)
-	.option("--no-ui", "Disable the local web UI")
-	.action(async (options: { config?: string; dataDir?: string; watchOnly?: boolean; ui?: string | boolean }) => {
+	.action(async (options: RunOptions) => {
 		try {
 			// Display ASCII art header
 			process.stdout.write(ASCII_HEADER)

--- a/sdk/packages/simplex/src/cli/run-options.ts
+++ b/sdk/packages/simplex/src/cli/run-options.ts
@@ -1,0 +1,37 @@
+import type { Command } from "commander"
+import { DEFAULT_CONFIG_FILENAME } from "@/cli/discover-config"
+
+/** Port the local web UI binds when `--ui` names no other one. */
+export const DEFAULT_UI_PORT = 8686
+
+/** What `run`'s action handler receives, in the shape `addRunOptions` produces. */
+export interface RunOptions {
+	config?: string
+	dataDir?: string
+	watchOnly?: boolean
+	/**
+	 * A bind address from `--ui <addr>`, `true` from a bare `--ui`, `false` from
+	 * `--no-ui`, and absent when neither flag is passed.
+	 */
+	ui?: string | boolean
+}
+
+/**
+ * Declares the flags of `simplex run`. Split out of the bin so tests can parse
+ * them: importing the bin runs `program.parse(process.argv)` at module load.
+ */
+export function addRunOptions(command: Command): Command {
+	// The `--ui` placeholder must contain no angle brackets. Commander derives
+	// `required` from a `<` *anywhere* in the flags string, and required beats
+	// optional — so the earlier `[<[host:]port>]` turned a valueless `--ui` into
+	// an "argument missing" error.
+	return command
+		.option("-c, --config <path>", `Path to TOML configuration file (default: ./${DEFAULT_CONFIG_FILENAME})`)
+		.option("-d, --data-dir <path>", "Directory for persistent data storage (bids database, etc.)")
+		.option("--watch-only", "Watch-only mode: monitor orders without executing fills", false)
+		.option(
+			"--ui [host:port]",
+			`Bind address for the local web UI (status, pause/resume, price curves); a bare port keeps the host at 127.0.0.1. Unauthenticated; default 127.0.0.1:${DEFAULT_UI_PORT}`,
+		)
+		.option("--no-ui", "Disable the local web UI")
+}

--- a/sdk/packages/simplex/src/tests/cli/run-options.test.ts
+++ b/sdk/packages/simplex/src/tests/cli/run-options.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest"
+import { Command } from "commander"
+import { addRunOptions, type RunOptions } from "@/cli/run-options"
+
+/**
+ * A `run`-shaped command with no action, so parsing stops once the flags are
+ * read. The bin itself cannot be imported here: it calls
+ * `program.parse(process.argv)` at module load.
+ */
+function parseRun(argv: string[]): RunOptions {
+	const command = addRunOptions(new Command().exitOverride())
+	command.parse(argv, { from: "user" })
+	return command.opts<RunOptions>()
+}
+
+describe("simplex run flags", () => {
+	/**
+	 * Regression: the placeholder used to be `[<[host:]port>]`, and commander
+	 * derives `required` from a `<` *anywhere* in the flags string. The option
+	 * came out both required and optional, required won, and a valueless `--ui`
+	 * died with "option '--ui [<[host:]port>]' argument missing".
+	 */
+	it("accepts --ui with no value", () => {
+		const ui = addRunOptions(new Command()).options.find((o) => o.long === "--ui" && !o.negate)
+		expect(ui?.required).toBe(false)
+		expect(ui?.optional).toBe(true)
+		expect(parseRun(["--ui"]).ui).toBe(true)
+	})
+
+	it("keeps the bind address, --no-ui and the default untouched", () => {
+		expect(parseRun(["--ui", "9000"]).ui).toBe("9000")
+		expect(parseRun(["--ui", "192.168.1.50:8686"]).ui).toBe("192.168.1.50:8686")
+		expect(parseRun(["--ui", "0.0.0.0:8686"]).ui).toBe("0.0.0.0:8686")
+		expect(parseRun(["--no-ui"]).ui).toBe(false)
+		// Absent, not `true`: the handler reads `options.ui !== false`, so an
+		// unpassed flag and a bare `--ui` both mean "UI on, default bind".
+		expect(parseRun([]).ui).toBeUndefined()
+	})
+
+	it("carries the other run flags", () => {
+		const options = parseRun(["-c", "filler-config.toml", "-d", "/data", "--watch-only"])
+		expect(options).toMatchObject({ config: "filler-config.toml", dataDir: "/data", watchOnly: true })
+		expect(parseRun([]).watchOnly).toBe(false)
+	})
+
+	/**
+	 * `run` is the default command, so the invocation that reaches an operator is
+	 * `simplex --ui`, with no subcommand named. That routes through the parent
+	 * program, which is where an argument-missing error surfaced.
+	 */
+	it("reaches the default command's handler from a bare simplex --ui", () => {
+		const seen: RunOptions[] = []
+		const program = new Command().name("simplex").version("0.0.0").exitOverride()
+		program.command("init").action(() => {})
+		addRunOptions(program.command("run", { isDefault: true })).action((options: RunOptions) => {
+			seen.push(options)
+		})
+
+		program.parse(["--ui"], { from: "user" })
+		expect(seen).toEqual([expect.objectContaining({ ui: true })])
+	})
+})


### PR DESCRIPTION
`simplex --ui` fails today:

```
$ simplex --ui
error: option '--ui [<[host:]port>]' argument missing
```

It shouldn't. The `[...]` around the placeholder is there to say "the value is optional".

### Why it breaks

Commander decides whether an option takes a value by looking for brackets anywhere in the flag string:

```js
this.required = flags.includes('<')
this.optional = flags.includes('[')
```

Our placeholder was `[<[host:]port>]`. It contains a `<`, so the option came out as both required and optional — and required wins.

### The fix

The placeholder is now `[host:port]`. No angle brackets, so nothing sets `required`.

Everything else parses the same as before, checked against the repo's pinned commander 12.1.0:

| you type | before | after |
|---|---|---|
| `simplex --ui` | error | UI on, `127.0.0.1:8686` |
| `simplex --ui 9000` | `127.0.0.1:9000` | unchanged |
| `simplex --ui 0.0.0.0:8686` | every interface | unchanged |
| `simplex --no-ui` | headless | unchanged |
| `simplex` | UI on, `127.0.0.1:8686` | unchanged |

The handler needed no changes. A valueless `--ui` arrives as `true`, and `uiEnabled = options.ui !== false` already reads that as "on at the default bind".

**How much does this matter?** Not a lot, honestly. The UI is on by default, so `simplex --ui` just means `simplex`. What you get is that the flag we document no longer errors — which matters if you pass `--ui` explicitly as the mirror of `--no-ui`, or if you read `--help` and try it.

### Why a file moved

`run`'s flags now live in `src/cli/run-options.ts`.

A test can't import the bin: it calls `program.parse(process.argv)` at the bottom, so importing it runs the CLI. Without the move, the test would have to retype the flag strings — and would keep passing if someone edited the real ones back.

That's how this bug survived. Nothing ever parsed the CLI's own flags.

Only the `.option(...)` calls moved, plus `DEFAULT_UI_PORT` and the options type. The 280-line action handler stays in the bin.

### Testing

- 9 CLI suites, 66 tests, all passing. 4 of the tests are new.
- The two `--ui` tests were mutation-checked: put the old placeholder back and both fail. The bind-address, `--no-ui` and no-flag tests stay green, which is the point — the fix shouldn't move them.
- `tsc --noEmit` reports the same 51 pre-existing errors as `main`.
- I could not boot the CLI itself. `ssh2` isn't installed anywhere in this checkout, so `simplex` won't start here. I drove commander directly instead, with the program built the way the bin builds it: parent program, `init` sibling, `run` as the default command.

### Docs

`dashboard.mdx` was the only file with the old spelling. `CHANGELOG.md` mentions it too, but that's a published release entry, so I left it alone.

---

Found while adding `--ui-socket` (#1237), which left `--ui` alone on purpose — its acceptance criteria required the existing TCP behaviour to stay unchanged.
