### PR TITLE
[simplex]: fix the flaky logger test

### DIFF
--- a/sdk/packages/simplex/docs/ai/changelog/2026-09-10-stop-charging-the-logger-test-s-service-imports-to-its-own-timeo.md
+++ b/sdk/packages/simplex/docs/ai/changelog/2026-09-10-stop-charging-the-logger-test-s-service-imports-to-its-own-timeo.md
@@ -1,0 +1,37 @@
+# 2026-09-10 — Stop charging the logger test's service imports to its own timeout
+
+`service wiring > routes services through their filler's context, not the process one` timed out
+intermittently at its 20s override — measured at 14.5s, 20.5s (fail) and 16.7s across three
+isolated runs, so roughly one run in three under load. The three services it needs were pulled in
+with `await import()` inside the test body, which charges the import to that test's timeout budget.
+
+The file's comment blamed `@polkadot` WASM crypto init. It is not that. A CPU profile of the same
+import outside vitest puts 9.5s of an 11.7s import in Node's ESM loader — `package_json_reader`
+resolving `exports` maps across the pnpm tree — against ~125ms of actual `@polkadot` execution.
+Any one of the three services costs this, because each reaches `@hyperbridge/sdk`, whose barrel
+drags in the whole dependency graph. Measured separately: `@hyperbridge/sdk` 11.4s, then
+`FillerConfigService` 118ms, `ChainClientManager` 850ms, `CacheService` 33ms on top.
+
+The imports are now static, which is what every other test file in the package already does. The
+cost lands in vitest's collect phase, which no timeout bounds, so both `20_000` overrides are gone
+(the second, on `LoggerContext isolation > does not write to the process-wide context`, came from
+the same commit and never had an import to pay for — that test is synchronous and touches nothing
+heavy). Test bodies now run in 113-352ms.
+
+Verified with 10 consecutive runs of `vitest run --maxConcurrency=1 src/tests/logger.test.ts`: 10
+passes, no timeouts. Collect ranged 5.5s-20.6s across those runs — one run spent 20.63s there,
+which would have failed under the old structure and is now harmless. Three further runs alongside
+five other sdk-importing suites at default concurrency: logger.test.ts passed in 107-258ms each
+time.
+
+Not bumping the package version: the change touches a test file only, and `files` publishes `dist`,
+so a bump would ship an identical tarball. Note also that CI's simplex step runs `test:filler`,
+which does not include this file — the flake only ever bit local full-suite runs.
+
+The absolute numbers here swing wildly with machine load. On the same tree, with no change to
+the code or the installed dependencies, the import measured 2.3s in collect on an idle box and
+52.9s at a load average of 99. The test body still finished in 229ms in that 52.9s run. No fixed
+timeout survives a 20x spread — which is the whole argument for moving the cost out of the timed
+region rather than raising the limit.
+
+Files: src/tests/logger.test.ts, docs/ai/changelog/ and docs/ai/decisions/ entries for this change.

--- a/sdk/packages/simplex/docs/ai/decisions/2026-09-10-heavy-test-imports-go-at-the-top-of-the-file-not-inside-a-test.md
+++ b/sdk/packages/simplex/docs/ai/decisions/2026-09-10-heavy-test-imports-go-at-the-top-of-the-file-not-inside-a-test.md
@@ -1,0 +1,31 @@
+# 2026-09-10 — Heavy test imports go at the top of the file, not inside a test
+
+Decided: `src/tests/logger.test.ts` imports `FillerConfigService`, `ChainClientManager` and
+`CacheService` statically. A dynamic `await import()` in the test body put the ~10s cost of loading
+`@hyperbridge/sdk` inside that test's timeout; a static import puts it in vitest's collect phase,
+which nothing times out. This is also what every other test file in the package does, so the
+dynamic import was the anomaly rather than a pattern.
+
+Rejected: raising the timeout past 20s. It moves the boundary instead of removing it. The cost is
+machine-dependent and grows with the dependency graph, so the next slow week reopens the same bug.
+
+Rejected: `vi.mock`-ing `@hyperbridge/sdk` so the real service classes load against a stub. It
+would cut the file to about a second, but the mock has to name every sdk export the three services
+touch, and it silently rots the moment one of them reaches for another. The failure would surface
+as a confusing collect-time `X is not a function` in a test about logging. This test is worth
+keeping honest — its whole claim is that the *real* services route through their filler's context.
+
+Rejected: hoisting into `beforeAll` with a generous hook timeout. Same effect as the static import
+but with a hook timeout still to tune, and it does not match the rest of the suite.
+
+Rejected: deduping `@polkadot/util` to kill the "multiple versions" warning. The warning is real
+but it is not this bug, and it is not a lockfile problem. `pnpm-lock.yaml` already pins simplex to
+`@polkadot/util@14.0.3`; the 13.5.9 tree belongs to `packages/indexer` via `@subql/utils@2.x`, a
+separate importer that pnpm is entitled to resolve separately. The duplicate only appears on a
+machine whose `node_modules` predates simplex's `^13` -> `^14` bump — there, the on-disk symlink
+still points at 13.5.9 and a plain `pnpm install` fixes it. Even resolved, it would not have moved
+the timeout: `@polkadot` accounts for ~125ms of an 11.7s import.
+
+The real lever on suite speed, if it is ever worth pulling, is that `@hyperbridge/sdk`'s barrel
+entry point makes every importer resolve the entire graph — `FillerConfigService` pays it for two
+symbols. That is an sdk export-map change with production consequences, not a test fix.

