### PR TITLE
[repo]: stop docs/ai logs conflicting on every concurrent PR

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# ChangeLog.md and Decisions.md under docs/ai are append-only logs: every change adds
+# its entry at the top of the file, so any two concurrent PRs collide on that same
+# line. `union` is git's built-in "keep both sides" driver — it takes both entries
+# instead of raising a conflict, which is what you want for a log.
+#
+# Flow.md is deliberately not listed. It is edited in place, so union would merge two
+# contradictory edits into a file that silently states both, with no conflict shown.
+**/docs/ai/ChangeLog.md merge=union
+**/docs/ai/Decisions.md merge=union


### PR DESCRIPTION
Every entry in `docs/ai/ChangeLog.md` and `Decisions.md` goes in at the same place, right
under the "newest first" header. So any two PRs open at once touch that exact line, and
whichever one merges second has to resolve a conflict. About 50 commits a month touch these
files, so that's most PRs.

This marks those two files as `merge=union`, git's built-in "keep both sides" driver. Instead
of raising a conflict it takes both entries.

Tested against the real 1743-line simplex ChangeLog: two branches each adding an entry, one
merged, the other rebased on top. Conflict before, clean after, both entries present. Moving
entries to the bottom of the file instead would not have helped — two appends at the end
collide the same way.

`Flow.md` is deliberately left out. It gets edited in place, so union would merge two
contradictory edits into a file that silently states both, with no conflict shown.

One cosmetic cost: two entries landing together can lose the blank line between them.
