### PR TITLE
[sdk]: bump sdk for release

### DIFF
--- a/sdk/packages/sdk/package.json
+++ b/sdk/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@hyperbridge/sdk",
-	"version": "2.8.12",
+	"version": "2.8.13",
 	"description": "The hyperclient SDK provides utilities for querying proofs and statuses for cross-chain requests from HyperBridge.",
 	"type": "module",
 	"types": "./dist/node/index.d.ts",


### PR DESCRIPTION
2.8.12 → 2.8.13, so the sdk can be tagged and published.

Three PRs have landed in `packages/sdk` since `sdk-v2.8.12` — #1228, #1230 and the docs/ai split — with the version left at 2.8.12 throughout. That blocks the simplex release: `publish-simplex.yml` refuses to publish while `packages/sdk` differs from its published tag, because simplex packs `workspace:*` into a hard `@hyperbridge/sdk@2.8.12` and npm's 2.8.12 is the older tree.

Patch rather than minor: #1230 only adds exports (`encodePhantomBidPaymasterAndData`, `decodePhantomBidPaymasterAndData`, `PERMIT2_SPONSORSHIP_BYTES` and two types) alongside the existing ones, which is how the rest of the 2.8.x line has been versioned.

Once this is in: tag `sdk-v2.8.13`, wait for npm, then `simplex-v0.16.2` on the same commit.