--- a/sdk/packages/simplex/src/tests/logger.test.ts
+++ b/sdk/packages/simplex/src/tests/logger.test.ts
@@ -1,5 +1,14 @@
 import { afterEach, describe, expect, it } from "vitest"
 import { addLogSink, configureLogger, getLogger, LoggerContext, type LogSink } from "@/services/Logger"
+// The service wiring tests at the bottom need the real classes, and importing any
+// of them pulls in @hyperbridge/sdk. That costs ~10s, almost all of it Node
+// resolving the sdk's dependency graph across the pnpm tree. Import them here
+// rather than inside a test: at the top the cost falls in vitest's collect phase,
+// which no timeout bounds. Imported inside a test it was charged to that test's
+// own budget, where it sat on the boundary and timed out about one run in three.
+import { CacheService } from "@/services/CacheService"
+import { ChainClientManager } from "@/services/ChainClientManager"
+import { FillerConfigService } from "@/services/FillerConfigService"
 
 /**
  * A library must not write to its host's stdout uninvited, so logging is silent
@@ -141,7 +150,7 @@ describe("LoggerContext isolation", () => {
 
 		expect(instance.lines).toHaveLength(1)
 		expect(process.lines).toHaveLength(0)
-	}, 20_000)
+	})
 
 	it("takes an initial level and accepts more sinks later", () => {
 		const first = collector()
@@ -159,13 +168,7 @@ describe("LoggerContext isolation", () => {
 })
 
 describe("service wiring", () => {
-	// 20s: the dynamic imports below pull in the polkadot graph, whose WASM crypto
-	// init runs past the 5s default when the whole suite is warming up at once.
-	it("routes services through their filler's context, not the process one", async () => {
-		const { FillerConfigService } = await import("@/services/FillerConfigService")
-		const { ChainClientManager } = await import("@/services/ChainClientManager")
-		const { CacheService } = await import("@/services/CacheService")
-
+	it("routes services through their filler's context, not the process one", () => {
 		const instance = collector()
 		const process = collector()
 		attach(process)
@@ -187,10 +190,9 @@ describe("service wiring", () => {
 		// Whatever any of them logged went to the filler's sink; the process-wide
 		// context — which a host would never have configured — stayed empty.
 		expect(process.lines).toHaveLength(0)
-	}, 20_000)
+	})
 
-	it("gives two config services independent contexts", async () => {
-		const { FillerConfigService } = await import("@/services/FillerConfigService")
+	it("gives two config services independent contexts", () => {
 		const a = new LoggerContext({ sink: collector() })
 		const b = new LoggerContext({ sink: collector() })
 		const chains = [{ chainId: 1, rpcUrls: ["https://rpc.example"] }]


### PR DESCRIPTION
A test in `logger.test.ts` fails about one run in three with `Test timed out in 20000ms`.

It loads three services from inside the test body:

```ts
const { FillerConfigService } = await import("@/services/FillerConfigService")
```

Each of those pulls in `@hyperbridge/sdk`. An import inside a test counts against that test's
time limit, so the test was spending its whole budget — and sometimes more — on a load it
doesn't test. All it checks is that services log to their filler's context instead of the
global one.

How long that load takes depends entirely on how busy the machine is. On the same tree I
measured 2.3 seconds on an idle box and 52.9 seconds at a load average of 99. No fixed timeout
survives a spread like that, which is why raising the limit wouldn't have fixed it.

So instead, move the imports to the top of the file. Vitest loads top-level imports before the
clock starts, so the same work no longer counts against the test. In that 52.9-second run the
test body still finished in 229ms. The 20-second overrides are gone, and every other test file
in this package already imports services this way.

The comment in the file blamed polkadot's WASM crypto setup. I profiled it, and polkadot is
about 125ms of that time. The rest is Node resolving the sdk's dependency tree.

Ran the file 10 times in a row: all passed, no timeouts.
