### PR TITLE
[indexer]: exclude transferred vault principal from LP yield

### DIFF
--- a/sdk/packages/indexer/docs/ai/changelog/2026-09-10-vault-accounting-stress-audit.md
+++ b/sdk/packages/indexer/docs/ai/changelog/2026-09-10-vault-accounting-stress-audit.md
@@ -1,0 +1,20 @@
+# 2026-09-10 — Stress-test vault capital flows and harden event failure handling
+
+Exercise real vault handlers, ABI decoding and generated models against an independent cash-flow
+model: Simplex redeem/send/sweep shapes, empty and established recipients, partial/full withdrawals,
+pre-delegation balances, same-block sequences, rounding, eligibility, replay, rollback and paging.
+The focused suite covers 99 cases and 3,000 generated actions; all audited executable lines run.
+
+Fix the failures identified: propagate vault decoding failures instead of silently dropping capital
+events, normalize transaction-hash IDs, avoid valuation RPC for completed transfer replays, exclude
+non-capital transfers before timestamp reads, and reject duplicate/invalid RPC log indexes. Other
+handlers keep the shared wrapper's default behavior. Production state and historical data are untouched.
+
+Files: `src/services/yieldVault.service.ts`, `src/services/__tests__/yieldVault.service.test.ts`,
+`src/services/__tests__/yieldVault.stress.test.ts`, `src/utils/vaultAccounting.ts`,
+`src/utils/__tests__/vaultAccounting.test.ts`, `src/utils/event.utils.ts`,
+`src/handlers/events/yieldVault/deposit.event.handler.ts`,
+`src/handlers/events/yieldVault/withdraw.event.handler.ts`,
+`src/handlers/events/yieldVault/transfer.event.handler.ts`,
+`docs/ai/flows/vault-accounting-stress-audit.md`,
+`docs/ai/decisions/2026-09-10-vault-transfer-principal.md`.

--- a/sdk/packages/indexer/docs/ai/changelog/2026-09-10-vault-historical-replay.md
+++ b/sdk/packages/indexer/docs/ai/changelog/2026-09-10-vault-historical-replay.md
@@ -1,0 +1,88 @@
+# 2026-09-10 — Historical Docker replay reproduces and fixes inflated vault yield
+
+Ran the actual SubQuery Ethereum node against Base archive data from the premium Alchemy RPC,
+with PostgreSQL persistence and the original vault handlers. The pre-fix control reproduced the
+reported API result exactly. The fixed build matched an independent calculation from the original
+event logs and historical contract calls, down to one raw USDC unit.
+
+## Inputs and scope
+
+- Wallet: `0xce319986ca4d5d0893751a628d0db3dc8fc91d62`.
+- Vault: `0xc768c589647798a6ee01a91fde98ef2ed046dbd6` on Base (`EVM-8453`), wrapping USDC.
+- Control source: `5d0e05806e6690c716de02e58e8401b609b93cd1` (`main` before the fix).
+- Fixed source: `ea8ba850af19e2b6906ab1a0ee4fb0716843cc4a`.
+- Node: `subquerynetwork/subql-node-ethereum:v6.5.0`, image digest
+  `sha256:f1ba196ce1da75d2a34ac78c940e77c457c6c8027997c11055fd6ed7794732e7`.
+- Database: `postgres:14-alpine`, separate fresh `control` and `fixed` schemas, historical indexing
+  by height, synchronous store flushing. No provider, ledger, position, or snapshot rows were seeded.
+
+An archive log scan covered blocks 51,090,774 through 51,104,550 inclusive. It found 27 logs on this
+vault in 13 blocks. The replay manifests retained those event blocks and explicitly bypassed the
+intervening blocks with no vault logs. Both runs invoked the original snapshot handler at block
+51,104,550 (2026-09-10 00:00:47 UTC), the same block as the incorrect production snapshot. The node
+also fetched intermediate boundary blocks while advancing its checkpoint; both runs finished at
+51,104,550 and exited successfully.
+
+This is a scoped vault integration replay: other protocol event datasources and cross-chain provider
+registration indexing were not run. Handler/service code was unchanged in isolated build copies;
+the generated RPC configuration pointed to a local proxy forwarding read-only requests to Alchemy.
+No contract responses or database operations were mocked. All contract, balance and delegation
+reads used explicit historical block tags. No chain transactions or production database writes occurred.
+
+## Original wallet events
+
+| Block | Event | Shares received | USDC deposited |
+| --- | --- | ---: | ---: |
+| 51,090,775 | Ordinary share Transfer | 174220559508 | 0 |
+| 51,090,824 | Ordinary share Transfer | 57243722070 | 0 |
+| 51,091,762 | Deposit (plus its mint Transfer) | 17666436 | 20.230586 |
+
+These were the only wallet share movements in the scanned window. Its opening share balance before
+the first transfer was zero. `eth_getCode` returned `0x` at both transfer blocks and delegation to
+`0x7cb55539d1144f62422099c3fa3405092022c88c` at the deposit block.
+
+With no existing provider row, both fresh runs therefore first tracked this wallet at the deposit.
+The fixed run established opening shares of `231464281578`, valued at `265059572508` raw USDC
+(265,059.572508 USDC) at block 51,091,762. It then recorded the real deposit exactly once. It did not
+invent historical deposits or transfer ledger rows for the earlier, ineligible period.
+
+## Persisted results at block 51,104,550
+
+Amounts below are USDC; share counts are raw integers.
+
+| Field | Pre-fix control | Fixed |
+| --- | ---: | ---: |
+| Position shares | 17666436 | 231481948014 |
+| Snapshot shares (onchain) | 231481948014 | 231481948014 |
+| Snapshot asset value | 265,087.704647 | 265,087.704647 |
+| Opening principal | Not recorded | 265,059.572508 |
+| Actual deposits | 20.230586 | 20.230586 |
+| Net principal | 20.230586 | 265,079.803094 |
+| Reported yield | **265,067.474061** | **7.901553** |
+| Deposit / withdrawal count | 1 / 0 | 1 / 0 |
+
+The control yield equals the incorrect live API snapshot captured during the original investigation.
+Independent assertions checked both database checkpoints, ledger counts, event types, deposited
+assets, opening shares/principal/block, tracked shares, counters, snapshot values and yields. All passed.
+
+The earlier receipt-time reconstruction gives **8.497566 USDC**. That calculation starts at the two
+original transfers. This fresh indexer run starts its opening basis at the later first eligible event,
+excluding 0.596013 USDC of pre-baseline appreciation. This is the documented opening-principal
+behavior, not an exact lifetime-yield backfill. Historical rows in an existing deployment still require
+the separate repair; this run does not test that repair or the upgrade of an existing database.
+
+## Local evidence
+
+The test workspace is `/tmp/hyperfx-historical-replay`. Its `compose.yaml`, isolated source builds and
+bounded `src/configs/replay.yaml` manifests describe the run. The `evidence` directory contains:
+
+- `vault-logs.json`, `wallet-logs.json`, and `onchain-states.json`: original archive inputs.
+- `independent-expectations.json`: separately calculated expected balances, principal and yields.
+- `fixed-db.json` and `control-db.json`: persisted wallet positions, ledgers and snapshots.
+- `rpc-requests.jsonl`: methods and parameters, without the premium credential.
+- Build and container logs for both runs.
+
+`python3 /tmp/hyperfx-historical-replay/verify-results.py` checks the saved database exports against
+the independent expectations and verifies historical RPC tags. The local Docker database volume is
+retained for inspection. Replay containers were removed and the temporary RPC credential file cleared
+after collecting evidence. The user's existing Docker services were left untouched.

--- a/sdk/packages/indexer/docs/ai/changelog/2026-09-10-vault-transfer-principal.md
+++ b/sdk/packages/indexer/docs/ai/changelog/2026-09-10-vault-transfer-principal.md
@@ -1,0 +1,20 @@
+# 2026-09-10 — Exclude transferred vault capital from LP yield
+
+Subscribe to ordinary vault-share transfers and account for both tracked owners using event-block
+asset values, with separate transfer totals and replay-safe ledger keys. Initialize preexisting shares
+as opening principal when a position is first tracked, including correct handling of additional events
+in the same block. Required accounting RPC failures propagate instead of silently dropping events.
+
+Daily LP snapshots defer until the current block's capital events are indexed and withhold yield for
+unreconciled share balances. Transient snapshot failures remain retryable without rewriting completed
+LP snapshots. Existing historical corruption is left for an explicit repair. Tests cover the reported
+Base USDC quantities, pre-delegation balances, multiple same-block events, transfers between tracked
+LPs, mint/burn exclusion, replay, losses and RPC failures.
+
+Files: `src/services/yieldVault.service.ts`, `src/utils/vaultAccounting.ts`,
+`src/handlers/events/yieldVault/transfer.event.handler.ts`, `src/mappings/mappingHandlers.ts`,
+`src/configs/abis/Erc4626.abi.json`, `src/configs/schema.graphql`,
+`scripts/templates/evm-chain.yaml.hbs`, `src/services/__tests__/yieldVault.service.test.ts`,
+`src/utils/__tests__/vaultAccounting.test.ts`,
+`docs/ai/decisions/2026-09-10-vault-transfer-principal.md`,
+`docs/ai/flows/pool-liquidity-refresh-orderfilled-partialfill-escrowreleased.md`.

--- a/sdk/packages/indexer/docs/ai/decisions/2026-09-10-vault-transfer-principal.md
+++ b/sdk/packages/indexer/docs/ai/decisions/2026-09-10-vault-transfer-principal.md
@@ -1,0 +1,46 @@
+# 2026-09-10 — Vault transfers are capital movements; pre-tracking shares have an opening basis
+
+Ordinary vault-share transfers are recorded as `TRANSFER_IN` and `TRANSFER_OUT` ledger entries,
+valued with `convertToAssets` at the event block. Transfer IDs append the LP address to the existing
+chain/transaction/log key because both owners can be tracked. Deposit and withdrawal IDs and counters
+retain their meaning; mint/burn transfers and self/zero transfers do not create capital movements.
+The new nullable position fields hold transfer totals and opening shares/principal/block. Existing
+rows interpret null amounts as zero. Reusing DEPOSIT/WITHDRAW for transfers was rejected because it
+misrepresents the onchain event and inflates actual deposit/withdrawal counts.
+
+Stress-audit follow-up: IDs and stored transaction hashes are lowercase. Completed transfer sides
+are deduplicated before valuation RPC. The non-capital Transfer predicate is shared by the handler,
+service and block decoder, and runs before timestamp reads. Capital handlers opt into rethrowing
+the shared wrapper's decode errors; acknowledging those errors could silently lose principal even
+when later share counts happen to reconcile. Missing arguments and duplicate/invalid RPC log indexes
+also fail processing. Other handlers retain the wrapper's default behavior. See the
+`flows/vault-accounting-stress-audit.md` case matrix and independent-model tests.
+
+For a new position, establish an opening basis for shares held before its first eligible vault event.
+The safe ethers provider reads end-of-handler-block state. Subtract all share movements at or after
+the triggering log in that same block from the live balance, then value the remainder at that block's
+exchange rate. Subtracting only the triggering event fails when more capital moves later in the block.
+The configured HTTP RPC supplies the single block's logs because SubQuery's safe provider does not
+support getLogs. Missing triggering logs, impossible balances, or required RPC failures abort event
+processing instead of recording an event with an invented zero baseline. No unbounded history scans
+are added to indexer handlers. Yield before this opening block is deliberately outside the new
+position's measurement period; receipt-time lifetime yield requires historical reconstruction.
+
+SubQuery's Ethereum indexer runs block handlers before log handlers. Defer an LP's daily snapshot if
+that block contains its capital movements, even if their share deltas cancel. Failed RPCs and deferred
+LPs leave the daily completion gate open; successful LP snapshots are deduplicated on retry. A persistent
+ledger/onchain share mismatch instead withholds that LP's snapshot and logs the need for reconciliation.
+It does not prevent other LPs or the independent vault aggregate from being published. Genuine losses
+remain negative yield. Share equality is a consistency check, not proof that an old ledger has complete
+capital history (untracked historical transfers can net to zero shares).
+
+Do not silently reset existing positions to today's value: that would erase earned yield and hide
+historical corruption. Existing incorrect ledger/position/snapshot history still needs the separate
+audited repair. Previously published snapshots are not rewritten by this change; clients can continue
+to display an old bad value until that repair is applied. Positions without any eligible vault event
+are not newly discovered just from enabling delegation.
+
+Rollout uses the existing additive schema migration: rebuild manifests, codegen and bundle; restart
+the substrate schema leader first, then EVM writers after it is healthy. New fields are nullable and
+enum values are additive. Regenerate the EVM manifests to install the Transfer subscription. No SQL
+repair, restart or production deployment is performed by the code change itself.

--- a/sdk/packages/indexer/docs/ai/flows/pool-liquidity-refresh-orderfilled-partialfill-escrowreleased.md
+++ b/sdk/packages/indexer/docs/ai/flows/pool-liquidity-refresh-orderfilled-partialfill-escrowreleased.md
@@ -1,4 +1,4 @@
-# Pool liquidity refresh (OrderFilled, PartialFill, EscrowReleased, vault Deposit/Withdraw)
+# Pool liquidity refresh (OrderFilled, PartialFill, EscrowReleased, vault Deposit/Withdraw/Transfer)
 
 Verified 2026-09-08 by unit tests against a mocked store (`inventoryReading.service.test.ts` for the EVM half,
 `liquidityPoolFold.service.test.ts` for the Hyperbridge half); the store behaviour the split rests on was read in
@@ -12,8 +12,8 @@ EVM nodes publish readings for it to fold.
 
 **EVM side — publish (`src/services/inventoryReading.service.ts`)**
 
-1. Four events reach it, each in its own try/catch — they read external RPCs, and stale depth is recoverable, so a
-   failure must never stall indexing:
+1. Order fills, partial fills, escrow releases and vault capital movements reach it. Inventory publication is
+   best-effort — stale depth is recoverable. Required vault principal reads still propagate failures:
    - `handleOrderFilledEventV3` and `handlePartialFilledEventV3` call `IntentGatewayV3Service.publishInventoryAfterFill`,
      which loads the order row for its **source** chain (a fill carries the inputs' addresses but not the chain they
      live on), resolves the pools with `poolsForFill`, and calls `publishPoolInventory`. No order row, or no
