### PR TITLE
[tesseract]: Retry submitting messages from hyperbridge that were cancelled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28396,7 +28396,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tesseract"
-version = "2.4.11"
+version = "2.4.12"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/tesseract/messaging/messaging/src/events.rs
+++ b/tesseract/messaging/messaging/src/events.rs
@@ -588,10 +588,49 @@ fn is_allowed_module(config: &RelayerConfig, module: &[u8]) -> bool {
 /// every module. Here it names none, which is what callers that need "the
 /// operator asked for this module by name" want.
 pub fn is_explicitly_filtered(config: &RelayerConfig, module: &[u8]) -> bool {
-	config.module_filter.as_ref().map_or(false, |filters| {
-		filters.iter().any(|filter| {
-			hex::decode(filter.replace("0x", "")).expect("Module identifier should be valid hex") ==
+	module_listed(config.module_filter.as_deref(), module)
+}
+
+/// Whether the operator asked, through `retry_modules`, for `module`'s requests
+/// to be parked and retried when a delivery to an EVM chain is cancelled or
+/// never lands. An absent or empty list names nothing, so nothing is parked.
+pub fn is_retry_module(config: &RelayerConfig, module: &[u8]) -> bool {
+	module_listed(config.retry_modules.as_deref(), module)
+}
+
+/// Whether `module` appears in an operator supplied list of hex encoded module
+/// ids, with or without a `0x` prefix.
+fn module_listed(list: Option<&[String]>, module: &[u8]) -> bool {
+	list.map_or(false, |entries| {
+		entries.iter().any(|entry| {
+			hex::decode(entry.replace("0x", "")).expect("Module identifier should be valid hex") ==
 				module
 		})
 	})
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	const LISTED: &[u8] = b"pall_hft";
+	const CONTRACT: &[u8] = &[0xAB; 20];
+
+	#[test]
+	fn retry_modules_names_nothing_when_unset_or_empty() {
+		assert!(!is_retry_module(&RelayerConfig::default(), LISTED));
+		let empty = RelayerConfig { retry_modules: Some(vec![]), ..Default::default() };
+		assert!(!is_retry_module(&empty, LISTED));
+	}
+
+	#[test]
+	fn retry_modules_matches_listed_modules_with_or_without_prefix() {
+		let config = RelayerConfig {
+			retry_modules: Some(vec![hex::encode(LISTED), format!("0x{}", hex::encode(CONTRACT))]),
+			..Default::default()
+		};
+		assert!(is_retry_module(&config, LISTED));
+		assert!(is_retry_module(&config, CONTRACT));
+		assert!(!is_retry_module(&config, b"pall_xyz"));
+	}
 }

--- a/tesseract/messaging/messaging/src/events.rs
+++ b/tesseract/messaging/messaging/src/events.rs
@@ -8,7 +8,7 @@ use ismp::{
 		Event as IsmpEvent, Meta, RequestResponseHandled, StateMachineUpdated, TimeoutHandled,
 	},
 	host::StateMachine,
-	messaging::{hash_request, hash_response, Message, Proof, RequestMessage, ResponseMessage},
+	messaging::{hash_response, Message, Proof, RequestMessage, ResponseMessage},
 	router::{GetResponse, PostRequest, Request},
 };
 use sp_core::{H160, U256};
@@ -129,15 +129,7 @@ pub async fn translate_events_to_messages(
 								return Ok(None);
 							}
 
-							let req = Request::Post(post.clone());
-							let hash = hash_request::<Hasher>(&req);
-
-							let query = Query {
-								source_chain: req.source_chain(),
-								dest_chain: req.dest_chain(),
-								nonce: req.nonce(),
-								commitment: hash,
-							};
+							let query = Query::from(&Request::Post(post.clone()));
 
 							let proof = source
 								.query_requests_proof(
@@ -381,12 +373,7 @@ async fn build_get_response_candidates(
 			// The `Query` describes the origin GetRequest, not the response: its commitment
 			// is the request commitment, which is what the EVM host keys both the fee
 			// metadata and the response receipt on.
-			queries.push(Query {
-				source_chain: res.get.source,
-				dest_chain: res.get.dest,
-				nonce: res.get.nonce,
-				commitment: hash_request::<Hasher>(&Request::Get(res.get.clone())),
-			});
+			queries.push(Query::from(&Request::Get(res.get.clone())));
 			messages.push(Message::Response(ResponseMessage {
 				requests: vec![res.get.clone()],
 				proof: Proof {
@@ -492,8 +479,7 @@ pub async fn return_successful_queries(
 				async move {
 					if !est.successful_execution && !deliver_failed {
 						tracing::info!(target: crate::LOG_TARGET, "Skipping Failed tx");
-						// if msg has not been delivered return the message as retriable
-						let relayer = match &msg {
+						let receipt = match &msg {
 							Message::Request(_) => {
 								sink.query_request_receipt(query.commitment).await?
 							}
@@ -503,7 +489,8 @@ pub async fn return_successful_queries(
 							_ => unreachable!("Relayer should only ever debug trace request or response messages")
 						};
 
-						if relayer == H160::zero().0.to_vec() && coprocessor != sink.state_machine_id().state_id {
+						// Anything the sink has not seen yet is worth another attempt later.
+						if !was_delivered(&receipt) && coprocessor != sink.state_machine_id().state_id {
 							return Ok((None, Some(msg)))
 						} else {
 							return Ok((None, None))
@@ -573,6 +560,13 @@ pub async fn return_successful_queries(
 	}
 
 	Ok(ProfitabilityResult { queries: queries_to_be_relayed, retriable_messages })
+}
+
+/// Whether a commitment has already been delivered. Hosts record the address of
+/// the relayer that delivered a message and hand back the zero address for one
+/// they have not seen.
+pub fn was_delivered(receipt: &[u8]) -> bool {
+	receipt != H160::zero().0.as_slice()
 }
 
 fn is_allowed_module(config: &RelayerConfig, module: &[u8]) -> bool {

--- a/tesseract/messaging/messaging/src/events.rs
+++ b/tesseract/messaging/messaging/src/events.rs
@@ -591,9 +591,10 @@ pub fn is_explicitly_filtered(config: &RelayerConfig, module: &[u8]) -> bool {
 	module_listed(config.module_filter.as_deref(), module)
 }
 
-/// Whether the operator asked, through `retry_modules`, for `module`'s requests
-/// to be parked and retried when a delivery to an EVM chain is cancelled or
-/// never lands. An absent or empty list names nothing, so nothing is parked.
+/// Whether the operator asked, through `retry_modules`, for requests addressed
+/// to `module` to be parked and retried when a delivery to an EVM chain is
+/// cancelled or never lands. Callers pass the request's `to`. An absent or
+/// empty list names nothing, so nothing is parked.
 pub fn is_retry_module(config: &RelayerConfig, module: &[u8]) -> bool {
 	module_listed(config.retry_modules.as_deref(), module)
 }
@@ -613,8 +614,10 @@ fn module_listed(list: Option<&[String]>, module: &[u8]) -> bool {
 mod tests {
 	use super::*;
 
-	const LISTED: &[u8] = b"pall_hft";
-	const CONTRACT: &[u8] = &[0xAB; 20];
+	/// Destination modules are matched, so on an EVM chain these are contract
+	/// addresses; a pallet id shows the same code path for a substrate target.
+	const LISTED: &[u8] = &[0xAB; 20];
+	const CONTRACT: &[u8] = &[0xCD; 20];
 
 	#[test]
 	fn retry_modules_names_nothing_when_unset_or_empty() {
@@ -631,6 +634,6 @@ mod tests {
 		};
 		assert!(is_retry_module(&config, LISTED));
 		assert!(is_retry_module(&config, CONTRACT));
-		assert!(!is_retry_module(&config, b"pall_xyz"));
+		assert!(!is_retry_module(&config, &[0xEF; 20]));
 	}
 }

--- a/tesseract/messaging/messaging/src/lib.rs
+++ b/tesseract/messaging/messaging/src/lib.rs
@@ -26,10 +26,9 @@ mod get_requests;
 pub mod outbound;
 pub mod outbound_claim;
 pub mod outbound_request_claim;
-/// Unprofitable-message retry loop. Kept public for callers that want to wire
-/// it up; **not** spawned by [`inbound`] in the consolidated relayer — the
-/// design is that retrying unprofitable messages is the outbound task's
-/// concern.
+/// Retry loop for deliveries that never landed. Spawned by
+/// [`outbound::initialize`], one per destination, not by [`inbound`]: retrying
+/// is the outbound task's concern.
 pub mod retries;
 
 use anyhow::anyhow;
@@ -63,10 +62,8 @@ type GetReqSender = Sender<(Vec<GetRequest>, StateMachineUpdated)>;
 ///   a single event-driven fan-out task.
 /// - Fee accumulation — spawned once per chain in `tesseract-relayer/src/cli.rs`.
 /// - Fee withdrawal — spawned globally in `tesseract-relayer/src/cli.rs`.
-/// - Unprofitable-message retries — the retry loop at
-///   [`crate::retries::retry_unprofitable_messages`] is kept in-tree but deliberately **not**
-///   spawned. Retrying unprofitable inbound messages is the outbound relayer's concern, not this
-///   one.
+/// - Retries of undelivered messages — [`crate::retries::retry_undelivered_messages`] is spawned
+///   per destination by [`outbound::initialize`], which is also what parks the messages it drains.
 ///
 /// The inbound messaging task already queries chain_b's events on every HB-side
 /// state-machine-update, so it also feeds the GET-request channel that
@@ -381,50 +378,10 @@ async fn handle_update(
 		let res = chain_a.submit(messages.clone(), coprocessor).await;
 		match res {
 			Ok(TxResult { receipts, unsuccessful, new_epochs: _ }) => {
-				if let Some(sender) = fee_acc_sender {
-					// We should not store messages when they are delivered to hyperbridge
-					if chain_a.state_machine_id().state_id != coprocessor {
-						// Filter out receipts for transactions that originated from the coprocessor
-						let receipts = receipts
-							.into_iter()
-							.filter(|receipt| receipt.source() != coprocessor)
-							.collect::<Vec<_>>();
-						if !receipts.is_empty() {
-							// Store receipts in database before auto accumulation
-							tracing::trace!(
-								target: LOG_TARGET,
-								source = %chain_b.name(),
-								dest = %chain_a.name(),
-								count = receipts.len(),
-								"Persisting deliveries to the db",
-							);
-							if let Err(err) = tx_payment.store_messages(receipts.clone()).await {
-								tracing::error!(
-									target: LOG_TARGET,
-									source = %chain_b.name(),
-									dest = %chain_a.name(),
-									count = receipts.len(),
-									?err,
-									"Failed to persist deliveries to database",
-								)
-							}
-							// Send receipts to the fee accumulation task.
-							// `try_send` so the inbound task never blocks on
-							// a backed-up fee-accumulator. Receipts are
-							// already persisted via `tx_payment.store_messages`
-							// above, so a dropped channel push is recoverable
-							// by the manual `accumulate-fees` subcommand.
-							if let Err(err) = sender.try_send(receipts) {
-								tracing::error!(
-									target: LOG_TARGET,
-									source = %chain_b.name(),
-									dest = %chain_a.name(),
-									?err,
-									"Fee auto accumulation channel send failed; you can try again manually",
-								);
-							}
-						}
-					}
+				// Deliveries to hyperbridge itself are not accumulated, hyperbridge is
+				// where those fees are claimed from.
+				if chain_a.state_machine_id().state_id != coprocessor {
+					record_deliveries(&tx_payment, &fee_acc_sender, receipts, coprocessor).await;
 				}
 
 				if !unsuccessful.is_empty() &&
@@ -501,6 +458,48 @@ async fn handle_update(
 	}
 
 	Ok(())
+}
+
+/// Persist deliveries and hand them to the fee accumulation task.
+///
+/// Receipts for requests that originated on hyperbridge are dropped: those are
+/// paid for by the outbound delivery reward, which the claim tasks collect, so
+/// accumulating them here would bill hyperbridge twice for the same delivery.
+/// Sending is a `try_send` so a backed up accumulator never stalls a delivery
+/// task; the rows are already in the db by then, which is what the manual
+/// `accumulate-fees` subcommand reads.
+pub(crate) async fn record_deliveries(
+	tx_payment: &TransactionPayment,
+	fee_acc_sender: &Option<FeeAccSender>,
+	receipts: Vec<TxReceipt>,
+	coprocessor: StateMachine,
+) {
+	let Some(sender) = fee_acc_sender else { return };
+	let receipts = receipts
+		.into_iter()
+		.filter(|receipt| receipt.source() != coprocessor)
+		.collect::<Vec<_>>();
+	if receipts.is_empty() {
+		return;
+	}
+
+	tracing::trace!(target: LOG_TARGET, count = receipts.len(), "Persisting deliveries to the db");
+	if let Err(err) = tx_payment.store_messages(receipts.clone()).await {
+		tracing::error!(
+			target: LOG_TARGET,
+			count = receipts.len(),
+			?err,
+			"Failed to persist deliveries to database",
+		);
+	}
+
+	if let Err(err) = sender.try_send(receipts) {
+		tracing::error!(
+			target: LOG_TARGET,
+			?err,
+			"Fee auto accumulation channel send failed; you can try again manually",
+		);
+	}
 }
 
 pub async fn fee_accumulation<A: IsmpProvider + Clone + Clone + HyperbridgeClaim + 'static>(

--- a/tesseract/messaging/messaging/src/lib.rs
+++ b/tesseract/messaging/messaging/src/lib.rs
@@ -385,7 +385,7 @@ async fn handle_update(
 				}
 
 				if !unsuccessful.is_empty() &&
-					config.unprofitable_retry_frequency.is_some() &&
+					config.retry_frequency.is_some() &&
 					chain_a.state_machine_id().state_id != coprocessor
 				{
 					tracing::error!(
@@ -433,7 +433,7 @@ async fn handle_update(
 
 	// Store currently unprofitable in messages in db
 	if !unprofitable.is_empty() &&
-		config.unprofitable_retry_frequency.is_some() &&
+		config.retry_frequency.is_some() &&
 		chain_a.state_machine_id().state_id != coprocessor
 	{
 		tracing::trace!(

--- a/tesseract/messaging/messaging/src/lib.rs
+++ b/tesseract/messaging/messaging/src/lib.rs
@@ -384,39 +384,18 @@ async fn handle_update(
 					record_deliveries(&tx_payment, &fee_acc_sender, receipts, coprocessor).await;
 				}
 
-				if !unsuccessful.is_empty() &&
-					config.retry_frequency.is_some() &&
-					chain_a.state_machine_id().state_id != coprocessor
-				{
+				// Nothing retries deliveries on this pipeline: the retry loop only
+				// serves the EVM destinations the outbound fan-out parks for. A
+				// cancelled batch here is picked up again by whichever relayer next
+				// sees the events, so it is only logged.
+				if !unsuccessful.is_empty() {
 					tracing::error!(
 						target: LOG_TARGET,
 						source = %chain_b.name(),
 						dest = %chain_a.name(),
 						count = unsuccessful.len(),
-						"Some transactions were cancelled and will be retried",
+						"Some transactions were cancelled",
 					);
-					tracing::trace!(
-						target: LOG_TARGET,
-						source = %chain_b.name(),
-						dest = %chain_a.name(),
-						count = unsuccessful.len(),
-						"Persisting cancelled transactions to the db",
-					);
-					if let Err(err) = tx_payment
-						.store_unprofitable_messages(
-							unsuccessful,
-							chain_a.state_machine_id().state_id,
-						)
-						.await
-					{
-						tracing::error!(
-							target: LOG_TARGET,
-							source = %chain_b.name(),
-							dest = %chain_a.name(),
-							?err,
-							"Failed to persist cancelled messages to the database",
-						)
-					}
 				}
 			},
 			Err(err) => {
@@ -431,30 +410,14 @@ async fn handle_update(
 		}
 	}
 
-	// Store currently unprofitable in messages in db
-	if !unprofitable.is_empty() &&
-		config.retry_frequency.is_some() &&
-		chain_a.state_machine_id().state_id != coprocessor
-	{
-		tracing::trace!(
+	if !unprofitable.is_empty() {
+		tracing::debug!(
 			target: LOG_TARGET,
 			source = %chain_b.name(),
 			dest = %chain_a.name(),
-			count = unprofitable.len(),
-			"Persisting unprofitable messages to the db",
+			dropped = unprofitable.len(),
+			"unprofitable messages dropped",
 		);
-		if let Err(err) = tx_payment
-			.store_unprofitable_messages(unprofitable, chain_a.state_machine_id().state_id)
-			.await
-		{
-			tracing::error!(
-				target: LOG_TARGET,
-				source = %chain_b.name(),
-				dest = %chain_a.name(),
-				?err,
-				"Error while storing unprofitable messages in the database",
-			)
-		}
 	}
 
 	Ok(())

--- a/tesseract/messaging/messaging/src/outbound.rs
+++ b/tesseract/messaging/messaging/src/outbound.rs
@@ -582,8 +582,8 @@ async fn submit_for_dest(
 /// messages are dropped since the next proof along supersedes them, and so are
 /// get responses, which are paid for on delivery rather than claimed.
 ///
-/// Parking is pointless with nothing draining the rows, so it also follows the
-/// `retry_frequency` toggle the retry task itself runs on.
+/// Parking is pointless with nothing draining the rows, so it is gated on the
+/// same non empty `retry_modules` that spawns the retry task.
 async fn park_undelivered(
 	dest_name: &str,
 	dest_state_machine: StateMachine,
@@ -591,8 +591,9 @@ async fn park_undelivered(
 	messages: Vec<Message>,
 	tx_payment: &Option<Arc<TransactionPayment>>,
 ) {
-	let retries_enabled = config.retry_frequency.is_some();
-	let Some(tx_payment) = tx_payment.as_ref().filter(|_| retries_enabled) else { return };
+	let Some(tx_payment) = tx_payment.as_ref().filter(|_| config.retries_enabled()) else {
+		return
+	};
 	let requests = messages
 		.into_iter()
 		.filter_map(|message| match message {
@@ -1034,10 +1035,9 @@ pub async fn initialize(
 	);
 
 	// One retry loop per destination, draining the requests the fan-out parked
-	// when a batch never landed. Off unless the operator set
-	// `retry_frequency`; which requests get parked at all is
-	// decided by `retry_modules`.
-	if relayer_config.retry_frequency.is_some() {
+	// when a batch never landed. Listing a module in `retry_modules` is what
+	// switches this on; `retry_frequency` only paces it.
+	if relayer_config.retries_enabled() {
 		for (state_machine, dest) in &destinations {
 			let ctx = crate::retries::RetryContext {
 				dest: dest.clone(),

--- a/tesseract/messaging/messaging/src/outbound.rs
+++ b/tesseract/messaging/messaging/src/outbound.rs
@@ -382,6 +382,10 @@ async fn submit_for_dest(
 		return Ok(());
 	}
 
+	// Parking is pointless with nothing draining the rows, so it follows the
+	// same toggle the retry task itself does.
+	let retries_enabled = relayer_config.unprofitable_retry_frequency.is_some();
+
 	let consensus_msg = Message::Consensus(ConsensusMessage {
 		consensus_proof: proof_bytes,
 		consensus_state_id: BEEFY_CONSENSUS_STATE_ID,
@@ -409,9 +413,14 @@ async fn submit_for_dest(
 		.await
 		{
 			Ok((deliverable, unprofitable)) => {
-				if !unprofitable.is_empty() {
-					tracing::debug!(target: LOG_TARGET, dropped = unprofitable.len(), "unprofitable messages dropped");
-				}
+				park_undelivered(
+					&dest_name,
+					dest_state_machine,
+					unprofitable,
+					&claim_tx_payment,
+					retries_enabled,
+				)
+				.await;
 				batch.extend(deliverable);
 			},
 			Err(err) => {
@@ -441,9 +450,12 @@ async fn submit_for_dest(
 	} else {
 		tracing::info!(target: "tesseract", msgs = batch.len(), "🛰️ Transmitting ismp messages to {dest_name}");
 	}
-	// Extract the post requests from the batch before submit consumes it,
-	// so the request-claim forwarder can index them by commitment.
-	let batch_requests: Vec<PostRequest> = batch
+	// Keep a copy of the request messages before submit consumes the batch:
+	// the request-claim forwarder indexes them by commitment, and a submission
+	// that never lands parks them for the retry task.
+	let requests: Vec<Message> =
+		batch.iter().filter(|msg| matches!(msg, Message::Request(_))).cloned().collect();
+	let batch_requests: Vec<PostRequest> = requests
 		.iter()
 		.flat_map(|msg| match msg {
 			Message::Request(req_msg) => req_msg.requests.clone(),
@@ -454,7 +466,29 @@ async fn submit_for_dest(
 	// `submit` transparently picks the right transport — EVM destinations
 	// whose handler supports IHandlerV2 dispatch the whole batch as a single
 	// `batchCall(bytes[])` tx; everything else uses the legacy serial path.
-	let result = dest.submit(batch, hb_state_machine_id.state_id).await?;
+	let result = match dest.submit(batch, hb_state_machine_id.state_id).await {
+		Ok(result) => result,
+		Err(err) => {
+			park_undelivered(
+				&dest_name,
+				dest_state_machine,
+				requests,
+				&claim_tx_payment,
+				retries_enabled,
+			)
+			.await;
+			return Err(err);
+		},
+	};
+
+	park_undelivered(
+		&dest_name,
+		dest_state_machine,
+		result.unsuccessful,
+		&claim_tx_payment,
+		retries_enabled,
+	)
+	.await;
 
 	// Forward a claim for every hyperbridge-originated request just delivered.
 	forward_request_delivery_claims(
@@ -537,6 +571,45 @@ async fn submit_for_dest(
 	.await;
 
 	Ok(())
+}
+
+/// Park requests the destination never received so the retry task can try them
+/// again. Deliveries out of hyperbridge are gated to a whitelisted relayer, so
+/// there is no one else to pick them up.
+///
+/// Only requests are parked. The consensus message in a failed batch is
+/// superseded by the next proof that comes along, and a get response is paid
+/// for on delivery rather than claimed, so it carries no reward to recover.
+async fn park_undelivered(
+	dest_name: &str,
+	dest_state_machine: StateMachine,
+	messages: Vec<Message>,
+	tx_payment: &Option<Arc<TransactionPayment>>,
+	retries_enabled: bool,
+) {
+	let Some(tx_payment) = tx_payment.as_ref().filter(|_| retries_enabled) else { return };
+	let requests = messages
+		.into_iter()
+		.filter(|msg| matches!(msg, Message::Request(_)))
+		.collect::<Vec<_>>();
+	if requests.is_empty() {
+		return;
+	}
+
+	tracing::debug!(
+		target: LOG_TARGET,
+		dest = %dest_name,
+		count = requests.len(),
+		"parking undelivered messages for retry",
+	);
+	if let Err(err) = tx_payment.store_unprofitable_messages(requests, dest_state_machine).await {
+		tracing::error!(
+			target: LOG_TARGET,
+			dest = %dest_name,
+			?err,
+			"failed to park undelivered messages",
+		);
+	}
 }
 
 /// Drop hyperbridge-originated requests whose `source_module` is neither on the
@@ -948,6 +1021,40 @@ pub async fn initialize(
 		.instrument(request_claim_span)
 		.boxed(),
 	);
+
+	// One retry loop per destination, draining the requests the fan-out parked
+	// when a batch never landed. Off unless the operator set
+	// `unprofitable_retry_frequency`.
+	if relayer_config.unprofitable_retry_frequency.is_some() {
+		for (state_machine, dest) in &destinations {
+			let ctx = crate::retries::RetryContext {
+				dest: dest.clone(),
+				hyperbridge: hyperbridge_provider.clone(),
+				client_map: provider_clients.clone(),
+				tx_payment: tx_payment.clone(),
+				config: relayer_config.clone(),
+				coprocessor: hyperbridge_provider.state_machine_id().state_id,
+				fee_acc_sender: fee_senders.get(state_machine).cloned(),
+			};
+			let name = format!("retries-{}-{}", hyperbridge_provider.name(), dest.name());
+			let span = tracing::info_span!(
+				"retries",
+				hb = %hyperbridge_provider.name(),
+				chain = %dest.name(),
+			);
+			task_manager.spawn_essential_handle().spawn_blocking(
+				Box::leak(Box::new(name)),
+				"outbound",
+				async move {
+					tracing::trace!(target: LOG_TARGET, "task started");
+					let res = crate::retries::retry_undelivered_messages(ctx).await;
+					tracing::error!(target: LOG_TARGET, ?res, "task terminated");
+				}
+				.instrument(span)
+				.boxed(),
+			);
+		}
+	}
 
 	// Outbound fan-out itself.
 	let outbound_name = format!("outbound-{}", hyperbridge_provider.name());

--- a/tesseract/messaging/messaging/src/outbound.rs
+++ b/tesseract/messaging/messaging/src/outbound.rs
@@ -574,16 +574,16 @@ async fn submit_for_dest(
 /// Park requests the destination never received so the retry task can try them
 /// again.
 ///
-/// Only requests from modules the operator listed in `retry_modules` are kept.
-/// Which modules those are is the operator's call: deliveries out of hyperbridge
-/// are gated to a whitelisted relayer, so nobody else is coming for those, while
-/// a user's request merely routed through hyperbridge is still up for grabs for
-/// any relayer. Consensus messages are dropped since the next proof along
-/// supersedes them, and so are get responses, which are paid for on delivery
-/// rather than claimed.
+/// Only requests addressed to a module the operator listed in `retry_modules`
+/// are kept, matched on the request's `to`. Which modules those are is the
+/// operator's call: deliveries out of hyperbridge are gated to a whitelisted
+/// relayer, so nobody else is coming for those, while a user's request merely
+/// routed through hyperbridge is still up for grabs for any relayer. Consensus
+/// messages are dropped since the next proof along supersedes them, and so are
+/// get responses, which are paid for on delivery rather than claimed.
 ///
 /// Parking is pointless with nothing draining the rows, so it also follows the
-/// `unprofitable_retry_frequency` toggle the retry task itself runs on.
+/// `retry_frequency` toggle the retry task itself runs on.
 async fn park_undelivered(
 	dest_name: &str,
 	dest_state_machine: StateMachine,
@@ -591,13 +591,13 @@ async fn park_undelivered(
 	messages: Vec<Message>,
 	tx_payment: &Option<Arc<TransactionPayment>>,
 ) {
-	let retries_enabled = config.unprofitable_retry_frequency.is_some();
+	let retries_enabled = config.retry_frequency.is_some();
 	let Some(tx_payment) = tx_payment.as_ref().filter(|_| retries_enabled) else { return };
 	let requests = messages
 		.into_iter()
 		.filter_map(|message| match message {
 			Message::Request(mut msg) => {
-				msg.requests.retain(|post| is_retry_module(config, &post.from));
+				msg.requests.retain(|post| is_retry_module(config, &post.to));
 				(!msg.requests.is_empty()).then_some(Message::Request(msg))
 			},
 			_ => None,
@@ -1035,9 +1035,9 @@ pub async fn initialize(
 
 	// One retry loop per destination, draining the requests the fan-out parked
 	// when a batch never landed. Off unless the operator set
-	// `unprofitable_retry_frequency`; which requests get parked at all is
+	// `retry_frequency`; which requests get parked at all is
 	// decided by `retry_modules`.
-	if relayer_config.unprofitable_retry_frequency.is_some() {
+	if relayer_config.retry_frequency.is_some() {
 		for (state_machine, dest) in &destinations {
 			let ctx = crate::retries::RetryContext {
 				dest: dest.clone(),

--- a/tesseract/messaging/messaging/src/outbound.rs
+++ b/tesseract/messaging/messaging/src/outbound.rs
@@ -39,7 +39,9 @@ use tokio::sync::mpsc::Sender;
 use tracing::Instrument;
 use transaction_fees::TransactionPayment;
 
-use crate::events::{filter_events, is_explicitly_filtered, translate_events_to_messages};
+use crate::events::{
+	filter_events, is_explicitly_filtered, is_retry_module, translate_events_to_messages,
+};
 
 /// Log/tracing target for the outbound pipeline.
 const LOG_TARGET: &str = concat!("messaging", "-outbound");
@@ -382,10 +384,6 @@ async fn submit_for_dest(
 		return Ok(());
 	}
 
-	// Parking is pointless with nothing draining the rows, so it follows the
-	// same toggle the retry task itself does.
-	let retries_enabled = relayer_config.unprofitable_retry_frequency.is_some();
-
 	let consensus_msg = Message::Consensus(ConsensusMessage {
 		consensus_proof: proof_bytes,
 		consensus_state_id: BEEFY_CONSENSUS_STATE_ID,
@@ -402,7 +400,7 @@ async fn submit_for_dest(
 			dest.clone(),
 			events,
 			state_machine_height,
-			relayer_config,
+			relayer_config.clone(),
 			coprocessor,
 			&client_map,
 			// Pass the consensus update as the gas-estimation prelude so EVM
@@ -416,10 +414,9 @@ async fn submit_for_dest(
 				park_undelivered(
 					&dest_name,
 					dest_state_machine,
-					coprocessor,
+					&relayer_config,
 					unprofitable,
 					&claim_tx_payment,
-					retries_enabled,
 				)
 				.await;
 				batch.extend(deliverable);
@@ -473,10 +470,9 @@ async fn submit_for_dest(
 			park_undelivered(
 				&dest_name,
 				dest_state_machine,
-				coprocessor,
+				&relayer_config,
 				requests,
 				&claim_tx_payment,
-				retries_enabled,
 			)
 			.await;
 			return Err(err);
@@ -486,10 +482,9 @@ async fn submit_for_dest(
 	park_undelivered(
 		&dest_name,
 		dest_state_machine,
-		coprocessor,
+		&relayer_config,
 		result.unsuccessful,
 		&claim_tx_payment,
-		retries_enabled,
 	)
 	.await;
 
@@ -579,26 +574,30 @@ async fn submit_for_dest(
 /// Park requests the destination never received so the retry task can try them
 /// again.
 ///
-/// Only requests hyperbridge itself dispatched are kept. Those are the ones
-/// gated to a whitelisted relayer, so nobody else is coming for them, while a
-/// user's request merely routed through hyperbridge is still up for grabs and
-/// another relayer will deliver it. Consensus messages are dropped since the
-/// next proof along supersedes them, and so are get responses, which are paid
-/// for on delivery rather than claimed.
+/// Only requests from modules the operator listed in `retry_modules` are kept.
+/// Which modules those are is the operator's call: deliveries out of hyperbridge
+/// are gated to a whitelisted relayer, so nobody else is coming for those, while
+/// a user's request merely routed through hyperbridge is still up for grabs for
+/// any relayer. Consensus messages are dropped since the next proof along
+/// supersedes them, and so are get responses, which are paid for on delivery
+/// rather than claimed.
+///
+/// Parking is pointless with nothing draining the rows, so it also follows the
+/// `unprofitable_retry_frequency` toggle the retry task itself runs on.
 async fn park_undelivered(
 	dest_name: &str,
 	dest_state_machine: StateMachine,
-	coprocessor: StateMachine,
+	config: &RelayerConfig,
 	messages: Vec<Message>,
 	tx_payment: &Option<Arc<TransactionPayment>>,
-	retries_enabled: bool,
 ) {
+	let retries_enabled = config.unprofitable_retry_frequency.is_some();
 	let Some(tx_payment) = tx_payment.as_ref().filter(|_| retries_enabled) else { return };
 	let requests = messages
 		.into_iter()
 		.filter_map(|message| match message {
 			Message::Request(mut msg) => {
-				msg.requests.retain(|post| post.source == coprocessor);
+				msg.requests.retain(|post| is_retry_module(config, &post.from));
 				(!msg.requests.is_empty()).then_some(Message::Request(msg))
 			},
 			_ => None,
@@ -1036,7 +1035,8 @@ pub async fn initialize(
 
 	// One retry loop per destination, draining the requests the fan-out parked
 	// when a batch never landed. Off unless the operator set
-	// `unprofitable_retry_frequency`.
+	// `unprofitable_retry_frequency`; which requests get parked at all is
+	// decided by `retry_modules`.
 	if relayer_config.unprofitable_retry_frequency.is_some() {
 		for (state_machine, dest) in &destinations {
 			let ctx = crate::retries::RetryContext {

--- a/tesseract/messaging/messaging/src/outbound.rs
+++ b/tesseract/messaging/messaging/src/outbound.rs
@@ -416,6 +416,7 @@ async fn submit_for_dest(
 				park_undelivered(
 					&dest_name,
 					dest_state_machine,
+					coprocessor,
 					unprofitable,
 					&claim_tx_payment,
 					retries_enabled,
@@ -472,6 +473,7 @@ async fn submit_for_dest(
 			park_undelivered(
 				&dest_name,
 				dest_state_machine,
+				coprocessor,
 				requests,
 				&claim_tx_payment,
 				retries_enabled,
@@ -484,6 +486,7 @@ async fn submit_for_dest(
 	park_undelivered(
 		&dest_name,
 		dest_state_machine,
+		coprocessor,
 		result.unsuccessful,
 		&claim_tx_payment,
 		retries_enabled,
@@ -574,15 +577,18 @@ async fn submit_for_dest(
 }
 
 /// Park requests the destination never received so the retry task can try them
-/// again. Deliveries out of hyperbridge are gated to a whitelisted relayer, so
-/// there is no one else to pick them up.
+/// again.
 ///
-/// Only requests are parked. The consensus message in a failed batch is
-/// superseded by the next proof that comes along, and a get response is paid
-/// for on delivery rather than claimed, so it carries no reward to recover.
+/// Only requests hyperbridge itself dispatched are kept. Those are the ones
+/// gated to a whitelisted relayer, so nobody else is coming for them, while a
+/// user's request merely routed through hyperbridge is still up for grabs and
+/// another relayer will deliver it. Consensus messages are dropped since the
+/// next proof along supersedes them, and so are get responses, which are paid
+/// for on delivery rather than claimed.
 async fn park_undelivered(
 	dest_name: &str,
 	dest_state_machine: StateMachine,
+	coprocessor: StateMachine,
 	messages: Vec<Message>,
 	tx_payment: &Option<Arc<TransactionPayment>>,
 	retries_enabled: bool,
@@ -590,7 +596,13 @@ async fn park_undelivered(
 	let Some(tx_payment) = tx_payment.as_ref().filter(|_| retries_enabled) else { return };
 	let requests = messages
 		.into_iter()
-		.filter(|msg| matches!(msg, Message::Request(_)))
+		.filter_map(|message| match message {
+			Message::Request(mut msg) => {
+				msg.requests.retain(|post| post.source == coprocessor);
+				(!msg.requests.is_empty()).then_some(Message::Request(msg))
+			},
+			_ => None,
+		})
 		.collect::<Vec<_>>();
 	if requests.is_empty() {
 		return;
@@ -1030,6 +1042,7 @@ pub async fn initialize(
 			let ctx = crate::retries::RetryContext {
 				dest: dest.clone(),
 				hyperbridge: hyperbridge_provider.clone(),
+				proof_source: proof_source.clone(),
 				client_map: provider_clients.clone(),
 				tx_payment: tx_payment.clone(),
 				config: relayer_config.clone(),

--- a/tesseract/messaging/messaging/src/retries.rs
+++ b/tesseract/messaging/messaging/src/retries.rs
@@ -24,7 +24,7 @@ use crate::{
 	record_deliveries, FeeAccSender,
 };
 
-/// How often a pass runs when the operator hasn't set `unprofitable_retry_frequency`.
+/// How often a pass runs when the operator hasn't set `retry_frequency`.
 const DEFAULT_RETRY_FREQUENCY: Duration = Duration::from_secs(5 * 60);
 
 /// Everything one destination's retry loop needs, assembled once by the caller.
@@ -45,15 +45,15 @@ pub struct RetryContext {
 
 /// Redeliver requests to an EVM chain that never landed.
 ///
-/// The outbound fan-out parks requests from the modules the operator listed in
-/// `retry_modules` whenever a batch is cancelled or fails to submit, and this
-/// loop drains them on a timer. Deliveries out of hyperbridge are the usual
+/// The outbound fan-out parks requests addressed to the modules the operator
+/// listed in `retry_modules` whenever a batch is cancelled or fails to submit,
+/// and this loop drains them on a timer. Deliveries out of hyperbridge are the usual
 /// reason to list a module: they are gated to a whitelisted relayer, so a batch
 /// this relayer failed to submit is not going to be picked up by anyone else.
 pub async fn retry_undelivered_messages(ctx: RetryContext) -> Result<(), anyhow::Error> {
 	let frequency = ctx
 		.config
-		.unprofitable_retry_frequency
+		.retry_frequency
 		.map_or(DEFAULT_RETRY_FREQUENCY, Duration::from_secs);
 	tracing::trace!(
 		target: crate::LOG_TARGET,
@@ -96,11 +96,11 @@ async fn retry_once(ctx: &RetryContext) -> Result<(), anyhow::Error> {
 	for (message, _) in parked {
 		let Message::Request(msg) = message else { continue };
 		let parked_at = msg.proof.height.height;
-		// Only modules the operator listed are retried. Rows left by an older build,
-		// or by a config that has since dropped a module, are swept up here and not
-		// carried any further.
+		// Only requests addressed to a listed module are retried. Rows left by an
+		// older build, or by a config that has since dropped a module, are swept up
+		// here and not carried any further.
 		for post in msg.requests {
-			if !is_retry_module(&ctx.config, &post.from) {
+			if !is_retry_module(&ctx.config, &post.to) {
 				continue;
 			}
 			let commitment = hash_request::<Hasher>(&Request::Post(post.clone()));

--- a/tesseract/messaging/messaging/src/retries.rs
+++ b/tesseract/messaging/messaging/src/retries.rs
@@ -1,309 +1,328 @@
 use std::{
-	collections::{BTreeSet, HashMap},
+	collections::{BTreeMap, HashMap},
 	sync::Arc,
 	time::Duration,
 };
 
+use futures::stream::FuturesOrdered;
 use ismp::{
 	consensus::StateMachineHeight,
 	host::StateMachine,
 	messaging::{hash_request, Message, Proof, RequestMessage},
-	router::Request,
+	router::{PostRequest, Request},
 };
+use primitive_types::H256;
 use tesseract_primitives::{config::RelayerConfig, Hasher, IsmpProvider, Query, TxResult};
+use tokio_stream::StreamExt;
 use transaction_fees::TransactionPayment;
 
 use crate::{
-	events::{chunk_size, return_successful_queries},
-	FeeAccSender,
+	events::{chunk_size, return_successful_queries, was_delivered},
+	record_deliveries, FeeAccSender,
 };
 
-/// Pull retriable messages from the database periodically and retry them.
-pub async fn retry_unprofitable_messages(
-	dest: Arc<dyn IsmpProvider>,
-	hyperbridge: Arc<dyn IsmpProvider>,
-	client_map: HashMap<StateMachine, Arc<dyn IsmpProvider>>,
-	tx_payment: Arc<TransactionPayment>,
-	config: RelayerConfig,
-	coprocessor: StateMachine,
-	fee_acc_sender: Option<FeeAccSender>,
-) -> Result<(), anyhow::Error> {
+/// How often a pass runs when the operator hasn't set `unprofitable_retry_frequency`.
+const DEFAULT_RETRY_FREQUENCY: Duration = Duration::from_secs(5 * 60);
+
+/// Everything one destination's retry loop needs, assembled once by the caller.
+pub struct RetryContext {
+	/// The chain the parked messages were meant for.
+	pub dest: Arc<dyn IsmpProvider>,
+	/// Where the requests came from, and where their proofs are read from.
+	pub hyperbridge: Arc<dyn IsmpProvider>,
+	pub client_map: HashMap<StateMachine, Arc<dyn IsmpProvider>>,
+	pub tx_payment: Arc<TransactionPayment>,
+	pub config: RelayerConfig,
+	pub coprocessor: StateMachine,
+	pub fee_acc_sender: Option<FeeAccSender>,
+}
+
+/// Redeliver requests from hyperbridge that never landed.
+///
+/// Deliveries out of hyperbridge are gated to a whitelisted relayer, so a batch
+/// this relayer failed to submit is not going to be picked up by anyone else.
+/// The delivery pipelines park those requests in the database and this loop
+/// drains them on a timer.
+pub async fn retry_undelivered_messages(ctx: RetryContext) -> Result<(), anyhow::Error> {
+	let frequency = ctx
+		.config
+		.unprofitable_retry_frequency
+		.map_or(DEFAULT_RETRY_FREQUENCY, Duration::from_secs);
 	tracing::trace!(
-		target: crate::LOG_TARGET, "Starting message retries background task for deliveries to  {:?}",
-		dest.name()
+		target: crate::LOG_TARGET,
+		dest = %ctx.dest.name(),
+		?frequency,
+		"Starting message retries background task",
 	);
-	// Default to every 5 minutes
-	let mut interval = tokio::time::interval(Duration::from_secs(
-		config.unprofitable_retry_frequency.unwrap_or(5 * 60),
-	));
+
+	let mut interval = tokio::time::interval(frequency);
 	loop {
 		interval.tick().await;
-		let unprofitables =
-			match tx_payment.unprofitable_messages(&dest.state_machine_id().state_id).await {
-				Ok(messages) => messages,
-				Err(_) => {
-					continue;
-				},
-			};
-
-		// Find messages that are  bundled as a batch and split them up so they can be reestimated
-		let mut batched_messages = vec![];
-		let mut unbatched_messages = vec![];
-
-		for (msg, id) in unprofitables {
-			match msg {
-				Message::Request(ref req_msg) =>
-					if req_msg.requests.len() > 1 {
-						batched_messages.push((msg, id))
-					} else {
-						unbatched_messages.push((msg, id))
-					},
-				Message::Response(ref resp_msg) =>
-					if resp_msg.requests().len() > 1 {
-						batched_messages.push((msg, id))
-					} else {
-						unbatched_messages.push((msg, id))
-					},
-				_ => {},
-			}
+		if let Err(err) = retry_once(&ctx).await {
+			tracing::error!(
+				target: crate::LOG_TARGET,
+				dest = %ctx.dest.name(),
+				?err,
+				"Retry pass failed",
+			);
 		}
+	}
+}
 
-		// Split batched messages into individual messages
-		for (msg, id) in batched_messages {
-			match msg {
-				Message::Request(req_msg) => {
-					let proof_height = req_msg.proof.height;
-					for post in req_msg.requests {
-						let query = {
-							let req = Request::Post(post.clone());
-							let hash = hash_request::<Hasher>(&req);
+/// One pass over everything parked for this destination.
+async fn retry_once(ctx: &RetryContext) -> Result<(), anyhow::Error> {
+	let dest_state_machine = ctx.dest.state_machine_id().state_id;
+	let parked = ctx.tx_payment.unprofitable_messages(&dest_state_machine).await?;
+	if parked.is_empty() {
+		return Ok(());
+	}
 
-							Query {
-								source_chain: req.source_chain(),
-								dest_chain: req.dest_chain(),
-								nonce: req.nonce(),
-								commitment: hash,
-							}
-						};
+	// Every row read here is dropped at the end of the pass; whatever is still
+	// worth another attempt is written back as a fresh row.
+	let rows = parked.iter().map(|(_, id)| *id).collect::<Vec<_>>();
 
-						let proof = hyperbridge
-							.query_requests_proof(
-								proof_height.height,
-								vec![query],
-								dest.state_machine_id().state_id,
-							)
-							.await?;
+	// A request can be parked twice, once on its own and once inside a batch
+	// that failed later, and a batch carrying the same request twice reverts on
+	// the duplicate. Keying by commitment keeps one copy of each.
+	let requests = parked
+		.into_iter()
+		.filter_map(|(message, _)| match message {
+			Message::Request(msg) => Some(msg.requests),
+			_ => None,
+		})
+		.flatten()
+		.map(|post| (hash_request::<Hasher>(&Request::Post(post.clone())), post))
+		.collect::<BTreeMap<H256, PostRequest>>();
 
-						let _msg = RequestMessage {
-							requests: vec![post.clone()],
-							proof: Proof { height: proof_height, proof },
-							signer: dest.address(),
-						};
+	let deliverable = deliverable_requests(&ctx.dest, requests.into_values().collect()).await?;
+	if deliverable.is_empty() {
+		ctx.tx_payment.delete_unprofitable_messages(rows).await?;
+		return Ok(());
+	}
 
-						unbatched_messages.push((Message::Request(_msg), id))
-					}
-				},
-				_ => {},
-			}
-		}
+	// The proof a request was parked with is anchored at a hyperbridge height
+	// the destination may never have received, since the consensus update it
+	// rode along with is exactly what failed to land. Prove against the height
+	// the destination is on now instead.
+	let height = StateMachineHeight {
+		id: ctx.hyperbridge.state_machine_id(),
+		height: ctx.dest.query_latest_height(ctx.hyperbridge.state_machine_id()).await? as u64,
+	};
 
-		if !unbatched_messages.is_empty() {
-			tracing::trace!(target: crate::LOG_TARGET, "Starting retries of previously unprofitable or failed messages");
-			let mut request_messages = vec![];
-			let mut ids = BTreeSet::new();
-			let mut request_queries = vec![];
-			let mut post_requests = vec![];
-			// Store the highest proof height in this variable
-			let mut state_machine_height: Option<StateMachineHeight> = None;
-			unbatched_messages.into_iter().for_each(|(message, id)| match message {
-				Message::Request(msg) => {
-					let post = msg.requests.get(0).cloned().expect(
-							"Inconsistent Database, withdraw all fees and  restart relayer with a fresh database",
-						);
-					let query = {
-						let req = Request::Post(post.clone());
-						let hash = hash_request::<Hasher>(&req);
+	tracing::trace!(
+		target: crate::LOG_TARGET,
+		dest = %ctx.dest.name(),
+		count = deliverable.len(),
+		height = height.height,
+		"Retrying previously undelivered messages",
+	);
 
-						Query {
-							source_chain: req.source_chain(),
-							dest_chain: req.dest_chain(),
-							nonce: req.nonce(),
-							commitment: hash,
-						}
-					};
-					if let Some(state_machine_height) = state_machine_height.as_mut() {
-						if msg.proof.height.height > state_machine_height.height {
-							*state_machine_height = msg.proof.height
-						}
-					} else {
-						state_machine_height = Some(msg.proof.height)
-					}
-					post_requests.push(post);
-					request_messages.push(Message::Request(msg));
-					request_queries.push(query);
-					ids.insert(id);
-				},
-				_ => panic!(
-					"Inconsistent Db, withdraw all fees and restart relayer with a fresh database"
-				),
-			});
+	let queries = deliverable
+		.iter()
+		.map(|post| Query::from(&Request::Post(post.clone())))
+		.collect::<Vec<_>>();
+	let messages = single_request_messages(ctx, &deliverable, height).await?;
+	let profitability = return_successful_queries(
+		ctx.dest.clone(),
+		messages,
+		queries,
+		ctx.config.minimum_profit_percentage,
+		ctx.coprocessor,
+		&ctx.client_map,
+		ctx.config.deliver_failed.unwrap_or_default(),
+		// No consensus update rides along with a retry, the destination's light
+		// client is already at the height these proofs are built against.
+		None,
+	)
+	.await?;
 
-			let mut outgoing_messages = vec![];
-			let mut new_unprofitable_messages = vec![];
-			match return_successful_queries(
-				dest.clone(),
-				request_messages,
-				request_queries,
-				config.minimum_profit_percentage,
-				coprocessor,
-				&client_map,
-				config.deliver_failed.unwrap_or_default(),
-				// Retry loop doesn't carry a fresh consensus update — by the
-				// time it runs the light client is already at whatever height
-				// the original delivery saw.
-				None,
-			)
-			.await
-			{
-				Ok(request_profitablility) => {
-					let post_requests: Vec<_> =
-						post_requests
-							.into_iter()
-							.zip(request_profitablility.queries.iter())
-							.filter_map(|(current_post, current_query)| {
-								if current_query.is_some() {
-									Some(current_post)
-								} else {
-									None
-								}
-							})
-							.collect();
+	let profitable = deliverable
+		.into_iter()
+		.zip(profitability.queries)
+		.filter_map(|(post, query)| query.map(|query| (post, query)))
+		.collect::<Vec<_>>();
 
-					let successful_queries: Vec<Query> = request_profitablility
-						.queries
-						.into_iter()
-						.filter_map(|query| query)
-						.collect();
+	let mut retriable = profitability.retriable_messages;
+	let outgoing = batch_requests(ctx, &profitable, height).await?;
 
-					if !successful_queries.is_empty() {
-						tracing::trace!(
-							target: crate::LOG_TARGET, "Unprofitable Messages Retries: Querying request proof for batch length {}",
-							successful_queries.len()
-						);
-						let chunks = chunk_size(dest.state_machine_id().state_id);
-						let query_chunks = successful_queries.chunks(chunks);
-						let post_request_chunks = post_requests.chunks(chunks);
-						for (queries, post_requests) in
-							query_chunks.into_iter().zip(post_request_chunks)
-						{
-							if let Some(state_machine_height) = state_machine_height {
-								if let Ok(requests_proof) = hyperbridge
-									.query_requests_proof(
-										state_machine_height.height,
-										queries.to_vec(),
-										dest.state_machine_id().state_id,
-									)
-									.await
-								{
-									let msg = RequestMessage {
-										requests: post_requests.to_vec(),
-										proof: Proof {
-											height: state_machine_height,
-											proof: requests_proof,
-										},
-										signer: dest.address(),
-									};
-									outgoing_messages.push(Message::Request(msg));
-								}
-							}
-						}
-					}
-
-					new_unprofitable_messages.extend(request_profitablility.retriable_messages);
-				},
-				Err(err) => {
-					tracing::error!(target: crate::LOG_TARGET, "Unprofitable Messages Retries: Debug tracing failed: {err:?}")
-				},
-			}
-
-			if !outgoing_messages.is_empty() {
-				tracing::info!(
+	if !outgoing.is_empty() {
+		tracing::info!(
+			target: crate::LOG_TARGET,
+			"🛰️ Retransmitting ismp messages from {} to {}",
+			ctx.hyperbridge.name(),
+			ctx.dest.name(),
+		);
+		match ctx.dest.submit(outgoing.clone(), ctx.coprocessor).await {
+			Ok(TxResult { receipts, unsuccessful, new_epochs: _ }) => {
+				record_deliveries(&ctx.tx_payment, &ctx.fee_acc_sender, receipts, ctx.coprocessor)
+					.await;
+				retriable.extend(unsuccessful);
+			},
+			Err(err) => {
+				tracing::error!(
 					target: crate::LOG_TARGET,
-					"Unprofitable Messages Retries: 🛰️ Transmitting ismp messages from {} to {}", hyperbridge.name(), dest.name()
+					dest = %ctx.dest.name(),
+					?err,
+					"Retry submission failed",
 				);
-				if let Ok(TxResult { receipts, unsuccessful, new_epochs: _ }) =
-					dest.submit(outgoing_messages, coprocessor).await
-				{
-					if let Some(fee_acc_sender) = fee_acc_sender.clone() {
-						if !receipts.is_empty() {
-							// Store receipts in database before auto accumulation
-							tracing::trace!(target: crate::LOG_TARGET, "Persisting {} deliveries from {}->{} to the db", receipts.len(), hyperbridge.name(), dest.name());
-							if let Err(err) = tx_payment.store_messages(receipts.clone()).await {
-								tracing::error!(
-									target: crate::LOG_TARGET, "Failed to persist {} deliveries to database: {err:?}",
-									receipts.len()
-								)
-							}
-							// Send receipts to the fee accumulation task.
-							// `try_send` so this retry path never blocks on a
-							// backed-up consumer; deliveries were already
-							// persisted to the local DB just above, so the
-							// `accumulate-fees` subcommand can recover any
-							// dropped trigger.
-							if let Err(err) = fee_acc_sender.try_send(receipts) {
-								tracing::error!(
-									target: crate::LOG_TARGET,
-									?err,
-									"Fee auto accumulation channel send failed; you can try again manually",
-								);
-							}
-						}
-					}
-
-					if !unsuccessful.is_empty() {
-						tracing::trace!(target: crate::LOG_TARGET, "Unprofitable Messages Retries: Persisting {} unsuccessful messages going to {} to the db", unsuccessful.len(), dest.name());
-						let _ = tx_payment
-							.store_unprofitable_messages(
-								unsuccessful,
-								dest.state_machine_id().state_id,
-							)
-							.await;
-					}
-				}
-			}
-			// Delete previous batch from db
-			if !ids.is_empty() {
-				tracing::trace!(target: crate::LOG_TARGET, "Unprofitable Messages Retries: Deleting some unprofitable messages from the Db");
-				let _ = tx_payment.delete_unprofitable_messages(ids).await;
-			}
-			// Store the new batch
-			if !new_unprofitable_messages.is_empty() {
-				// remove timedout messages from the list
-				let dest_timestamp = dest.query_timestamp().await?;
-				let retriable_msgs = new_unprofitable_messages
-					.into_iter()
-					.filter_map(|msg| match &msg {
-						Message::Request(req_msg) => {
-							let req = Request::Post(req_msg.requests[0].clone());
-							if req.timed_out(dest_timestamp) {
-								None
-							} else {
-								Some(msg.clone())
-							}
-						},
-						_ => None,
-					})
-					.collect::<Vec<_>>();
-				if !retriable_msgs.is_empty() {
-					tracing::trace!(target: crate::LOG_TARGET, "Unprofitable Messages Retries: Persisting {} unprofitable messages going to {} to the db", retriable_msgs.len(), dest.name());
-					let _ = tx_payment
-						.store_unprofitable_messages(
-							retriable_msgs,
-							dest.state_machine_id().state_id,
-						)
-						.await;
-				}
-			}
+				retriable.extend(outgoing);
+			},
 		}
+	}
+
+	ctx.tx_payment.delete_unprofitable_messages(rows).await?;
+	if !retriable.is_empty() {
+		tracing::trace!(
+			target: crate::LOG_TARGET,
+			dest = %ctx.dest.name(),
+			count = retriable.len(),
+			"Parking messages for the next retry",
+		);
+		ctx.tx_payment
+			.store_unprofitable_messages(retriable, dest_state_machine)
+			.await?;
+	}
+
+	Ok(())
+}
+
+/// Requests that are still worth submitting.
+///
+/// A request the destination already has a receipt for was delivered by some
+/// other submission, and one past its timeout is never accepted again. Both
+/// revert on delivery, so neither is carried any further.
+async fn deliverable_requests(
+	dest: &Arc<dyn IsmpProvider>,
+	requests: Vec<PostRequest>,
+) -> Result<Vec<PostRequest>, anyhow::Error> {
+	let timestamp = dest.query_timestamp().await?;
+	let mut deliverable = vec![];
+
+	for chunk in requests.chunks(dest.max_concurrent_queries()) {
+		let checked = chunk
+			.iter()
+			.map(|post| async move {
+				let request = Request::Post(post.clone());
+				if request.timed_out(timestamp) {
+					return Ok::<_, anyhow::Error>(None);
+				}
+
+				let receipt = dest.query_request_receipt(hash_request::<Hasher>(&request)).await?;
+				Ok((!was_delivered(&receipt)).then(|| post.clone()))
+			})
+			.collect::<FuturesOrdered<_>>()
+			.collect::<Result<Vec<_>, _>>()
+			.await?;
+
+		deliverable.extend(checked.into_iter().flatten());
+	}
+
+	Ok(deliverable)
+}
+
+/// One message per request, each with its own proof, which is the shape gas
+/// estimation and the profitability check work on.
+async fn single_request_messages(
+	ctx: &RetryContext,
+	requests: &[PostRequest],
+	height: StateMachineHeight,
+) -> Result<Vec<Message>, anyhow::Error> {
+	let dest_state_machine = ctx.dest.state_machine_id().state_id;
+	let mut messages = vec![];
+
+	for chunk in requests.chunks(ctx.hyperbridge.max_concurrent_queries()) {
+		let built = chunk
+			.iter()
+			.map(|post| async move {
+				let query = Query::from(&Request::Post(post.clone()));
+				let proof = ctx
+					.hyperbridge
+					.query_requests_proof(height.height, vec![query], dest_state_machine)
+					.await?;
+
+				Ok::<_, anyhow::Error>(Message::Request(RequestMessage {
+					requests: vec![post.clone()],
+					proof: Proof { height, proof },
+					signer: ctx.dest.address(),
+				}))
+			})
+			.collect::<FuturesOrdered<_>>()
+			.collect::<Result<Vec<_>, _>>()
+			.await?;
+
+		messages.extend(built);
+	}
+
+	Ok(messages)
+}
+
+/// Regroup the requests that made it through into batches the destination can
+/// take in one call, each proved once for the whole batch.
+async fn batch_requests(
+	ctx: &RetryContext,
+	profitable: &[(PostRequest, Query)],
+	height: StateMachineHeight,
+) -> Result<Vec<Message>, anyhow::Error> {
+	let dest_state_machine = ctx.dest.state_machine_id().state_id;
+	let mut messages = vec![];
+
+	for chunk in profitable.chunks(chunk_size(dest_state_machine)) {
+		let (requests, queries): (Vec<_>, Vec<_>) = chunk.iter().cloned().unzip();
+		let proof = ctx
+			.hyperbridge
+			.query_requests_proof(height.height, queries, dest_state_machine)
+			.await?;
+
+		messages.push(Message::Request(RequestMessage {
+			requests,
+			proof: Proof { height, proof },
+			signer: ctx.dest.address(),
+		}));
+	}
+
+	Ok(messages)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use tesseract_primitives::mocks::MockHost;
+
+	const HB: StateMachine = StateMachine::Kusama(4009);
+	const DEST: StateMachine = StateMachine::Evm(1);
+
+	fn post(nonce: u64, timeout_timestamp: u64) -> PostRequest {
+		PostRequest {
+			source: HB,
+			dest: DEST,
+			nonce,
+			from: vec![1],
+			to: vec![2],
+			timeout_timestamp,
+			body: vec![],
+		}
+	}
+
+	fn commitment(post: &PostRequest) -> H256 {
+		hash_request::<Hasher>(&Request::Post(post.clone()))
+	}
+
+	#[tokio::test]
+	async fn keeps_only_requests_the_destination_can_still_take() {
+		let pending = post(1, 0);
+		let delivered = post(2, 0);
+		let expired = post(3, 100);
+
+		let dest: Arc<dyn IsmpProvider> = Arc::new(
+			MockHost::new((), 0, DEST)
+				.with_request_receipt(commitment(&delivered), vec![0xab; 20])
+				.with_timestamp(Duration::from_secs(200)),
+		);
+
+		let deliverable = deliverable_requests(&dest, vec![pending.clone(), delivered, expired])
+			.await
+			.unwrap();
+
+		assert_eq!(deliverable, vec![pending]);
 	}
 }

--- a/tesseract/messaging/messaging/src/retries.rs
+++ b/tesseract/messaging/messaging/src/retries.rs
@@ -47,7 +47,8 @@ pub struct RetryContext {
 ///
 /// The outbound fan-out parks requests addressed to the modules the operator
 /// listed in `retry_modules` whenever a batch is cancelled or fails to submit,
-/// and this loop drains them on a timer. Deliveries out of hyperbridge are the usual
+/// and this loop drains them every `retry_frequency` seconds, five minutes when
+/// unset. Listing a module is what brings the loop up in the first place. Deliveries out of hyperbridge are the usual
 /// reason to list a module: they are gated to a whitelisted relayer, so a batch
 /// this relayer failed to submit is not going to be picked up by anyone else.
 pub async fn retry_undelivered_messages(ctx: RetryContext) -> Result<(), anyhow::Error> {

--- a/tesseract/messaging/messaging/src/retries.rs
+++ b/tesseract/messaging/messaging/src/retries.rs
@@ -20,7 +20,7 @@ use tokio_stream::StreamExt;
 use transaction_fees::TransactionPayment;
 
 use crate::{
-	events::{chunk_size, return_successful_queries, was_delivered},
+	events::{chunk_size, is_retry_module, return_successful_queries, was_delivered},
 	record_deliveries, FeeAccSender,
 };
 
@@ -43,12 +43,13 @@ pub struct RetryContext {
 	pub fee_acc_sender: Option<FeeAccSender>,
 }
 
-/// Redeliver requests from hyperbridge that never landed.
+/// Redeliver requests to an EVM chain that never landed.
 ///
-/// Deliveries out of hyperbridge are gated to a whitelisted relayer, so a batch
+/// The outbound fan-out parks requests from the modules the operator listed in
+/// `retry_modules` whenever a batch is cancelled or fails to submit, and this
+/// loop drains them on a timer. Deliveries out of hyperbridge are the usual
+/// reason to list a module: they are gated to a whitelisted relayer, so a batch
 /// this relayer failed to submit is not going to be picked up by anyone else.
-/// The delivery pipelines park those requests in the database and this loop
-/// drains them on a timer.
 pub async fn retry_undelivered_messages(ctx: RetryContext) -> Result<(), anyhow::Error> {
 	let frequency = ctx
 		.config
@@ -95,10 +96,13 @@ async fn retry_once(ctx: &RetryContext) -> Result<(), anyhow::Error> {
 	for (message, _) in parked {
 		let Message::Request(msg) = message else { continue };
 		let parked_at = msg.proof.height.height;
-		// Only what hyperbridge dispatched is this relayer's to redeliver. Rows left
-		// by the inbound pipeline or an older build can carry a user's request, and
-		// another relayer is free to take those.
-		for post in msg.requests.into_iter().filter(|post| post.source == ctx.coprocessor) {
+		// Only modules the operator listed are retried. Rows left by an older build,
+		// or by a config that has since dropped a module, are swept up here and not
+		// carried any further.
+		for post in msg.requests {
+			if !is_retry_module(&ctx.config, &post.from) {
+				continue;
+			}
 			let commitment = hash_request::<Hasher>(&Request::Post(post.clone()));
 			requests
 				.entry(commitment)

--- a/tesseract/messaging/messaging/src/retries.rs
+++ b/tesseract/messaging/messaging/src/retries.rs
@@ -8,11 +8,14 @@ use futures::stream::FuturesOrdered;
 use ismp::{
 	consensus::StateMachineHeight,
 	host::StateMachine,
-	messaging::{hash_request, Message, Proof, RequestMessage},
+	messaging::{hash_request, ConsensusMessage, Message, Proof, RequestMessage},
 	router::{PostRequest, Request},
 };
 use primitive_types::H256;
-use tesseract_primitives::{config::RelayerConfig, Hasher, IsmpProvider, Query, TxResult};
+use tesseract_primitives::{
+	config::RelayerConfig, ConsensusProofSource, Hasher, IsmpProvider, ProofKey, Query, TxResult,
+	BEEFY_CONSENSUS_STATE_ID,
+};
 use tokio_stream::StreamExt;
 use transaction_fees::TransactionPayment;
 
@@ -30,6 +33,9 @@ pub struct RetryContext {
 	pub dest: Arc<dyn IsmpProvider>,
 	/// Where the requests came from, and where their proofs are read from.
 	pub hyperbridge: Arc<dyn IsmpProvider>,
+	/// Supplies the beefy proof that carries a destination up to the height a
+	/// parked request needs.
+	pub proof_source: Arc<dyn ConsensusProofSource>,
 	pub client_map: HashMap<StateMachine, Arc<dyn IsmpProvider>>,
 	pub tx_payment: Arc<TransactionPayment>,
 	pub config: RelayerConfig,
@@ -77,46 +83,29 @@ async fn retry_once(ctx: &RetryContext) -> Result<(), anyhow::Error> {
 		return Ok(());
 	}
 
-	// Everything is proved again against the height the destination is on now.
-	// The proof a request was parked with is anchored at a hyperbridge height the
-	// destination may never have received, since the consensus update it rode
-	// along with is exactly what failed to land.
-	let height = StateMachineHeight {
-		id: ctx.hyperbridge.state_machine_id(),
-		height: ctx.dest.query_latest_height(ctx.hyperbridge.state_machine_id()).await? as u64,
-	};
-
-	let (ready, waiting): (Vec<_>, Vec<_>) =
-		parked.into_iter().partition(|(message, _)| provable_at(message, height.height));
-	if !waiting.is_empty() {
-		tracing::trace!(
-			target: crate::LOG_TARGET,
-			dest = %ctx.dest.name(),
-			count = waiting.len(),
-			height = height.height,
-			"Leaving rows parked until the destination catches up",
-		);
-	}
-	if ready.is_empty() {
-		return Ok(());
-	}
-
-	// Every row taken here is dropped at the end of the pass; whatever is still
+	// Every row read here is dropped at the end of the pass; whatever is still
 	// worth another attempt is written back as a fresh row.
-	let rows = ready.iter().map(|(_, id)| *id).collect::<Vec<_>>();
+	let rows = parked.iter().map(|(_, id)| *id).collect::<Vec<_>>();
 
-	// A request can be parked twice, once on its own and once inside a batch
-	// that failed later, and a batch carrying the same request twice reverts on
-	// the duplicate. Keying by commitment keeps one copy of each.
-	let requests = ready
-		.into_iter()
-		.filter_map(|(message, _)| match message {
-			Message::Request(msg) => Some(msg.requests),
-			_ => None,
-		})
-		.flatten()
-		.map(|post| (hash_request::<Hasher>(&Request::Post(post.clone())), post))
-		.collect::<BTreeMap<H256, PostRequest>>();
+	// A request can be parked more than once, on its own and inside a batch that
+	// failed later, and a batch carrying it twice reverts on the duplicate.
+	// Keying by commitment keeps one copy, at the lowest height it was seen,
+	// which is the one the destination is likeliest to already be past.
+	let mut requests: BTreeMap<H256, (PostRequest, u64)> = BTreeMap::new();
+	for (message, _) in parked {
+		let Message::Request(msg) = message else { continue };
+		let parked_at = msg.proof.height.height;
+		// Only what hyperbridge dispatched is this relayer's to redeliver. Rows left
+		// by the inbound pipeline or an older build can carry a user's request, and
+		// another relayer is free to take those.
+		for post in msg.requests.into_iter().filter(|post| post.source == ctx.coprocessor) {
+			let commitment = hash_request::<Hasher>(&Request::Post(post.clone()));
+			requests
+				.entry(commitment)
+				.and_modify(|(_, height)| *height = (*height).min(parked_at))
+				.or_insert((post, parked_at));
+		}
+	}
 
 	let deliverable = deliverable_requests(&ctx.dest, requests.into_values().collect()).await?;
 	if deliverable.is_empty() {
@@ -124,50 +113,84 @@ async fn retry_once(ctx: &RetryContext) -> Result<(), anyhow::Error> {
 		return Ok(());
 	}
 
-	tracing::trace!(
-		target: crate::LOG_TARGET,
-		dest = %ctx.dest.name(),
-		count = deliverable.len(),
-		height = height.height,
-		"Retrying previously undelivered messages",
-	);
+	let dest_height =
+		ctx.dest.query_latest_height(ctx.hyperbridge.state_machine_id()).await? as u64;
 
-	let queries = deliverable
-		.iter()
-		.map(|post| Query::from(&Request::Post(post.clone())))
-		.collect::<Vec<_>>();
-	let messages = single_request_messages(ctx, &deliverable, height).await?;
-	let profitability = return_successful_queries(
-		ctx.dest.clone(),
-		messages,
-		queries,
-		ctx.config.minimum_profit_percentage,
-		ctx.coprocessor,
-		&ctx.client_map,
-		ctx.config.deliver_failed.unwrap_or_default(),
-		// No consensus update rides along with a retry, the destination's light
-		// client is already at the height these proofs are built against.
-		None,
-	)
-	.await?;
+	let mut retriable = vec![];
+	for (target, posts) in group_by_proof_height(deliverable, dest_height) {
+		let height = StateMachineHeight { id: ctx.hyperbridge.state_machine_id(), height: target };
+		let messages = single_request_messages(ctx, &posts, height).await?;
 
-	let profitable = deliverable
-		.into_iter()
-		.zip(profitability.queries)
-		.filter_map(|(post, query)| query.map(|query| (post, query)))
-		.collect::<Vec<_>>();
+		// A height the destination has not reached yet rides with the beefy proof
+		// that takes it there, so the batch verifies now instead of waiting on the
+		// next consensus update. Without that proof there is nothing to submit
+		// against, so the rows go back in the table for the next pass.
+		let prelude = match target > dest_height {
+			true => match ctx.proof_source.fetch(ProofKey::Messaging(target)).await {
+				Ok(consensus_proof) => Some(Message::Consensus(ConsensusMessage {
+					consensus_proof,
+					consensus_state_id: BEEFY_CONSENSUS_STATE_ID,
+					signer: ctx.dest.address(),
+				})),
+				Err(err) => {
+					tracing::warn!(
+						target: crate::LOG_TARGET,
+						dest = %ctx.dest.name(),
+						height = target,
+						?err,
+						"No beefy proof for the parked height, leaving the rows for the next pass",
+					);
+					retriable.extend(messages);
+					continue;
+				},
+			},
+			false => None,
+		};
 
-	let mut retriable = profitability.retriable_messages;
-	let outgoing = batch_requests(ctx, &profitable, height).await?;
+		tracing::trace!(
+			target: crate::LOG_TARGET,
+			dest = %ctx.dest.name(),
+			count = posts.len(),
+			height = target,
+			consensus = prelude.is_some(),
+			"Retrying previously undelivered messages",
+		);
 
-	if !outgoing.is_empty() {
+		let queries = posts
+			.iter()
+			.map(|post| Query::from(&Request::Post(post.clone())))
+			.collect::<Vec<_>>();
+		let profitability = return_successful_queries(
+			ctx.dest.clone(),
+			messages,
+			queries,
+			ctx.config.minimum_profit_percentage,
+			ctx.coprocessor,
+			&ctx.client_map,
+			ctx.config.deliver_failed.unwrap_or_default(),
+			prelude.clone(),
+		)
+		.await?;
+		retriable.extend(profitability.retriable_messages);
+
+		let profitable = posts
+			.into_iter()
+			.zip(profitability.queries)
+			.filter_map(|(post, query)| query.map(|query| (post, query)))
+			.collect::<Vec<_>>();
+		let outgoing = batch_requests(ctx, &profitable, height).await?;
+		if outgoing.is_empty() {
+			continue;
+		}
+
 		tracing::info!(
 			target: crate::LOG_TARGET,
 			"🛰️ Retransmitting ismp messages from {} to {}",
 			ctx.hyperbridge.name(),
 			ctx.dest.name(),
 		);
-		match ctx.dest.submit(outgoing.clone(), ctx.coprocessor).await {
+		let batch = prelude.into_iter().chain(outgoing.iter().cloned()).collect::<Vec<_>>();
+		match ctx.dest.submit(batch, ctx.coprocessor).await {
 			Ok(TxResult { receipts, unsuccessful, new_epochs: _ }) => {
 				record_deliveries(&ctx.tx_payment, &ctx.fee_acc_sender, receipts, ctx.coprocessor)
 					.await;
@@ -201,17 +224,17 @@ async fn retry_once(ctx: &RetryContext) -> Result<(), anyhow::Error> {
 	Ok(())
 }
 
-/// Whether hyperbridge can prove this row for a destination sitting at `height`.
-/// A request only enters the mmr at the block it was committed in, so a row
-/// built past where the destination's light client has reached cannot be proved
-/// for it yet and has to wait.
-fn provable_at(message: &Message, height: u64) -> bool {
-	match message {
-		Message::Request(msg) => msg.proof.height.height <= height,
-		// Rows the delivery pipelines never write. Sweeping them up keeps a stale
-		// one from sitting in the table for good.
-		_ => true,
-	}
+/// Bucket each request by the height its proof should be built at: the height the
+/// destination is already on once it has gone past where the request was parked,
+/// and the parked height otherwise.
+fn group_by_proof_height(
+	deliverable: Vec<(PostRequest, u64)>,
+	dest_height: u64,
+) -> BTreeMap<u64, Vec<PostRequest>> {
+	deliverable.into_iter().fold(BTreeMap::new(), |mut groups, (post, parked_at)| {
+		groups.entry(parked_at.max(dest_height)).or_default().push(post);
+		groups
+	})
 }
 
 /// Requests that are still worth submitting.
@@ -221,22 +244,22 @@ fn provable_at(message: &Message, height: u64) -> bool {
 /// revert on delivery, so neither is carried any further.
 async fn deliverable_requests(
 	dest: &Arc<dyn IsmpProvider>,
-	requests: Vec<PostRequest>,
-) -> Result<Vec<PostRequest>, anyhow::Error> {
+	requests: Vec<(PostRequest, u64)>,
+) -> Result<Vec<(PostRequest, u64)>, anyhow::Error> {
 	let timestamp = dest.query_timestamp().await?;
 	let mut deliverable = vec![];
 
 	for chunk in requests.chunks(dest.max_concurrent_queries()) {
 		let checked = chunk
 			.iter()
-			.map(|post| async move {
+			.map(|(post, height)| async move {
 				let request = Request::Post(post.clone());
 				if request.timed_out(timestamp) {
 					return Ok::<_, anyhow::Error>(None);
 				}
 
 				let receipt = dest.query_request_receipt(hash_request::<Hasher>(&request)).await?;
-				Ok((!was_delivered(&receipt)).then(|| post.clone()))
+				Ok((!was_delivered(&receipt)).then(|| (post.clone(), *height)))
 			})
 			.collect::<FuturesOrdered<_>>()
 			.collect::<Result<Vec<_>, _>>()
@@ -314,7 +337,6 @@ async fn batch_requests(
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use ismp::consensus::StateMachineId;
 	use tesseract_primitives::mocks::MockHost;
 
 	const HB: StateMachine = StateMachine::Kusama(4009);
@@ -336,38 +358,25 @@ mod tests {
 		hash_request::<Hasher>(&Request::Post(post.clone()))
 	}
 
-	fn parked_row(post: PostRequest, proof_height: u64, id: i32) -> (Message, i32) {
-		let message = Message::Request(RequestMessage {
-			requests: vec![post],
-			proof: Proof {
-				height: StateMachineHeight {
-					id: StateMachineId { state_id: HB, consensus_state_id: *b"BEEF" },
-					height: proof_height,
-				},
-				proof: vec![],
-			},
-			signer: vec![],
-		});
-		(message, id)
-	}
-
-	/// Hyperbridge cannot prove a request at a height before it was committed, so
-	/// a row built past where the destination's light client has reached has to
-	/// wait rather than fail the whole pass.
+	/// Requests the destination has already gone past are proved at its own height,
+	/// so they need no consensus proof. One parked beyond it keeps its own height
+	/// and rides with the proof that takes the destination there.
 	#[test]
-	fn rows_past_the_destination_height_stay_parked() {
+	fn requests_group_by_the_height_they_can_be_proved_at() {
 		let dest_height = 100;
-		let parked = vec![
-			parked_row(post(1, 0), 90, 1),
-			parked_row(post(2, 0), 100, 2),
-			parked_row(post(3, 0), 130, 3),
-		];
+		let deliverable =
+			vec![(post(1, 0), 90), (post(2, 0), 100), (post(3, 0), 130), (post(4, 0), 130)];
 
-		let (ready, waiting): (Vec<_>, Vec<_>) =
-			parked.into_iter().partition(|(message, _)| provable_at(message, dest_height));
+		let groups = group_by_proof_height(deliverable, dest_height);
 
-		assert_eq!(ready.iter().map(|(_, id)| *id).collect::<Vec<_>>(), vec![1, 2]);
-		assert_eq!(waiting.iter().map(|(_, id)| *id).collect::<Vec<_>>(), vec![3]);
+		let nonces = |height: u64| {
+			groups
+				.get(&height)
+				.map(|posts| posts.iter().map(|p| p.nonce).collect::<Vec<_>>())
+		};
+		assert_eq!(nonces(100), Some(vec![1, 2]), "proved at the height the destination is on");
+		assert_eq!(nonces(130), Some(vec![3, 4]), "proved at the height they were parked at");
+		assert_eq!(groups.len(), 2);
 	}
 
 	#[tokio::test]
@@ -382,10 +391,13 @@ mod tests {
 				.with_timestamp(Duration::from_secs(200)),
 		);
 
-		let deliverable = deliverable_requests(&dest, vec![pending.clone(), delivered, expired])
-			.await
-			.unwrap();
+		let deliverable = deliverable_requests(
+			&dest,
+			vec![(pending.clone(), 10), (delivered, 10), (expired, 10)],
+		)
+		.await
+		.unwrap();
 
-		assert_eq!(deliverable, vec![pending]);
+		assert_eq!(deliverable, vec![(pending, 10)]);
 	}
 }

--- a/tesseract/messaging/messaging/src/retries.rs
+++ b/tesseract/messaging/messaging/src/retries.rs
@@ -77,14 +77,38 @@ async fn retry_once(ctx: &RetryContext) -> Result<(), anyhow::Error> {
 		return Ok(());
 	}
 
-	// Every row read here is dropped at the end of the pass; whatever is still
+	// Everything is proved again against the height the destination is on now.
+	// The proof a request was parked with is anchored at a hyperbridge height the
+	// destination may never have received, since the consensus update it rode
+	// along with is exactly what failed to land.
+	let height = StateMachineHeight {
+		id: ctx.hyperbridge.state_machine_id(),
+		height: ctx.dest.query_latest_height(ctx.hyperbridge.state_machine_id()).await? as u64,
+	};
+
+	let (ready, waiting): (Vec<_>, Vec<_>) =
+		parked.into_iter().partition(|(message, _)| provable_at(message, height.height));
+	if !waiting.is_empty() {
+		tracing::trace!(
+			target: crate::LOG_TARGET,
+			dest = %ctx.dest.name(),
+			count = waiting.len(),
+			height = height.height,
+			"Leaving rows parked until the destination catches up",
+		);
+	}
+	if ready.is_empty() {
+		return Ok(());
+	}
+
+	// Every row taken here is dropped at the end of the pass; whatever is still
 	// worth another attempt is written back as a fresh row.
-	let rows = parked.iter().map(|(_, id)| *id).collect::<Vec<_>>();
+	let rows = ready.iter().map(|(_, id)| *id).collect::<Vec<_>>();
 
 	// A request can be parked twice, once on its own and once inside a batch
 	// that failed later, and a batch carrying the same request twice reverts on
 	// the duplicate. Keying by commitment keeps one copy of each.
-	let requests = parked
+	let requests = ready
 		.into_iter()
 		.filter_map(|(message, _)| match message {
 			Message::Request(msg) => Some(msg.requests),
@@ -99,15 +123,6 @@ async fn retry_once(ctx: &RetryContext) -> Result<(), anyhow::Error> {
 		ctx.tx_payment.delete_unprofitable_messages(rows).await?;
 		return Ok(());
 	}
-
-	// The proof a request was parked with is anchored at a hyperbridge height
-	// the destination may never have received, since the consensus update it
-	// rode along with is exactly what failed to land. Prove against the height
-	// the destination is on now instead.
-	let height = StateMachineHeight {
-		id: ctx.hyperbridge.state_machine_id(),
-		height: ctx.dest.query_latest_height(ctx.hyperbridge.state_machine_id()).await? as u64,
-	};
 
 	tracing::trace!(
 		target: crate::LOG_TARGET,
@@ -184,6 +199,19 @@ async fn retry_once(ctx: &RetryContext) -> Result<(), anyhow::Error> {
 	}
 
 	Ok(())
+}
+
+/// Whether hyperbridge can prove this row for a destination sitting at `height`.
+/// A request only enters the mmr at the block it was committed in, so a row
+/// built past where the destination's light client has reached cannot be proved
+/// for it yet and has to wait.
+fn provable_at(message: &Message, height: u64) -> bool {
+	match message {
+		Message::Request(msg) => msg.proof.height.height <= height,
+		// Rows the delivery pipelines never write. Sweeping them up keeps a stale
+		// one from sitting in the table for good.
+		_ => true,
+	}
 }
 
 /// Requests that are still worth submitting.
@@ -286,6 +314,7 @@ async fn batch_requests(
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use ismp::consensus::StateMachineId;
 	use tesseract_primitives::mocks::MockHost;
 
 	const HB: StateMachine = StateMachine::Kusama(4009);
@@ -305,6 +334,40 @@ mod tests {
 
 	fn commitment(post: &PostRequest) -> H256 {
 		hash_request::<Hasher>(&Request::Post(post.clone()))
+	}
+
+	fn parked_row(post: PostRequest, proof_height: u64, id: i32) -> (Message, i32) {
+		let message = Message::Request(RequestMessage {
+			requests: vec![post],
+			proof: Proof {
+				height: StateMachineHeight {
+					id: StateMachineId { state_id: HB, consensus_state_id: *b"BEEF" },
+					height: proof_height,
+				},
+				proof: vec![],
+			},
+			signer: vec![],
+		});
+		(message, id)
+	}
+
+	/// Hyperbridge cannot prove a request at a height before it was committed, so
+	/// a row built past where the destination's light client has reached has to
+	/// wait rather than fail the whole pass.
+	#[test]
+	fn rows_past_the_destination_height_stay_parked() {
+		let dest_height = 100;
+		let parked = vec![
+			parked_row(post(1, 0), 90, 1),
+			parked_row(post(2, 0), 100, 2),
+			parked_row(post(3, 0), 130, 3),
+		];
+
+		let (ready, waiting): (Vec<_>, Vec<_>) =
+			parked.into_iter().partition(|(message, _)| provable_at(message, dest_height));
+
+		assert_eq!(ready.iter().map(|(_, id)| *id).collect::<Vec<_>>(), vec![1, 2]);
+		assert_eq!(waiting.iter().map(|(_, id)| *id).collect::<Vec<_>>(), vec![3]);
 	}
 
 	#[tokio::test]

--- a/tesseract/messaging/primitives/src/config.rs
+++ b/tesseract/messaging/primitives/src/config.rs
@@ -31,6 +31,10 @@ pub struct RelayerConfig {
 	/// How frequently to retry unprofitable or failed messages in seconds.
 	/// If this is value not supplied retries will not be enabled
 	pub unprofitable_retry_frequency: Option<u64>,
+	/// Modules, as hex encoded module ids, whose requests are parked and retried when a
+	/// delivery to an EVM chain is cancelled or never lands. Absent or empty parks nothing.
+	/// The retry loop itself only runs when `unprofitable_retry_frequency` is set.
+	pub retry_modules: Option<Vec<String>>,
 	/// Delivery endpoints: chains you intend to deliver messages to
 	pub delivery_endpoints: Vec<String>,
 	/// Flag to tell the messsaging process to deliver failed transactions

--- a/tesseract/messaging/primitives/src/config.rs
+++ b/tesseract/messaging/primitives/src/config.rs
@@ -28,13 +28,13 @@ pub struct RelayerConfig {
 	pub withdrawal_frequency: Option<u64>,
 	/// Minimum amount to withdraw when auto-withdrawing
 	pub minimum_withdrawal_amount: Option<u64>,
-	/// How frequently to retry parked deliveries, in seconds. Unset disables
-	/// retries, and with them the parking of undelivered messages.
+	/// How frequently to retry parked deliveries, in seconds. Defaults to five
+	/// minutes when unset; whether retries run at all is decided by `retry_modules`.
 	pub retry_frequency: Option<u64>,
 	/// Destination modules, as hex encoded module ids, whose requests are parked and retried
 	/// when a delivery to an EVM chain is cancelled or never lands. Matched on the request's
-	/// `to` field. Absent or empty parks nothing. The retry loop itself only runs when
-	/// `retry_frequency` is set.
+	/// `to` field. A non empty list is what switches the retry task on; absent or empty
+	/// parks nothing and spawns no retry loop.
 	pub retry_modules: Option<Vec<String>>,
 	/// Delivery endpoints: chains you intend to deliver messages to
 	pub delivery_endpoints: Vec<String>,
@@ -42,4 +42,12 @@ pub struct RelayerConfig {
 	pub deliver_failed: Option<bool>,
 	/// Should the relayer run the fee accumulation task?
 	pub disable_fee_accumulation: Option<bool>,
+}
+
+impl RelayerConfig {
+	/// Whether undelivered messages are parked and a retry loop drains them, which
+	/// is the case as soon as the operator lists a module in `retry_modules`.
+	pub fn retries_enabled(&self) -> bool {
+		self.retry_modules.as_ref().map_or(false, |modules| !modules.is_empty())
+	}
 }

--- a/tesseract/messaging/primitives/src/config.rs
+++ b/tesseract/messaging/primitives/src/config.rs
@@ -28,12 +28,13 @@ pub struct RelayerConfig {
 	pub withdrawal_frequency: Option<u64>,
 	/// Minimum amount to withdraw when auto-withdrawing
 	pub minimum_withdrawal_amount: Option<u64>,
-	/// How frequently to retry unprofitable or failed messages in seconds.
-	/// If this is value not supplied retries will not be enabled
-	pub unprofitable_retry_frequency: Option<u64>,
-	/// Modules, as hex encoded module ids, whose requests are parked and retried when a
-	/// delivery to an EVM chain is cancelled or never lands. Absent or empty parks nothing.
-	/// The retry loop itself only runs when `unprofitable_retry_frequency` is set.
+	/// How frequently to retry parked deliveries, in seconds. Unset disables
+	/// retries, and with them the parking of undelivered messages.
+	pub retry_frequency: Option<u64>,
+	/// Destination modules, as hex encoded module ids, whose requests are parked and retried
+	/// when a delivery to an EVM chain is cancelled or never lands. Matched on the request's
+	/// `to` field. Absent or empty parks nothing. The retry loop itself only runs when
+	/// `retry_frequency` is set.
 	pub retry_modules: Option<Vec<String>>,
 	/// Delivery endpoints: chains you intend to deliver messages to
 	pub delivery_endpoints: Vec<String>,

--- a/tesseract/messaging/primitives/src/lib.rs
+++ b/tesseract/messaging/primitives/src/lib.rs
@@ -146,8 +146,8 @@ use ismp::{
 	consensus::{ConsensusStateId, StateCommitment, StateMachineHeight, StateMachineId},
 	events::{Event, StateCommitmentVetoed},
 	host::StateMachine,
-	messaging::{CreateConsensusState, Keccak256, Message},
-	router::PostRequest,
+	messaging::{hash_request, CreateConsensusState, Keccak256, Message},
+	router::{PostRequest, Request},
 };
 use pallet_ismp_host_executive::HostParam;
 pub use pallet_ismp_relayer::withdrawal::{Signature, WithdrawalProof};
@@ -243,6 +243,17 @@ pub struct Query {
 	pub dest_chain: StateMachine,
 	pub nonce: u64,
 	pub commitment: H256,
+}
+
+impl From<&Request> for Query {
+	fn from(request: &Request) -> Self {
+		Query {
+			source_chain: request.source_chain(),
+			dest_chain: request.dest_chain(),
+			nonce: request.nonce(),
+			commitment: hash_request::<Hasher>(request),
+		}
+	}
 }
 
 /// A type that should be returned when messages are submitted successfully.

--- a/tesseract/messaging/primitives/src/mocks.rs
+++ b/tesseract/messaging/primitives/src/mocks.rs
@@ -13,8 +13,9 @@ use ismp::{
 use pallet_ismp_host_executive::HostParam;
 use pallet_ismp_relayer::withdrawal::WithdrawalProof;
 use parity_scale_codec::Codec;
-use primitive_types::{H256, U256};
+use primitive_types::{H160, H256, U256};
 use std::{
+	collections::BTreeMap,
 	sync::{Arc, Mutex},
 	time::Duration,
 };
@@ -34,6 +35,11 @@ pub struct MockHost<C> {
 	pub name: Arc<Mutex<String>>,
 	/// The consensus state id embedded in [`IsmpProvider::state_machine_id`].
 	pub consensus_state_id: Arc<Mutex<ConsensusStateId>>,
+	/// Commitments this host has a delivery receipt for, keyed to the relayer
+	/// that delivered them.
+	pub request_receipts: Arc<Mutex<BTreeMap<H256, Vec<u8>>>>,
+	/// The timestamp returned by [`IsmpProvider::query_timestamp`].
+	pub timestamp: Arc<Mutex<Duration>>,
 }
 
 impl<C> MockHost<C> {
@@ -47,6 +53,8 @@ impl<C> MockHost<C> {
 			address: Arc::new(Mutex::new(Vec::new())),
 			name: Arc::new(Mutex::new("Mock".to_string())),
 			consensus_state_id: Arc::new(Mutex::new(*b"Mock")),
+			request_receipts: Arc::new(Mutex::new(BTreeMap::new())),
+			timestamp: Arc::new(Mutex::new(Duration::from_secs(0))),
 		}
 	}
 
@@ -72,6 +80,17 @@ impl<C> MockHost<C> {
 
 	pub fn with_consensus_state_id(self, id: ConsensusStateId) -> Self {
 		*self.consensus_state_id.lock().unwrap() = id;
+		self
+	}
+
+	/// Record `commitment` as already delivered by `relayer`.
+	pub fn with_request_receipt(self, commitment: H256, relayer: Vec<u8>) -> Self {
+		self.request_receipts.lock().unwrap().insert(commitment, relayer);
+		self
+	}
+
+	pub fn with_timestamp(self, timestamp: Duration) -> Self {
+		*self.timestamp.lock().unwrap() = timestamp;
 		self
 	}
 }
@@ -170,7 +189,7 @@ impl<C: Codec + Send + Sync> IsmpProvider for MockHost<C> {
 	}
 
 	async fn query_timestamp(&self) -> Result<Duration, Error> {
-		Ok(Duration::from_secs(0))
+		Ok(*self.timestamp.lock().unwrap())
 	}
 
 	async fn query_requests_proof(
@@ -310,8 +329,9 @@ impl<C: Codec + Send + Sync> IsmpProvider for MockHost<C> {
 		todo!()
 	}
 
-	async fn query_request_receipt(&self, _hash: H256) -> Result<Vec<u8>, anyhow::Error> {
-		todo!()
+	async fn query_request_receipt(&self, hash: H256) -> Result<Vec<u8>, anyhow::Error> {
+		let receipts = self.request_receipts.lock().unwrap();
+		Ok(receipts.get(&hash).cloned().unwrap_or_else(|| H160::zero().0.to_vec()))
 	}
 
 	async fn query_response_receipt(&self, _hash: H256) -> Result<Vec<u8>, anyhow::Error> {
@@ -334,6 +354,8 @@ impl<C: Send + Sync> Clone for MockHost<C> {
 			address: self.address.clone(),
 			name: self.name.clone(),
 			consensus_state_id: self.consensus_state_id.clone(),
+			request_receipts: self.request_receipts.clone(),
+			timestamp: self.timestamp.clone(),
 		}
 	}
 }

--- a/tesseract/relayer/Cargo.toml
+++ b/tesseract/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tesseract"
-version = "2.4.11"
+version = "2.4.12"
 edition = "2021"
 description = "Consolidated Hyperbridge relayer — inbound and outbound consensus + messaging"
 authors = ["Polytope Labs <hello@polytope.technology>"]

--- a/tesseract/relayer/src/config.rs
+++ b/tesseract/relayer/src/config.rs
@@ -65,6 +65,10 @@ pub struct RelayerConfig {
 	pub withdrawal_frequency: Option<u64>,
 	pub minimum_withdrawal_amount: Option<u64>,
 	pub unprofitable_retry_frequency: Option<u64>,
+	/// Hex encoded module ids whose requests are parked and retried when a
+	/// delivery to an EVM chain is cancelled or never lands. Absent or empty
+	/// parks nothing; `unprofitable_retry_frequency` must also be set.
+	pub retry_modules: Option<Vec<String>>,
 	pub deliver_failed: Option<bool>,
 	pub disable_fee_accumulation: Option<bool>,
 	/// Per-`(state_machine_id, max_interval_secs)` entries enabling the
@@ -85,6 +89,7 @@ impl Default for RelayerConfig {
 			withdrawal_frequency: None,
 			minimum_withdrawal_amount: None,
 			unprofitable_retry_frequency: None,
+			retry_modules: None,
 			deliver_failed: None,
 			disable_fee_accumulation: None,
 			maximum_update_intervals: None,
@@ -100,6 +105,7 @@ impl From<RelayerConfig> for tesseract_primitives::config::RelayerConfig {
 			withdrawal_frequency: config.withdrawal_frequency,
 			minimum_withdrawal_amount: config.minimum_withdrawal_amount,
 			unprofitable_retry_frequency: config.unprofitable_retry_frequency,
+			retry_modules: config.retry_modules,
 			// Unused by the consolidated relayer — every chain in `[chains.*]`
 			// gets inbound messaging spawned automatically.
 			delivery_endpoints: Vec::new(),

--- a/tesseract/relayer/src/config.rs
+++ b/tesseract/relayer/src/config.rs
@@ -64,10 +64,14 @@ pub struct RelayerConfig {
 	pub minimum_profit_percentage: u32,
 	pub withdrawal_frequency: Option<u64>,
 	pub minimum_withdrawal_amount: Option<u64>,
-	pub unprofitable_retry_frequency: Option<u64>,
-	/// Hex encoded module ids whose requests are parked and retried when a
-	/// delivery to an EVM chain is cancelled or never lands. Absent or empty
-	/// parks nothing; `unprofitable_retry_frequency` must also be set.
+	/// How often, in seconds, to retry parked deliveries. Unset disables retries
+	/// and parking. The old `unprofitable_retry_frequency` key is still accepted.
+	#[serde(alias = "unprofitable_retry_frequency")]
+	pub retry_frequency: Option<u64>,
+	/// Hex encoded ids of destination modules whose requests are parked and
+	/// retried when a delivery to an EVM chain is cancelled or never lands,
+	/// matched on the request's `to` field. Absent or empty parks nothing;
+	/// `retry_frequency` must also be set.
 	pub retry_modules: Option<Vec<String>>,
 	pub deliver_failed: Option<bool>,
 	pub disable_fee_accumulation: Option<bool>,
@@ -88,7 +92,7 @@ impl Default for RelayerConfig {
 			minimum_profit_percentage: 0,
 			withdrawal_frequency: None,
 			minimum_withdrawal_amount: None,
-			unprofitable_retry_frequency: None,
+			retry_frequency: None,
 			retry_modules: None,
 			deliver_failed: None,
 			disable_fee_accumulation: None,
@@ -104,7 +108,7 @@ impl From<RelayerConfig> for tesseract_primitives::config::RelayerConfig {
 			minimum_profit_percentage: config.minimum_profit_percentage,
 			withdrawal_frequency: config.withdrawal_frequency,
 			minimum_withdrawal_amount: config.minimum_withdrawal_amount,
-			unprofitable_retry_frequency: config.unprofitable_retry_frequency,
+			retry_frequency: config.retry_frequency,
 			retry_modules: config.retry_modules,
 			// Unused by the consolidated relayer — every chain in `[chains.*]`
 			// gets inbound messaging spawned automatically.

--- a/tesseract/relayer/src/config.rs
+++ b/tesseract/relayer/src/config.rs
@@ -64,14 +64,14 @@ pub struct RelayerConfig {
 	pub minimum_profit_percentage: u32,
 	pub withdrawal_frequency: Option<u64>,
 	pub minimum_withdrawal_amount: Option<u64>,
-	/// How often, in seconds, to retry parked deliveries. Unset disables retries
-	/// and parking. The old `unprofitable_retry_frequency` key is still accepted.
+	/// How often, in seconds, to retry parked deliveries. Defaults to five minutes
+	/// when unset. The old `unprofitable_retry_frequency` key is still accepted.
 	#[serde(alias = "unprofitable_retry_frequency")]
 	pub retry_frequency: Option<u64>,
 	/// Hex encoded ids of destination modules whose requests are parked and
 	/// retried when a delivery to an EVM chain is cancelled or never lands,
-	/// matched on the request's `to` field. Absent or empty parks nothing;
-	/// `retry_frequency` must also be set.
+	/// matched on the request's `to` field. Listing at least one module is what
+	/// turns the retry task on; absent or empty parks nothing.
 	pub retry_modules: Option<Vec<String>>,
 	pub deliver_failed: Option<bool>,
 	pub disable_fee_accumulation: Option<bool>,


### PR DESCRIPTION
## What this does

Deliveries out of hyperbridge are gated to a whitelisted relayer, so a batch that never landed was quietly lost: the fan out logged the messages it skipped and dropped them, and a failed submission took the whole batch with it. Requests addressed to the modules an operator lists are now parked in the same table the retry loop reads, and the outbound pipeline spawns that loop per EVM destination so something finally drains it. Every pass asks the destination for a request receipt before doing any proof or gas work, so anything already delivered, or past its timeout, is dropped rather than resubmitted into a revert.

## Configuration

`retry_modules` is an optional list of hex encoded module ids, matched against a request's `to` field. Listing at least one module is what switches parking and the retry loop on; absent or empty parks nothing and spawns no loop. `retry_frequency` (formerly `unprofitable_retry_frequency`, the old key is still accepted) only paces the loop, in seconds, and defaults to five minutes when unset.

## Notes

A parked request is proved at the height the destination is already on whenever that is at or past the height it was parked with, and no consensus message is added. Only when the destination has not reached that height does the batch carry the beefy proof for it, so it verifies on arrival instead of waiting for the next consensus update. Rows are deduplicated by commitment, keeping the lowest height a request was seen at.

Only post requests are parked. The consensus message in a failed batch is superseded by the next proof that comes along, and a get response is paid for on delivery rather than claimed.

This only covers deliveries to EVM chains. The inbound pipeline no longer parks cancelled or unprofitable messages for substrate destinations, since nothing ever drained those rows; they are logged and dropped.

closes #1252