@@ -21,8 +21,9 @@ EVM nodes publish readings for it to fold.
    - `handleEscrowReleasedEventV3` (source chain) calls `publishInventoryAfterEscrowRelease`: the solver was just paid
      the order's inputs back, so its inventory there ROSE. The event names no filler, so the handler first reads
      the gateway's `_filled(commitment)` at that block.
-   - `YieldVaultService.recordLedger` (vault `Deposit`/`Withdraw`) ends with the same call for (chain, lp,
-     underlying token), after its own known-solver gate and duplicate-log guard.
+   - `YieldVaultService.recordLedger` (vault `Deposit`/`Withdraw` and each tracked side of an ordinary
+     share `Transfer`) ends with the same call for (chain, lp, underlying token), after its own
+     known-solver gate and duplicate-log guard. Mint/burn, self and zero-share transfers are excluded.
    The last two name a solver and a token but no pool, so they enter through `publishProviderInventory`.
 2. Both entry points select `PoolBidder` rows of **this chain only** with field queries (which go to Postgres;
    `get` would serve the process cache), and collapse them to distinct (solver, output token) targets. A target

--- a/sdk/packages/indexer/docs/ai/flows/vault-accounting-stress-audit.md
+++ b/sdk/packages/indexer/docs/ai/flows/vault-accounting-stress-audit.md
@@ -1,0 +1,89 @@
+# Vault accounting stress audit
+
+Verified 2026-09-10 against the vault service, four vault handlers, ABI/log reader, generated models,
+manifest template, and Simplex's `TokenSender` / `VaultFundingPlanner` call construction. The focused
+suite has 99 passing cases, including 25 deterministic seeds with 120 generated actions each (3,000
+actions, excluding setup), and a 205-LP paging case. It exercises 100% of executable lines/statements
+and functions in the vault service, handlers and accounting helpers; branch coverage across those
+files and the shared event wrapper is 97.27%, with every handler branch covered.
+
+The stress harness feeds ABI-encoded logs through the real deposit, withdrawal and transfer handlers,
+the real block-log decoder and generated store models. An independent model maintains wallet share
+balances and a single signed capital-flow total, while RPC returns end-of-block state. Each snapshot
+is checked against `value(shares) - net capital`. RPC/store boundaries and inventory publication are
+mocked. Reorg and failed-block cases explicitly simulate the node's store rollback before replay;
+these are not live-node or fork-chain tests. No transactions or database repairs were sent.
+
+## Simplex sends and receives
+
+`TokenSender.send` redeems configured share tokens with `redeem(shares, recipient, solver)`. The
+recipient gets underlying assets. For an underlying-token send with insufficient working balance,
+it batches `withdraw(amount, solver, solver)` and an ERC-20 transfer. A later vault sweep calls
+`deposit(amount, solver)`. A share transfer from another wallet or tool is a separate ERC-20 Transfer
+on the vault contract and needs transfer principal accounting.
+
+| Scenario | Expected accounting and test result |
+| --- | --- |
+| Deposit and mint into an empty tracked wallet | Deposit events alone add emitted assets and minted shares; mint Transfer logs add nothing. Pass. |
+| Partial withdraw, full redeem, then deposit again | Withdraw owner loses shares; withdrawn assets reduce net capital. Previously earned yield survives an empty position and later deposits. Pass. |
+| Simplex redeems shares directly to an empty recipient | Only the solver's withdrawal is recorded. Recipient owns underlying, not shares, and has no vault position. Pass. |
+| Simplex redeems to a recipient with its own vault shares | Recipient's existing principal/shares are unchanged; its wallet token balance cannot enter vault yield. Pass. |
+| Receiver subsequently sweeps underlying into a vault | Exactly one new Deposit adds principal for the receiver. Pass. |
+| Simplex withdraws a shortfall and sends underlying in one batch | One withdrawal for the solver; underlying transfer adds no vault ledger entry. Pass. |
+| Raw underlying sends/receipts and paymaster token charges | No change to vault principal. Pass. |
+| Direct share transfer to an empty tracked recipient | Recipient gets transfer principal at the event-block share value; sender retains previously earned yield. Pass. |
+| Direct share transfer to an existing recipient | Transfer totals extend its existing deposit/withdrawal history without overwriting counters or principal. Pass. |
+| Sender/receiver eligibility combinations | Both, only sender, only receiver, and neither tracked are covered. Only eligible sides get ledger entries. Pass. |
+| Shares received before delegation | First eligible vault event establishes an opening basis for shares already present. Pre-baseline appreciation is not reported as newly earned yield. Pass. |
+| Delegation revoked after tracking began | Existing position continues to record outgoing transfers and redemptions. Pass. |
+| Caller, share owner and withdrawal recipient differ | Deposits belong to Deposit.owner; withdrawals to Withdraw.owner. Pass. |
+| Multiple transactions, deposits, withdrawals and share round trips in one block | Opening shares exclude all remaining block movements; subsequent events are counted once. Pass. |
+| Snapshot before a zero-net-share round trip is indexed | Defer until event principal is folded; share equality alone is not enough. Pass. |
+| Share decimals differ from underlying decimals | Six- and eighteen-decimal share cases use raw integers and convertToAssets; no assumed 1:1 conversion. Pass. |
+| Dust, floor/ceil rounding and falling exchange rates | Zero-asset transfers still move nonzero shares; genuine rounding losses and vault losses remain signed. Pass. |
+| Duplicate event delivery, including different hex casing | No repeated principal or share adjustments. Pass. |
+| Self, mint, burn and zero-share transfers | Excluded before timestamp RPC; no capital movement. Pass. |
+| Unknown vault/chain or unrelated delegation | No invented position. Pass. |
+| RPC failures, incomplete logs and duplicate RPC log indexes | Required accounting failures propagate; no invented opening baseline. Snapshot failures remain retryable. Pass. |
+| Store failure between the two transfer sides | Error propagates; simulated block rollback/replay applies both sides once. Pass. |
+| Reorg replaces a transfer's recipient | Simulated historical rollback removes the orphaned recipient and replay produces the canonical balances. Pass. |
+| 205 LPs, multiple vaults/chains, day rollover | All pages are covered, positions stay isolated, and completed daily snapshots are not overwritten. Pass. |
+| Legacy position with unexplained share drift | Withhold that LP's new yield, while healthy LPs and vault aggregate continue. Pass. |
+
+## Findings fixed during this audit
+
+- The generic event wrapper acknowledged decoding failures after logging them. Capital handlers now
+  opt into rethrowing decode failures and reject missing arguments, so these movements cannot be
+  silently skipped. The default behavior for other handlers is unchanged and tested.
+- Transaction hash casing previously changed ledger IDs and allowed duplicate folding. IDs and stored
+  hashes are canonicalized to lowercase. Transfer replay checks run before valuation RPC.
+- Excluded Transfer events previously reached timestamp/RPC processing before the service filtered
+  them. A shared predicate now filters in the handler, service and block-log decoder.
+- Duplicate RPC log indexes previously doubled movements used to infer opening capital. The reader
+  now rejects duplicate or invalid indexes.
+
+## Remaining limits
+
+Existing incorrect historical rows still need the audited repair. Equal historical share counts do
+not prove complete historical cash flows, since missed incoming and outgoing transfers can cancel.
+Newly tracked opening capital is valued at the first eligible event's block; earlier lifetime yield
+requires reconstructing earlier receipts. Enabling delegation without any later eligible vault
+event does not itself create a vault position. Current-block share transfers use the block's exchange
+rate; the tests do not claim transaction-intermediate pricing when a vault rate changes inside a
+block. These are vault-yield figures, not whole-wallet trading P&L or gas-adjusted returns.
+
+## Reproduce
+
+From `sdk/packages/indexer`, after normal codegen:
+
+```sh
+../../node_modules/.bin/jest --runInBand --silent \
+  src/services/__tests__/yieldVault.service.test.ts \
+  src/services/__tests__/yieldVault.stress.test.ts \
+  src/utils/__tests__/vaultAccounting.test.ts \
+  --coverage \
+  --collectCoverageFrom='src/services/yieldVault.service.ts' \
+  --collectCoverageFrom='src/handlers/events/yieldVault/*.ts' \
+  --collectCoverageFrom='src/utils/vaultAccounting.ts' \
+  --collectCoverageFrom='src/utils/event.utils.ts'
+```

--- a/sdk/packages/indexer/scripts/templates/evm-chain.yaml.hbs
+++ b/sdk/packages/indexer/scripts/templates/evm-chain.yaml.hbs
@@ -125,6 +125,11 @@ dataSources:
           filter:
             topics:
               - 'Withdraw(address,address,address,uint256,uint256)'
+        - kind: ethereum/LogHandler
+          handler: handleVaultTransferEvent
+          filter:
+            topics:
+              - 'Transfer(address,address,uint256)'
   {{/each}}
   {{#if yieldVaults.length}}
   - kind: ethereum/Runtime

--- a/sdk/packages/indexer/src/configs/abis/Erc4626.abi.json
+++ b/sdk/packages/indexer/src/configs/abis/Erc4626.abi.json
@@ -68,6 +68,31 @@
 		"anonymous": false
 	},
 	{
+		"type": "event",
+		"name": "Transfer",
+		"inputs": [
+			{
+				"name": "from",
+				"type": "address",
+				"indexed": true,
+				"internalType": "address"
+			},
+			{
+				"name": "to",
+				"type": "address",
+				"indexed": true,
+				"internalType": "address"
+			},
+			{
+				"name": "value",
+				"type": "uint256",
+				"indexed": false,
+				"internalType": "uint256"
+			}
+		],
+		"anonymous": false
+	},
+	{
 		"type": "function",
 		"name": "asset",
 		"inputs": [],

--- a/sdk/packages/indexer/src/configs/schema.graphql
+++ b/sdk/packages/indexer/src/configs/schema.graphql
@@ -2937,23 +2937,25 @@ type PoolRoute @entity @compositeIndexes(fields: [["sourceChain", "chain"], ["po
 }
 
 """
-Whether a yield-vault ledger entry records capital entering (Deposit) or leaving (Withdraw/redeem)
-an LP's position. ERC-4626 `redeem` emits the same `Withdraw` event as `withdraw`, so both are WITHDRAW.
+Capital entering or leaving an LP through ERC-4626 deposits/withdrawals or ordinary share transfers.
+Mint/burn Transfer events are excluded because Deposit/Withdraw already account for them.
 """
 enum VaultLedgerEventType {
 	DEPOSIT
 	WITHDRAW
+	TRANSFER_IN
+	TRANSFER_OUT
 }
 
 """
-A single ERC-4626 Deposit or Withdraw event on a supported yield vault, recording an LP moving
-principal in or out. Both `withdraw` and `redeem` surface here as WITHDRAW (they share the
-`Withdraw` event). The running sum of these per LP is the principal tracked by VaultLpPosition;
-each row is the immutable audit trail behind that sum.
+A capital movement in a supported vault. Deposits/withdrawals use emitted asset amounts;
+ordinary share transfers use convertToAssets at the transfer block. Each tracked side of a
+transfer has its own row. Together with openingPrincipal these rows explain net capital.
 """
 type VaultLedgerEvent @entity @compositeIndexes(fields: [["chain", "vault"], ["vault", "lp"]]) {
 	"""
-	Composite identifier: {chain}-{transactionHash}-{logIndex}.
+	Composite identifier: {chain}-{transactionHash}-{logIndex} for deposits/withdrawals;
+	transfers append -{lp} because one log can affect two tracked owners.
 	"""
 	id: ID!
 
@@ -2979,28 +2981,30 @@ type VaultLedgerEvent @entity @compositeIndexes(fields: [["chain", "vault"], ["v
 	lp: String! @index
 
 	"""
-	EVM address that initiated the call (Deposit.sender / Withdraw.sender), for provenance.
+	Deposit.sender / Withdraw.sender, or the previous share owner (Transfer.from).
+	For transfers this is not necessarily the transaction caller.
 	"""
 	caller: String!
 
 	"""
 	For Withdraw events, the EVM address that received the withdrawn assets (Withdraw.receiver).
-	Equal to `lp` for a plain `redeem`/`withdraw`; null for Deposit events.
+	Equal to `lp` for a plain `redeem`/`withdraw`; null for Deposit events. Transfer.to for share transfers.
 	"""
 	receiver: String
 
 	"""
-	Whether this entry is a DEPOSIT or a WITHDRAW.
+	Whether capital entered/exited through a deposit/withdrawal or a share transfer.
 	"""
 	eventType: VaultLedgerEventType! @index
 
 	"""
-	Amount of the underlying asset moved, in its smallest unit (assets field of the ERC-4626 event).
+	Underlying asset amount in its smallest unit: emitted assets for Deposit/Withdraw,
+	or the transferred shares valued by convertToAssets at the event block.
 	"""
 	assets: BigInt!
 
 	"""
-	Amount of vault shares minted (Deposit) or burned (Withdraw), in the share token's smallest unit.
+	Amount of vault shares minted, burned or transferred, in the share token's smallest unit.
 	"""
 	shares: BigInt!
 
@@ -3021,11 +3025,10 @@ type VaultLedgerEvent @entity @compositeIndexes(fields: [["chain", "vault"], ["v
 }
 
 """
-An LP's running position in a single yield vault, accumulated from VaultLedgerEvent rows. Tracks
-the cumulative principal an LP has deposited and withdrawn so net principal
-(totalAssetsDeposited - totalAssetsWithdrawn) can be compared against the live asset value of their
-shares to derive yield. Also serves as the registry of LPs the daily snapshot iterates over for a
-given (chain, vault).
+An LP's running position in a single vault. Net capital is openingPrincipal + deposits + incoming
+transfer values - withdrawals - outgoing transfer values. Opening capital is valued when tracking
+begins; yield before that baseline is not attributed to this LP. Positions are registered on the
+first eligible vault event and serve as the LP registry for daily snapshots.
 """
 type VaultLpPosition @entity @compositeIndexes(fields: [["chain", "vault"]]) {
 	"""
@@ -3054,11 +3057,38 @@ type VaultLpPosition @entity @compositeIndexes(fields: [["chain", "vault"]]) {
 	lp: String! @index
 
 	"""
-	Net vault shares the LP holds as accounted from Deposit (minted) minus Withdraw (burned) events.
-	Informational only — the daily snapshot reads the authoritative balance via `balanceOf` so this
-	can drift if shares are transferred LP-to-LP (vault ERC-20 transfers are not indexed).
+	Vault shares accounted from the opening balance, deposits, withdrawals and ordinary transfers.
+	Snapshots are withheld when this differs from the onchain balance.
 	"""
 	shares: BigInt!
+
+	"""
+	Shares already held before the first tracked event. Null on positions created by older indexers.
+	"""
+	openingShares: BigInt
+
+	"""
+	Underlying value of openingShares at openingBlock. Yield before this baseline is not attributed
+	to this LP. Null on legacy positions means no opening principal was recorded.
+	"""
+	openingPrincipal: BigInt
+
+	"""
+	Block of the first tracked event, whose exchange rate values the opening shares.
+	"""
+	openingBlock: BigInt
+
+	"""
+	Cumulative underlying value of ordinary incoming share transfers at their event blocks.
+	Null on legacy positions is treated as zero.
+	"""
+	totalAssetsTransferredIn: BigInt
+
+	"""
+	Cumulative underlying value of ordinary outgoing share transfers at their event blocks.
+	Null on legacy positions is treated as zero.
+	"""
+	totalAssetsTransferredOut: BigInt
 
 	"""
 	Cumulative underlying assets the LP has ever deposited, smallest unit. Monotonically increasing.
@@ -3067,7 +3097,7 @@ type VaultLpPosition @entity @compositeIndexes(fields: [["chain", "vault"]]) {
 
 	"""
 	Cumulative underlying assets the LP has ever withdrawn/redeemed, smallest unit. Monotonically increasing.
-	Net principal currently at risk is totalAssetsDeposited - totalAssetsWithdrawn.
+	Net principal also includes openingPrincipal and transferred-in minus transferred-out asset values.
 	"""
 	totalAssetsWithdrawn: BigInt!
 
@@ -3141,7 +3171,8 @@ type VaultPositionSnapshot @entity @compositeIndexes(fields: [["chain", "vault"]
 	assetValue: BigInt!
 
 	"""
-	The LP's net principal at snapshot time (totalAssetsDeposited - totalAssetsWithdrawn from VaultLpPosition).
+	The LP's net capital at snapshot time: openingPrincipal + totalAssetsDeposited +
+	totalAssetsTransferredIn - totalAssetsWithdrawn - totalAssetsTransferredOut.
 	"""
 	netPrincipal: BigInt!
 

--- a/sdk/packages/indexer/src/handlers/events/yieldVault/deposit.event.handler.ts
+++ b/sdk/packages/indexer/src/handlers/events/yieldVault/deposit.event.handler.ts
@@ -9,24 +9,27 @@ import { wrap } from "@/utils/event.utils"
  * Handles the ERC-4626 Deposit event on a supported yield vault — an LP adding principal.
  * `owner` is the share recipient (the LP), `sender` the caller.
  */
-export const handleVaultDepositEvent = wrap(async (event: DepositLog): Promise<void> => {
-	if (!event.args) return
+export const handleVaultDepositEvent = wrap(
+	async (event: DepositLog): Promise<void> => {
+		if (!event.args) throw new Error("[yield-vault] Missing decoded Deposit arguments")
 
-	const { args, address, blockNumber, blockHash, transactionHash, logIndex } = event
-	const chain = getHostStateMachine(chainId)
-	const timestamp = await getBlockTimestamp(blockHash, chain)
+		const { args, address, blockNumber, blockHash, transactionHash, logIndex } = event
+		const chain = getHostStateMachine(chainId)
+		const timestamp = await getBlockTimestamp(blockHash, chain)
 
-	await YieldVaultService.recordLedger({
-		chain,
-		vault: address,
-		lp: args.owner,
-		caller: args.sender,
-		assets: BigInt(args.assets.toString()),
-		shares: BigInt(args.shares.toString()),
-		eventType: VaultLedgerEventType.DEPOSIT,
-		blockNumber: BigInt(blockNumber),
-		transactionHash,
-		logIndex,
-		timestamp,
-	})
-})
+		await YieldVaultService.recordLedger({
+			chain,
+			vault: address,
+			lp: args.owner,
+			caller: args.sender,
+			assets: BigInt(args.assets.toString()),
+			shares: BigInt(args.shares.toString()),
+			eventType: VaultLedgerEventType.DEPOSIT,
+			blockNumber: BigInt(blockNumber),
+			transactionHash,
+			logIndex,
+			timestamp,
+		})
+	},
+	{ rethrowDecodeErrors: true },
+)

--- a/sdk/packages/indexer/src/handlers/events/yieldVault/transfer.event.handler.ts
+++ b/sdk/packages/indexer/src/handlers/events/yieldVault/transfer.event.handler.ts
@@ -1,0 +1,29 @@
+import { TransferLog } from "@/configs/src/types/abi-interfaces/Erc4626Abi"
+import { YieldVaultService } from "@/services/yieldVault.service"
+import { getBlockTimestamp } from "@/utils/rpc.helpers"
+import { getHostStateMachine } from "@/utils/substrate.helpers"
+import { wrap } from "@/utils/event.utils"
+import { isOrdinaryVaultTransfer } from "@/utils/vaultAccounting"
+
+/** Account for existing vault shares moving between owners. Mint/burns are handled separately. */
+export const handleVaultTransferEvent = wrap(
+	async (event: TransferLog): Promise<void> => {
+		if (!event.args) throw new Error("[yield-vault] Missing decoded Transfer arguments")
+		const { args, address, blockNumber, blockHash, transactionHash, logIndex } = event
+		const shares = BigInt(args.value.toString())
+		if (!isOrdinaryVaultTransfer(args.from, args.to, shares)) return
+		const chain = getHostStateMachine(chainId)
+		await YieldVaultService.recordTransfer({
+			chain,
+			vault: address,
+			from: args.from,
+			to: args.to,
+			shares,
+			blockNumber: BigInt(blockNumber),
+			transactionHash,
+			logIndex,
+			timestamp: await getBlockTimestamp(blockHash, chain),
+		})
+	},
+	{ rethrowDecodeErrors: true },
+)

--- a/sdk/packages/indexer/src/handlers/events/yieldVault/withdraw.event.handler.ts
+++ b/sdk/packages/indexer/src/handlers/events/yieldVault/withdraw.event.handler.ts
@@ -10,25 +10,28 @@ import { wrap } from "@/utils/event.utils"
  * Both `withdraw` and `redeem` emit this; `owner` is the LP whose shares were burned, `receiver`
  * the address that got the assets, `sender` the caller.
  */
-export const handleVaultWithdrawEvent = wrap(async (event: WithdrawLog): Promise<void> => {
-	if (!event.args) return
+export const handleVaultWithdrawEvent = wrap(
+	async (event: WithdrawLog): Promise<void> => {
+		if (!event.args) throw new Error("[yield-vault] Missing decoded Withdraw arguments")
 
-	const { args, address, blockNumber, blockHash, transactionHash, logIndex } = event
-	const chain = getHostStateMachine(chainId)
-	const timestamp = await getBlockTimestamp(blockHash, chain)
+		const { args, address, blockNumber, blockHash, transactionHash, logIndex } = event
+		const chain = getHostStateMachine(chainId)
+		const timestamp = await getBlockTimestamp(blockHash, chain)
 
-	await YieldVaultService.recordLedger({
-		chain,
-		vault: address,
-		lp: args.owner,
-		caller: args.sender,
-		receiver: args.receiver,
-		assets: BigInt(args.assets.toString()),
-		shares: BigInt(args.shares.toString()),
-		eventType: VaultLedgerEventType.WITHDRAW,
-		blockNumber: BigInt(blockNumber),
-		transactionHash,
-		logIndex,
-		timestamp,
-	})
-})
+		await YieldVaultService.recordLedger({
+			chain,
+			vault: address,
+			lp: args.owner,
+			caller: args.sender,
+			receiver: args.receiver,
+			assets: BigInt(args.assets.toString()),
+			shares: BigInt(args.shares.toString()),
+			eventType: VaultLedgerEventType.WITHDRAW,
+			blockNumber: BigInt(blockNumber),
+			transactionHash,
+			logIndex,
+			timestamp,
+		})
+	},
+	{ rethrowDecodeErrors: true },
+)

--- a/sdk/packages/indexer/src/mappings/mappingHandlers.ts
+++ b/sdk/packages/indexer/src/mappings/mappingHandlers.ts
@@ -44,6 +44,7 @@ export { handlePendingStatusFlushEvm } from "@/handlers/events/pendingStatus/han
 // Yield Vault Handlers
 export { handleVaultDepositEvent } from "@/handlers/events/yieldVault/deposit.event.handler"
 export { handleVaultWithdrawEvent } from "@/handlers/events/yieldVault/withdraw.event.handler"
+export { handleVaultTransferEvent } from "@/handlers/events/yieldVault/transfer.event.handler"
 export { handleVaultSnapshotIndexing } from "@/handlers/events/yieldVault/snapshot.block.handler"
 
 export { handleRelayerRewardedEvent } from "@/handlers/events/incentives/relayerRewarded.event.handler"

--- a/sdk/packages/indexer/src/services/__tests__/yieldVault.service.test.ts
+++ b/sdk/packages/indexer/src/services/__tests__/yieldVault.service.test.ts
@@ -1,0 +1,413 @@
+;(global as any).logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+
+const records = new Map<string, any>()
+const rows = (entity: string) =>
+	[...records.entries()].filter(([key]) => key.startsWith(`${entity}:`)).map(([, row]) => row)
+;(global as any).store = {
+	get: jest.fn(async (entity: string, id: string) => records.get(`${entity}:${id}`)),
+	set: jest.fn(async (entity: string, id: string, props: any) => records.set(`${entity}:${id}`, { ...props })),
+	getByFields: jest.fn(async (entity: string, filters: [string, string, any][], options: any) =>
+		rows(entity)
+			.filter((row) => filters.every(([field, , value]) => row[field] === value))
+			.sort((a, b) => a.id.localeCompare(b.id))
+			.slice(options.offset ?? 0, (options.offset ?? 0) + options.limit),
+	),
+}
+
+const balances = new Map<string, bigint>()
+let price: (shares: bigint) => bigint = (shares) => shares
+const mockContract = {
+	balanceOf: jest.fn(async (lp: string) => (balances.get(lp) ?? 0n).toString()),
+	convertToAssets: jest.fn(async (shares: any) => price(BigInt(shares.toString())).toString()),
+	totalAssets: jest.fn(async () => "1000000"),
+	totalSupply: jest.fn(async () => "1000000"),
+	decimals: jest.fn(async () => 6),
+}
+jest.mock("ethers", () => {
+	const actual = jest.requireActual("ethers")
+	return { ...actual, ethers: { ...actual.ethers, Contract: jest.fn(() => mockContract) } }
+})
+jest.mock("@/utils/vaultAccounting", () => ({
+	...jest.requireActual("@/utils/vaultAccounting"),
+	readVaultBlockMovements: jest.fn(async () => []),
+}))
+jest.mock("@/services/inventoryReading.service", () => ({ publishProviderInventory: jest.fn() }))
+jest.mock("@/utils/solverBalance", () => ({ inventoryReadContext: jest.fn(() => ({})) }))
+
+import { ethers } from "ethers"
+import { VaultLedgerEventType as Type } from "@/configs/src/types"
+import {
+	YieldVaultService as Service,
+	type VaultLedgerInput,
+	type VaultTransferInput,
+} from "@/services/yieldVault.service"
+import { readVaultBlockMovements } from "@/utils/vaultAccounting"
+import { publishProviderInventory } from "@/services/inventoryReading.service"
+
+const CHAIN = "EVM-8453"
+const VAULT = "0xc768c589647798a6ee01a91fde98ef2ed046dbd6"
+const TOKEN = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+const LP = "0xce319986ca4d5d0893751a628d0db3dc8fc91d62"
+const OTHER = "0x13e41cde1d55880cbe031c69f206c2e9bc3c94c2"
+const THIRD = "0x18f23e630077b1da3ed97c0469d0504a93fad9e2"
+const position = (lp = LP) => records.get(`VaultLpPosition:${CHAIN}-${VAULT}-${lp}`)
+const getSnapshot = (lp = LP) => rows("VaultPositionSnapshot").find((row) => row.lp === lp)
+const movements = jest.mocked(readVaultBlockMovements)
+
+function ledger(overrides: Partial<VaultLedgerInput> = {}): VaultLedgerInput {
+	return {
+		chain: CHAIN,
+		vault: VAULT,
+		lp: LP,
+		caller: LP,
+		assets: 20n,
+		shares: 20n,
+		eventType: Type.DEPOSIT,
+		blockNumber: 50n,
+		transactionHash: "0xabc",
+		logIndex: 2,
+		timestamp: 86400n,
+		...overrides,
+	}
+}
+function transfer(overrides: Partial<VaultTransferInput> = {}): VaultTransferInput {
+	return {
+		chain: CHAIN,
+		vault: VAULT,
+		from: OTHER,
+		to: LP,
+		shares: 100n,
+		blockNumber: 50n,
+		transactionHash: "0xdef",
+		logIndex: 3,
+		timestamp: 86400n,
+		...overrides,
+	}
+}
+function blockEvents(...events: VaultLedgerInput[]): void {
+	movements.mockResolvedValue(
+		events.map((e) => ({
+			transactionHash: e.transactionHash,
+			logIndex: e.logIndex,
+			lp: e.lp,
+			shares: e.eventType === Type.DEPOSIT || e.eventType === Type.TRANSFER_IN ? e.shares : -e.shares,
+		})),
+	)
+}
+function legacy(lp = LP, shares = 100n, deposited = 100n): void {
+	const id = `${CHAIN}-${VAULT}-${lp}`
+	records.set(`VaultLpPosition:${id}`, {
+		id,
+		chain: CHAIN,
+		vault: VAULT,
+		underlyingToken: TOKEN,
+		lp,
+		shares,
+		totalAssetsDeposited: deposited,
+		totalAssetsWithdrawn: 0n,
+		depositCount: 1,
+		withdrawCount: 0,
+		createdAt: new Date(0),
+		lastUpdatedAt: new Date(0),
+	})
+	balances.set(lp, shares)
+}
+async function snapshot(): Promise<void> {
+	movements.mockResolvedValue([])
+	await Service.snapshotChain(CHAIN, 100n, 86500n)
+}
+
+beforeEach(() => {
+	jest.clearAllMocks()
+	jest.restoreAllMocks()
+	records.clear()
+	balances.clear()
+	price = (shares) => shares
+	movements.mockReset().mockResolvedValue([])
+	mockContract.balanceOf.mockReset().mockImplementation(async (lp) => (balances.get(lp) ?? 0n).toString())
+	mockContract.convertToAssets
+		.mockReset()
+		.mockImplementation(async (shares) => price(BigInt(shares.toString())).toString())
+	;(global as any).api = { getCode: jest.fn(async () => "0x") }
+	jest.spyOn(Service, "configuredVaults").mockReturnValue([{ vault: VAULT, underlyingToken: TOKEN }])
+	records.set(`LiquidityProvider:${LP}`, { id: LP })
+})
+
+it("seeds shares received before delegation as opening capital at the first tracked event", async () => {
+	records.delete(`LiquidityProvider:${LP}`)
+	await Service.recordTransfer(transfer())
+	expect(position()).toBeUndefined()
+	;(global as any).api.getCode.mockResolvedValue("0xef01007cb55539d1144f62422099c3fa3405092022c88c")
+	balances.set(LP, 1020n)
+	blockEvents(ledger())
+	await Service.recordLedger(ledger())
+	expect(position()).toMatchObject({
+		openingShares: 1000n,
+		openingPrincipal: 1000n,
+		openingBlock: 50n,
+		shares: 1020n,
+		totalAssetsDeposited: 20n,
+		depositCount: 1,
+	})
+	price = (shares) => (shares * 101n) / 100n
+	await snapshot()
+	expect(getSnapshot()).toMatchObject({ netPrincipal: 1020n, assetValue: 1030n, yieldEarned: 10n })
+})
+
+it("backs out all later same-block movements when establishing the opening balance", async () => {
+	const deposit = ledger()
+	const incoming = ledger({ eventType: Type.TRANSFER_IN, shares: 30n, assets: 30n, logIndex: 4 })
+	const withdrawal = ledger({ eventType: Type.WITHDRAW, shares: 10n, assets: 10n, logIndex: 6 })
+	balances.set(LP, 1040n)
+	blockEvents(deposit, incoming, withdrawal)
+	await Service.recordLedger(deposit)
+	await Service.recordLedger(incoming)
+	await Service.recordLedger(withdrawal)
+	expect(position()).toMatchObject({
+		openingShares: 1000n,
+		openingPrincipal: 1000n,
+		shares: 1040n,
+		totalAssetsDeposited: 20n,
+		totalAssetsWithdrawn: 10n,
+		totalAssetsTransferredIn: 30n,
+	})
+	await snapshot()
+	expect(getSnapshot().yieldEarned).toBe(0n)
+})
+
+it("establishes opening capital even when the first tracked event withdraws the entire position", async () => {
+	const withdrawal = ledger({ eventType: Type.WITHDRAW, assets: 110n, shares: 100n })
+	price = (shares) => (shares * 110n) / 100n
+	blockEvents(withdrawal)
+	await Service.recordLedger(withdrawal)
+	expect(position()).toMatchObject({
+		openingShares: 100n,
+		openingPrincipal: 110n,
+		shares: 0n,
+		totalAssetsWithdrawn: 110n,
+		totalAssetsDeposited: 0n,
+	})
+	await snapshot()
+	expect(getSnapshot().yieldEarned).toBe(0n)
+})
+
+it("rejects impossible opening balances without recording the event", async () => {
+	blockEvents(ledger())
+	await expect(Service.recordLedger(ledger())).rejects.toThrow("Negative vault opening shares")
+	expect(rows("VaultLedgerEvent")).toHaveLength(0)
+	expect(position()).toBeUndefined()
+})
+
+it("keeps the reported wallet's transferred USDC principal out of yield", async () => {
+	legacy(LP, 0n, 0n)
+	const values = new Map([
+		[174220559508n, 199506902673n],
+		[57243722070n, 65552073822n],
+		[231481948014n, 265087704647n],
+	])
+	price = (shares) => values.get(shares) ?? shares
+	await Service.recordTransfer(transfer({ shares: 174220559508n }))
+	await Service.recordTransfer(transfer({ from: THIRD, shares: 57243722070n, logIndex: 4 }))
+	await Service.recordLedger(ledger({ assets: 20230586n, shares: 17666436n, logIndex: 5 }))
+	balances.set(LP, 231481948014n)
+	await snapshot()
+	expect(position()).toMatchObject({
+		shares: 231481948014n,
+		totalAssetsDeposited: 20230586n,
+		totalAssetsTransferredIn: 265058976495n,
+	})
+	expect(getSnapshot()).toMatchObject({ netPrincipal: 265079207081n, yieldEarned: 8497566n })
+})
+
+it("accounts for both tracked owners once and preserves earned yield when all shares leave", async () => {
+	legacy(OTHER, 100n, 100n)
+	price = (shares) => (shares * 110n) / 100n
+	balances.set(OTHER, 0n)
+	balances.set(LP, 100n)
+	const event = transfer()
+	blockEvents(
+		ledger({
+			lp: LP,
+			eventType: Type.TRANSFER_IN,
+			shares: 100n,
+			transactionHash: event.transactionHash,
+			logIndex: 3,
+		}),
+		ledger({
+			lp: OTHER,
+			eventType: Type.TRANSFER_OUT,
+			shares: 100n,
+			transactionHash: event.transactionHash,
+			logIndex: 3,
+		}),
+	)
+	await Service.recordTransfer(event)
+	await Service.recordTransfer(event)
+	expect(rows("VaultLedgerEvent")).toHaveLength(2)
+	expect(position(OTHER)).toMatchObject({ shares: 0n, totalAssetsTransferredOut: 110n, withdrawCount: 0 })
+	expect(position()).toMatchObject({
+		shares: 100n,
+		openingPrincipal: 0n,
+		totalAssetsTransferredIn: 110n,
+		depositCount: 0,
+	})
+	expect(publishProviderInventory).toHaveBeenCalledTimes(2)
+	await snapshot()
+	expect(getSnapshot(OTHER).yieldEarned).toBe(10n)
+	expect(getSnapshot().yieldEarned).toBe(0n)
+})
+
+it.each([{ from: ethers.constants.AddressZero }, { to: ethers.constants.AddressZero }, { from: LP }, { shares: 0n }])(
+	"ignores mint, burn, self and zero-share transfers: %p",
+	async (overrides) => {
+		await Service.recordTransfer(transfer(overrides))
+		expect(rows("VaultLedgerEvent")).toHaveLength(0)
+		expect(mockContract.convertToAssets).not.toHaveBeenCalled()
+	},
+)
+
+it("counts mint/deposit and burn/withdraw only once", async () => {
+	balances.set(LP, 20n)
+	blockEvents(ledger())
+	await Service.recordTransfer(transfer({ from: ethers.constants.AddressZero, shares: 20n }))
+	await Service.recordLedger(ledger())
+	await Service.recordLedger(ledger())
+	await Service.recordTransfer(transfer({ from: LP, to: ethers.constants.AddressZero, shares: 20n }))
+	await Service.recordLedger(ledger({ eventType: Type.WITHDRAW, logIndex: 10 }))
+	expect(position()).toMatchObject({
+		shares: 0n,
+		totalAssetsDeposited: 20n,
+		totalAssetsWithdrawn: 20n,
+		totalAssetsTransferredIn: 0n,
+		totalAssetsTransferredOut: 0n,
+		depositCount: 1,
+		withdrawCount: 1,
+	})
+})
+
+it("does not persist an event if the opening balance RPC is incomplete, then succeeds on retry", async () => {
+	balances.set(LP, 20n)
+	await expect(Service.recordLedger(ledger())).rejects.toThrow("missing the triggering log")
+	expect(rows("VaultLedgerEvent")).toHaveLength(0)
+	expect(position()).toBeUndefined()
+	blockEvents(ledger())
+	await Service.recordLedger(ledger())
+	expect(position().shares).toBe(20n)
+})
+
+it("retries delegation RPC failures instead of silently discarding a transfer", async () => {
+	;(global as any).api.getCode.mockRejectedValue(new Error("RPC unavailable"))
+	await expect(Service.recordTransfer(transfer())).rejects.toThrow("RPC unavailable")
+	expect(rows("VaultLedgerEvent")).toHaveLength(0)
+})
+
+it("withholds snapshots for unexplained legacy share balances", async () => {
+	legacy(LP, 17666436n, 20230586n)
+	legacy(OTHER)
+	balances.set(LP, 231481948014n)
+	await snapshot()
+	expect(getSnapshot()).toBeUndefined()
+	expect(getSnapshot(OTHER)).toBeDefined()
+	expect(rows("VaultSnapshot")).toHaveLength(1)
+	expect((global as any).logger.error).toHaveBeenCalledWith(
+		expect.stringContaining("principal requires reconciliation"),
+	)
+})
+
+it("defers snapshots before same-block logs even when their net share movement is zero", async () => {
+	legacy()
+	blockEvents(
+		ledger({ assets: 10n, shares: 10n }),
+		ledger({ eventType: Type.WITHDRAW, assets: 11n, shares: 10n, logIndex: 4 }),
+	)
+	await Service.snapshotChain(CHAIN, 50n, 86400n)
+	expect(getSnapshot()).toBeUndefined()
+	expect(rows("VaultSnapshot")).toHaveLength(0)
+	await Service.recordLedger(ledger({ assets: 10n, shares: 10n }))
+	await Service.recordLedger(ledger({ eventType: Type.WITHDRAW, assets: 11n, shares: 10n, logIndex: 4 }))
+	await snapshot()
+	expect(getSnapshot().yieldEarned).toBe(1n)
+	expect(rows("VaultSnapshot")).toHaveLength(1)
+})
+
+it("retries failed LP snapshots without rewriting already completed LPs", async () => {
+	legacy()
+	legacy(OTHER)
+	mockContract.balanceOf.mockImplementation(async (lp) => {
+		if (lp === OTHER) throw new Error("RPC unavailable")
+		return "100"
+	})
+	await snapshot()
+	expect(getSnapshot()).toBeDefined()
+	expect(getSnapshot(OTHER)).toBeUndefined()
+	expect(rows("VaultSnapshot")).toHaveLength(0)
+	mockContract.balanceOf.mockResolvedValue("100")
+	price = (shares) => shares * 2n
+	await snapshot()
+	expect(getSnapshot().yieldEarned).toBe(0n)
+	expect(getSnapshot(OTHER).yieldEarned).toBe(100n)
+	expect(rows("VaultSnapshot")).toHaveLength(1)
+})
+
+it("preserves genuine losses instead of clamping yield to zero", async () => {
+	legacy()
+	price = (shares) => (shares * 9n) / 10n
+	await snapshot()
+	expect(getSnapshot().yieldEarned).toBe(-10n)
+})
+
+it("does not repeat transfer valuation after both owners' ledger entries already exist", async () => {
+	legacy(OTHER)
+	legacy(LP, 0n, 0n)
+	await Service.recordTransfer(transfer())
+	mockContract.convertToAssets.mockRejectedValueOnce(new Error("RPC unavailable"))
+	await expect(Service.recordTransfer(transfer())).resolves.toBeUndefined()
+	expect(rows("VaultLedgerEvent")).toHaveLength(2)
+})
+
+it("keeps principal when best-effort inventory publication fails", async () => {
+	legacy()
+	jest.mocked(publishProviderInventory).mockRejectedValueOnce(new Error("inventory RPC unavailable"))
+	await Service.recordLedger(ledger())
+	expect(position()).toMatchObject({ shares: 120n, totalAssetsDeposited: 120n })
+	expect(rows("VaultLedgerEvent")).toHaveLength(1)
+})
+
+it("ignores unknown chains and vaults without reading balances or writing accounting", async () => {
+	await Service.recordLedger(ledger({ chain: "EVM-999" }))
+	await Service.recordLedger(ledger({ vault: OTHER }))
+	await Service.recordTransfer(transfer({ vault: OTHER }))
+	expect(rows("VaultLedgerEvent")).toHaveLength(0)
+	expect(mockContract.balanceOf).not.toHaveBeenCalled()
+})
+
+it.each(["0x", "0x60006000", "0xef0100" + "ab".repeat(20), "0xef0100"])(
+	"rejects unrelated or malformed delegations: %s",
+	async (code) => {
+		;(global as any).api.getCode.mockResolvedValue(code)
+		expect(await Service.isDelegatedSolver(CHAIN, OTHER)).toBe(false)
+	},
+)
+
+it("matches configured vaults and SolverAccount addresses case-insensitively", async () => {
+	jest.mocked(Service.configuredVaults).mockRestore()
+	expect(Service.configuredVaults("EVM-999")).toEqual([])
+	expect(Service.configuredVaults(CHAIN)).toContainEqual({ vault: VAULT, underlyingToken: TOKEN })
+	expect(Service.underlyingTokenFor(CHAIN, ethers.utils.getAddress(VAULT))).toBe(TOKEN)
+	;(global as any).api.getCode.mockResolvedValue("0xEF01007CB55539D1144F62422099C3FA3405092022C88C")
+	expect(await Service.isDelegatedSolver(CHAIN, LP)).toBe(true)
+	expect(await Service.isDelegatedSolver("EVM-999", LP)).toBe(false)
+})
+
+it.each([new Error("vault RPC unavailable"), "vault RPC unavailable"])(
+	"does not close the daily gate after a vault RPC failure: %p",
+	async (error) => {
+		legacy()
+		movements.mockRejectedValueOnce(error)
+		await Service.snapshotChain(CHAIN, 100n, 86500n)
+		expect(getSnapshot()).toBeUndefined()
+		expect(rows("VaultSnapshot")).toHaveLength(0)
+		await snapshot()
+		expect(getSnapshot()).toBeDefined()
+	},
+)

--- a/sdk/packages/indexer/src/services/__tests__/yieldVault.stress.test.ts
+++ b/sdk/packages/indexer/src/services/__tests__/yieldVault.stress.test.ts
@@ -1,0 +1,635 @@
+import fs from "node:fs"
+import path from "node:path"
+
+// Exercise the actual handlers, generated models, ABI decoder and single-block log reader.
+// Only the store, RPC boundary and unrelated inventory publisher are replaced. The reference
+// model maintains onchain shares and cash flows independently of the indexer's ledger fields.
+const records = new Map<string, any>()
+const rows = (entity: string) =>
+	[...records.entries()].filter(([key]) => key.startsWith(`${entity}:`)).map(([, row]) => row)
+const mockState = new Map<
+	string,
+	{ shares: Map<string, bigint>; cash: Map<string, bigint>; numerator: bigint; denominator: bigint }
+>()
+const mockCodes = new Map<string, string>()
+const mockContract = (vault: string) => {
+	const state = mockState.get(`EVM-${(global as any).chainId}:${vault.toLowerCase()}`)!
+	return {
+		balanceOf: async (lp: string) => (state.shares.get(lp.toLowerCase()) ?? 0n).toString(),
+		convertToAssets: async (shares: any) =>
+			((BigInt(shares.toString()) * state.numerator) / state.denominator).toString(),
+		totalAssets: async () => "1000000000000",
+		totalSupply: async () => "1000000000000",
+		decimals: async () => (state.denominator === 10n ** 12n ? 18 : 6),
+	}
+}
+jest.mock("ethers", () => {
+	const actual = jest.requireActual("ethers")
+	return { ...actual, ethers: { ...actual.ethers, Contract: jest.fn((vault) => mockContract(vault)) } }
+})
+jest.mock("@/constants", () => ({
+	ENV_CONFIG: { "EVM-8453": "https://base.example", "EVM-42161": "https://arb.example" },
+}))
+jest.mock("@/utils/rpc.helpers", () => ({
+	getBlockTimestamp: jest.fn(),
+	replaceWebsocketWithHttp: (url: string) => url,
+}))
+jest.mock("@/utils/substrate.helpers", () => ({ getHostStateMachine: (chain: string) => `EVM-${chain}` }))
+jest.mock("@/utils/safeFetch", () => ({ safeFetch: jest.fn() }))
+jest.mock("@/services/inventoryReading.service", () => ({ publishProviderInventory: jest.fn() }))
+jest.mock("@/utils/solverBalance", () => ({ inventoryReadContext: jest.fn(() => ({})) }))
+
+import { ethers } from "ethers"
+import Erc4626Abi from "@/configs/abis/Erc4626.abi.json"
+import { YieldVaultService as Service } from "@/services/yieldVault.service"
+import { handleVaultDepositEvent } from "@/handlers/events/yieldVault/deposit.event.handler"
+import { handleVaultWithdrawEvent } from "@/handlers/events/yieldVault/withdraw.event.handler"
+import { handleVaultTransferEvent } from "@/handlers/events/yieldVault/transfer.event.handler"
+import { handleVaultSnapshotIndexing } from "@/handlers/events/yieldVault/snapshot.block.handler"
+import { getBlockTimestamp } from "@/utils/rpc.helpers"
+import { safeFetch } from "@/utils/safeFetch"
+import { wrap } from "@/utils/event.utils"
+
+const BASE = "EVM-8453"
+const ARB = "EVM-42161"
+const USDC = "0xc768c589647798a6ee01a91fde98ef2ed046dbd6"
+const CNGN = "0xa82a3531021317240fb32e67f9c7bc091f737d3b"
+const ARB_USDC = "0x7f6501d3b98ee91f9b9535e4b0ac710fb0f9e0bc"
+const TOKEN = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+const address = (i: number) => `0x${i.toString(16).padStart(40, "0")}`
+const A = address(1),
+	B = address(2),
+	C = address(3),
+	ROUTER = address(9)
+const ZERO = ethers.constants.AddressZero
+const abi = new ethers.utils.Interface(Erc4626Abi)
+let height = 100
+let day = 20000n
+let logs: any[] = []
+let timestamp = day * 86400n
+const state = (vault = USDC, chain = BASE) => mockState.get(`${chain}:${vault}`)!
+const position = (lp: string, vault = USDC, chain = BASE) => records.get(`VaultLpPosition:${chain}-${vault}-${lp}`)
+const latest = (lp: string, vault = USDC, chain = BASE) =>
+	rows("VaultPositionSnapshot")
+		.filter((row) => row.lp === lp && row.vault === vault && row.chain === chain)
+		.sort((x, y) => Number(y.dayStartTimestamp - x.dayStartTimestamp))[0]
+const register = (lp: string) => records.set(`LiquidityProvider:${lp}`, { id: lp })
+const value = (shares: bigint, vault = USDC, chain = BASE) =>
+	(shares * state(vault, chain).numerator) / state(vault, chain).denominator
+const ceil = (n: bigint, d: bigint) => (n + d - 1n) / d
+
+type Action = {
+	kind: "deposit" | "mint" | "withdraw" | "redeem" | "share" | "token"
+	lp?: string
+	from?: string
+	to?: string
+	caller?: string
+	amount: bigint
+	vault?: string
+}
+
+function prepare(actions: Action[], chain = BASE): any[] {
+	height++
+	;(global as any).chainId = chain.slice(4)
+	timestamp = day * 86400n + BigInt(height)
+	logs = []
+	for (const [i, action] of actions.entries()) {
+		const vault = action.vault ?? USDC
+		const s = state(vault, chain)
+		const lp = action.lp ?? A
+		const caller = action.caller ?? lp
+		const receiver = action.to ?? lp
+		const tx = `0x${(height * 1000 + i).toString(16).padStart(64, "0")}`
+		const emit = (name: string, args: any[], contract = vault) =>
+			logs.push({
+				...abi.encodeEventLog(abi.getEvent(name), args),
+				address: contract,
+				transactionHash: tx,
+				blockNumber: height,
+				blockHash: `0x${height.toString(16).padStart(64, "0")}`,
+				logIndex: logs.length,
+			})
+		const change = (owner: string, shares: bigint, cash: bigint) => {
+			s.shares.set(owner, (s.shares.get(owner) ?? 0n) + shares)
+			s.cash.set(owner, (s.cash.get(owner) ?? 0n) + cash)
+			if (s.shares.get(owner)! < 0n) throw new Error("invalid test action: insufficient shares")
+		}
+		if (action.kind === "token") {
+			// Plain underlying-token transfers never touch the vault share supply or LP cash basis.
+			emit("Transfer", [action.from ?? A, receiver, action.amount], TOKEN)
+		} else if (action.kind === "share") {
+			const from = action.from ?? A
+			const assets = value(action.amount, vault, chain)
+			change(from, -action.amount, -assets)
+			change(receiver, action.amount, assets)
+			emit("Transfer", [from, receiver, action.amount])
+		} else if (action.kind === "deposit" || action.kind === "mint") {
+			const shares = action.kind === "mint" ? action.amount : (action.amount * s.denominator) / s.numerator
+			const assets = action.kind === "deposit" ? action.amount : ceil(shares * s.numerator, s.denominator)
+			change(lp, shares, assets)
+			emit("Transfer", [ZERO, lp, shares])
+			emit("Deposit", [caller, lp, assets, shares])
+		} else {
+			const shares = action.kind === "redeem" ? action.amount : ceil(action.amount * s.denominator, s.numerator)
+			const assets = action.kind === "withdraw" ? action.amount : value(shares, vault, chain)
+			change(lp, -shares, -assets)
+			emit("Transfer", [lp, ZERO, shares])
+			emit("Withdraw", [caller, receiver, lp, assets, shares])
+			// ERC-20 underlying Transfer emitted by the redemption is not a share transfer.
+			emit("Transfer", [vault, receiver, assets], TOKEN)
+		}
+	}
+	return logs
+}
+
+async function dispatch(blockLogs = logs): Promise<void> {
+	for (const log of blockLogs) {
+		if (!Service.underlyingTokenFor(`EVM-${(global as any).chainId}`, log.address)) continue
+		const decoded = abi.parseLog(log)
+		const event = { ...log, args: decoded.args }
+		if (decoded.name === "Deposit") await handleVaultDepositEvent(event as any)
+		else if (decoded.name === "Withdraw") await handleVaultWithdrawEvent(event as any)
+		else await handleVaultTransferEvent(event as any)
+	}
+}
+async function block(actions: Action[], chain = BASE): Promise<void> {
+	prepare(actions, chain)
+	await dispatch()
+}
+async function snapshot(chain = BASE, nextDay = true): Promise<void> {
+	if (nextDay) day++
+	prepare([], chain)
+	await handleVaultSnapshotIndexing({ number: height, timestamp } as any)
+}
+function checkOracle(vault = USDC, chain = BASE): void {
+	for (const [lp, cash] of state(vault, chain).cash) {
+		const p = position(lp, vault, chain)
+		if (!p) continue
+		expect(p.shares).toBe(state(vault, chain).shares.get(lp))
+		expect(latest(lp, vault, chain)).toMatchObject({
+			assetValue: value(p.shares, vault, chain),
+			netPrincipal: cash,
+			yieldEarned: value(p.shares, vault, chain) - cash,
+		})
+	}
+}
+
+beforeEach(() => {
+	jest.restoreAllMocks()
+	jest.clearAllMocks()
+	records.clear()
+	mockState.clear()
+	mockCodes.clear()
+	height = 100
+	day = 20000n
+	logs = []
+	;(global as any).chainId = "8453"
+	;(global as any).logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+	;(global as any).api = { getCode: jest.fn(async (lp: string) => mockCodes.get(lp) ?? "0x") }
+	;(global as any).store = {
+		get: jest.fn(async (entity: string, id: string) => records.get(`${entity}:${id}`)),
+		set: jest.fn(async (entity: string, id: string, props: any) => records.set(`${entity}:${id}`, { ...props })),
+		getByFields: jest.fn(async (entity: string, filters: [string, string, any][], options: any) =>
+			rows(entity)
+				.filter((row) => filters.every(([field, , v]) => row[field] === v))
+				.sort((x, y) => x.id.localeCompare(y.id))
+				.slice(options.offset ?? 0, (options.offset ?? 0) + options.limit),
+		),
+	}
+	for (const [chain, vault] of [
+		[BASE, USDC],
+		[BASE, CNGN],
+		[ARB, ARB_USDC],
+	]) {
+		mockState.set(`${chain}:${vault}`, { shares: new Map(), cash: new Map(), numerator: 1n, denominator: 1n })
+	}
+	jest.spyOn(Service, "configuredVaults").mockImplementation((chain) =>
+		(chain === BASE ? [USDC, CNGN] : [ARB_USDC]).map((vault) => ({
+			vault,
+			underlyingToken: Service.underlyingTokenFor(chain, vault)!,
+		})),
+	)
+	jest.mocked(getBlockTimestamp)
+		.mockReset()
+		.mockImplementation(async () => timestamp)
+	jest.mocked(safeFetch)
+		.mockReset()
+		.mockImplementation(async (_url, options) => {
+			const filter = JSON.parse(options!.body!).params[0]
+			expect(filter.fromBlock).toBe(`0x${height.toString(16)}`)
+			expect(filter.toBlock).toBe(filter.fromBlock)
+			return {
+				ok: true,
+				json: async () => ({
+					result: logs
+						.filter((log) => log.address === filter.address)
+						.map((log) => ({
+							...log,
+							blockNumber: `0x${log.blockNumber.toString(16)}`,
+							logIndex: `0x${log.logIndex.toString(16)}`,
+						})),
+				}),
+			} as any
+		})
+	for (const lp of [A, B, C]) register(lp)
+})
+
+it("mints, deposits, partially withdraws, redeems fully, then deposits again without losing earned yield", async () => {
+	await block([
+		{ kind: "deposit", amount: 1000n },
+		{ kind: "mint", amount: 100n },
+	])
+	state().numerator = 11n
+	state().denominator = 10n
+	await block([{ kind: "withdraw", amount: 330n, caller: ROUTER, to: B }])
+	await snapshot()
+	checkOracle()
+	expect(latest(A).yieldEarned).toBe(110n)
+	await block([{ kind: "redeem", amount: 800n }])
+	await snapshot()
+	expect(latest(A)).toMatchObject({ shares: 0n, yieldEarned: 110n })
+	await block([{ kind: "deposit", amount: 110n }])
+	await snapshot()
+	checkOracle()
+	expect(position(B)).toBeUndefined()
+	expect(position(ROUTER)).toBeUndefined()
+	expect(position(A)).toMatchObject({
+		depositCount: 3,
+		withdrawCount: 2,
+		totalAssetsTransferredIn: 0n,
+		totalAssetsTransferredOut: 0n,
+	})
+})
+
+it.each([0n, 500n])(
+	"Simplex redeem-to-recipient changes only the owner's principal (recipient starts with %s shares)",
+	async (initial) => {
+		await block([
+			{ kind: "deposit", lp: A, amount: 1000n },
+			...(initial ? [{ kind: "deposit" as const, lp: B, amount: initial }] : []),
+		])
+		state().numerator = 12n
+		state().denominator = 10n
+		await block([{ kind: "redeem", lp: A, amount: 200n, to: B }])
+		await snapshot()
+		checkOracle()
+		expect(latest(A).yieldEarned).toBe(200n)
+		expect(position(A).totalAssetsWithdrawn).toBe(240n)
+		if (initial) expect(latest(B)).toMatchObject({ shares: 500n, netPrincipal: 500n, yieldEarned: 100n })
+		else expect(position(B)).toBeUndefined()
+		// Receiving underlying and later sweeping it creates exactly one new deposit.
+		await block([{ kind: "deposit", lp: B, amount: 240n }])
+		await snapshot()
+		checkOracle()
+		expect(position(B).totalAssetsDeposited).toBe(initial + 240n)
+	},
+)
+
+it.each([0n, 500n])(
+	"direct share transfers preserve both owners' prior yield (recipient starts with %s shares)",
+	async (initial) => {
+		await block([
+			{ kind: "deposit", lp: A, amount: 1000n },
+			...(initial ? [{ kind: "deposit" as const, lp: B, amount: initial }] : []),
+		])
+		state().numerator = 12n
+		state().denominator = 10n
+		await block([{ kind: "share", from: A, to: B, amount: 200n }])
+		await snapshot()
+		checkOracle()
+		expect(latest(A).yieldEarned).toBe(200n)
+		expect(latest(B).yieldEarned).toBe(initial / 5n)
+		expect(position(B).totalAssetsTransferredIn).toBe(240n)
+		await block([{ kind: "share", from: B, to: A, amount: 100n }])
+		await snapshot()
+		checkOracle()
+	},
+)
+
+it("raw underlying sends and paymaster charges leave existing vault principal alone", async () => {
+	await block([{ kind: "deposit", amount: 1000n }])
+	const before = { ...position(A) }
+	await block([
+		{ kind: "token", from: A, to: B, amount: 999999n },
+		{ kind: "token", from: B, to: A, amount: 500n },
+		{ kind: "token", from: A, to: ROUTER, amount: 1n },
+	])
+	expect(position(A)).toEqual(before)
+	expect(position(B)).toBeUndefined()
+	await snapshot()
+	checkOracle()
+})
+
+it("Simplex withdraw-shortfall plus underlying transfer and later sweep counts each vault event once", async () => {
+	await block([{ kind: "deposit", amount: 1000n }])
+	state().numerator = 11n
+	state().denominator = 10n
+	await block([
+		{ kind: "withdraw", amount: 220n },
+		{ kind: "token", from: A, to: B, amount: 300n },
+		{ kind: "deposit", lp: B, amount: 220n },
+	])
+	await snapshot()
+	checkOracle()
+	expect(latest(A).yieldEarned).toBe(100n)
+	expect(latest(B).yieldEarned).toBe(0n)
+})
+
+it("attributes third-party deposits to the share owner and third-party withdrawals to the burned-share owner", async () => {
+	await block([{ kind: "deposit", lp: B, caller: ROUTER, amount: 1000n }])
+	state().numerator = 11n
+	state().denominator = 10n
+	await block([{ kind: "withdraw", lp: B, caller: ROUTER, to: C, amount: 110n }])
+	await snapshot()
+	checkOracle()
+	expect(latest(B).yieldEarned).toBe(100n)
+	for (const lp of [A, C, ROUTER]) expect(position(lp)).toBeUndefined()
+})
+
+it("retains an existing recipient's deposit/withdrawal history when shares are added and removed", async () => {
+	await block([
+		{ kind: "deposit", lp: A, amount: 1000n },
+		{ kind: "deposit", lp: B, amount: 500n },
+	])
+	state().numerator = 12n
+	state().denominator = 10n
+	await block([
+		{ kind: "withdraw", lp: B, amount: 120n },
+		{ kind: "share", from: A, to: B, amount: 200n },
+		{ kind: "deposit", lp: B, amount: 120n },
+		{ kind: "share", from: B, to: A, amount: 50n },
+	])
+	await snapshot()
+	checkOracle()
+	expect(position(B)).toMatchObject({
+		totalAssetsDeposited: 620n,
+		totalAssetsWithdrawn: 120n,
+		totalAssetsTransferredIn: 240n,
+		totalAssetsTransferredOut: 60n,
+		depositCount: 2,
+		withdrawCount: 1,
+	})
+	expect(latest(B).yieldEarned).toBe(100n)
+})
+
+it.each([
+	[true, true],
+	[true, false],
+	[false, true],
+	[false, false],
+])("tracks the eligible sides of a share transfer (sender=%s, recipient=%s)", async (sender, recipient) => {
+	if (!sender) records.delete(`LiquidityProvider:${A}`)
+	if (!recipient) records.delete(`LiquidityProvider:${B}`)
+	await block([{ kind: "deposit", lp: A, amount: 1000n }])
+	state().numerator = 12n
+	state().denominator = 10n
+	await block([{ kind: "share", from: A, to: B, amount: 100n }])
+	await snapshot()
+	checkOracle()
+	expect(!!position(A)).toBe(sender)
+	expect(!!position(B)).toBe(recipient)
+})
+
+it("uses a new opening basis for pre-delegation shares and continues tracking after delegation is revoked", async () => {
+	records.delete(`LiquidityProvider:${B}`)
+	await block([
+		{ kind: "deposit", lp: A, amount: 1000n },
+		{ kind: "share", from: A, to: B, amount: 200n },
+	])
+	expect(position(B)).toBeUndefined()
+	state().numerator = 12n
+	state().denominator = 10n
+	mockCodes.set(B, "0xef01007cb55539d1144f62422099c3fa3405092022c88c")
+	state().cash.set(B, 240n) // B's measurement starts here; pre-tracking appreciation is excluded.
+	await block([{ kind: "deposit", lp: B, amount: 120n }])
+	expect(position(B)).toMatchObject({ openingShares: 200n, openingPrincipal: 240n })
+	mockCodes.delete(B)
+	await block([
+		{ kind: "share", from: B, to: A, amount: 50n },
+		{ kind: "redeem", lp: B, amount: 250n },
+	])
+	await snapshot()
+	checkOracle()
+	expect(latest(B)).toMatchObject({ shares: 0n, yieldEarned: 0n })
+})
+
+it.each([handleVaultDepositEvent, handleVaultWithdrawEvent, handleVaultTransferEvent])(
+	"propagates undecodable capital events instead of acknowledging and losing them",
+	async (handler) => {
+		const event = {
+			get args(): never {
+				throw new Error("ABI decoding failed")
+			},
+		}
+		await expect(handler(event as any)).rejects.toThrow("ABI decoding failed")
+	},
+)
+
+it.each([handleVaultDepositEvent, handleVaultWithdrawEvent, handleVaultTransferEvent])(
+	"rejects missing decoded capital arguments instead of silently skipping the event",
+	async (handler) => {
+		await expect(handler({} as any)).rejects.toThrow("Missing decoded")
+	},
+)
+
+it("normalizes transaction hash casing for replay-safe ledger IDs", async () => {
+	prepare([{ kind: "deposit", amount: 1000n }])
+	for (const log of logs) log.transactionHash = `0x${"ab".repeat(32)}`
+	await dispatch()
+	await dispatch(logs.map((log) => ({ ...log, transactionHash: `0x${"AB".repeat(32)}` })))
+	expect(position(A)).toMatchObject({ shares: 1000n, totalAssetsDeposited: 1000n, depositCount: 1 })
+})
+
+it.each([
+	[ZERO, A, 100n],
+	[A, ZERO, 100n],
+	[A, A, 100n],
+	[A, B, 0n],
+])("ignores non-capital Transfer events before requesting timestamps (%s → %s, %s)", async (from, to, amount) => {
+	jest.mocked(getBlockTimestamp).mockRejectedValueOnce(new Error("timestamp RPC unavailable"))
+	const encoded = abi.encodeEventLog(abi.getEvent("Transfer"), [from, to, amount])
+	await expect(
+		handleVaultTransferEvent({
+			address: USDC,
+			args: abi.parseLog(encoded).args,
+			blockNumber: height,
+			blockHash: `0x${height.toString(16).padStart(64, "0")}`,
+			transactionHash: `0x${"ab".repeat(32)}`,
+			logIndex: 0,
+		} as any),
+	).resolves.toBeUndefined()
+	expect(getBlockTimestamp).not.toHaveBeenCalled()
+})
+
+it("handles multiple transactions and share round trips in one block, including new owners", async () => {
+	await block([
+		{ kind: "deposit", lp: A, amount: 1000n },
+		{ kind: "share", from: A, to: B, amount: 300n },
+		{ kind: "share", from: B, to: C, amount: 100n },
+		{ kind: "share", from: C, to: A, amount: 100n },
+		{ kind: "withdraw", lp: B, amount: 50n },
+		{ kind: "deposit", lp: A, amount: 100n },
+	])
+	await dispatch() // duplicate delivery of every log, including both sides of each transfer
+	await snapshot()
+	checkOracle()
+	for (const lp of [A, B, C]) expect(latest(lp).yieldEarned).toBe(0n)
+})
+
+it.each([USDC, CNGN])("respects rounding and distinct share/underlying decimals for %s", async (vault) => {
+	state(vault).numerator = 1003n
+	state(vault).denominator = vault === CNGN ? 10n ** 12n : 1000n
+	await block([
+		{ kind: "deposit", vault, amount: 1000001n },
+		{ kind: "mint", vault, lp: B, amount: 101n },
+	])
+	await block([
+		{ kind: "share", vault, from: A, to: B, amount: 1n },
+		{ kind: "withdraw", vault, amount: 333n },
+	])
+	await snapshot()
+	checkOracle(vault)
+	// Real floor/ceil loss remains signed; a zero-asset dust transfer still moves shares.
+	expect(latest(A, vault).yieldEarned).toBeLessThanOrEqual(0n)
+})
+
+it("isolates the same LP across two vaults and chains", async () => {
+	await block([
+		{ kind: "deposit", amount: 100n },
+		{ kind: "deposit", vault: CNGN, amount: 200n },
+	])
+	await block([{ kind: "deposit", vault: ARB_USDC, amount: 300n }], ARB)
+	state(CNGN).numerator = 2n
+	await block([{ kind: "share", from: A, to: B, vault: CNGN, amount: 50n }])
+	await snapshot()
+	await snapshot(ARB)
+	checkOracle()
+	checkOracle(CNGN)
+	checkOracle(ARB_USDC, ARB)
+	expect(latest(A).yieldEarned).toBe(0n)
+	expect(latest(A, CNGN).yieldEarned).toBe(200n)
+	expect(latest(A, ARB_USDC, ARB).yieldEarned).toBe(0n)
+})
+
+it("snapshots every LP across the store's 100-row page boundary", async () => {
+	const owners = Array.from({ length: 205 }, (_, i) => address(i + 100))
+	owners.forEach(register)
+	for (const lp of owners) await block([{ kind: "deposit", lp, amount: 1000n }])
+	await snapshot()
+	expect(rows("VaultPositionSnapshot")).toHaveLength(205)
+	checkOracle()
+})
+
+it("handles UTC day rollover and repeated daily snapshot invocations", async () => {
+	await block([{ kind: "deposit", amount: 1000n }])
+	await snapshot()
+	state().numerator = 2n
+	await snapshot(BASE, false)
+	expect(latest(A).yieldEarned).toBe(0n)
+	await snapshot()
+	expect(latest(A).yieldEarned).toBe(1000n)
+	expect(rows("VaultPositionSnapshot")).toHaveLength(2)
+})
+
+it("replays after a simulated block rollback without retaining orphaned principal", async () => {
+	await block([{ kind: "deposit", amount: 1000n }])
+	const beforeRecords = new Map([...records].map(([key, row]) => [key, { ...row }]))
+	const beforeShares = new Map(state().shares),
+		beforeCash = new Map(state().cash)
+	await block([{ kind: "share", from: A, to: B, amount: 200n }])
+	records.clear()
+	beforeRecords.forEach((row, key) => records.set(key, row))
+	state().shares = beforeShares
+	state().cash = beforeCash
+	height--
+	await block([{ kind: "share", from: A, to: C, amount: 300n }])
+	await snapshot()
+	checkOracle()
+	expect(position(B)).toBeUndefined()
+})
+
+it("retries both transfer sides after a simulated store failure and block rollback", async () => {
+	await block([
+		{ kind: "deposit", lp: A, amount: 1000n },
+		{ kind: "deposit", lp: B, amount: 500n },
+	])
+	const before = new Map([...records].map(([key, row]) => [key, { ...row }]))
+	prepare([{ kind: "share", from: A, to: B, amount: 200n }])
+	let fail = true
+	;(global as any).store.set.mockImplementation(async (entity: string, id: string, props: any) => {
+		if (fail && entity === "VaultLpPosition" && id.endsWith(B)) {
+			fail = false
+			throw new Error("store write failed")
+		}
+		records.set(`${entity}:${id}`, { ...props })
+	})
+	await expect(dispatch()).rejects.toThrow("store write failed")
+	// Model the indexer's transaction rollback, then replay the same canonical block.
+	records.clear()
+	before.forEach((row, key) => records.set(key, row))
+	await dispatch()
+	await snapshot()
+	checkOracle()
+	expect(rows("VaultLedgerEvent").filter((row) => row.eventType.startsWith("TRANSFER"))).toHaveLength(2)
+})
+
+it.each([new Error("store unavailable"), "store unavailable"])(
+	"logs a snapshot store failure and retries on the next invocation: %p",
+	async (error) => {
+		await block([{ kind: "deposit", amount: 1000n }])
+		;(global as any).store.getByFields.mockRejectedValueOnce(error)
+		await snapshot()
+		expect(latest(A)).toBeUndefined()
+		expect((global as any).logger.error).toHaveBeenCalledWith(expect.stringContaining("store unavailable"))
+		await snapshot(BASE, false)
+		checkOracle()
+	},
+)
+
+it("preserves the shared wrapper's default behavior for other indexer handlers", async () => {
+	const event = {
+		get args(): never {
+			throw new Error("bad ABI")
+		},
+	}
+	const handler = wrap(async (value: typeof event) => {
+		void value.args
+	})
+	await expect(handler(event)).resolves.toBeUndefined()
+	expect((global as any).logger.error).toHaveBeenCalledWith(expect.stringContaining("Error decoding event"))
+})
+
+it("registers only configured vault Transfer subscriptions in the manifest template", () => {
+	const template = fs.readFileSync(path.resolve(__dirname, "../../../scripts/templates/evm-chain.yaml.hbs"), "utf8")
+	const vaultSection = template.slice(
+		template.indexOf("{{#each yieldVaults}}"),
+		template.indexOf("{{/each}}", template.indexOf("{{#each yieldVaults}}")),
+	)
+	expect(vaultSection).toContain("address: '{{this.vault}}'")
+	for (const handler of ["handleVaultDepositEvent", "handleVaultWithdrawEvent", "handleVaultTransferEvent"])
+		expect(vaultSection).toContain(handler)
+})
+
+it.each(Array.from({ length: 25 }, (_, i) => i + 1))(
+	"matches independent cash-flow accounting across 120 generated actions (seed %i)",
+	async (seed) => {
+		let random = seed
+		const next = () => (random = (Math.imul(random, 1664525) + 1013904223) >>> 0)
+		await block([A, B, C].map((lp) => ({ kind: "deposit", lp, amount: 1000000n })))
+		for (let round = 0; round < 40; round++) {
+			state().numerator = BigInt(900 + (next() % 400))
+			state().denominator = 1000n
+			const actions: Action[] = []
+			for (let i = 0; i < 3; i++) {
+				const lp = [A, B, C][next() % 3]
+				const to = [A, B, C][next() % 3]
+				const kind = (["deposit", "mint", "withdraw", "redeem", "share", "token"] as const)[next() % 6]
+				actions.push({ kind, lp, from: lp, to, amount: BigInt((next() % 100) + 1) })
+			}
+			await block(actions)
+			if (round % 7 === 0) await dispatch()
+			await snapshot()
+			checkOracle()
+		}
+	},
+)

--- a/sdk/packages/indexer/src/services/yieldVault.service.ts
+++ b/sdk/packages/indexer/src/services/yieldVault.service.ts
@@ -15,6 +15,7 @@ import { SOLVER_ACCOUNT_ADDRESSES } from "@/solver-account-addresses"
 import { timestampToDate } from "@/utils/date.helpers"
 import { publishProviderInventory } from "@/services/inventoryReading.service"
 import { inventoryReadContext } from "@/utils/solverBalance"
+import { isOrdinaryVaultTransfer, readVaultBlockMovements, type VaultCapitalMovement } from "@/utils/vaultAccounting"
 
 const SECONDS_PER_DAY = 86400n
 
@@ -30,16 +31,16 @@ export interface ConfiguredVault {
 	underlyingToken: string
 }
 
-/** Inputs for recording one ERC-4626 Deposit or Withdraw event. */
+/** Inputs for recording one deposit, withdrawal or side of an ordinary share transfer. */
 export interface VaultLedgerInput {
 	chain: string
 	/** The vault address the event was emitted by (event.address). */
 	vault: string
 	/** The share owner whose principal moved (Deposit.owner / Withdraw.owner). */
 	lp: string
-	/** The address that initiated the call (Deposit.sender / Withdraw.sender). */
+	/** Deposit.sender / Withdraw.sender, or Transfer.from for ordinary share transfers. */
 	caller: string
-	/** For withdrawals, who received the assets (Withdraw.receiver). Omitted for deposits. */
+	/** Withdraw.receiver or Transfer.to. Omitted for deposits. */
 	receiver?: string
 	assets: bigint
 	shares: bigint
@@ -49,6 +50,20 @@ export interface VaultLedgerInput {
 	logIndex: number
 	/** Block timestamp in UNIX seconds. */
 	timestamp: bigint
+}
+
+export interface VaultTransferInput
+	extends Omit<VaultLedgerInput, "lp" | "caller" | "receiver" | "assets" | "eventType"> {
+	from: string
+	to: string
+}
+
+function isCapitalIn(type: VaultLedgerEventType): boolean {
+	return type === VaultLedgerEventType.DEPOSIT || type === VaultLedgerEventType.TRANSFER_IN
+}
+
+function capitalEventId(input: Pick<VaultLedgerInput, "chain" | "transactionHash" | "logIndex">, lp?: string): string {
+	return `${input.chain}-${input.transactionHash.toLowerCase()}-${input.logIndex}${lp ? `-${lp.toLowerCase()}` : ""}`
 }
 
 export class YieldVaultService {
@@ -75,7 +90,7 @@ export class YieldVaultService {
 		)
 	}
 
-	/** Whether `lp` is EIP-7702-delegated to one of the chain's SolverAccount contracts. Fails closed. */
+	/** Whether `lp` is delegated to one of our SolverAccounts at the handler's block. */
 	static async isDelegatedSolver(chain: string, lp: string): Promise<boolean> {
 		const solverAccounts = SOLVER_ACCOUNT_ADDRESSES[chain]
 		if (!solverAccounts?.length) return false
@@ -88,13 +103,83 @@ export class YieldVaultService {
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error)
 			logger.warn(`[yield-vault] Delegation check failed for ${lp} on ${chain}: ${message}`)
-			return false
+			// A failed RPC is not evidence that this is an unrelated wallet. Retry the block instead
+			// of permanently dropping a capital movement and overstating the next snapshot's yield.
+			throw error
+		}
+	}
+
+	private static async tracksLp(chain: string, vault: string, lp: string): Promise<boolean> {
+		return (
+			!!(await VaultLpPosition.get(`${chain}-${vault}-${lp}`)) ||
+			!!(await LiquidityProvider.get(lp)) ||
+			(await this.isDelegatedSolver(chain, lp))
+		)
+	}
+
+	/** A share transfer is capital moving between owners, valued at this block's exchange rate. */
+	static async recordTransfer(input: VaultTransferInput): Promise<void> {
+		const from = input.from.toLowerCase()
+		const to = input.to.toLowerCase()
+		const vault = input.vault.toLowerCase()
+		if (!isOrdinaryVaultTransfer(from, to, input.shares)) return
+		if (!this.underlyingTokenFor(input.chain, vault)) return
+		const owners: string[] = []
+		for (const lp of [from, to]) {
+			if (await VaultLedgerEvent.get(capitalEventId(input, lp))) continue
+			if (await this.tracksLp(input.chain, vault, lp)) owners.push(lp)
+		}
+		if (!owners.length) return
+		const contract = new ethers.Contract(vault, Erc4626Abi, api as any)
+		const assets = BigInt((await contract.convertToAssets(input.shares.toString())).toString())
+		// Sequential, with a distinct ledger key per owner: one log can affect two tracked LPs.
+		for (const lp of owners) {
+			await this.recordLedger({
+				...input,
+				vault,
+				lp,
+				caller: from,
+				receiver: to,
+				assets,
+				eventType: lp === from ? VaultLedgerEventType.TRANSFER_OUT : VaultLedgerEventType.TRANSFER_IN,
+			})
 		}
 	}
 
 	/**
-	 * Persist one ledger event and fold it into the LP's running position. The position's net
-	 * principal (deposited - withdrawn) is the baseline the daily snapshot measures yield against.
+	 * Seed capital held before tracking began. balanceOf is end-of-block, so subtract ALL later
+	 * capital movements in that block, including the triggering event. Subtracting only that
+	 * event would count a later deposit/transfer twice (or lose a later withdrawal).
+	 */
+	private static async openingBalance(input: VaultLedgerInput): Promise<{ shares: bigint; assets: bigint }> {
+		const movements = await readVaultBlockMovements(input.chain, input.vault, input.blockNumber)
+		const delta = isCapitalIn(input.eventType) ? input.shares : -input.shares
+		if (
+			!movements.some(
+				(m) =>
+					m.lp === input.lp &&
+					m.logIndex === input.logIndex &&
+					m.transactionHash === input.transactionHash.toLowerCase() &&
+					m.shares === delta,
+			)
+		) {
+			throw new Error(
+				`Vault opening balance is missing the triggering log for ${input.chain}:${input.vault}:${input.lp}`,
+			)
+		}
+		const remainingShares = movements
+			.filter((m) => m.lp === input.lp && m.logIndex >= input.logIndex)
+			.reduce((sum, m) => sum + m.shares, 0n)
+		const contract = new ethers.Contract(input.vault, Erc4626Abi, api as any)
+		const shares = BigInt((await contract.balanceOf(input.lp)).toString()) - remainingShares
+		if (shares < 0n) throw new Error(`Negative vault opening shares for ${input.chain}:${input.vault}:${input.lp}`)
+		const assets = shares === 0n ? 0n : BigInt((await contract.convertToAssets(shares.toString())).toString())
+		return { shares, assets }
+	}
+
+	/**
+	 * Persist one capital movement and fold it into the LP's running position. Opening capital,
+	 * deposits/withdrawals and transfers form the baseline the daily snapshot measures yield against.
 	 */
 	static async recordLedger(input: VaultLedgerInput): Promise<void> {
 		const vault = input.vault.toLowerCase()
@@ -121,13 +206,18 @@ export class YieldVaultService {
 		// corrupt principal. Skip if this exact log was already recorded. (A reorg rolls back both the
 		// ledger row and the position together under historical indexing, so legitimate reprocessing
 		// still re-applies cleanly — this only blocks true duplicate delivery.)
-		const ledgerId = `${input.chain}-${input.transactionHash}-${input.logIndex}`
+		const isTransfer =
+			input.eventType === VaultLedgerEventType.TRANSFER_IN ||
+			input.eventType === VaultLedgerEventType.TRANSFER_OUT
+		const ledgerId = capitalEventId(input, isTransfer ? lp : undefined)
 		if (await VaultLedgerEvent.get(ledgerId)) {
 			logger.debug(`[yield-vault] Ledger event ${ledgerId} already recorded, skipping`)
 			return
 		}
 
 		const eventTime = timestampToDate(input.timestamp)
+		// Complete every required RPC before persisting the dedup row.
+		const opening = existingPosition ? undefined : await this.openingBalance({ ...input, lp, vault })
 
 		await VaultLedgerEvent.create({
 			id: ledgerId,
@@ -141,7 +231,7 @@ export class YieldVaultService {
 			assets: input.assets,
 			shares: input.shares,
 			blockNumber: input.blockNumber,
-			transactionHash: input.transactionHash,
+			transactionHash: input.transactionHash.toLowerCase(),
 			timestamp: eventTime,
 		}).save()
 
@@ -153,7 +243,12 @@ export class YieldVaultService {
 				vault,
 				underlyingToken,
 				lp,
-				shares: 0n,
+				shares: opening!.shares,
+				openingShares: opening!.shares,
+				openingPrincipal: opening!.assets,
+				openingBlock: input.blockNumber,
+				totalAssetsTransferredIn: 0n,
+				totalAssetsTransferredOut: 0n,
 				totalAssetsDeposited: 0n,
 				totalAssetsWithdrawn: 0n,
 				depositCount: 0,
@@ -167,10 +262,16 @@ export class YieldVaultService {
 			position.totalAssetsDeposited += input.assets
 			position.shares += input.shares
 			position.depositCount += 1
-		} else {
+		} else if (input.eventType === VaultLedgerEventType.WITHDRAW) {
 			position.totalAssetsWithdrawn += input.assets
 			position.shares -= input.shares
 			position.withdrawCount += 1
+		} else if (input.eventType === VaultLedgerEventType.TRANSFER_IN) {
+			position.totalAssetsTransferredIn = (position.totalAssetsTransferredIn ?? 0n) + input.assets
+			position.shares += input.shares
+		} else {
+			position.totalAssetsTransferredOut = (position.totalAssetsTransferredOut ?? 0n) + input.assets
+			position.shares -= input.shares
 		}
 		position.lastUpdatedAt = eventTime
 
@@ -208,11 +309,15 @@ export class YieldVaultService {
 			if (await VaultSnapshot.get(vaultSnapshotId)) continue
 
 			const contract = new ethers.Contract(vault, Erc4626Abi, api as any)
+			// Ethereum block handlers run BEFORE this block's log handlers. Even a zero-net-share
+			// round trip can change principal, so do not snapshot an LP touched by this block.
+			let movements: VaultCapitalMovement[]
 
 			let totalAssets: bigint
 			let totalShares: bigint
 			let assetsPerShare: bigint
 			try {
+				movements = await readVaultBlockMovements(chain, vault, blockNumber)
 				const [assetsRaw, supplyRaw, decimalsRaw] = await Promise.all([
 					contract.totalAssets(),
 					contract.totalSupply(),
@@ -233,7 +338,19 @@ export class YieldVaultService {
 			// per-day completion gate (checked at the top), so persisting it only after the LP loop
 			// finishes means a mid-loop failure leaves the gate open and the next run retries — the
 			// per-LP dedup skips LPs already done, so the remainder is filled in rather than lost.
-			await this.snapshotLpPositions(chain, vault, underlyingToken, contract, dayStart, blockNumber, snapshotTime)
+			if (
+				!(await this.snapshotLpPositions(
+					chain,
+					vault,
+					underlyingToken,
+					contract,
+					dayStart,
+					blockNumber,
+					snapshotTime,
+					movements,
+				))
+			)
+				continue
 
 			await VaultSnapshot.create({
 				id: vaultSnapshotId,
@@ -258,8 +375,10 @@ export class YieldVaultService {
 		dayStart: bigint,
 		blockNumber: bigint,
 		snapshotTime: Date,
-	): Promise<void> {
+		movements: VaultCapitalMovement[],
+	): Promise<boolean> {
 		let offset = 0
+		let complete = true
 		// Stream the vault's LPs page by page so a vault with many positions doesn't load them all at once.
 		for (;;) {
 			const positions = await VaultLpPosition.getByFields(
@@ -272,7 +391,7 @@ export class YieldVaultService {
 			)
 			if (positions.length === 0) break
 
-			await Promise.all(
+			const results = await Promise.all(
 				positions.map((position) =>
 					this.snapshotLpPosition(
 						position,
@@ -283,13 +402,16 @@ export class YieldVaultService {
 						dayStart,
 						blockNumber,
 						snapshotTime,
+						movements,
 					),
 				),
 			)
+			if (results.includes("retry")) complete = false
 
 			if (positions.length < LP_PAGE_SIZE) break
 			offset += LP_PAGE_SIZE
 		}
+		return complete
 	}
 
 	/** Price one LP's live share balance into assets and persist its daily snapshot. */
@@ -302,9 +424,11 @@ export class YieldVaultService {
 		dayStart: bigint,
 		blockNumber: bigint,
 		snapshotTime: Date,
-	): Promise<void> {
+		movements: VaultCapitalMovement[],
+	): Promise<"complete" | "retry" | "unreconciled"> {
 		const snapshotId = `${chain}-${vault}-${position.lp}-${dayStart}`
-		if (await VaultPositionSnapshot.get(snapshotId)) return
+		if (await VaultPositionSnapshot.get(snapshotId)) return "complete"
+		if (movements.some((m) => m.lp === position.lp)) return "retry"
 
 		let shares: bigint
 		let assetValue: bigint
@@ -316,10 +440,25 @@ export class YieldVaultService {
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error)
 			logger.error(`[yield-vault] LP read failed for ${position.lp} on ${vault}: ${message}`)
-			return
+			return "retry"
 		}
 
-		const netPrincipal = position.totalAssetsDeposited - position.totalAssetsWithdrawn
+		if (shares !== position.shares) {
+			logger.error(
+				`[yield-vault] Withholding yield for ${chain}:${vault}:${position.lp}: ` +
+					`accounted shares=${position.shares}, onchain shares=${shares}; principal requires reconciliation`,
+			)
+			// This needs a historical repair, not another RPC in 50 blocks. Do not prevent the
+			// independent vault aggregate from being published or repeatedly scan every LP today.
+			return "unreconciled"
+		}
+
+		const netPrincipal =
+			(position.openingPrincipal ?? 0n) +
+			position.totalAssetsDeposited -
+			position.totalAssetsWithdrawn +
+			(position.totalAssetsTransferredIn ?? 0n) -
+			(position.totalAssetsTransferredOut ?? 0n)
 		const yieldEarned = assetValue - netPrincipal
 		if (yieldEarned < 0n) {
 			// Expected transiently (a fresh deposit before yield accrues, or a vesting/loss vault), but
@@ -344,5 +483,6 @@ export class YieldVaultService {
 			blockNumber,
 			snapshotTime,
 		}).save()
+		return "complete"
 	}
 }

--- a/sdk/packages/indexer/src/utils/__tests__/vaultAccounting.test.ts
+++ b/sdk/packages/indexer/src/utils/__tests__/vaultAccounting.test.ts
@@ -1,0 +1,97 @@
+jest.mock("@/constants", () => ({ ENV_CONFIG: { "EVM-8453": "https://base.example" } }))
+jest.mock("@/utils/rpc.helpers", () => ({ replaceWebsocketWithHttp: (url: string) => url }))
+jest.mock("@/utils/safeFetch", () => ({ safeFetch: jest.fn() }))
+
+import { ethers } from "ethers"
+import Erc4626Abi from "@/configs/abis/Erc4626.abi.json"
+import { readVaultBlockMovements, vaultCapitalMovements } from "@/utils/vaultAccounting"
+import { safeFetch } from "@/utils/safeFetch"
+
+const abi = new ethers.utils.Interface(Erc4626Abi)
+const FROM = "0x1111111111111111111111111111111111111111"
+const TO = "0x2222222222222222222222222222222222222222"
+const VAULT = "0xc768c589647798a6ee01a91fde98ef2ed046dbd6"
+const tx = `0x${"ab".repeat(32)}`
+const log = (name: string, values: any[]) => ({
+	...abi.encodeEventLog(abi.getEvent(name), values),
+	transactionHash: tx,
+	logIndex: 2,
+})
+
+beforeEach(() => jest.resetAllMocks())
+
+it("decodes deposits and withdrawals with the share owner rather than the caller or receiver", () => {
+	expect(vaultCapitalMovements(log("Deposit", [FROM, TO, 110, 100]))).toEqual([
+		{ transactionHash: tx, logIndex: 2, lp: TO, shares: 100n },
+	])
+	expect(vaultCapitalMovements(log("Withdraw", [FROM, FROM, TO, 110, 100]))).toEqual([
+		{ transactionHash: tx, logIndex: 2, lp: TO, shares: -100n },
+	])
+})
+
+it("decodes both ordinary transfer sides, excluding mint, burn, self and zero-value transfers", () => {
+	expect(vaultCapitalMovements(log("Transfer", [FROM, TO, 100]))).toEqual([
+		{ transactionHash: tx, logIndex: 2, lp: FROM, shares: -100n },
+		{ transactionHash: tx, logIndex: 2, lp: TO, shares: 100n },
+	])
+	for (const args of [
+		[ethers.constants.AddressZero, TO, 100],
+		[FROM, ethers.constants.AddressZero, 100],
+		[FROM, FROM, 100],
+		[FROM, TO, 0],
+	]) {
+		expect(vaultCapitalMovements(log("Transfer", args))).toEqual([])
+	}
+})
+
+it("pins the RPC to the handler block and decodes hex log indexes", async () => {
+	jest.mocked(safeFetch).mockResolvedValue({
+		ok: true,
+		json: async () => ({
+			result: [{ ...log("Transfer", [FROM, TO, 100]), address: VAULT, blockNumber: "0x32", logIndex: "0xa" }],
+		}),
+	} as any)
+	const result = await readVaultBlockMovements("EVM-8453", VAULT, 50n)
+	expect(result.map((m) => m.logIndex)).toEqual([10, 10])
+	const request = JSON.parse(jest.mocked(safeFetch).mock.calls[0][1]!.body as string)
+	expect(request).toMatchObject({
+		method: "eth_getLogs",
+		params: [{ address: VAULT, fromBlock: "0x32", toBlock: "0x32" }],
+	})
+})
+
+it.each([
+	{ error: { message: "rate limited" } },
+	{ result: null },
+	{ result: [{ ...log("Transfer", [FROM, TO, 100]), address: VAULT, blockNumber: "0x31", logIndex: "0x2" }] },
+	{
+		result: [
+			{
+				...log("Transfer", [FROM, TO, 100]),
+				address: VAULT,
+				blockNumber: "0x32",
+				logIndex: "0x2",
+				removed: true,
+			},
+		],
+	},
+])("rejects incomplete or mismatched RPC data", async (body) => {
+	jest.mocked(safeFetch).mockResolvedValue({ ok: true, json: async () => body } as any)
+	await expect(readVaultBlockMovements("EVM-8453", VAULT, 50n)).rejects.toThrow()
+})
+
+it("rejects duplicate log indexes instead of using them to corrupt an opening balance", async () => {
+	const entry = { ...log("Transfer", [FROM, TO, 100]), address: VAULT, blockNumber: "0x32", logIndex: "0x2" }
+	jest.mocked(safeFetch).mockResolvedValue({ ok: true, json: async () => ({ result: [entry, entry] }) } as any)
+	await expect(readVaultBlockMovements("EVM-8453", VAULT, 50n)).rejects.toThrow("Duplicate")
+})
+
+it("rejects HTTP failures even if the payload looks like a valid empty log result", async () => {
+	jest.mocked(safeFetch).mockResolvedValue({ ok: false, json: async () => ({ result: [] }) } as any)
+	await expect(readVaultBlockMovements("EVM-8453", VAULT, 50n)).rejects.toThrow("Could not read")
+})
+
+it("rejects a chain without configured RPC rather than treating its history as empty", async () => {
+	await expect(readVaultBlockMovements("EVM-999", VAULT, 50n)).rejects.toThrow("No RPC configured")
+	expect(safeFetch).not.toHaveBeenCalled()
+})

--- a/sdk/packages/indexer/src/utils/event.utils.ts
+++ b/sdk/packages/indexer/src/utils/event.utils.ts
@@ -30,12 +30,12 @@ export function getSafeEvent<T>(event: T): T & { args: object } {
 	})
 }
 
-export function wrap<const T>(handler: (event: T) => Promise<void>) {
+export function wrap<const T>(handler: (event: T) => Promise<void>, options: { rethrowDecodeErrors?: boolean } = {}) {
 	return async (event: T) => {
 		try {
 			await handler(getSafeEvent(event))
 		} catch (error) {
-			if (error instanceof EventDecodeError) {
+			if (error instanceof EventDecodeError && !options.rethrowDecodeErrors) {
 				logger.error(`Error decoding event: ${error.message}`)
 				return
 			}

--- a/sdk/packages/indexer/src/utils/vaultAccounting.ts
+++ b/sdk/packages/indexer/src/utils/vaultAccounting.ts
@@ -1,0 +1,104 @@
+import { ethers } from "ethers"
+
+import Erc4626Abi from "@/configs/abis/Erc4626.abi.json"
+import { ENV_CONFIG } from "@/constants"
+import { replaceWebsocketWithHttp } from "@/utils/rpc.helpers"
+import { safeFetch } from "@/utils/safeFetch"
+
+const abi = new ethers.utils.Interface(Erc4626Abi)
+const ZERO_ADDRESS = ethers.constants.AddressZero
+
+/** Mint/burns are accounted by Deposit/Withdraw; self and zero-share transfers move no capital. */
+export function isOrdinaryVaultTransfer(from: string, to: string, shares: bigint): boolean {
+	return (
+		from.toLowerCase() !== ZERO_ADDRESS &&
+		to.toLowerCase() !== ZERO_ADDRESS &&
+		from.toLowerCase() !== to.toLowerCase() &&
+		shares !== 0n
+	)
+}
+
+export interface VaultCapitalMovement {
+	transactionHash: string
+	logIndex: number
+	lp: string
+	shares: bigint
+}
+
+/** Share changes represented by Deposit/Withdraw and ordinary (non-mint/burn) Transfers. */
+export function vaultCapitalMovements(log: {
+	topics: string[]
+	data: string
+	transactionHash: string
+	logIndex: number
+}): VaultCapitalMovement[] {
+	const event = abi.parseLog(log)
+	const movement = (lp: string, shares: bigint): VaultCapitalMovement => ({
+		transactionHash: log.transactionHash.toLowerCase(),
+		logIndex: log.logIndex,
+		lp: lp.toLowerCase(),
+		shares,
+	})
+	if (event.name === "Deposit") return [movement(event.args.owner, BigInt(event.args.shares.toString()))]
+	if (event.name === "Withdraw") return [movement(event.args.owner, -BigInt(event.args.shares.toString()))]
+	const from = event.args.from.toLowerCase()
+	const to = event.args.to.toLowerCase()
+	const shares = BigInt(event.args.value.toString())
+	if (!isOrdinaryVaultTransfer(from, to, shares)) return []
+	return [movement(from, -shares), movement(to, shares)]
+}
+
+/**
+ * SubQuery's safe provider pins calls to the handler block, but does not expose getLogs.
+ * Read just that block through the configured HTTP RPC; never scan history or read latest.
+ * Do not cache across handler invocations: retries/reorgs must re-read the canonical block.
+ */
+export async function readVaultBlockMovements(
+	chain: string,
+	vault: string,
+	blockNumber: bigint,
+): Promise<VaultCapitalMovement[]> {
+	const url = replaceWebsocketWithHttp(ENV_CONFIG[chain] ?? "")
+	if (!url) throw new Error(`No RPC configured for vault accounting on ${chain}`)
+	const block = `0x${blockNumber.toString(16)}`
+	const response = await safeFetch(url, {
+		method: "POST",
+		headers: { "content-type": "application/json" },
+		body: JSON.stringify({
+			jsonrpc: "2.0",
+			id: 1,
+			method: "eth_getLogs",
+			params: [
+				{
+					address: vault,
+					fromBlock: block,
+					toBlock: block,
+					topics: [
+						[abi.getEventTopic("Deposit"), abi.getEventTopic("Withdraw"), abi.getEventTopic("Transfer")],
+					],
+				},
+			],
+		}),
+	})
+	const body = await response.json()
+	if (!response.ok || body.error || !Array.isArray(body.result)) {
+		throw new Error(`Could not read vault capital movements for ${chain}:${vault}:${blockNumber}`)
+	}
+	const seen = new Set<number>()
+	return body.result.flatMap((log: any) => {
+		const logIndex = Number(BigInt(log.logIndex))
+		if (
+			log.removed ||
+			BigInt(log.blockNumber) !== blockNumber ||
+			log.address.toLowerCase() !== vault.toLowerCase() ||
+			!Number.isSafeInteger(logIndex) ||
+			logIndex < 0
+		) {
+			throw new Error(`Unexpected vault log for ${chain}:${vault}:${blockNumber}`)
+		}
+		// An RPC returning a log twice must not double the share movement used to infer capital.
+		if (seen.has(logIndex)) throw new Error(`Duplicate vault log for ${chain}:${vault}:${blockNumber}:${logIndex}`)
+		seen.add(logIndex)
+		return vaultCapitalMovements({ ...log, logIndex })
+	})
+}


### PR DESCRIPTION
Vault yield previously subtracted only deposits minus withdrawals from the wallet’s total share value. Receiving existing vault shares therefore counted transferred principal as earnings.

This change:

- Accounts for incoming and outgoing share transfers at their event-block asset value.
- Establishes opening principal for shares held before tracking begins.
- Preserves existing deposit/withdrawal history and excludes mint/burn transfers from duplicate accounting.
- Defers snapshots until same-block capital events are processed and withholds yield when tracked shares disagree with onchain balances.
- Prevents silent decoding failures, duplicate event application, and duplicate RPC logs from corrupting principal.

Validation: 99 focused tests, including 3,000 generated actions, plus 58 related regression tests passed. Audited code has 100% executable-line coverage and 97.3% branch coverage. TypeScript checking and the indexer build passed. Unit/stress tests simulate RPC/store boundaries and rollback.

A separate Docker replay used the actual SubQuery node, PostgreSQL, and premium Base archive RPC against the reported wallet’s historical vault events and snapshot block 51,104,550. Pre-fix `main` reproduced **265,067.474061 USDC** of yield; the fixed build recorded **7.901553 USDC**, matching independent historical contract reads exactly. Fresh schemas had no seeded provider or position rows. The opening basis starts at the first eligible deposit, so receipt-time lifetime yield remains a separate backfill. [Replay evidence](https://github.com/polytope-labs/hyperbridge/blob/fix/indexer-vault-transfer-principal/sdk/packages/indexer/docs/ai/changelog/2026-09-10-vault-historical-replay.md).

Rollout requires the additive schema migration and regenerated EVM manifests. Existing incorrect historical positions and snapshots require a separate backfill.
